### PR TITLE
kernel: +4 real connectors (PayPal, OneDrive, Pipedrive, ClickUp) → 63

### DIFF
--- a/kernel/connectors/crm-pipedrive.mjs
+++ b/kernel/connectors/crm-pipedrive.mjs
@@ -1,0 +1,110 @@
+// Connector: data — Pipedrive. Read deals out of Pipedrive CRM via its REST API (zero-dependency,
+// native fetch). Pipedrive is a common sales-pipeline CRM for SEA SMBs; this connector lets the
+// SuperMega kernel pull the deals a business already tracks — so an agent can reconcile pipeline
+// against DeskPOS sales, surface open opportunities, and enrich CRM records without re-keying.
+//
+// category 'data' · configured = PIPEDRIVE_API_TOKEN present.
+// The API host is a hardcoded https constant (Pipedrive) — no user value ever chooses the host.
+//
+// Quick setup:
+//   1. In Pipedrive: Settings → Personal preferences → API → copy your personal API token.
+//   2. Set it as PIPEDRIVE_API_TOKEN. The host is fixed (api.pipedrive.com).
+//
+// Env:
+//   PIPEDRIVE_API_TOKEN  (required)  Pipedrive personal API token.
+//
+// Auth: api_token query parameter. Pipedrive authenticates by appending `?api_token=<token>` to the
+// request URL (there is no bearer header for the classic token). We URL-encode the token so it can
+// never break out of the query string.
+//
+// Base: https://api.pipedrive.com/v1 (fixed host — never chosen from a user value).
+//
+// Capabilities:
+//   listDeals({ limit }) — GET /deals?limit=<limit> (a page of deals from the pipeline).
+
+import { register } from './registry.mjs'
+
+// Fixed API base — hardcoded https constant, so no user value ever chooses the host.
+const API_BASE = 'https://api.pipedrive.com/v1'
+
+const apiToken = () => String(process.env.PIPEDRIVE_API_TOKEN || '').trim()
+
+// configured — this is a FIXED-host service, so configured() only checks that the required env var
+// is present. The token rides as a query param (URL-encoded at call time), never as a host segment.
+const configured = () => Boolean(apiToken())
+
+/**
+ * listDeals — read a page of deals from the Pipedrive pipeline.
+ *
+ * GETs /deals?limit=<limit>&api_token=<token>. Pipedrive returns { success, data:[...] }; a
+ * top-level success:false (or non-2xx) is surfaced via reason (never thrown).
+ *
+ * @param {object} [payload]
+ * @param {number} [payload.limit=20]  max deals to return (page size).
+ * @returns {Promise<{ ok:boolean, status?:number, deals?:any[], reason?:string }>}
+ */
+export async function listDeals(_input = {}) {
+  if (!configured()) return { ok: false, reason: 'crm-pipedrive_not_configured' }
+  const { limit = 20 } = _input || {}
+  const n = Math.max(1, Math.min(500, parseInt(limit, 10) || 20))
+  try {
+    const qs = new URLSearchParams({ limit: String(n), api_token: apiToken() })
+    const res = await fetch(`${API_BASE}/deals?${qs.toString()}`, {
+      method: 'GET',
+      headers: {
+        accept: 'application/json',
+        'user-agent': 'supermega-kernel/1.0',
+      },
+      signal: AbortSignal.timeout(8000),
+    })
+    const data = await res.json().catch(() => null)
+    if (!res.ok || (data && data.success === false)) {
+      const reason = data?.error || data?.message || `http_${res.status}`
+      return { ok: false, status: res.status, reason: `crm-pipedrive_${String(reason)}`.slice(0, 200) }
+    }
+    const deals = data?.data || []
+    return { ok: true, status: res.status, deals: Array.isArray(deals) ? deals : [] }
+  } catch (e) {
+    return { ok: false, reason: String(e?.message || 'crm-pipedrive_error').slice(0, 200) }
+  }
+}
+
+export const crmPipedrive = {
+  key: 'crm-pipedrive',
+  name: 'Pipedrive',
+  category: 'data',
+  docs: 'kernel/connectors/crm-pipedrive.mjs',
+  configured,
+  /**
+   * health — GET /users/me is Pipedrive's cheapest authenticated read: it returns the token owner's
+   * own user record, confirming the token is valid without touching any pipeline data.
+   *
+   * @returns {Promise<{ ok:boolean, detail:string }>}
+   */
+  async health() {
+    if (!configured()) return { ok: false, detail: 'missing PIPEDRIVE_API_TOKEN' }
+    try {
+      const qs = new URLSearchParams({ api_token: apiToken() })
+      const res = await fetch(`${API_BASE}/users/me?${qs.toString()}`, {
+        method: 'GET',
+        headers: {
+          accept: 'application/json',
+          'user-agent': 'supermega-kernel/1.0',
+        },
+        signal: AbortSignal.timeout(8000),
+      })
+      const data = await res.json().catch(() => null)
+      if (!res.ok || (data && data.success === false)) {
+        return { ok: false, detail: `crm-pipedrive_${res.status}: ${(data?.error || data?.message || '')}`.slice(0, 160) }
+      }
+      const label = data?.data?.name || data?.data?.email || 'user ok'
+      return { ok: true, detail: String(label).slice(0, 160) }
+    } catch (e) {
+      return { ok: false, detail: String(e?.message || 'crm-pipedrive_error').slice(0, 160) }
+    }
+  },
+  listDeals,
+}
+
+register(crmPipedrive)
+export default crmPipedrive

