### PR TITLE
Kernel: add isolated workcell client provisioner

### DIFF
--- a/kernel/README.md
+++ b/kernel/README.md
@@ -52,7 +52,7 @@ environment contract, and activation proof.
 - `SUPERMEGA_OPS_KEY` for protected APIs and the console.
 - `CRON_SECRET` for Vercel cron authentication.
 - `SUPABASE_URL` plus `SUPABASE_SERVICE_ROLE_KEY`, or a supported Postgres URL.
-- `SUPERMEGA_CLIENT_TOKEN_CAP` for the monthly client ceiling; default 2,000,000 weighted tokens.
+- `SUPERMEGA_CLIENT_TOKEN_CAP` for the monthly client ceiling; default 150,000 weighted tokens.
 - `SUPERMEGA_CLIENT_CAP_SOFT_RATIO` for pre-cap tier downgrade; default `0.8`.
 
 ## Honest Limits
@@ -66,7 +66,8 @@ environment contract, and activation proof.
 
 ## Next
 
-1. Automate isolated client-project provisioning and environment setup.
+1. Bootstrap the dedicated client data spine with `supabase/workcell-client.sql`, then use
+   `npm run workcell:provision` to plan or apply its isolated Vercel project.
 2. Add an approval inbox before any write-capable connector action.
 3. Move from one cron per client deployment to a durable scheduler when a shared control plane is
    justified by real client volume.

--- a/kernel/package.json
+++ b/kernel/package.json
@@ -7,6 +7,7 @@
     "brand:verify": "node scripts/verify-brand.mjs",
     "connector:resilience": "node ../tools/test_connector_resilience.mjs",
     "crew:resilience": "node ../tools/test_crew_resilience.mjs",
+    "workcell:provision": "node scripts/provision-workcell-client.mjs",
     "verify": "npm test && npm run brand:verify && npm run connector:resilience && npm run crew:resilience",
     "deploy:prod": "npm run verify && npx vercel deploy --prod -y"
   },

