### PR TITLE
fix: quiet unauthenticated kernel console

### DIFF
--- a/kernel/public/favicon.svg
+++ b/kernel/public/favicon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="12" fill="#07111f"/>
+  <rect x="1" y="1" width="62" height="62" rx="11" fill="none" stroke="#3B82F6" stroke-opacity=".5" stroke-width="2"/>
+  <path d="M16 20l13 12-13 12M33 44h15" fill="none" stroke="#3B82F6" stroke-width="6" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/kernel/public/index.html
+++ b/kernel/public/index.html
@@ -5,6 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <meta name="robots" content="noindex,nofollow" />
 <title>SuperMega Console</title>
+<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 <style>
   @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Space+Grotesk:wght@500;600;700&display=swap');
   :root{color-scheme:dark;--bg:#07111f;--deep:#06101d;--ink:#f6fbff;--muted:#a9b8c7;--accent:#3B82F6;--accent-2:#60A5FA;--accent-soft:rgba(59,130,246,.14);--line:rgba(255,255,255,.15);--surf:rgba(255,255,255,.075);--surf-2:rgba(255,255,255,.045);--field:#0c1929;--good:#34D399;--warn:#F59E0B;--bad:#F87171;--shadow:0 24px 60px rgba(0,0,0,.45)}
@@ -82,7 +83,7 @@
   <span class="badge" id="modeBadge">store: …</span>
   <span class="badge" id="aiBadge">ai: …</span>
   <span class="grow"></span>
-  <input class="key" id="opsKey" placeholder="ops passcode" />
+  <input class="key" id="opsKey" type="password" autocomplete="current-password" aria-label="ops passcode" placeholder="ops passcode" />
 </header>
 <nav>
   <button data-view="overview" class="active">Overview</button>
@@ -163,13 +164,22 @@ const $=(s)=>document.querySelector(s)
 const esc=(s)=>String(s==null?'':s).replace(/[&<>"']/g,(c)=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]))
 const toast=(m)=>{const t=$('#toast');t.textContent=m;t.classList.add('show');setTimeout(()=>t.classList.remove('show'),1800)}
 const usd=(n)=>'$'+Number(n||0).toLocaleString()
+const getOpsKey=()=>$('#opsKey').value.trim()
+const hasOpsKey=()=>getOpsKey().length>0
 let dealLead=null, lastPacket=null
 
 $('#opsKey').value=localStorage.getItem('sm.ops')||''
-$('#opsKey').addEventListener('change',()=>{localStorage.setItem('sm.ops',$('#opsKey').value.trim());refresh();loadOverview()})
+$('#opsKey').addEventListener('change',()=>{
+  const key=getOpsKey()
+  if(key)localStorage.setItem('sm.ops',key);else localStorage.removeItem('sm.ops')
+  loadProtectedState()
+})
+$('#opsKey').addEventListener('keydown',(event)=>{if(event.key==='Enter')event.currentTarget.blur()})
 
 async function api(method,path,body){
-  const res=await fetch(path,{method,headers:{'content-type':'application/json','x-ops-key':$('#opsKey').value.trim()},body:body?JSON.stringify(body):undefined})
+  const key=getOpsKey()
+  if(!key){toast('Enter the ops passcode');$('#opsKey').focus();return {ok:false,reason:'ops passcode required'}}
+  const res=await fetch(path,{method,headers:{'content-type':'application/json','x-ops-key':key},body:body?JSON.stringify(body):undefined})
   const json=await res.json().catch(()=>({}))
   if(res.status===401){toast('Enter the ops passcode');$('#opsKey').focus()}
   if(!res.ok&&json.reason)toast(json.reason)
@@ -197,11 +207,7 @@ document.querySelectorAll('nav button').forEach(b=>b.onclick=()=>{
   if(b.dataset.view==='connectors')loadConnectors()
 })
 
-async function loadOverview(){
-  $('#stats').innerHTML='<div class="loading-pulse">Loading overview…</div>'
-  let r
-  try{r=await api('GET','/api/dashboard')}catch(e){$('#stats').innerHTML=`<div class="err-banner">Could not load overview — ${esc(String(e.message||'network error'))}</div>`;return}
-  const s=r||{}
+function renderOverview(s={}){
   $('#stats').innerHTML=[
     ['Leads',(s.leads&&s.leads.total)||0,'in the funnel'],
     ['Pipeline value',usd(s.projects&&s.projects.pipelineUsd),'open builds'],
@@ -214,6 +220,27 @@ async function loadOverview(){
   $('#bars').innerHTML=order.map(k=>`<div class="bar"><span class="muted">${k}</span><i style="width:${Math.round((bs[k]||0)/max*100)}%"></i><span>${bs[k]||0}</span></div>`).join('')||'<div class="muted">No projects yet.</div>'
   const act=(s.activity||[])
   $('#feed').innerHTML=act.length?act.map(a=>`<div><span class="k">${esc(a.kind)}</span>${esc(a.summary)}</div>`).join(''):'<div class="muted">No activity yet.</div>'
+}
+
+function renderLockedOverview(){
+  $('#modeBadge').textContent='store: locked';$('#modeBadge').className='badge'
+  $('#aiBadge').textContent='ai: locked';$('#aiBadge').className='badge'
+  renderOverview()
+  $('#feed').innerHTML='<div class="muted">Enter the ops passcode to load live activity.</div>'
+}
+
+function loadProtectedState(){
+  if(!hasOpsKey()){renderLockedOverview();return}
+  refresh();loadOverview()
+}
+
+async function loadOverview(){
+  if(!hasOpsKey()){renderLockedOverview();return}
+  $('#stats').innerHTML='<div class="loading-pulse">Loading overview…</div>'
+  let r
+  try{r=await api('GET','/api/dashboard')}catch(e){$('#stats').innerHTML=`<div class="err-banner">Could not load overview — ${esc(String(e.message||'network error'))}</div>`;return}
+  if(!r.ok){$('#stats').innerHTML='<div class="err-banner">Could not load overview. Check the ops passcode.</div>';return}
+  renderOverview(r)
 }
 
 async function loadLeads(){
@@ -412,6 +439,7 @@ async function loadConnectors(){
 }
 
 async function refresh(){
+  if(!hasOpsKey()){renderLockedOverview();return}
   const r=await api('GET','/api/state')
   const dbBad=r.dbStatus==='error'
   $('#modeBadge').textContent=dbBad?'db: '+String(r.dbError||'error').slice(0,30):'store: '+(r.mode||'?')
@@ -420,7 +448,7 @@ async function refresh(){
   $('#aiBadge').textContent='ai: '+(r.aiConfigured?'on':'off')
   $('#aiBadge').className='badge '+(r.aiConfigured?'on':'off')
 }
-refresh();loadOverview()
+loadProtectedState()
 </script>
 </body>
 </html>

--- a/kernel/scripts/verify-brand.mjs
+++ b/kernel/scripts/verify-brand.mjs
@@ -6,6 +6,7 @@ const pages = {
   console: read('index.html'),
   status: read('status.html'),
 }
+const favicon = read('favicon.svg')
 
 const banned = /Fraunces|Georgia|#f7f4e[cd]|#c2603f|#D97757|#d9895f|#C9A24B|rgba\(217,137,95|--clay|--gold|radial-gradient|linear-gradient/i
 
@@ -19,11 +20,19 @@ for (const [name, html] of Object.entries(pages)) {
 
 assert.match(pages.console, /&gt;_<\/b>SuperMega/)
 assert.match(pages.status, /M6\.5 8 L11 12 L6\.5 16/)
+assert.match(pages.console, /href="\/favicon\.svg"/)
+assert.match(pages.status, /href="\/favicon\.svg"/)
+assert.match(favicon, /#07111f/i)
+assert.match(favicon, /#3B82F6/i)
+assert.doesNotMatch(favicon, banned)
+assert.match(pages.console, /function loadProtectedState\(\)/)
+assert.match(pages.console, /if\(!hasOpsKey\(\)\)\{renderLockedOverview\(\);return\}/)
+assert.doesNotMatch(pages.console, /refresh\(\);loadOverview\(\)\s*\n<\/script>/)
 
 console.log(
   JSON.stringify({
     ok: true,
     contract: 'kernel_void_electric_brand',
-    pages: Object.keys(pages),
+    pages: [...Object.keys(pages), 'favicon'],
   })
 )


### PR DESCRIPTION
## What changed
- gate protected console API reads until an ops passcode exists
- render an explicit locked state instead of generating initial 401 errors
- mask and label the passcode field
- add the canonical Void/Electric terminal-mark favicon to console and status pages
- extend the kernel brand verifier to enforce the auth gate and favicon contract

## Why
Live browser verification after PR #23 found avoidable unauthenticated API requests and missing favicon responses. The UI rendered correctly, but those requests produced noisy browser errors and weakened the first-load experience.

## Validation
- `npm --prefix kernel run verify` (49 tests, brand contract, 66 connectors / 923 adversarial calls)
- inline console script syntax check
- Playwright Edge mobile check: locked state, password input, no overflow
- Playwright network check: no protected API requests before passcode; favicon 200
- Playwright console check: 0 errors, 0 warnings