--- a/kernel/connectors/data-clickup.mjs
+++ b/kernel/connectors/data-clickup.mjs
@@ -1,0 +1,114 @@
+// Connector: data — ClickUp. Read tasks out of ClickUp via its REST API (zero-dependency, native
+// fetch). ClickUp is a common work/project tracker; this connector lets the SuperMega kernel pull
+// the tasks a team already manages — so an agent can surface open work, tie tasks to DeskPOS
+// operations, and keep an operating picture without anyone re-entering the list by hand.
+//
+// category 'data' · configured = CLICKUP_API_TOKEN present.
+// The API host is a hardcoded https constant (ClickUp) — no user value ever chooses the host.
+//
+// Quick setup:
+//   1. In ClickUp: Settings → Apps → "Generate" a personal API token (pk_…).
+//   2. Set it as CLICKUP_API_TOKEN. The host is fixed (api.clickup.com).
+//   3. (Per call) pass the ClickUp list id to listTasks — open a List and copy the id from its URL.
+//
+// Env:
+//   CLICKUP_API_TOKEN  (required)  ClickUp personal API token (pk_…).
+//
+// Auth: raw token in the Authorization header — NO "Bearer " prefix. ClickUp expects
+//   Authorization: <CLICKUP_API_TOKEN>  (the token value alone).
+//
+// Base: https://api.clickup.com/api/v2 (fixed host — never chosen from a user value).
+//
+// Capabilities:
+//   listTasks({ listId }) — GET /list/{listId}/task (tasks in a ClickUp list).
+
+import { register } from './registry.mjs'
+
+// Fixed API base — hardcoded https constant, so no user value ever chooses the host.
+const API_BASE = 'https://api.clickup.com/api/v2'
+
+const apiToken = () => String(process.env.CLICKUP_API_TOKEN || '').trim()
+
+// ClickUp uses the raw token as the Authorization header value — no "Bearer " prefix.
+const authHeader = () => apiToken()
+
+// configured — this is a FIXED-host service, so configured() only checks that the required env var
+// is present. No user value ever selects the host.
+const configured = () => Boolean(apiToken())
+
+/**
+ * listTasks — read the tasks in a ClickUp list.
+ *
+ * GETs /list/{listId}/task. ClickUp returns { tasks:[...] }; any non-2xx is surfaced via reason
+ * (never thrown). The listId is required and URL-encoded before it goes into the path.
+ *
+ * @param {object} [payload]
+ * @param {string} [payload.listId]  the ClickUp list id to read tasks from (required).
+ * @returns {Promise<{ ok:boolean, status?:number, tasks?:any[], reason?:string }>}
+ */
+export async function listTasks(_input = {}) {
+  if (!configured()) return { ok: false, reason: 'data-clickup_not_configured' }
+  const { listId } = _input || {}
+  const id = String(listId || '').trim()
+  if (!id) return { ok: false, reason: 'data-clickup_missing_listId' }
+  try {
+    const res = await fetch(`${API_BASE}/list/${encodeURIComponent(id)}/task`, {
+      method: 'GET',
+      headers: {
+        authorization: authHeader(),
+        accept: 'application/json',
+        'user-agent': 'supermega-kernel/1.0',
+      },
+      signal: AbortSignal.timeout(8000),
+    })
+    const data = await res.json().catch(() => null)
+    if (!res.ok) {
+      const reason = data?.err || data?.error || data?.message || `http_${res.status}`
+      return { ok: false, status: res.status, reason: `data-clickup_${String(reason)}`.slice(0, 200) }
+    }
+    const tasks = data?.tasks || []
+    return { ok: true, status: res.status, tasks: Array.isArray(tasks) ? tasks : [] }
+  } catch (e) {
+    return { ok: false, reason: String(e?.message || 'data-clickup_error').slice(0, 200) }
+  }
+}
+
+export const dataClickup = {
+  key: 'data-clickup',
+  name: 'ClickUp',
+  category: 'data',
+  docs: 'kernel/connectors/data-clickup.mjs',
+  configured,
+  /**
+   * health — GET /team is ClickUp's cheapest authenticated read: it returns the workspaces (teams)
+   * the token can see, confirming the token is valid without touching any task data.
+   *
+   * @returns {Promise<{ ok:boolean, detail:string }>}
+   */
+  async health() {
+    if (!configured()) return { ok: false, detail: 'missing CLICKUP_API_TOKEN' }
+    try {
+      const res = await fetch(`${API_BASE}/team`, {
+        method: 'GET',
+        headers: {
+          authorization: authHeader(),
+          accept: 'application/json',
+          'user-agent': 'supermega-kernel/1.0',
+        },
+        signal: AbortSignal.timeout(8000),
+      })
+      const data = await res.json().catch(() => null)
+      if (!res.ok) {
+        return { ok: false, detail: `data-clickup_${res.status}: ${(data?.err || data?.error || data?.message || '')}`.slice(0, 160) }
+      }
+      const count = Array.isArray(data?.teams) ? data.teams.length : 0
+      return { ok: true, detail: `${count} workspace(s)`.slice(0, 160) }
+    } catch (e) {
+      return { ok: false, detail: String(e?.message || 'data-clickup_error').slice(0, 160) }
+    }
+  },
+  listTasks,
+}
+
+register(dataClickup)
+export default dataClickup