--- a/kernel/scripts/provision-workcell-client.mjs
+++ b/kernel/scripts/provision-workcell-client.mjs
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+
+import { readFile } from 'node:fs/promises'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { applyProvisionPlan, buildProvisionPlan, isSourceClean } from '../workcell-provision.mjs'
+
+const KERNEL_DIR = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+
+function parseArgs(argv) {
+  const out = { apply: false, plan: false, allowExisting: false, allowDirtySource: false, keepTemp: false }
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index]
+    if (arg === '--apply') out.apply = true
+    else if (arg === '--plan') out.plan = true
+    else if (arg === '--allow-existing') out.allowExisting = true
+    else if (arg === '--allow-dirty-source') out.allowDirtySource = true
+    else if (arg === '--keep-temp') out.keepTemp = true
+    else if (arg === '--help' || arg === '-h') out.help = true
+    else if (['--manifest', '--scope', '--confirm', '--source'].includes(arg)) {
+      const value = argv[index + 1]
+      if (!value || value.startsWith('--')) throw new Error(`argument_value_required:${arg}`)
+      out[arg.slice(2)] = value
+      index += 1
+    } else throw new Error(`unknown_argument:${arg}`)
+  }
+  if (out.apply && out.plan) throw new Error('choose_plan_or_apply')
+  if (!out.apply) out.plan = true
+  return out
+}
+
+function help() {
+  return [
+    'SuperMega isolated workcell provisioner',
+    '',
+    'Plan only (default, no mutation):',
+    '  npm run workcell:provision -- --manifest workcells/client-manifest.example.json --scope <vercel-team>',
+    '',
+    'Apply:',
+    '  npm run workcell:provision -- --apply --manifest <manifest.json> --scope <vercel-team> --confirm "PROVISION <project>"',
+    '',
+    'Apply reads required secret values from the current process environment. Secrets are sent to',
+    'Vercel over stdin and are never included in the printed plan or command arguments. Every',
+    'client value must use the SUPERMEGA_NEW_CLIENT_* input name printed by the plan.',
+    '',
+    'Before apply, run supabase/workcell-client.sql in the dedicated client Supabase project.',
+    'Apply verifies the schema and a temporary idempotent claim before it changes Vercel.',
+  ].join('\n')
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2))
+  if (args.help) { process.stdout.write(`${help()}\n`); return }
+  if (!args.manifest) throw new Error('manifest_path_required')
+  const manifestPath = resolve(args.manifest)
+  const manifest = JSON.parse(await readFile(manifestPath, 'utf8'))
+  const sourceDirectory = resolve(args.source || KERNEL_DIR)
+  const scope = args.scope || process.env.VERCEL_SCOPE
+
+  if (args.plan) {
+    const plan = buildProvisionPlan(manifest, { scope, env: process.env, sourceDirectory })
+    const sourceClean = await isSourceClean(sourceDirectory)
+    process.stdout.write(`${JSON.stringify({ ok: true, mode: 'plan', sourceClean, ...plan }, null, 2)}\n`)
+    return
+  }
+
+  const result = await applyProvisionPlan(manifest, {
+    scope,
+    env: process.env,
+    sourceDirectory,
+    confirm: args.confirm,
+    allowExisting: args.allowExisting,
+    allowDirtySource: args.allowDirtySource,
+    keepTemp: args.keepTemp,
+  })
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`)
+}
+
+main().catch((error) => {
+  process.stderr.write(`${JSON.stringify({ ok: false, reason: String(error?.message || 'provision_failed').slice(0, 500) })}\n`)
+  process.exitCode = 1
+})

--- a/kernel/store.mjs
+++ b/kernel/store.mjs
@@ -501,7 +501,14 @@ export async function recordPaymentEvent(provider, eventId, meta = {}) {
 export async function ping() {
   if (mode === 'memory') return { ok: true, mode, detail: 'in-memory (no external DB)' }
   try {
-    if (mode === 'supabase') { await rest('GET', 'supermega_leads?select=lead_id&limit=1'); return { ok: true, mode } }
+    if (mode === 'supabase') {
+      const workcellMode = Boolean(String(process.env.SUPERMEGA_WORKCELL_SLUGS || process.env.SUPERMEGA_WORKCELL_SLUG || '').trim())
+      const probe = workcellMode
+        ? 'supermega_console_activity?select=id&limit=1'
+        : 'supermega_leads?select=lead_id&limit=1'
+      await rest('GET', probe)
+      return { ok: true, mode }
+    }
     if (mode === 'postgres') { await q('select 1'); return { ok: true, mode } }
   } catch (e) { return { ok: false, mode, detail: String((e && e.message) || 'ping_failed').slice(0, 120) } }
   return { ok: false, mode, detail: 'unknown_mode' }

--- a/kernel/supabase/workcell-client.sql
+++ b/kernel/supabase/workcell-client.sql
@@ -1,0 +1,42 @@
+-- Minimal durable state for one isolated SuperMega workcell deployment.
+-- Apply once in the client's dedicated Supabase project before provisioning Vercel.
+
+begin;
+
+create table if not exists public.supermega_console_activity (
+  id text primary key,
+  at timestamptz not null default now(),
+  kind text,
+  summary text,
+  ref text
+);
+
+create table if not exists public.supermega_token_ledger (
+  tenant_id text not null,
+  "window" text not null,
+  in_tokens bigint not null default 0,
+  out_tokens bigint not null default 0,
+  calls bigint not null default 0,
+  updated_at timestamptz not null default now(),
+  primary key (tenant_id, "window")
+);
+
+create table if not exists public.supermega_ai_cache (
+  cache_key text primary key,
+  payload jsonb not null,
+  created_at timestamptz not null default now()
+);
+
+alter table public.supermega_console_activity enable row level security;
+alter table public.supermega_token_ledger enable row level security;
+alter table public.supermega_ai_cache enable row level security;
+
+revoke all on public.supermega_console_activity from anon, authenticated;
+revoke all on public.supermega_token_ledger from anon, authenticated;
+revoke all on public.supermega_ai_cache from anon, authenticated;
+
+grant select, insert, update, delete on public.supermega_console_activity to service_role;
+grant select, insert, update, delete on public.supermega_token_ledger to service_role;
+grant select, insert, update, delete on public.supermega_ai_cache to service_role;
+
+commit;

--- a/kernel/workcell-provision.mjs
+++ b/kernel/workcell-provision.mjs
@@ -1,0 +1,484 @@
+// Controlled client workcell provisioner.
+// Plan mode is pure. Apply mode creates one isolated Vercel project, supplies secrets only over
+// stdin, deploys a clean kernel copy, and verifies the protected workcell catalog before success.
+
+import { randomBytes } from 'node:crypto'
+import { cp, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { basename, join, resolve } from 'node:path'
+import { spawn } from 'node:child_process'
+
+import { getWorkcell } from './workcells.mjs'
+
+const CLIENT_SLUG_RE = /^[a-z0-9][a-z0-9-]{1,39}$/
+const CLIENT_ID_RE = /^[a-zA-Z0-9][a-zA-Z0-9._:-]{0,79}$/
+const PROJECT_RE = /^[a-z0-9][a-z0-9-]{0,99}$/
+const VERCEL_SCOPE_RE = /^[a-zA-Z0-9][a-zA-Z0-9_-]{0,119}$/
+const CLICKUP_LIST_RE = /^\d{1,32}$/
+const DAILY_TIME_RE = /^(?:[01]\d|2[0-3]):[0-5]\d$/
+const SECRET_LINE_BREAK_RE = /[\r\n]/
+const CONTROL_CHARACTER_RE = /[\u0000-\u001f\u007f]/
+const WORKCELL_DATA_TABLES = [
+  ['supermega_console_activity', 'id'],
+  ['supermega_token_ledger', 'tenant_id'],
+  ['supermega_ai_cache', 'cache_key'],
+]
+
+function text(value, max = 200) {
+  try { return String(value ?? '').trim().slice(0, max) } catch { return '' }
+}
+
+function integer(value, fallback, min, max) {
+  const parsed = Number.parseInt(text(value, 20), 10)
+  if (!Number.isFinite(parsed)) return fallback
+  return Math.max(min, Math.min(max, parsed))
+}
+
+function plainText(value, max, reason) {
+  const candidate = text(value, max)
+  if (!candidate || CONTROL_CHARACTER_RE.test(candidate)) throw new Error(reason)
+  return candidate
+}
+
+function timeZone(value) {
+  const candidate = text(value, 80) || 'Asia/Yangon'
+  try {
+    new Intl.DateTimeFormat('en-US', { timeZone: candidate }).format(new Date(0))
+    return candidate
+  } catch {
+    throw new Error('manifest_invalid_time_zone')
+  }
+}
+
+function projectNameFor(clientSlug, requested) {
+  const value = text(requested, 100) || `supermega-wc-${clientSlug}`
+  if (!PROJECT_RE.test(value)) throw new Error('manifest_invalid_project_name')
+  return value
+}
+
+export function validateClientManifest(input) {
+  if (!input || typeof input !== 'object' || Array.isArray(input)) throw new Error('manifest_object_required')
+  if (Number(input.version) !== 1) throw new Error('manifest_version_must_be_1')
+  const clientSlug = text(input.clientSlug, 40).toLowerCase()
+  if (!CLIENT_SLUG_RE.test(clientSlug)) throw new Error('manifest_invalid_client_slug')
+  const clientName = plainText(input.clientName, 120, 'manifest_client_name_required')
+  const clientId = text(input.clientId, 80) || `workcell-${clientSlug}`
+  if (!CLIENT_ID_RE.test(clientId)) throw new Error('manifest_invalid_client_id')
+
+  const requested = Array.isArray(input.workcells) ? input.workcells : []
+  const workcells = []
+  for (const value of requested) {
+    const slug = text(value, 60).toLowerCase()
+    if (!getWorkcell(slug)) throw new Error(`manifest_unknown_workcell:${slug || 'blank'}`)
+    if (!workcells.includes(slug)) workcells.push(slug)
+  }
+  if (!workcells.length || workcells.length > 3) throw new Error('manifest_workcells_1_to_3_required')
+
+  const clickupRequired = workcells.some((slug) => slug === 'pipeline-control' || slug === 'owner-command')
+  const clickupListId = text(input.clickupListId, 32)
+  if (clickupRequired && !CLICKUP_LIST_RE.test(clickupListId)) throw new Error('manifest_clickup_list_id_required')
+  if (clickupListId && !CLICKUP_LIST_RE.test(clickupListId)) throw new Error('manifest_invalid_clickup_list_id')
+
+  const deliveryUtc = text(input.deliveryUtc, 5) || '01:30'
+  if (!DAILY_TIME_RE.test(deliveryUtc)) throw new Error('manifest_invalid_delivery_utc')
+  const currency = (text(input.currency, 8) || 'MMK').toUpperCase()
+  if (!/^[A-Z]{3,8}$/.test(currency)) throw new Error('manifest_invalid_currency')
+
+  return {
+    version: 1,
+    clientSlug,
+    clientName,
+    clientId,
+    projectName: projectNameFor(clientSlug, input.projectName),
+    workcells,
+    timeZone: timeZone(input.timeZone),
+    currency,
+    lookbackHours: integer(input.lookbackHours, 24, 1, 168),
+    clickupListId,
+    deliveryUtc,
+    tokenCap: integer(input.tokenCap, 150_000, 10_000, 5_000_000),
+  }
+}
+
+function needsConnector(manifest, connector) {
+  return manifest.workcells.some((slug) => getWorkcell(slug)?.requiredConnectors.includes(connector))
+}
+
+function clientSecret(target, sourceSuffix = target) {
+  return { name: `SUPERMEGA_NEW_CLIENT_${sourceSuffix}`, target }
+}
+
+export function requiredSecretGroups(manifestInput) {
+  const manifest = validateClientManifest(manifestInput)
+  const groups = [
+    { target: 'SUPERMEGA_OPS_KEY', sources: [clientSecret('SUPERMEGA_OPS_KEY', 'OPS_KEY')] },
+    {
+      target: 'ANTHROPIC_API_KEY|CLAUDE_API_KEY|OPENROUTER_API_KEY',
+      sources: [
+        clientSecret('ANTHROPIC_API_KEY'),
+        clientSecret('CLAUDE_API_KEY'),
+        clientSecret('OPENROUTER_API_KEY'),
+      ],
+      oneOf: true,
+    },
+    { target: 'SUPABASE_URL', sources: [clientSecret('SUPABASE_URL')] },
+    { target: 'SUPABASE_SERVICE_ROLE_KEY', sources: [clientSecret('SUPABASE_SERVICE_ROLE_KEY')] },
+    { target: 'TELEGRAM_BOT_TOKEN', sources: [clientSecret('TELEGRAM_BOT_TOKEN')] },
+    {
+      target: 'TELEGRAM_ALERT_CHAT_ID',
+      sources: [clientSecret('TELEGRAM_ALERT_CHAT_ID'), clientSecret('TELEGRAM_ALERT_CHAT_ID', 'TELEGRAM_CHAT_ID')],
+      oneOf: true,
+    },
+  ]
+  if (needsConnector(manifest, 'payment-paypal')) {
+    groups.push(
+      { target: 'PAYPAL_CLIENT_ID', sources: [clientSecret('PAYPAL_CLIENT_ID')] },
+      { target: 'PAYPAL_CLIENT_SECRET', sources: [clientSecret('PAYPAL_CLIENT_SECRET')] },
+    )
+  }
+  if (needsConnector(manifest, 'crm-pipedrive')) {
+    groups.push({
+      target: 'PIPEDRIVE_ACCESS_TOKEN|PIPEDRIVE_API_TOKEN',
+      sources: [clientSecret('PIPEDRIVE_ACCESS_TOKEN'), clientSecret('PIPEDRIVE_API_TOKEN')],
+      oneOf: true,
+    })
+  }
+  if (needsConnector(manifest, 'data-clickup')) {
+    groups.push({
+      target: 'CLICKUP_ACCESS_TOKEN|CLICKUP_API_TOKEN',
+      sources: [clientSecret('CLICKUP_ACCESS_TOKEN'), clientSecret('CLICKUP_API_TOKEN')],
+      oneOf: true,
+    })
+  }
+  return groups
+}
+
+function pickSecret(group, env) {
+  for (const source of group.sources) {
+    const value = text(env[source.name], 20_000)
+    if (value) {
+      if (SECRET_LINE_BREAK_RE.test(value)) throw new Error(`secret_contains_line_break:${source.name}`)
+      return { source: source.name, target: source.target, value }
+    }
+  }
+  return null
+}
+
+export function resolveProvisionEnvironment(manifestInput, env = process.env, options = {}) {
+  const manifest = validateClientManifest(manifestInput)
+  const secrets = new Map()
+  const missingSecrets = []
+  const missingSecretInputs = []
+  for (const group of requiredSecretGroups(manifest)) {
+    const selected = pickSecret(group, env)
+    if (!selected) {
+      missingSecrets.push(group.target)
+      missingSecretInputs.push(group.sources.map((source) => source.name).join('|'))
+    }
+    else secrets.set(selected.target, selected.value)
+  }
+  const suppliedCron = text(env.SUPERMEGA_NEW_CLIENT_CRON_SECRET, 20_000)
+  if (suppliedCron && SECRET_LINE_BREAK_RE.test(suppliedCron)) throw new Error('secret_contains_line_break:SUPERMEGA_NEW_CLIENT_CRON_SECRET')
+  secrets.set('CRON_SECRET', suppliedCron || (options.randomBytes || randomBytes)(32).toString('base64url'))
+
+  const variables = new Map([
+    ['SUPERMEGA_WORKCELL_SLUGS', manifest.workcells.join(',')],
+    ['WORKCELL_CLIENT_NAME', manifest.clientName],
+    ['WORKCELL_CLIENT_ID', manifest.clientId],
+    ['WORKCELL_TIME_ZONE', manifest.timeZone],
+    ['WORKCELL_CURRENCY', manifest.currency],
+    ['WORKCELL_LOOKBACK_HOURS', String(manifest.lookbackHours)],
+    ['SUPERMEGA_CLIENT_TOKEN_CAP', String(manifest.tokenCap)],
+  ])
+  if (manifest.clickupListId) variables.set('WORKCELL_CLICKUP_LIST_ID', manifest.clickupListId)
+  return { manifest, variables, secrets, missingSecrets, missingSecretInputs }
+}
+
+export function buildProvisionPlan(manifestInput, options = {}) {
+  const scope = text(options.scope || process.env.VERCEL_SCOPE, 120)
+  if (!VERCEL_SCOPE_RE.test(scope)) throw new Error('vercel_scope_required')
+  const resolved = resolveProvisionEnvironment(manifestInput, options.env || process.env, options)
+  const requiredSecretInputs = requiredSecretGroups(resolved.manifest)
+    .map((group) => group.sources.map((source) => source.name).join('|'))
+  requiredSecretInputs.push('SUPERMEGA_NEW_CLIENT_CRON_SECRET (optional; generated when absent)')
+  const [hour, minute] = resolved.manifest.deliveryUtc.split(':').map(Number)
+  return {
+    version: 1,
+    projectName: resolved.manifest.projectName,
+    scope,
+    confirmation: `PROVISION ${resolved.manifest.projectName}`,
+    client: {
+      slug: resolved.manifest.clientSlug,
+      name: resolved.manifest.clientName,
+      timeZone: resolved.manifest.timeZone,
+      currency: resolved.manifest.currency,
+    },
+    workcells: [...resolved.manifest.workcells],
+    cron: { utc: resolved.manifest.deliveryUtc, expression: `${minute} ${hour} * * *` },
+    variableNames: [...resolved.variables.keys()].sort(),
+    secretNames: [...resolved.secrets.keys()].sort(),
+    requiredSecretInputs,
+    missingSecrets: [...resolved.missingSecrets],
+    missingSecretInputs: [...resolved.missingSecretInputs],
+    sourceDirectory: options.sourceDirectory ? resolve(options.sourceDirectory) : null,
+  }
+}
+
+function defaultRunner(args, options = {}) {
+  return new Promise((resolvePromise) => {
+    const direct = args[0] === 'git'
+    const executable = direct ? 'git' : (process.platform === 'win32' ? 'npx.cmd' : 'npx')
+    const spawnArgs = direct ? args.slice(1) : args
+    const child = spawn(executable, spawnArgs, {
+      cwd: options.cwd,
+      env: options.env || process.env,
+      stdio: ['pipe', 'pipe', 'pipe'],
+      windowsHide: true,
+    })
+    let stdout = ''
+    let stderr = ''
+    child.stdout.on('data', (chunk) => { stdout = (stdout + chunk).slice(-100_000) })
+    child.stderr.on('data', (chunk) => { stderr = (stderr + chunk).slice(-100_000) })
+    if (options.input !== undefined) child.stdin.end(`${options.input}\n`)
+    else child.stdin.end()
+    child.on('error', (error) => resolvePromise({ code: -1, stdout, stderr: error.message }))
+    child.on('close', (code) => resolvePromise({ code: Number(code), stdout, stderr }))
+  })
+}
+
+async function requireSuccess(run, args, options = {}) {
+  const result = await run(args, options)
+  if (result.code !== 0) {
+    const error = new Error(options.reason || 'provision_command_failed')
+    error.command = args.slice(0, 4).join(' ')
+    error.detail = text(result.stderr || result.stdout, 500)
+    throw error
+  }
+  return result
+}
+
+function sourceFilter(source) {
+  const name = basename(source)
+  if (name === 'node_modules' || name === '.vercel' || name === 'output' || name === '.git') return false
+  if (name === '.env' || name.startsWith('.env.')) return false
+  return true
+}
+
+async function prepareSource(sourceDirectory, cronExpression, options = {}) {
+  const source = resolve(sourceDirectory)
+  const tempRoot = await mkdtemp(join(options.tempRoot || tmpdir(), 'supermega-workcell-'))
+  await cp(source, tempRoot, { recursive: true, filter: sourceFilter })
+  const configPath = join(tempRoot, 'vercel.json')
+  const config = JSON.parse(await readFile(configPath, 'utf8'))
+  config.crons = [{ path: '/api/brief', schedule: cronExpression }]
+  await writeFile(configPath, `${JSON.stringify(config, null, 2)}\n`, 'utf8')
+  return tempRoot
+}
+
+export async function isSourceClean(sourceDirectory, options = {}) {
+  const run = options.run || defaultRunner
+  const result = await run(['git', '-C', resolve(sourceDirectory), 'status', '--porcelain', '--', '.'], { cwd: sourceDirectory })
+  return result.code === 0 && !text(result.stdout, 100_000)
+}
+
+export async function verifyClientDataSpine(resolvedInput, options = {}) {
+  const resolved = resolvedInput?.secrets instanceof Map
+    ? resolvedInput
+    : resolveProvisionEnvironment(resolvedInput, options.env || process.env, options)
+  const rawUrl = resolved.secrets.get('SUPABASE_URL')
+  const serviceKey = resolved.secrets.get('SUPABASE_SERVICE_ROLE_KEY')
+  let baseUrl
+  try {
+    const parsed = new URL(rawUrl)
+    if (parsed.protocol !== 'https:' || parsed.username || parsed.password) throw new Error('invalid')
+    baseUrl = parsed.toString().replace(/\/$/, '')
+  } catch {
+    throw new Error('client_data_spine_invalid_url')
+  }
+  if (!serviceKey) throw new Error('client_data_spine_key_required')
+
+  const fetchImpl = options.fetch || fetch
+  const tables = []
+  for (const [table, column] of WORKCELL_DATA_TABLES) {
+    let response
+    try {
+      response = await fetchImpl(`${baseUrl}/rest/v1/${table}?select=${column}&limit=1`, {
+        headers: { apikey: serviceKey, authorization: `Bearer ${serviceKey}` },
+        signal: AbortSignal.timeout(10_000),
+      })
+    } catch {
+      throw new Error(`client_data_spine_unreachable:${table}`)
+    }
+    if (!response?.ok) throw new Error(`client_data_spine_schema_missing:${table}`)
+    tables.push(table)
+  }
+
+  const probeId = `workcell-provision:${(options.randomBytes || randomBytes)(12).toString('hex')}`
+  const activityUrl = `${baseUrl}/rest/v1/supermega_console_activity`
+  const writeHeaders = {
+    apikey: serviceKey,
+    authorization: `Bearer ${serviceKey}`,
+    'content-type': 'application/json',
+    prefer: 'resolution=ignore-duplicates,return=representation',
+  }
+  let failure = null
+  try {
+    const first = await fetchImpl(`${activityUrl}?on_conflict=id`, {
+      method: 'POST',
+      headers: writeHeaders,
+      body: JSON.stringify({ id: probeId, kind: 'workcell_provision_probe', summary: 'temporary idempotency proof' }),
+      signal: AbortSignal.timeout(10_000),
+    })
+    const firstRows = await first.json().catch(() => null)
+    if (!first.ok || !Array.isArray(firstRows) || firstRows.length !== 1) {
+      throw new Error('client_data_spine_claim_insert_failed')
+    }
+
+    const duplicate = await fetchImpl(`${activityUrl}?on_conflict=id`, {
+      method: 'POST',
+      headers: writeHeaders,
+      body: JSON.stringify({ id: probeId, kind: 'workcell_provision_probe', summary: 'must not insert twice' }),
+      signal: AbortSignal.timeout(10_000),
+    })
+    const duplicateRows = await duplicate.json().catch(() => null)
+    if (!duplicate.ok || !Array.isArray(duplicateRows) || duplicateRows.length !== 0) {
+      throw new Error('client_data_spine_claim_not_idempotent')
+    }
+  } catch (error) {
+    failure = error
+  }
+  const cleanup = await fetchImpl(`${activityUrl}?id=eq.${encodeURIComponent(probeId)}`, {
+    method: 'DELETE',
+    headers: { ...writeHeaders, prefer: 'return=minimal' },
+    signal: AbortSignal.timeout(10_000),
+  }).catch(() => null)
+  if (!cleanup?.ok && !failure) failure = new Error('client_data_spine_probe_cleanup_failed')
+  if (failure) throw failure
+  return { ok: true, tables, idempotentClaim: true, probeCleaned: true }
+}
+
+async function addEnvironmentVariable(run, cwd, scope, name, value, sensitive) {
+  const args = [
+    'vercel', 'env', 'add', name, 'production', '--force', '--yes',
+    sensitive ? '--sensitive' : '--no-sensitive',
+    '--scope', scope, '--cwd', cwd,
+  ]
+  await requireSuccess(run, args, { cwd, input: value, reason: `vercel_env_failed:${name}` })
+}
+
+function deploymentUrlFrom(output) {
+  const urls = String(output || '').match(/https:\/\/[a-zA-Z0-9.-]+\.vercel\.app/g) || []
+  return urls.at(-1) || ''
+}
+
+function projectDoesNotExist(result, projectName) {
+  if (result?.code === 0) return false
+  const output = text(`${result?.stdout || ''}\n${result?.stderr || ''}`, 2_000).toLowerCase()
+  const name = projectName.toLowerCase()
+  return output.includes(`there is no project for "${name}"`)
+    || output.includes(`project "${name}" not found`)
+}
+
+export async function verifyProvisionedClient(deploymentUrl, options = {}) {
+  const fetchImpl = options.fetch || fetch
+  const opsKey = options.opsKey
+  const selectedSlugs = options.workcells || []
+  const statusResponse = await fetchImpl(`${deploymentUrl}/api/status`, { signal: AbortSignal.timeout(15_000) })
+  const status = await statusResponse.json().catch(() => null)
+  if (!statusResponse.ok || !status?.ok) throw new Error('provision_status_check_failed')
+  const catalogResponse = await fetchImpl(`${deploymentUrl}/api/workcells`, {
+    headers: { 'x-ops-key': opsKey },
+    signal: AbortSignal.timeout(15_000),
+  })
+  const catalog = await catalogResponse.json().catch(() => null)
+  if (!catalogResponse.ok || !catalog?.ok) throw new Error('provision_catalog_check_failed')
+  const rows = Array.isArray(catalog.workcells) ? catalog.workcells : []
+  for (const slug of selectedSlugs) {
+    const row = rows.find((item) => item.slug === slug)
+    if (!row) throw new Error(`provision_workcell_missing:${slug}`)
+    if (!row.configured) throw new Error(`provision_workcell_not_configured:${slug}`)
+  }
+  return {
+    service: status.service,
+    connectors: status.connectors?.total || 0,
+    registrationErrors: status.connectors?.registrationErrors || 0,
+    workcells: rows.filter((row) => selectedSlugs.includes(row.slug)).map((row) => ({
+      slug: row.slug,
+      configured: Boolean(row.configured),
+      missing: row.missing || [],
+    })),
+  }
+}
+
+export async function applyProvisionPlan(manifestInput, options = {}) {
+  const sourceDirectory = resolve(options.sourceDirectory || '.')
+  const env = options.env || process.env
+  const scope = text(options.scope || env.VERCEL_SCOPE, 120)
+  const plan = buildProvisionPlan(manifestInput, { scope, env, sourceDirectory, randomBytes: options.randomBytes })
+  if (options.confirm !== plan.confirmation) throw new Error(`confirmation_required:${plan.confirmation}`)
+  if (plan.missingSecrets.length) throw new Error(`missing_secrets:${plan.missingSecrets.join(',')}`)
+
+  const sourceClean = options.sourceClean === undefined
+    ? await isSourceClean(sourceDirectory, { run: options.sourceStatusRun })
+    : Boolean(options.sourceClean)
+  if (!sourceClean && options.allowDirtySource !== true) throw new Error('source_tree_not_clean')
+
+  const resolved = resolveProvisionEnvironment(manifestInput, env, { randomBytes: options.randomBytes })
+  const dataSpine = await (options.verifyDataSpine || verifyClientDataSpine)(resolved)
+  const run = options.run || defaultRunner
+  let tempDirectory
+  try {
+    tempDirectory = await prepareSource(sourceDirectory, plan.cron.expression, { tempRoot: options.tempRoot })
+    const inspect = await run(['vercel', 'project', 'inspect', plan.projectName, '--scope', scope, '--yes'], { cwd: tempDirectory })
+    const exists = inspect.code === 0
+    if (!exists && !projectDoesNotExist(inspect, plan.projectName)) throw new Error('vercel_project_inspection_failed')
+    if (exists && options.allowExisting !== true) throw new Error('project_already_exists')
+    if (!exists) {
+      await requireSuccess(run, ['vercel', 'project', 'add', plan.projectName, '--scope', scope], {
+        cwd: tempDirectory,
+        reason: 'vercel_project_create_failed',
+      })
+    }
+    await requireSuccess(run, ['vercel', 'link', '--yes', '--team', scope, '--project', plan.projectName, '--cwd', tempDirectory], {
+      cwd: tempDirectory,
+      reason: 'vercel_project_link_failed',
+    })
+
+    for (const [name, value] of resolved.variables) await addEnvironmentVariable(run, tempDirectory, scope, name, value, false)
+    for (const [name, value] of resolved.secrets) await addEnvironmentVariable(run, tempDirectory, scope, name, value, true)
+
+    const deployment = await requireSuccess(run, [
+      'vercel', 'deploy', '--prod', '--yes', '--scope', scope, '--cwd', tempDirectory, '--project', plan.projectName,
+    ], { cwd: tempDirectory, reason: 'vercel_deploy_failed' })
+    const deploymentUrl = deploymentUrlFrom(`${deployment.stdout}\n${deployment.stderr}`)
+    if (!deploymentUrl) throw new Error('vercel_deployment_url_missing')
+    const verification = await (options.verify || verifyProvisionedClient)(deploymentUrl, {
+      opsKey: resolved.secrets.get('SUPERMEGA_OPS_KEY'),
+      workcells: resolved.manifest.workcells,
+    })
+    return {
+      ok: true,
+      projectName: plan.projectName,
+      scope,
+      deploymentUrl,
+      workcells: [...resolved.manifest.workcells],
+      variablesApplied: plan.variableNames,
+      secretsApplied: plan.secretNames,
+      dataSpine,
+      verification,
+    }
+  } finally {
+    if (tempDirectory && options.keepTemp !== true) await rm(tempDirectory, { recursive: true, force: true })
+  }
+}
+
+export default {
+  validateClientManifest,
+  requiredSecretGroups,
+  resolveProvisionEnvironment,
+  buildProvisionPlan,
+  applyProvisionPlan,
+  verifyProvisionedClient,
+  verifyClientDataSpine,
+  isSourceClean,
+}

--- a/kernel/workcell-provision.test.mjs
+++ b/kernel/workcell-provision.test.mjs
@@ -1,0 +1,342 @@
+import { mkdtemp, mkdir, readFile, rm, stat, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  applyProvisionPlan,
+  buildProvisionPlan,
+  requiredSecretGroups,
+  resolveProvisionEnvironment,
+  validateClientManifest,
+  verifyClientDataSpine,
+  verifyProvisionedClient,
+} from './workcell-provision.mjs'
+
+const MANIFEST = {
+  version: 1,
+  clientSlug: 'acme-trading',
+  clientName: 'Acme Trading',
+  workcells: ['owner-command'],
+  timeZone: 'Asia/Yangon',
+  currency: 'MMK',
+  lookbackHours: 24,
+  clickupListId: '123456789',
+  deliveryUtc: '01:30',
+  tokenCap: 150000,
+}
+
+const SECRET_ENV = {
+  SUPERMEGA_NEW_CLIENT_OPS_KEY: 'new-client-ops-secret',
+  SUPERMEGA_NEW_CLIENT_ANTHROPIC_API_KEY: 'anthropic-secret',
+  SUPERMEGA_NEW_CLIENT_SUPABASE_URL: 'https://client-project.supabase.co',
+  SUPERMEGA_NEW_CLIENT_SUPABASE_SERVICE_ROLE_KEY: 'supabase-secret',
+  SUPERMEGA_NEW_CLIENT_TELEGRAM_BOT_TOKEN: 'telegram-secret',
+  SUPERMEGA_NEW_CLIENT_TELEGRAM_ALERT_CHAT_ID: '123456',
+  SUPERMEGA_NEW_CLIENT_PAYPAL_CLIENT_ID: 'paypal-client',
+  SUPERMEGA_NEW_CLIENT_PAYPAL_CLIENT_SECRET: 'paypal-secret',
+  SUPERMEGA_NEW_CLIENT_PIPEDRIVE_ACCESS_TOKEN: 'pipedrive-secret',
+  SUPERMEGA_NEW_CLIENT_CLICKUP_ACCESS_TOKEN: 'clickup-secret',
+}
+
+test('client manifest normalizes one isolated owner-command project', () => {
+  const manifest = validateClientManifest(MANIFEST)
+  assert.equal(manifest.projectName, 'supermega-wc-acme-trading')
+  assert.equal(manifest.clientId, 'workcell-acme-trading')
+  assert.deepEqual(manifest.workcells, ['owner-command'])
+  assert.equal(manifest.tokenCap, 150000)
+  assert.equal(manifest.deliveryUtc, '01:30')
+  assert.throws(() => validateClientManifest({ ...MANIFEST, clientSlug: '../escape' }), /manifest_invalid_client_slug/)
+  assert.throws(() => validateClientManifest({ ...MANIFEST, timeZone: 'Mars/Olympus' }), /manifest_invalid_time_zone/)
+  assert.throws(() => validateClientManifest({ ...MANIFEST, workcells: ['invented'] }), /manifest_unknown_workcell/)
+  assert.throws(() => validateClientManifest({ ...MANIFEST, clickupListId: '../../secret' }), /manifest_clickup_list_id_required/)
+  assert.throws(() => validateClientManifest({ ...MANIFEST, clientName: 'Acme\u001b[2J' }), /manifest_client_name_required/)
+  assert.throws(() => validateClientManifest({ ...MANIFEST, clientId: '../shared' }), /manifest_invalid_client_id/)
+})
+
+test('required secrets derive from selected workcells and plan output never contains values', () => {
+  const groups = requiredSecretGroups(MANIFEST).map((group) => group.target)
+  assert.ok(groups.includes('PAYPAL_CLIENT_ID'))
+  assert.ok(groups.includes('PIPEDRIVE_ACCESS_TOKEN|PIPEDRIVE_API_TOKEN'))
+  assert.ok(groups.includes('CLICKUP_ACCESS_TOKEN|CLICKUP_API_TOKEN'))
+
+  const plan = buildProvisionPlan(MANIFEST, {
+    scope: 'test-team',
+    env: SECRET_ENV,
+    sourceDirectory: 'C:\\source\\kernel',
+    randomBytes: () => Buffer.from('deterministic-cron-secret'),
+  })
+  assert.equal(plan.confirmation, 'PROVISION supermega-wc-acme-trading')
+  assert.equal(plan.cron.expression, '30 1 * * *')
+  assert.equal(plan.missingSecrets.length, 0)
+  assert.equal(plan.missingSecretInputs.length, 0)
+  assert.ok(plan.secretNames.includes('CRON_SECRET'))
+  assert.ok(plan.requiredSecretInputs.includes('SUPERMEGA_NEW_CLIENT_SUPABASE_SERVICE_ROLE_KEY'))
+  const serialized = JSON.stringify(plan)
+  for (const secret of Object.values(SECRET_ENV)) assert.doesNotMatch(serialized, new RegExp(secret.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')))
+
+  const inherited = resolveProvisionEnvironment(MANIFEST, {
+    SUPABASE_URL: 'https://shared.supabase.co',
+    SUPABASE_SERVICE_ROLE_KEY: 'shared-service-role',
+    PAYPAL_CLIENT_SECRET: 'shared-paypal',
+    ANTHROPIC_API_KEY: 'shared-model',
+  })
+  assert.ok(inherited.missingSecretInputs.includes('SUPERMEGA_NEW_CLIENT_SUPABASE_URL'))
+  assert.equal(inherited.secrets.has('SUPABASE_URL'), false)
+  assert.equal(inherited.secrets.has('PAYPAL_CLIENT_SECRET'), false)
+})
+
+test('secret resolution uses aliases, generates cron auth, and rejects multiline values', () => {
+  const env = {
+    ...SECRET_ENV,
+    SUPERMEGA_NEW_CLIENT_ANTHROPIC_API_KEY: '',
+    SUPERMEGA_NEW_CLIENT_OPENROUTER_API_KEY: 'openrouter-secret',
+    SUPERMEGA_NEW_CLIENT_TELEGRAM_ALERT_CHAT_ID: '',
+    SUPERMEGA_NEW_CLIENT_TELEGRAM_CHAT_ID: 'fallback-chat',
+    SUPERMEGA_NEW_CLIENT_PIPEDRIVE_ACCESS_TOKEN: '',
+    SUPERMEGA_NEW_CLIENT_PIPEDRIVE_API_TOKEN: 'pipedrive-api-secret',
+  }
+  const result = resolveProvisionEnvironment(MANIFEST, env, {
+    randomBytes: () => Buffer.from('generated-cron'),
+  })
+  assert.equal(result.missingSecrets.length, 0)
+  assert.equal(result.secrets.get('SUPERMEGA_OPS_KEY'), 'new-client-ops-secret')
+  assert.equal(result.secrets.get('OPENROUTER_API_KEY'), 'openrouter-secret')
+  assert.equal(result.secrets.get('TELEGRAM_ALERT_CHAT_ID'), 'fallback-chat')
+  assert.equal(result.secrets.get('PIPEDRIVE_API_TOKEN'), 'pipedrive-api-secret')
+  assert.equal(result.secrets.get('CRON_SECRET'), Buffer.from('generated-cron').toString('base64url'))
+  assert.throws(
+    () => resolveProvisionEnvironment(MANIFEST, { ...SECRET_ENV, SUPERMEGA_NEW_CLIENT_PAYPAL_CLIENT_SECRET: 'bad\nvalue' }),
+    /secret_contains_line_break:SUPERMEGA_NEW_CLIENT_PAYPAL_CLIENT_SECRET/,
+  )
+})
+
+test('data-spine preflight proves table access and atomic claims without leaving its probe', async () => {
+  const resolved = resolveProvisionEnvironment(MANIFEST, SECRET_ENV)
+  const calls = []
+  let writes = 0
+  const result = await verifyClientDataSpine(resolved, {
+    fetch: async (url, options) => {
+      calls.push({ url, options })
+      if (options?.method === 'POST') {
+        writes += 1
+        return { ok: true, async json() { return writes === 1 ? [{ id: 'probe' }] : [] } }
+      }
+      return { ok: true, async json() { return [] } }
+    },
+    randomBytes: () => Buffer.from('fixed-probe'),
+  })
+  assert.deepEqual(result.tables, ['supermega_console_activity', 'supermega_token_ledger', 'supermega_ai_cache'])
+  assert.equal(result.idempotentClaim, true)
+  assert.equal(result.probeCleaned, true)
+  assert.deepEqual(calls.map((call) => call.options?.method || 'GET'), ['GET', 'GET', 'GET', 'POST', 'POST', 'DELETE'])
+  assert.equal(calls.every((call) => call.options.headers.apikey === 'supabase-secret'), true)
+  assert.equal(JSON.parse(calls[3].options.body).id, JSON.parse(calls[4].options.body).id)
+  assert.doesNotMatch(JSON.stringify(result), /supabase-secret/)
+  await assert.rejects(
+    verifyClientDataSpine(resolved, { fetch: async () => ({ ok: false, status: 404 }) }),
+    /client_data_spine_schema_missing:supermega_console_activity/,
+  )
+
+  const failedCalls = []
+  await assert.rejects(
+    verifyClientDataSpine(resolved, {
+      fetch: async (url, options) => {
+        failedCalls.push(options?.method || 'GET')
+        if (options?.method === 'POST') return { ok: true, async json() { return [] } }
+        return { ok: true, async json() { return [] } }
+      },
+    }),
+    /client_data_spine_claim_insert_failed/,
+  )
+  assert.equal(failedCalls.at(-1), 'DELETE')
+})
+
+async function fixtureSource() {
+  const source = await mkdtemp(join(tmpdir(), 'workcell-source-'))
+  await mkdir(join(source, 'public'))
+  await writeFile(join(source, 'public', 'index.html'), '<!doctype html><title>Workcell</title>')
+  await writeFile(join(source, 'vercel.json'), JSON.stringify({ crons: [{ path: '/api/brief', schedule: '30 1 * * *' }], routes: [] }))
+  return source
+}
+
+test('apply creates, links, configures, deploys, and verifies without secrets in command arguments', async () => {
+  const source = await fixtureSource()
+  const tempParent = await mkdtemp(join(tmpdir(), 'workcell-apply-parent-'))
+  const calls = []
+  let copiedConfig
+  let applyCwd
+  const run = async (args, options = {}) => {
+    calls.push({ args: [...args], input: options.input, cwd: options.cwd })
+    if (args.slice(0, 3).join(' ') === 'vercel project inspect') {
+      return { code: 1, stdout: '', stderr: 'Error: There is no project for "supermega-wc-acme-trading"' }
+    }
+    if (args.slice(0, 2).join(' ') === 'vercel deploy') {
+      applyCwd = options.cwd
+      copiedConfig = JSON.parse(await readFile(join(options.cwd, 'vercel.json'), 'utf8'))
+      return { code: 0, stdout: 'https://supermega-wc-acme-trading.vercel.app\n', stderr: '' }
+    }
+    return { code: 0, stdout: '{}', stderr: '' }
+  }
+  try {
+    const result = await applyProvisionPlan(MANIFEST, {
+      scope: 'test-team',
+      env: SECRET_ENV,
+      sourceDirectory: source,
+      sourceClean: true,
+      confirm: 'PROVISION supermega-wc-acme-trading',
+      tempRoot: tempParent,
+      randomBytes: () => Buffer.from('generated-cron'),
+      run,
+      verifyDataSpine: async () => ({ ok: true, idempotentClaim: true, probeCleaned: true }),
+      verify: async (url, options) => ({ url, selected: options.workcells, connectors: 69 }),
+    })
+    assert.equal(result.ok, true)
+    assert.equal(result.dataSpine.idempotentClaim, true)
+    assert.equal(result.deploymentUrl, 'https://supermega-wc-acme-trading.vercel.app')
+    assert.deepEqual(copiedConfig.crons, [{ path: '/api/brief', schedule: '30 1 * * *' }])
+    assert.ok(calls.some((call) => call.args.slice(0, 4).join(' ') === 'vercel project add supermega-wc-acme-trading'))
+    assert.ok(calls.some((call) => call.args.slice(0, 2).join(' ') === 'vercel link'))
+    assert.ok(calls.some((call) => call.args.slice(0, 2).join(' ') === 'vercel deploy'))
+    assert.equal(calls.some((call) => call.args.includes('--format')), false)
+    const envCalls = calls.filter((call) => call.args.slice(0, 3).join(' ') === 'vercel env add')
+    assert.equal(envCalls.length, result.variablesApplied.length + result.secretsApplied.length)
+    const commandText = JSON.stringify(calls.map((call) => call.args))
+    const resultText = JSON.stringify(result)
+    for (const secret of [...Object.values(SECRET_ENV), Buffer.from('generated-cron').toString('base64url')]) {
+      assert.doesNotMatch(commandText, new RegExp(secret.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')))
+      assert.doesNotMatch(resultText, new RegExp(secret.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')))
+      assert.ok(envCalls.some((call) => call.input === secret), `secret ${secret.slice(0, 4)}... must travel over stdin`)
+    }
+    await assert.rejects(stat(applyCwd), /ENOENT/)
+  } finally {
+    await rm(source, { recursive: true, force: true })
+    await rm(tempParent, { recursive: true, force: true })
+  }
+})
+
+test('apply refuses missing confirmation, missing secrets, dirty source, and existing projects', async () => {
+  const source = await fixtureSource()
+  try {
+    await assert.rejects(
+      applyProvisionPlan(MANIFEST, { scope: 'team', env: SECRET_ENV, sourceDirectory: source, sourceClean: true }),
+      /confirmation_required:PROVISION supermega-wc-acme-trading/,
+    )
+    await assert.rejects(
+      applyProvisionPlan(MANIFEST, { scope: 'team', env: {}, sourceDirectory: source, sourceClean: true, confirm: 'PROVISION supermega-wc-acme-trading' }),
+      /missing_secrets:/,
+    )
+    await assert.rejects(
+      applyProvisionPlan(MANIFEST, { scope: 'team', env: SECRET_ENV, sourceDirectory: source, sourceClean: false, confirm: 'PROVISION supermega-wc-acme-trading' }),
+      /source_tree_not_clean/,
+    )
+    await assert.rejects(
+      applyProvisionPlan(MANIFEST, {
+        scope: 'team', env: SECRET_ENV, sourceDirectory: source, sourceClean: true,
+        confirm: 'PROVISION supermega-wc-acme-trading',
+        verifyDataSpine: async () => ({ ok: true }),
+        run: async () => ({ code: 0, stdout: '{}', stderr: '' }),
+      }),
+      /project_already_exists/,
+    )
+  } finally {
+    await rm(source, { recursive: true, force: true })
+  }
+})
+
+test('failed data-spine proof stops before every Vercel command', async () => {
+  const source = await fixtureSource()
+  let commands = 0
+  try {
+    await assert.rejects(
+      applyProvisionPlan(MANIFEST, {
+        scope: 'team',
+        env: SECRET_ENV,
+        sourceDirectory: source,
+        sourceClean: true,
+        confirm: 'PROVISION supermega-wc-acme-trading',
+        verifyDataSpine: async () => { throw new Error('client_data_spine_claim_not_idempotent') },
+        run: async () => { commands += 1; return { code: 0, stdout: '', stderr: '' } },
+      }),
+      /client_data_spine_claim_not_idempotent/,
+    )
+    assert.equal(commands, 0)
+  } finally {
+    await rm(source, { recursive: true, force: true })
+  }
+})
+
+test('project inspection auth or network failures never become create operations', async () => {
+  const source = await fixtureSource()
+  const calls = []
+  try {
+    await assert.rejects(
+      applyProvisionPlan(MANIFEST, {
+        scope: 'team',
+        env: SECRET_ENV,
+        sourceDirectory: source,
+        sourceClean: true,
+        confirm: 'PROVISION supermega-wc-acme-trading',
+        verifyDataSpine: async () => ({ ok: true }),
+        run: async (args) => {
+          calls.push(args)
+          return { code: 1, stdout: '', stderr: 'Error: Authentication required' }
+        },
+      }),
+      /vercel_project_inspection_failed/,
+    )
+    assert.equal(calls.length, 1)
+    assert.deepEqual(calls[0].slice(0, 3), ['vercel', 'project', 'inspect'])
+  } finally {
+    await rm(source, { recursive: true, force: true })
+  }
+})
+
+test('client SQL bootstrap contains the exact durable workcell contract', async () => {
+  const sql = await readFile(new URL('./supabase/workcell-client.sql', import.meta.url), 'utf8')
+  for (const table of ['supermega_console_activity', 'supermega_token_ledger', 'supermega_ai_cache']) {
+    assert.match(sql, new RegExp(`create table if not exists public\\.${table}`))
+    assert.match(sql, new RegExp(`alter table public\\.${table} enable row level security`))
+    assert.match(sql, new RegExp(`revoke all on public\\.${table} from anon, authenticated`))
+  }
+  assert.match(sql, /primary key \(tenant_id, "window"\)/)
+})
+
+test('live verifier requires healthy status and every selected workcell', async () => {
+  const responses = [
+    { ok: true, service: 'supermega-kernel', connectors: { total: 69, registrationErrors: 0 } },
+    { ok: true, workcells: [{ slug: 'owner-command', configured: true, missing: [] }] },
+  ]
+  const fetchCalls = []
+  const fetch = async (url, options = {}) => {
+    fetchCalls.push({ url, options })
+    const body = responses.shift()
+    return { ok: true, async json() { return body } }
+  }
+  const result = await verifyProvisionedClient('https://client.vercel.app', {
+    fetch,
+    opsKey: 'ops-secret',
+    workcells: ['owner-command'],
+  })
+  assert.equal(result.connectors, 69)
+  assert.equal(result.workcells[0].configured, true)
+  assert.equal(fetchCalls[1].options.headers['x-ops-key'], 'ops-secret')
+  assert.doesNotMatch(JSON.stringify(result), /ops-secret/)
+
+  await assert.rejects(
+    verifyProvisionedClient('https://client.vercel.app', {
+      fetch: async (url) => ({
+        ok: true,
+        async json() {
+          return url.endsWith('/api/status')
+            ? { ok: true, service: 'supermega-kernel', connectors: {} }
+            : { ok: true, workcells: [{ slug: 'owner-command', configured: false, missing: ['tool:crm_deals_read'] }] }
+        },
+      }),
+      opsKey: 'ops-secret',
+      workcells: ['owner-command'],
+    }),
+    /provision_workcell_not_configured:owner-command/,
+  )
+})

--- a/kernel/workcells/README.md
+++ b/kernel/workcells/README.md
@@ -62,3 +62,43 @@ fails closed without durable storage, so duplicate cron events cannot send the o
 The default production cron remains `01:30 UTC` (08:00 Myanmar). Because each client has an isolated
 deployment, set that deployment's `vercel.json` schedule to the client's desired UTC delivery time
 before release. Vercel cron schedules are UTC and only production deployments register them.
+
+## Provisioner
+
+Create a client manifest from `client-manifest.example.json`, then run the no-mutation plan:
+
+```text
+npm run workcell:provision -- --manifest workcells/client-manifest.example.json --scope <vercel-team>
+```
+
+The plan prints the exact project, UTC cron, non-secret variable names, deployed secret names,
+required `SUPERMEGA_NEW_CLIENT_*` input names, missing inputs, clean-source state, and required
+confirmation. It never prints values.
+
+Before apply, create a dedicated Supabase project for the customer and run
+`supabase/workcell-client.sql` in its SQL editor. The bootstrap creates only the durable delivery
+claim, token ledger, and AI cache tables required by the workcells. It enables RLS, removes
+`anon`/`authenticated` access, and grants access only to the Supabase service role.
+
+Apply only after loading the plan's exact `SUPERMEGA_NEW_CLIENT_*` inputs into the current process
+environment:
+
+```text
+npm run workcell:provision -- --apply --manifest <client.json> --scope <vercel-team> --confirm "PROVISION <project-name>"
+```
+
+Apply refuses dirty source and an existing project by default. `--allow-existing` is the explicit
+upgrade path. Before touching Vercel, it checks all three required tables in the dedicated Supabase
+project, inserts the same claim twice to prove duplicate suppression, and deletes the temporary
+probe. Every environment value is then piped to Vercel over stdin, never placed in command
+arguments. The provisioner copies the clean kernel to an isolated temporary directory, patches only
+that copy's daily cron, deploys, verifies `/api/status`, verifies that every selected workcell is
+configured in the protected `/api/workcells` catalog, reports names and readiness without values,
+then removes the temporary copy.
+
+All credential inputs are deliberately client-namespaced, including Supabase, Telegram, provider,
+and model keys. Generic names such as `SUPABASE_URL` or `PAYPAL_CLIENT_SECRET` are ignored by the
+provisioner, preventing inherited shell credentials from silently crossing the client boundary.
+`SUPERMEGA_NEW_CLIENT_OPS_KEY` must be distinct from the shared console key.
+`SUPERMEGA_NEW_CLIENT_CRON_SECRET` is optional; the provisioner generates a random cron secret when
+it is absent.

--- a/kernel/workcells/client-manifest.example.json
+++ b/kernel/workcells/client-manifest.example.json
@@ -1,0 +1,15 @@
+{
+  "version": 1,
+  "clientSlug": "acme-trading",
+  "clientName": "Acme Trading",
+  "projectName": "supermega-wc-acme-trading",
+  "workcells": [
+    "owner-command"
+  ],
+  "timeZone": "Asia/Yangon",
+  "currency": "MMK",
+  "lookbackHours": 24,
+  "clickupListId": "123456789",
+  "deliveryUtc": "01:30",
+  "tokenCap": 150000
+}


### PR DESCRIPTION
## What changed

- adds a manifest-driven `workcell:provision` CLI with plan-only default and explicit apply confirmation
- isolates every credential behind `SUPERMEGA_NEW_CLIENT_*` inputs so inherited shared credentials are ignored
- adds a minimal dedicated Supabase workcell schema and verifies table access, atomic duplicate suppression, and probe cleanup before touching Vercel
- creates or upgrades one isolated Vercel project, sends environment values over stdin, patches cron only in a temporary clean-source copy, deploys, and verifies status plus protected workcell readiness
- makes workcell deployments probe their durable activity table rather than the unrelated central lead table

## Why

The three operator workcells are live, but onboarding a customer still required manual project/environment work and could accidentally cross client credential boundaries. This makes activation repeatable and fail-closed while keeping the default command non-mutating.

## Safety

- no shared plaintext vault
- no secret value in plans, command arguments, or returned results
- dirty source, missing exact confirmation, missing credentials, invalid data-spine schema, failed idempotency, existing project, and ambiguous Vercel inspection all stop apply
- no client project was created during development; only plan mode and fake-runner apply tests were executed
- provider behavior remains read-only; no send, pay, refund, CRM write, or task mutation is added

## Verification

- `npm run verify`
- 94 unit/product tests
- brand contract
- 69 connectors / 953 adversarial calls / 0 violations
- 5 crews / 74 checks / 0 violations
- installed Vercel CLI v55 command contract checked; unsupported inspect `--format` was removed
