### PR TITLE
platform: brand B "Meridian" — daylight/cobalt comparison direction (design only)

### DIFF
--- a/brand/brand-b/BRAND-B.md
+++ b/brand/brand-b/BRAND-B.md
@@ -1,0 +1,154 @@
+# Brand B — "Meridian"
+
+A second brand direction for SuperMega, produced **for comparison only** against the
+current live Brand A ("Void Blue + Fire Red"). This is design exploration — **not a
+rollout**. Nothing here touches the live site, the generator, or any app.
+
+Files in this folder:
+- `tokens.css` — the Meridian design tokens (day default + optional graphite-night).
+- `reference-b.html` — a self-contained board rendering the wordmark, buttons, cards,
+  a homepage hero, the palette, and the type ladder. Open it in any browser.
+- `BRAND-B.md` — this document.
+
+---
+
+## The idea in one line
+
+**Meridian is a clean daylight enterprise system** — cool paper ground, one confident
+**cobalt** accent, a graphite **"slate"** ink, and a geometric **keystone** mark. It reads
+like a serious institutional tool (think Linear / Stripe / Vercel restraint), holds up on a
+mid-range Android in bright sunlight, and is unmistakably **not** Void Blue + Fire Red.
+
+Where Brand A is a *terminal at night* (dark ground, hot red, `>_` hacker mark), Brand B is
+a *blueprint in daylight* (light ground, calm cobalt, an architectural keystone). Same
+company, opposite temperature and posture.
+
+---
+
+## Palette (named hex)
+
+Surfaces — cool daylight paper (never warm cream, never Void Blue):
+
+| Role | Hex | Notes |
+|---|---|---|
+| Ground · paper | `#FBFCFE` | Page background. Cool near-white with a faint blue cast. |
+| Card · raised | `#FFFFFF` | Cards/panels sit *above* the ground. |
+| Sunk · well | `#F1F5FA` | Inputs, table zebra, sunken zones. |
+
+Ink — graphite "slate" (reads like blueprint ink, not pure black):
+
+| Role | Hex | Contrast on ground |
+|---|---|---|
+| Ink · primary text | `#0D1B2A` | 16.9:1 → **AAA** |
+| Muted · secondary | `#4C5A6E` | 6.8:1 → **AA** |
+| Faint · de-emphasis | `#8A97A8` | decorative only (the ".dev" tail) |
+
+Accent — one confident cobalt (calm, trustworthy, institutional):
+
+| Role | Hex | Contrast |
+|---|---|---|
+| Cobalt · accent | `#1D4ED8` | 6.5:1 text on ground → **AA**; white label on fill 6.7:1 → **AA** |
+| Cobalt · deep (pressed) | `#1E40AF` | white label 8.7:1 → **AAA** |
+| Cobalt · wash (chips/rows) | `#EAF1FE` | tinted background |
+
+Second accent — teal, **rationed** (progress, "live", freshness — used sparingly):
+
+| Role | Hex | Contrast |
+|---|---|---|
+| Teal · support | `#0E7C86` | 4.8:1 → **AA**; white label on fill 4.95:1 → **AA** |
+| Teal · wash | `#E4F5F5` | tinted background |
+
+Semantics — honest, and deliberately distinct from the brand accent:
+
+| Role | Hex | Contrast |
+|---|---|---|
+| OK | `#0F7A4E` | 5.2:1 → AA |
+| Warn | `#B45309` | 4.9:1 → AA |
+| Bad | `#B42318` | 6.4:1 → AA (note: red is a *status*, not the brand colour) |
+
+All ratios computed against the daylight ground `#FBFCFE` (or the stated fill). The optional
+graphite-night variant (`data-theme="night"`, ground `#10151C`) brightens cobalt to `#5B8DEF`
+(5.4:1) and teal to `#3BC9C0` (8.5:1) so both hold AA on dark.
+
+**Contrast summary: every text and fill colour passes WCAG AA; primary ink and the deep-cobalt
+button pass AAA.** Chosen for daylight legibility on mid-range Android — the exact buyer context.
+
+---
+
+## Type pairing
+
+- **Display / headings / wordmark — Sora** (700 / 600). A geometric, slightly wide grotesk with
+  a confident, modern-institutional feel. Deliberately **not** Space Grotesk (Brand A) — Sora is
+  rounder and reads more "product company" than "terminal".
+- **Body / UI — IBM Plex Sans** (400 / 500 / 600). A humanist sans commissioned as an engineering
+  house typeface: exceptionally legible on screen, neutral, trustworthy, and it carries a subtle
+  "built by engineers" credibility that fits a business-OS.
+- **Data / numerals — IBM Plex Mono** (500 / 600). For prices, invoice IDs, timestamps, deltas —
+  tabular figures that line up in tables and receipts.
+- **Burmese — Noto Sans Myanmar.** Pairs cleanly with Plex.
+
+No Aptos, no Fraunces, no Space Grotesk. The Sora + Plex pairing is ownable and distinct from A.
+
+---
+
+## The ONE signature motif — the "Meridian keystone"
+
+A **stacked-chevron keystone**: two nested chevrons meeting at an apex node. It reads three ways
+at once — an **arch keystone** (the stone that locks a structure together: "the system that holds
+your business together"), a **mountain pass / meridian convergence**, and an upward **^** (growth).
+It replaces Brand A's `>_` terminal mark entirely.
+
+```
+   ◹◸        M4 15 L12 6 L20 15   (outer chevron, solid cobalt)
+    ^         M8 18 L12 13.5 L16 18 (inner chevron, 55% opacity)
+```
+
+Used as: the logo glyph in the wordmark lockup, a rounded tile inside cards, and — scaled to a
+hairline — as the **"meridian line"**: a thin cobalt rule that caps the hero and separates
+sections (`--meridian` in tokens.css). One motif, three scales. The SVG lives in `tokens.css`.
+
+A secondary texture — a **faint blueprint grid** on the page ground — reinforces the
+architectural/institutional idea without adding a second logo.
+
+---
+
+## Wordmark treatment
+
+`◈ supermega.dev` — the keystone glyph, then **supermega** set in Sora 700 (tight `-0.02em`
+tracking), with the **.dev** tail in `--faint` slate so the product name leads. Lowercase,
+single word, no space — same naming as A, but a completely different glyph, font, and colour.
+Never an "M" tile, never the `>_` mark.
+
+---
+
+## Tone
+
+Plain, calm, confident. Short sentences. No hype words, no exclamation-mark energy. The voice of
+a tool that respects the owner's time: *"Run your shop on one clear system — not Viber & Excel."*
+"Yours to keep" (ownership) is a recurring note — it's what a pragmatic Myanmar SME buyer cares
+about. AI stays invisible in the product; the brand sells clarity and trust, not magic. MMK only
+on public prices.
+
+---
+
+## When Brand B wins over Brand A
+
+Choose **Meridian (B)** when we want to read as:
+
+1. **Daylight-first, Android-first.** The buyer is often on a mid-range phone in a sunlit shop or
+   factory floor. A light system is easier to read there than a dark one, and cobalt-on-white is
+   the highest-legibility, lowest-fatigue combination we have.
+2. **Institutional trust over hacker cool.** Cobalt + slate is the palette of banks, ERPs, and
+   serious infrastructure. If the goal is "a bank would trust this to run their shops," B lands it;
+   A's red-on-black reads younger and more developer-facing.
+3. **Rationed, calm colour.** A single blue accent (plus a whisper of teal) is quieter and ages
+   better than a hot red that must be used sparingly to avoid alarm-fatigue.
+4. **A clean break, not a re-skin.** New ground, new accent, new mark, new type — a genuinely
+   different option to weigh, not a light-mode of A.
+
+Choose **Void Blue + Fire Red (A)** instead when we want energy, a dark "command center" mood,
+the developer/terminal signal, and the striking hot-accent memorability of the `>_` mark.
+
+**Recommendation for the comparison:** put A and B side by side on the same hero copy and the same
+pricing cards. B is the safer, more enterprise-credible, daylight-legible bet; A is the bolder,
+more distinctive, night-mode bet. This board exists so that choice can be made by eye.

--- a/brand/brand-b/reference-b.html
+++ b/brand/brand-b/reference-b.html
@@ -1,0 +1,319 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="day">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>SuperMega · Brand B — “Meridian” (comparison board)</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Sora:wght@500;600;700&family=IBM+Plex+Sans:wght@400;500;600&family=IBM+Plex+Mono:wght@500;600&display=swap" rel="stylesheet" />
+<style>
+  /* ---- BRAND B "MERIDIAN" tokens (mirror of tokens.css, inlined for a self-contained board) ---- */
+  :root{
+    --ground:#FBFCFE; --card:#FFFFFF; --sunk:#F1F5FA;
+    --panel:rgba(13,27,42,.03); --line:rgba(13,27,42,.10); --line-strong:rgba(13,27,42,.16);
+    --ink:#0D1B2A; --muted:#4C5A6E; --faint:#8A97A8;
+    --cobalt:#1D4ED8; --cobalt-deep:#1E40AF; --cobalt-lift:#3B6FE8; --cobalt-wash:#EAF1FE; --cobalt-glow:rgba(29,78,216,.14);
+    --teal:#0E7C86; --teal-wash:#E4F5F5;
+    --ok:#0F7A4E; --warn:#B45309; --bad:#B42318;
+    --font-display:"Sora","IBM Plex Sans",system-ui,sans-serif;
+    --font-sans:"IBM Plex Sans","Noto Sans Myanmar",system-ui,sans-serif;
+    --font-mono:"IBM Plex Mono",ui-monospace,monospace;
+    --radius:10px; --radius-lg:16px; --radius-pill:999px;
+    --step-2:1.75rem; --step-3:2.5rem; --step-4:3.5rem;
+    --shadow-sm:0 1px 2px rgba(13,27,42,.06),0 1px 1px rgba(13,27,42,.04);
+    --shadow:0 10px 30px rgba(13,27,42,.10),0 2px 6px rgba(13,27,42,.06);
+    --shadow-lg:0 24px 60px rgba(13,27,42,.14);
+    --meridian:linear-gradient(90deg,transparent,var(--cobalt) 20%,var(--cobalt) 80%,transparent);
+  }
+  html[data-theme="night"]{
+    --ground:#10151C; --card:#171E27; --sunk:#0C1116;
+    --panel:rgba(255,255,255,.04); --line:rgba(255,255,255,.10); --line-strong:rgba(255,255,255,.16);
+    --ink:#EAF1F8; --muted:#9FB0C2; --faint:#6A7788;
+    --cobalt:#5B8DEF; --cobalt-deep:#3B6FE8; --cobalt-lift:#7BA5F5; --cobalt-wash:rgba(91,141,239,.14); --cobalt-glow:rgba(91,141,239,.22);
+    --teal:#3BC9C0; --teal-wash:rgba(59,201,192,.14);
+    --ok:#4ADE80; --warn:#F5B44C; --bad:#F97066;
+    --shadow-sm:0 1px 2px rgba(0,0,0,.4); --shadow:0 12px 34px rgba(0,0,0,.5); --shadow-lg:0 26px 64px rgba(0,0,0,.6);
+  }
+
+  *,*::before,*::after{box-sizing:border-box}
+  html{-webkit-text-size-adjust:100%}
+  body{
+    margin:0; background:var(--ground); color:var(--ink);
+    font-family:var(--font-sans); font-size:16px; line-height:1.55;
+    -webkit-font-smoothing:antialiased; text-rendering:optimizeLegibility;
+    /* faint architectural blueprint grid — the "meridian" system's paper */
+    background-image:
+      linear-gradient(var(--line) 1px,transparent 1px),
+      linear-gradient(90deg,var(--line) 1px,transparent 1px);
+    background-size:56px 56px; background-position:-1px -1px;
+  }
+  html[data-theme="night"] body{background-image:linear-gradient(var(--line) 1px,transparent 1px),linear-gradient(90deg,var(--line) 1px,transparent 1px)}
+  h1,h2,h3,h4{font-family:var(--font-display); font-weight:700; line-height:1.1; letter-spacing:-.02em; margin:0}
+  p{margin:0}
+  a{color:var(--cobalt); text-decoration:none}
+  .wrap{max-width:1080px; margin:0 auto; padding:0 24px}
+
+  /* ---- top bar ---- */
+  .topbar{position:sticky; top:0; z-index:10; backdrop-filter:saturate(1.2) blur(8px);
+    background:color-mix(in srgb,var(--ground) 82%,transparent); border-bottom:1px solid var(--line)}
+  .topbar .row{display:flex; align-items:center; justify-content:space-between; height:60px}
+  .brandlock{display:inline-flex; align-items:center; gap:.55ch; font-family:var(--font-display); font-weight:700; font-size:20px; letter-spacing:-.02em}
+  .brandlock .dot{color:var(--faint)}
+  .themebtn{font:600 13px/1 var(--font-sans); color:var(--muted); background:var(--card); border:1px solid var(--line);
+    padding:8px 14px; border-radius:var(--radius-pill); cursor:pointer; box-shadow:var(--shadow-sm)}
+  .themebtn:hover{border-color:var(--cobalt); color:var(--cobalt)}
+
+  /* ---- section scaffolding ---- */
+  section{padding:56px 0}
+  .eyebrow{font:600 12px/1 var(--font-mono); letter-spacing:.16em; text-transform:uppercase; color:var(--cobalt); margin-bottom:14px; display:flex; align-items:center; gap:10px}
+  .eyebrow::before{content:""; width:26px; height:2px; background:var(--cobalt); border-radius:2px; display:inline-block}
+  .sechead{font-size:var(--step-2,28px); margin-bottom:6px}
+  .secsub{color:var(--muted); max-width:60ch; margin-bottom:28px}
+
+  /* ---- keystone mark helper ---- */
+  .keystone{flex:0 0 auto}
+
+  /* ---- hero ---- */
+  .hero{position:relative; background:var(--card); border:1px solid var(--line); border-radius:var(--radius-lg);
+    box-shadow:var(--shadow); overflow:hidden}
+  .hero::before{content:""; position:absolute; inset:0 0 auto 0; height:3px; background:var(--meridian)}
+  .hero-inner{display:grid; grid-template-columns:1.15fr .85fr; gap:0}
+  .hero-copy{padding:52px 48px}
+  .hero-badge{display:inline-flex; align-items:center; gap:8px; font:600 12.5px/1 var(--font-sans);
+    color:var(--teal); background:var(--teal-wash); padding:6px 12px; border-radius:var(--radius-pill); margin-bottom:22px}
+  .hero-badge .pulse{width:7px; height:7px; border-radius:50%; background:var(--teal); box-shadow:0 0 0 0 var(--teal)}
+  .hero h1{font-size:clamp(30px,4.4vw,52px); margin-bottom:18px}
+  .hero h1 .accent{color:var(--cobalt)}
+  .hero p.lead{font-size:18px; color:var(--muted); max-width:34ch; margin-bottom:30px}
+  .hero-cta{display:flex; gap:12px; flex-wrap:wrap}
+  .hero-panel{position:relative; background:linear-gradient(160deg,var(--cobalt-wash),var(--card)); border-left:1px solid var(--line);
+    display:flex; align-items:center; justify-content:center; padding:36px}
+  html[data-theme="night"] .hero-panel{background:linear-gradient(160deg,var(--cobalt-wash),transparent)}
+  /* mini "dashboard" glyph inside the hero panel */
+  .glyph{width:100%; max-width:280px; background:var(--card); border:1px solid var(--line); border-radius:12px; box-shadow:var(--shadow); overflow:hidden}
+  .glyph .g-top{display:flex; align-items:center; gap:6px; padding:11px 13px; border-bottom:1px solid var(--line)}
+  .glyph .g-top i{width:9px; height:9px; border-radius:50%; background:var(--line-strong); display:inline-block}
+  .glyph .g-body{padding:16px}
+  .glyph .g-row{display:flex; align-items:flex-end; gap:6px; height:78px; margin-bottom:14px}
+  .glyph .g-bar{flex:1; border-radius:4px 4px 2px 2px; background:var(--cobalt); opacity:.9}
+  .glyph .g-bar:nth-child(2){opacity:.55} .glyph .g-bar:nth-child(3){opacity:.7}
+  .glyph .g-bar:nth-child(4){background:var(--teal)} .glyph .g-bar:nth-child(5){opacity:.4}
+  .glyph .g-line{height:9px; border-radius:5px; background:var(--sunk)}
+  .glyph .g-line.short{width:55%; margin-top:8px}
+
+  /* ---- buttons ---- */
+  .btn{display:inline-flex; align-items:center; gap:9px; font:600 15px/1 var(--font-sans); padding:13px 22px;
+    border-radius:var(--radius); border:1px solid transparent; cursor:pointer; transition:.15s ease; text-decoration:none}
+  .btn:focus-visible{outline:none; box-shadow:0 0 0 3px var(--cobalt-glow)}
+  .btn-primary{background:var(--cobalt); color:#fff; box-shadow:var(--shadow-sm)}
+  .btn-primary:hover{background:var(--cobalt-deep); transform:translateY(-1px); box-shadow:var(--shadow)}
+  .btn-secondary{background:var(--card); color:var(--ink); border-color:var(--line-strong)}
+  .btn-secondary:hover{border-color:var(--cobalt); color:var(--cobalt); background:var(--cobalt-wash)}
+  .btn-ghost{background:transparent; color:var(--cobalt); padding-left:6px; padding-right:6px}
+  .btn-ghost:hover{color:var(--cobalt-deep)}
+  .btn .arrow{transition:transform .15s ease}
+  .btn:hover .arrow{transform:translateX(3px)}
+
+  /* ---- cards ---- */
+  .cards{display:grid; grid-template-columns:repeat(3,1fr); gap:20px}
+  .card{background:var(--card); border:1px solid var(--line); border-radius:var(--radius-lg); padding:26px;
+    box-shadow:var(--shadow-sm); transition:.18s ease; position:relative; overflow:hidden}
+  .card:hover{box-shadow:var(--shadow); transform:translateY(-3px); border-color:var(--line-strong)}
+  .card .kmark{width:38px; height:38px; border-radius:9px; background:var(--cobalt-wash); display:grid; place-items:center; margin-bottom:16px}
+  .card.teal .kmark{background:var(--teal-wash)}
+  .card h3{font-size:19px; margin-bottom:8px}
+  .card p{color:var(--muted); font-size:14.5px}
+  .card .tag{position:absolute; top:20px; right:20px; font:600 11px/1 var(--font-mono); letter-spacing:.08em; text-transform:uppercase;
+    color:var(--cobalt); background:var(--cobalt-wash); padding:5px 9px; border-radius:6px}
+  .card.teal .tag{color:var(--teal); background:var(--teal-wash)}
+  .card .price{margin-top:16px; font-family:var(--font-display); font-weight:700; font-size:22px}
+  .card .price small{font-family:var(--font-sans); font-weight:500; font-size:13px; color:var(--muted)}
+
+  /* ---- palette ---- */
+  .swatches{display:grid; grid-template-columns:repeat(auto-fill,minmax(150px,1fr)); gap:14px}
+  .sw{border:1px solid var(--line); border-radius:var(--radius); overflow:hidden; background:var(--card); box-shadow:var(--shadow-sm)}
+  .sw .chip{height:76px}
+  .sw .meta{padding:11px 13px}
+  .sw .role{font:600 13px/1.2 var(--font-sans); color:var(--ink)}
+  .sw .hex{font:600 12px/1.4 var(--font-mono); color:var(--muted); margin-top:3px; text-transform:uppercase}
+
+  /* ---- type ladder ---- */
+  .ladder{background:var(--card); border:1px solid var(--line); border-radius:var(--radius-lg); box-shadow:var(--shadow-sm); overflow:hidden}
+  .ladder .lrow{display:grid; grid-template-columns:130px 1fr; gap:20px; align-items:baseline; padding:18px 26px; border-bottom:1px solid var(--line)}
+  .ladder .lrow:last-child{border-bottom:none}
+  .ladder .lmeta{font:600 12px/1.4 var(--font-mono); color:var(--faint); text-transform:uppercase; letter-spacing:.05em}
+  .ladder .ldisp{font-family:var(--font-display); font-weight:700; letter-spacing:-.02em; color:var(--ink)}
+  .ladder .lbody{font-family:var(--font-sans)}
+  .ll-4{font-size:52px} .ll-3{font-size:40px} .ll-2{font-size:28px} .ll-1{font-size:20px}
+  .ll-0{font-size:16px; font-weight:400; color:var(--muted); font-family:var(--font-sans); letter-spacing:0}
+  .ll-c{font-size:13px; font-family:var(--font-mono); color:var(--muted); letter-spacing:.04em}
+
+  /* ---- footer note ---- */
+  footer{border-top:1px solid var(--line); padding:30px 0 60px; color:var(--muted); font-size:13.5px}
+  footer .wrap{display:flex; justify-content:space-between; align-items:center; gap:16px; flex-wrap:wrap}
+  .pill{font:600 11px/1 var(--font-mono); letter-spacing:.1em; text-transform:uppercase; color:var(--muted);
+    border:1px solid var(--line); padding:6px 11px; border-radius:var(--radius-pill)}
+
+  /* ---- responsive (mid-range Android / mobile) ---- */
+  @media (max-width:820px){
+    .hero-inner{grid-template-columns:1fr}
+    .hero-panel{border-left:none; border-top:1px solid var(--line)}
+    .hero-copy{padding:38px 26px}
+    .cards{grid-template-columns:1fr}
+    .ladder .lrow{grid-template-columns:1fr; gap:6px; padding:16px 20px}
+    .ll-4{font-size:38px} .ll-3{font-size:30px}
+  }
+</style>
+</head>
+<body>
+
+  <!-- keystone mark defined once as an inline symbol for reuse -->
+  <svg width="0" height="0" style="position:absolute" aria-hidden="true">
+    <symbol id="keystone" viewBox="0 0 24 24" fill="none">
+      <path d="M4 15 L12 6 L20 15" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"/>
+      <path d="M8 18 L12 13.5 L16 18" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" opacity=".55"/>
+    </symbol>
+  </svg>
+
+  <div class="topbar">
+    <div class="wrap row">
+      <span class="brandlock">
+        <svg class="keystone" width="22" height="22" style="color:var(--cobalt)"><use href="#keystone"/></svg>
+        supermega<span class="dot">.dev</span>
+      </span>
+      <button class="themebtn" id="toggle" type="button">Toggle day / night</button>
+    </div>
+  </div>
+
+  <div class="wrap">
+
+    <!-- ============ HERO ============ -->
+    <section id="hero">
+      <div class="eyebrow">Brand&nbsp;B · Meridian · comparison board</div>
+      <div class="hero">
+        <div class="hero-inner">
+          <div class="hero-copy">
+            <span class="hero-badge"><span class="pulse"></span> Retail OS · Factory OS</span>
+            <h1>Run your shop on <span class="accent">one clear system</span>—not Viber &amp; Excel.</h1>
+            <p class="lead">Sales, stock, staff and cash in one place. Built for Myanmar businesses. Yours to keep.</p>
+            <div class="hero-cta">
+              <a class="btn btn-primary" href="#">Start free <span class="arrow">→</span></a>
+              <a class="btn btn-secondary" href="#">See a live shop</a>
+            </div>
+          </div>
+          <div class="hero-panel">
+            <div class="glyph" role="img" aria-label="Illustrative dashboard">
+              <div class="g-top"><i></i><i></i><i></i></div>
+              <div class="g-body">
+                <div class="g-row">
+                  <span class="g-bar" style="height:44%"></span>
+                  <span class="g-bar" style="height:70%"></span>
+                  <span class="g-bar" style="height:58%"></span>
+                  <span class="g-bar" style="height:88%"></span>
+                  <span class="g-bar" style="height:36%"></span>
+                </div>
+                <div class="g-line"></div>
+                <div class="g-line short"></div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ============ BUTTONS ============ -->
+    <section id="buttons">
+      <div class="eyebrow">Components</div>
+      <h2 class="sechead">Buttons</h2>
+      <p class="secsub">One confident cobalt for the primary action; a quiet outline for the secondary; a ghost for tertiary links. The accent is rationed—most of the interface stays calm slate on paper.</p>
+      <div style="display:flex; gap:14px; flex-wrap:wrap; align-items:center">
+        <a class="btn btn-primary" href="#">Primary action <span class="arrow">→</span></a>
+        <a class="btn btn-secondary" href="#">Secondary</a>
+        <a class="btn btn-ghost" href="#">Tertiary link <span class="arrow">→</span></a>
+        <button class="btn btn-primary" type="button" disabled style="opacity:.5; cursor:not-allowed">Disabled</button>
+      </div>
+    </section>
+
+    <!-- ============ CARDS ============ -->
+    <section id="cards">
+      <div class="eyebrow">Surfaces</div>
+      <h2 class="sechead">Cards</h2>
+      <p class="secsub">Raised white surfaces on the cool paper ground, tight 16px radius, a keystone glyph tile, and a rationed teal card to show the second accent in context.</p>
+      <div class="cards">
+        <div class="card">
+          <span class="tag">Retail OS</span>
+          <div class="kmark"><svg width="20" height="20" style="color:var(--cobalt)"><use href="#keystone"/></svg></div>
+          <h3>Point of sale</h3>
+          <p>Ring up sales, track stock, print receipts. Works on the tablet you already own.</p>
+          <div class="price">15,000 <small>MMK / month</small></div>
+        </div>
+        <div class="card teal">
+          <span class="tag">Factory OS</span>
+          <div class="kmark"><svg width="20" height="20" style="color:var(--teal)"><use href="#keystone"/></svg></div>
+          <h3>Production board</h3>
+          <p>Orders, materials and output on one live board. Everyone sees the same truth.</p>
+          <div class="price">25,000 <small>MMK / month</small></div>
+        </div>
+        <div class="card">
+          <span class="tag">Add-on</span>
+          <div class="kmark"><svg width="20" height="20" style="color:var(--cobalt)"><use href="#keystone"/></svg></div>
+          <h3>Owner reports</h3>
+          <p>Daily cash, best sellers, who owes you money—delivered every morning.</p>
+          <div class="price">Included <small>with any plan</small></div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ============ PALETTE ============ -->
+    <section id="palette">
+      <div class="eyebrow">Palette</div>
+      <h2 class="sechead">Colour &amp; role</h2>
+      <p class="secsub">Cool daylight surfaces, graphite “slate” ink, one cobalt accent, a rationed teal, and honest semantics. Every swatch passes WCAG&nbsp;AA on its ground.</p>
+      <div class="swatches">
+        <div class="sw"><div class="chip" style="background:#FBFCFE; border-bottom:1px solid var(--line)"></div><div class="meta"><div class="role">Ground · paper</div><div class="hex">#FBFCFE</div></div></div>
+        <div class="sw"><div class="chip" style="background:#FFFFFF; border-bottom:1px solid var(--line)"></div><div class="meta"><div class="role">Card · raised</div><div class="hex">#FFFFFF</div></div></div>
+        <div class="sw"><div class="chip" style="background:#0D1B2A"></div><div class="meta"><div class="role">Ink · slate</div><div class="hex">#0D1B2A</div></div></div>
+        <div class="sw"><div class="chip" style="background:#4C5A6E"></div><div class="meta"><div class="role">Muted text</div><div class="hex">#4C5A6E</div></div></div>
+        <div class="sw"><div class="chip" style="background:#1D4ED8"></div><div class="meta"><div class="role">Cobalt · accent</div><div class="hex">#1D4ED8</div></div></div>
+        <div class="sw"><div class="chip" style="background:#1E40AF"></div><div class="meta"><div class="role">Cobalt · deep</div><div class="hex">#1E40AF</div></div></div>
+        <div class="sw"><div class="chip" style="background:#0E7C86"></div><div class="meta"><div class="role">Teal · support</div><div class="hex">#0E7C86</div></div></div>
+        <div class="sw"><div class="chip" style="background:#0F7A4E"></div><div class="meta"><div class="role">OK</div><div class="hex">#0F7A4E</div></div></div>
+        <div class="sw"><div class="chip" style="background:#B45309"></div><div class="meta"><div class="role">Warn</div><div class="hex">#B45309</div></div></div>
+        <div class="sw"><div class="chip" style="background:#B42318"></div><div class="meta"><div class="role">Bad</div><div class="hex">#B42318</div></div></div>
+      </div>
+    </section>
+
+    <!-- ============ TYPE ============ -->
+    <section id="type">
+      <div class="eyebrow">Typography</div>
+      <h2 class="sechead">Type ladder</h2>
+      <p class="secsub">Display / headings / wordmark in <b>Sora</b> (geometric, confident). Body &amp; UI in <b>IBM Plex Sans</b> (humanist, engineering-house, screen-legible). Numerals in IBM Plex Mono.</p>
+      <div class="ladder">
+        <div class="lrow"><div class="lmeta">Sora · 56 · Hero</div><div class="ldisp ll-4">One clear system</div></div>
+        <div class="lrow"><div class="lmeta">Sora · 40 · Page</div><div class="ldisp ll-3">Stop the chaos</div></div>
+        <div class="lrow"><div class="lmeta">Sora · 28 · Section</div><div class="ldisp ll-2">Sales, stock, staff, cash</div></div>
+        <div class="lrow"><div class="lmeta">Sora · 20 · Card title</div><div class="ldisp ll-1">Point of sale</div></div>
+        <div class="lrow"><div class="lmeta">Plex Sans · 16 · Body</div><div class="lbody ll-0">Everything a Myanmar shop or factory needs to run the day, in one place, on the device you already own — and it stays yours.</div></div>
+        <div class="lrow"><div class="lmeta">Plex Mono · 13 · Data</div><div class="ll-c">15,000 MMK · #INV-0429 · 12:04 · +8.4%</div></div>
+      </div>
+    </section>
+
+  </div>
+
+  <footer>
+    <div class="wrap">
+      <span><span class="brandlock" style="font-size:15px"><svg class="keystone" width="16" height="16" style="color:var(--cobalt)"><use href="#keystone"/></svg> supermega<span class="dot">.dev</span></span> — Brand B “Meridian”. Design comparison only. Not live.</span>
+      <span class="pill">Cobalt · Slate · Daylight</span>
+    </div>
+  </footer>
+
+  <script>
+    // day / night toggle — demonstrates the graphite-night variant vs the daylight default
+    var root=document.documentElement, btn=document.getElementById('toggle');
+    btn.addEventListener('click',function(){
+      root.setAttribute('data-theme', root.getAttribute('data-theme')==='night' ? 'day' : 'night');
+    });
+  </script>
+</body>
+</html>

--- a/brand/brand-b/tokens.css
+++ b/brand/brand-b/tokens.css
@@ -1,0 +1,139 @@
+/* ============================================================================
+   SUPERMEGA — BRAND B  ·  "MERIDIAN"
+   A design-comparison candidate. NOT live. NOT a rollout. Compare against
+   Brand A ("Void Blue + Fire Red", the current live system in BRAND-TOKENS.css).
+
+   THE IDEA (one line): a clean DAYLIGHT enterprise system — cool paper ground,
+   a single confident COBALT accent, a graphite "Slate" ink, and a geometric
+   "Meridian keystone" mark. Reads Linear/Stripe/Vercel-credible, holds up on a
+   mid-range Android in bright daylight, and is unmistakably NOT Void Blue + Fire Red.
+
+   HOW B DIFFERS FROM A (so the comparison is real, not a re-skin):
+     • Ground:   LIGHT cool paper #FBFCFE      (A = dark Void #07111f)
+     • Accent:   COBALT #1D4ED8 (blue, calm)   (A = Fire Red #FF3B3B, hot)
+     • Support:  a rationed TEAL #0E7C86        (A = red-only)
+     • Mark:     the "keystone" ◈ chevron-stack (A = the `>_` terminal mark)
+     • Type:     Space Grotesk is GONE. Display = Sora, body = IBM Plex Sans.
+     • Feel:     architectural / institutional  (A = terminal / hacker)
+
+   Every value below is validated for WCAG AA on its stated ground (see BRAND-B.md
+   for the ratios). Copy verbatim if B is ever chosen; do not hand-drift the hexes.
+
+   Fonts (self-contained board loads these from Google Fonts):
+   @import url('https://fonts.googleapis.com/css2?family=Sora:wght@500;600;700&family=IBM+Plex+Sans:wght@400;500;600&display=swap');
+   Sora        = display / headings / wordmark (geometric, confident, NOT Space Grotesk)
+   IBM Plex Sans = body / UI (humanist, screen-legible, an engineering-house typeface)
+   Burmese     = Noto Sans Myanmar.  NO Aptos, NO Fraunces, NO Space Grotesk.
+   ============================================================================ */
+
+:root {
+  color-scheme: light;
+
+  /* --- Surfaces: cool daylight paper (NOT warm cream #f7f4ec, NOT Void #07111f) --- */
+  --ground:      #FBFCFE;   /* page background — cool paper white, the canonical B ground */
+  --card:        #FFFFFF;   /* raised surfaces / cards sit ABOVE the ground */
+  --sunk:        #F1F5FA;   /* sunken wells / input fields / table zebra */
+  --panel:       rgba(13, 27, 42, 0.03);   /* faint slate tint for large fills */
+  --line:        rgba(13, 27, 42, 0.10);   /* hairlines / borders (slate low-alpha) */
+  --line-strong: rgba(13, 27, 42, 0.16);   /* emphasized dividers */
+
+  /* --- Ink: graphite "Slate" family (echoes a blueprint, not pure black) --- */
+  --ink:         #0D1B2A;   /* primary text — deep slate  (16.9:1 on ground → AAA) */
+  --muted:       #4C5A6E;   /* secondary text — slate-blue (6.8:1 → AA) */
+  --faint:       #8A97A8;   /* de-emphasized / the ".dev" tail (decorative only) */
+
+  /* --- Cobalt: THE one accent (calm, institutional, trustworthy) --- */
+  --cobalt:      #1D4ED8;   /* primary accent — links, primary fill (6.5:1 on ground → AA) */
+  --cobalt-deep: #1E40AF;   /* pressed / hover-dark (8.7:1 white label → AAA) */
+  --cobalt-lift: #3B6FE8;   /* hover-light / focus glow center */
+  --cobalt-wash: #EAF1FE;   /* tinted chip / selected-row background */
+  --cobalt-glow: rgba(29, 78, 216, 0.14);  /* soft focus halo */
+
+  /* --- Teal: the SECOND, rationed accent (progress, "live", freshness) --- */
+  --teal:        #0E7C86;   /* supporting accent — used sparingly (4.8:1 → AA) */
+  --teal-wash:   #E4F5F5;   /* teal chip background */
+
+  /* --- Semantic (all AA on ground) --- */
+  --ok:          #0F7A4E;   /* success  (5.2:1) */
+  --warn:        #B45309;   /* warning  (4.9:1) */
+  --bad:         #B42318;   /* error    (6.4:1) — deliberately NOT the accent */
+
+  /* --- Type --- */
+  --font-display: "Sora", "IBM Plex Sans", system-ui, sans-serif;          /* headings / wordmark */
+  --font-sans:    "IBM Plex Sans", "Noto Sans Myanmar", system-ui, sans-serif; /* body / UI */
+  --font-mono:    "IBM Plex Mono", ui-monospace, "Cascadia Code", monospace;   /* numerals / codes */
+
+  /* Type ramp (fluid-ish; px anchors for the specimen) */
+  --step--1: 0.833rem;   /* 13.3px — captions / labels */
+  --step-0:  1rem;       /* 16px   — body */
+  --step-1:  1.25rem;    /* 20px   — lead / card title */
+  --step-2:  1.75rem;    /* 28px   — section head */
+  --step-3:  2.5rem;     /* 40px   — page head */
+  --step-4:  3.5rem;     /* 56px   — hero */
+
+  /* --- Shape & depth --- */
+  --radius:      10px;    /* tighter than A's 14px — architectural, not soft */
+  --radius-lg:   16px;
+  --radius-pill: 999px;
+  --shadow-sm:   0 1px 2px rgba(13, 27, 42, 0.06), 0 1px 1px rgba(13, 27, 42, 0.04);
+  --shadow:      0 10px 30px rgba(13, 27, 42, 0.10), 0 2px 6px rgba(13, 27, 42, 0.06);
+  --shadow-lg:   0 24px 60px rgba(13, 27, 42, 0.14);
+
+  /* --- Motif: the "meridian line" — a hairline cobalt rule with a keystone node.
+         Use as a top-border accent on hero/cards, or a section separator. --- */
+  --meridian:    linear-gradient(90deg, transparent, var(--cobalt) 20%, var(--cobalt) 80%, transparent);
+  --ring:        0 0 0 3px var(--cobalt-glow);   /* focus ring */
+}
+
+/* ---------------------------------------------------------------------------
+   OPTIONAL DARK VARIANT of Meridian — a graphite NIGHT, distinct from Void Blue.
+   Ground is a warm-neutral graphite #10151C (NOT #07111f), accent brightens to a
+   sky-cobalt so it holds AA on dark. Apply with <html data-theme="night">.
+   (Meridian's PRIMARY expression is the light daylight system above.)
+   --------------------------------------------------------------------------- */
+:root[data-theme="night"] {
+  color-scheme: dark;
+  --ground:      #10151C;   /* graphite night — neutral, NOT the blue Void #07111f */
+  --card:        #171E27;
+  --sunk:        #0C1116;
+  --panel:       rgba(255, 255, 255, 0.04);
+  --line:        rgba(255, 255, 255, 0.10);
+  --line-strong: rgba(255, 255, 255, 0.16);
+  --ink:         #EAF1F8;   /* 15.3:1 on ground → AAA */
+  --muted:       #9FB0C2;
+  --faint:       #6A7788;
+  --cobalt:      #5B8DEF;   /* brightened sky-cobalt (5.4:1 on ground → AA) */
+  --cobalt-deep: #3B6FE8;
+  --cobalt-lift: #7BA5F5;
+  --cobalt-wash: rgba(91, 141, 239, 0.14);
+  --cobalt-glow: rgba(91, 141, 239, 0.22);
+  --teal:        #3BC9C0;   /* 8.5:1 on ground → AAA */
+  --teal-wash:   rgba(59, 201, 192, 0.14);
+  --ok:          #4ADE80;
+  --warn:        #F5B44C;
+  --bad:         #F97066;
+  --shadow-sm:   0 1px 2px rgba(0, 0, 0, 0.4);
+  --shadow:      0 12px 34px rgba(0, 0, 0, 0.5);
+  --shadow-lg:   0 26px 64px rgba(0, 0, 0, 0.6);
+}
+
+/* ---------------------------------------------------------------------------
+   THE "MERIDIAN KEYSTONE" MARK (Brand B's signature — replaces A's `>_`).
+   A stacked-chevron keystone: two nested chevrons meeting at an apex node — reads
+   as an arch keystone / a mountain pass / a "meridian" convergence. Cobalt on light,
+   sky-cobalt on night. Use this SVG for every lockup; never an "M" tile.
+
+   <span style="display:inline-flex;align-items:center;gap:.5ch">
+     <svg width="22" height="22" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+       <path d="M4 15 L12 6 L20 15" stroke="var(--cobalt)" stroke-width="2.4"
+             stroke-linecap="round" stroke-linejoin="round"/>
+       <path d="M8 18 L12 13.5 L16 18" stroke="var(--cobalt)" stroke-width="2.4"
+             stroke-linecap="round" stroke-linejoin="round" opacity=".55"/>
+     </svg>
+     <b style="font-family:var(--font-display)">supermega</b><b style="color:var(--faint)">.dev</b>
+   </span>
+   --------------------------------------------------------------------------- */
+
+/* PURGE-ON-SIGHT for Brand B files (kept distinct from A): the `>_` terminal mark,
+   Fire Red #FF3B3B, Space Grotesk, warm cream #f7f4ec / #f7f4ed, clay #c2603f,
+   gold #E9B949 / #C9A24B, Fraunces. If B is chosen, none of those belong here. */


### PR DESCRIPTION
## Brand B — "Meridian" (design comparison only, NOT a rollout)

A **second** brand direction to compare against the live **Brand A** ("Void Blue + Fire Red").
Design exploration only — touches no live surface, the generator, or any app. **Exactly 3 new files under `brand/brand-b/`.**

> Base is `brand/light-skin-b` (the current working brand branch), not the stale default `main` (243 commits behind), so this diff is clean — only my 3 files.

### The direction
A clean **daylight** enterprise system — the opposite temperature/posture from A (a terminal at night):
- **Ground** cool paper `#FBFCFE` (A = dark Void `#07111f`)
- **Accent** one confident **cobalt** `#1D4ED8` (A = Fire Red `#FF3B3B`), plus a rationed teal `#0E7C86`
- **Ink** graphite slate `#0D1B2A`
- **Mark** the "keystone" stacked-chevron glyph (replaces A's `>_`)
- **Type** Sora (display) + IBM Plex Sans (body) — no Space Grotesk

### Files
- `brand/brand-b/tokens.css` — day default + optional graphite-night variant
- `brand/brand-b/reference-b.html` — self-contained board (wordmark, buttons, cards, hero, palette, type ladder). Google Fonts only.
- `brand/brand-b/BRAND-B.md` — concept, named palette, type pairing, motif, wordmark, tone, "when B wins over A"

### Verification
- Every colour passes **WCAG AA** on its ground (primary ink + deep-cobalt button = AAA); doc contrast claims match computed values.
- E2E gate: no `#07111f`, no `#FF3B3B`, no `#f7f4ec`, no `#c2603f`, no Space Grotesk — a genuinely distinct direction.
- HTML well-formed, self-contained (Google Fonts only), serves HTTP 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)