--- a/kernel/connectors/data-onedrive.mjs
+++ b/kernel/connectors/data-onedrive.mjs
@@ -1,0 +1,126 @@
+// Connector: data — OneDrive. List files in the user's OneDrive via the Microsoft Graph API
+// (zero-dependency, native fetch). Many Myanmar/SEA SMBs keep their real operating documents —
+// price lists, supplier invoices, stock sheets, payroll — in OneDrive. This connector lets the
+// SuperMega kernel enumerate those files so an agent can find and ingest the business's own data
+// (the "upload your data → AI that knows your business" moat) without a manual export.
+//
+// category 'data' · configured = ONEDRIVE_ACCESS_TOKEN present.
+// The API host is a hardcoded https constant (Microsoft Graph) — no user value ever chooses the host.
+//
+// Quick setup:
+//   1. Register an app in the Azure portal (Azure Active Directory → App registrations).
+//   2. Grant delegated Microsoft Graph permissions Files.Read (or Files.ReadWrite) + offline_access.
+//   3. Complete the OAuth 2.0 flow to obtain an access token (short-lived — refresh out-of-band and
+//      keep ONEDRIVE_ACCESS_TOKEN current).
+//   4. Set ONEDRIVE_ACCESS_TOKEN to that bearer token. The host is fixed (graph.microsoft.com).
+//
+// Env:
+//   ONEDRIVE_ACCESS_TOKEN  (required)  Microsoft Graph OAuth 2.0 bearer access token.
+//
+// Auth: HTTP Bearer. Authorization: 'Bearer ' + ONEDRIVE_ACCESS_TOKEN.
+//
+// Base: https://graph.microsoft.com/v1.0 (fixed host — never chosen from a user value).
+//
+// Capabilities:
+//   listFiles({ path }) — GET /me/drive/root/children (root) or /me/drive/root:/{path}:/children.
+
+import { register } from './registry.mjs'
+
+// Fixed Microsoft Graph base — HARDCODED https constant. No env/user value contributes to the host,
+// so listFiles()/health() can never be steered at an arbitrary host (no SSRF surface).
+const API_BASE = 'https://graph.microsoft.com/v1.0'
+
+const token = () => String(process.env.ONEDRIVE_ACCESS_TOKEN || '').trim()
+
+const authHeader = () => 'Bearer ' + token()
+
+// configured — this is a FIXED-host service (Microsoft Graph), so the base URL is the hardcoded
+// API_BASE constant and configured() only checks that the required env var is present. No user
+// value ever selects the host, so there's nothing host-shaped to validate here.
+const configured = () => Boolean(token())
+
+/**
+ * listFiles — list the children (files + folders) of a OneDrive folder.
+ *
+ * With no path, lists the drive root (/me/drive/root/children). With a path, lists that folder's
+ * children (/me/drive/root:/{path}:/children). The path segment is URL-encoded (keeping '/') so a
+ * nested folder like "Invoices/2026" is addressed correctly. Any non-2xx or transport failure is
+ * surfaced via reason (never thrown).
+ *
+ * @param {object} [payload]
+ * @param {string} [payload.path]  folder path relative to the drive root (default '' = root).
+ * @returns {Promise<{ ok:boolean, status?:number, files?:any[], reason?:string }>}
+ */
+export async function listFiles(_input = {}) {
+  const { path = '' } = _input || {}
+  if (!configured()) return { ok: false, reason: 'data-onedrive_not_configured' }
+  const rel = String(path || '').trim().replace(/^\/+|\/+$/g, '')
+
+  // Root vs. a sub-path. Encode each segment but keep the '/' separators intact.
+  const url = rel
+    ? `${API_BASE}/me/drive/root:/${rel.split('/').map(encodeURIComponent).join('/')}:/children`
+    : `${API_BASE}/me/drive/root/children`
+
+  try {
+    const res = await fetch(url, {
+      method: 'GET',
+      headers: {
+        authorization: authHeader(),
+        accept: 'application/json',
+        'user-agent': 'supermega-kernel/1.0',
+      },
+      signal: AbortSignal.timeout(8000),
+    })
+    const data = await res.json().catch(() => null)
+    if (!res.ok) {
+      const reason = data?.error?.message || data?.error || data?.message || `http_${res.status}`
+      return { ok: false, status: res.status, reason: `data-onedrive_${String(reason)}`.slice(0, 200) }
+    }
+    const files = data?.value || []
+    return { ok: true, status: res.status, files: Array.isArray(files) ? files : [] }
+  } catch (e) {
+    return { ok: false, reason: String(e?.message || 'data-onedrive_error').slice(0, 200) }
+  }
+}
+
+export const dataOnedrive = {
+  key: 'data-onedrive',
+  name: 'OneDrive',
+  category: 'data',
+  docs: 'kernel/connectors/data-onedrive.mjs',
+  configured,
+  /**
+   * health — GET /me/drive is Graph's cheapest authenticated read of the signed-in user's default
+   * drive: it returns the drive's own metadata (name + driveType) and confirms the token is valid
+   * without listing any files.
+   *
+   * @returns {Promise<{ ok:boolean, detail:string }>}
+   */
+  async health() {
+    if (!configured()) return { ok: false, detail: 'missing ONEDRIVE_ACCESS_TOKEN' }
+    try {
+      const res = await fetch(`${API_BASE}/me/drive`, {
+        method: 'GET',
+        headers: {
+          authorization: authHeader(),
+          accept: 'application/json',
+          'user-agent': 'supermega-kernel/1.0',
+        },
+        signal: AbortSignal.timeout(8000),
+      })
+      const data = await res.json().catch(() => null)
+      if (!res.ok) {
+        const reason = data?.error?.message || data?.error || data?.message || ''
+        return { ok: false, detail: `data-onedrive_${res.status}: ${String(reason)}`.slice(0, 160) }
+      }
+      const label = data?.driveType ? `${data.name || 'drive'} (${data.driveType})` : (data?.name || 'drive ok')
+      return { ok: true, detail: String(label).slice(0, 160) }
+    } catch (e) {
+      return { ok: false, detail: String(e?.message || 'data-onedrive_error').slice(0, 160) }
+    }
+  },
+  listFiles,
+}
+
+register(dataOnedrive)
+export default dataOnedrive

--- a/kernel/connectors/index.mjs
+++ b/kernel/connectors/index.mjs
@@ -67,6 +67,10 @@ import './data-zoho-books.mjs'
 import './ai-perplexity.mjs'
 import './marketing-meta-ads.mjs'
 import './data-ga4.mjs'
+import './payment-paypal.mjs'
+import './data-onedrive.mjs'
+import './crm-pipedrive.mjs'
+import './data-clickup.mjs'
 
 export * from './registry.mjs'
 export default registry

--- a/kernel/connectors/payment-paypal.mjs
+++ b/kernel/connectors/payment-paypal.mjs
@@ -1,0 +1,147 @@
+// Connector: payment — PayPal. Read settled transactions out of PayPal's REST reporting API
+// (zero-dependency, native fetch) so a Myanmar/SEA SMB that takes cross-border card and PayPal
+// payments can pull its real money movement into the SuperMega kernel — reconciling DeskPOS sales
+// against what actually cleared, and enriching the ledger without exporting CSVs by hand.
+//
+// category 'payment' · configured = PAYPAL_CLIENT_ID AND PAYPAL_CLIENT_SECRET both present.
+//
+// Quick setup:
+//   1. In the PayPal Developer Dashboard (https://developer.paypal.com) create a LIVE REST app.
+//   2. Copy the app's Client ID and Secret. Grant it the "Transaction Search" feature so the
+//      reporting endpoint is available.
+//   3. Set PAYPAL_CLIENT_ID and PAYPAL_CLIENT_SECRET. The host is fixed (api-m.paypal.com, live).
+//
+// Env:
+//   PAYPAL_CLIENT_ID      (required)  REST app client id.
+//   PAYPAL_CLIENT_SECRET  (required)  REST app secret.
+//
+// Auth: OAuth 2.0 client-credentials. We POST /v1/oauth2/token with an HTTP Basic header built from
+// base64(client_id:client_secret) and body grant_type=client_credentials to mint a short-lived
+// access token, then send that token as a Bearer on the reporting call. The token is fetched
+// per-request (no caching) — simplest correct behaviour for a health/read connector.
+//
+// Base: https://api-m.paypal.com (fixed LIVE host — never chosen from a user value).
+//
+// Capabilities:
+//   listTransactions({ startDate, endDate }) — GET /v1/reporting/transactions (settled money movement).
+
+import { register } from './registry.mjs'
+
+// Fixed, documented LIVE API host — hardcoded https constant, so no env/user value ever chooses the
+// host (no SSRF surface via configuration).
+const API_BASE = 'https://api-m.paypal.com'
+
+const clientId = () => String(process.env.PAYPAL_CLIENT_ID || '').trim()
+const clientSecret = () => String(process.env.PAYPAL_CLIENT_SECRET || '').trim()
+
+// configured — ONLY checks that both required env vars are present. The host is a hardcoded https
+// constant (never derived from a user/env value), so this stays SSRF-safe.
+const configured = () => Boolean(clientId() && clientSecret())
+
+// Basic auth header for the token exchange: base64(client_id:client_secret).
+const basicAuth = () => 'Basic ' + Buffer.from(`${clientId()}:${clientSecret()}`).toString('base64')
+
+/**
+ * getAccessToken — mint a short-lived OAuth 2.0 access token via client-credentials.
+ *
+ * POSTs /v1/oauth2/token with the Basic header and grant_type=client_credentials. Returns the raw
+ * token string on success, or an { ok:false, reason } object on any failure (never throws).
+ *
+ * @returns {Promise<string | { ok:false, status?:number, reason:string }>}
+ */
+async function getAccessToken() {
+  try {
+    const res = await fetch(`${API_BASE}/v1/oauth2/token`, {
+      method: 'POST',
+      headers: {
+        authorization: basicAuth(),
+        'content-type': 'application/x-www-form-urlencoded',
+        'user-agent': 'supermega-kernel/1.0',
+      },
+      body: 'grant_type=client_credentials',
+      signal: AbortSignal.timeout(8000),
+    })
+    const data = await res.json().catch(() => null)
+    if (!res.ok) {
+      const reason = data?.error_description || data?.error || data?.message || `http_${res.status}`
+      return { ok: false, status: res.status, reason: `payment-paypal_${String(reason)}`.slice(0, 200) }
+    }
+    const token = data?.access_token
+    if (!token) return { ok: false, reason: 'payment-paypal_no_access_token' }
+    return String(token)
+  } catch (e) {
+    return { ok: false, reason: String(e?.message || 'payment-paypal_error').slice(0, 200) }
+  }
+}
+
+/**
+ * listTransactions — read settled transactions from PayPal's REST reporting API.
+ *
+ * First mints an access token (client-credentials), then GETs /v1/reporting/transactions for the
+ * given window. PayPal requires both start_date and end_date as RFC 3339 timestamps and caps the
+ * window at 31 days per call. Any non-2xx or transport failure is surfaced via reason (never thrown).
+ *
+ * @param {object} [payload]
+ * @param {string} [payload.startDate]  RFC 3339 start (e.g. '2026-07-01T00:00:00-0000'). Required.
+ * @param {string} [payload.endDate]    RFC 3339 end   (e.g. '2026-07-08T23:59:59-0000'). Required.
+ * @returns {Promise<{ ok:boolean, status?:number, transactions?:any[], reason?:string }>}
+ */
+export async function listTransactions(_input = {}) {
+  const { startDate, endDate } = _input || {}
+  if (!configured()) return { ok: false, reason: 'payment-paypal_not_configured' }
+  const start = String(startDate || '').trim()
+  const end = String(endDate || '').trim()
+  if (!start) return { ok: false, reason: 'payment-paypal_missing_startDate' }
+  if (!end) return { ok: false, reason: 'payment-paypal_missing_endDate' }
+
+  const token = await getAccessToken()
+  if (typeof token !== 'string') return token // { ok:false, reason } passthrough
+
+  try {
+    const qs = new URLSearchParams({ start_date: start, end_date: end, fields: 'transaction_info' })
+    const res = await fetch(`${API_BASE}/v1/reporting/transactions?${qs.toString()}`, {
+      method: 'GET',
+      headers: {
+        authorization: `Bearer ${token}`,
+        'content-type': 'application/json',
+        'user-agent': 'supermega-kernel/1.0',
+      },
+      signal: AbortSignal.timeout(8000),
+    })
+    const data = await res.json().catch(() => null)
+    if (!res.ok) {
+      const reason = data?.message || data?.error_description || data?.name || `http_${res.status}`
+      return { ok: false, status: res.status, reason: `payment-paypal_${String(reason)}`.slice(0, 200) }
+    }
+    const transactions = data?.transaction_details || []
+    return { ok: true, status: res.status, transactions: Array.isArray(transactions) ? transactions : [] }
+  } catch (e) {
+    return { ok: false, reason: String(e?.message || 'payment-paypal_error').slice(0, 200) }
+  }
+}
+
+export const paymentPaypal = {
+  key: 'payment-paypal',
+  name: 'PayPal',
+  category: 'payment',
+  docs: 'kernel/connectors/payment-paypal.mjs',
+  configured,
+  /**
+   * health — mint an access token via client-credentials. A successful token proves the client id
+   * and secret are valid and live, without pulling any transaction data.
+   *
+   * @returns {Promise<{ ok:boolean, detail:string }>}
+   */
+  async health() {
+    if (!configured()) return { ok: false, detail: 'missing PAYPAL_CLIENT_ID or PAYPAL_CLIENT_SECRET' }
+    const token = await getAccessToken()
+    if (typeof token !== 'string') {
+      return { ok: false, detail: `token failed: ${token.reason}`.slice(0, 160) }
+    }
+    return { ok: true, detail: 'token ok'.slice(0, 160) }
+  },
+  listTransactions,
+}
+
+register(paymentPaypal)
+export default paymentPaypal


### PR DESCRIPTION
## What

Adds 4 real, API-backed, zero-dependency connectors to the SuperMega kernel, extending the technical value-prop moat from 59 → 63.

| Key | Category | Base host | Auth | Capability | Health |
|---|---|---|---|---|---|
| `payment-paypal` | payment | `api-m.paypal.com` | OAuth2 client-credentials (Basic → token) | `listTransactions({startDate,endDate})` → `/v1/reporting/transactions` | mint token |
| `data-onedrive` | data | `graph.microsoft.com/v1.0` | Bearer `ONEDRIVE_ACCESS_TOKEN` | `listFiles({path})` → `/me/drive/root...children` | `GET /me/drive` |
| `crm-pipedrive` | data | `api.pipedrive.com/v1` | `?api_token=` query | `listDeals({limit})` → `/deals` | `GET /users/me` |
| `data-clickup` | data | `api.clickup.com/api/v2` | raw `Authorization:` (no Bearer) | `listTasks({listId})` → `/list/{listId}/task` | `GET /team` |

## Contract (verbatim to existing connectors)

- ESM, zero npm deps (native `fetch`), `register()` at load.
- **Fixed host** hardcoded as an https const — `configured()` only checks env presence (SSRF-safe).
- Every capability: `{ok:true,...}` / `{ok:false, reason:'<key>_<code>'}`, **never throws**. `AbortSignal.timeout(8000)`, `user-agent: supermega-kernel/1.0`, error bodies sliced to 200, arg/config guards.
- `health()` returns `{ok, detail}` (not `reason`).
- Ends with `register(<obj>)` + `export default`.

Wired into `kernel/connectors/index.mjs` (4 import lines appended before `export *`).

## Verification (E2E, no browser)

- `node --check` on all 4 new files + index.mjs → SYNTAX_OK.
- Registry load: **total 63, 0 registrationErrors**; each of the 6 targets (incl. pre-existing tiktok-shop, perplexity) prints `configured=false` and an `{ok:false, reason}` capability result.
- `health()` on all 6 returns proper `{ok,detail}` shape (no `reason` key) when unconfigured.
- Arg-guards fire before any network call (clickup missing `listId`; paypal missing dates).
- **Live bad-credential probes** (fake creds) confirm real endpoints reachable and every method returns `{ok:false}` with **no throw**: Pipedrive 401 `unauthorized access`, PayPal `Client Authentication failed` (proves the OAuth token exchange + passthrough into `listTransactions`).

Note: base is `brand/light-skin-b` — the branch that owns the `kernel/connectors/` framework. `origin/main` does not contain `kernel/connectors/` at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)