### PR TITLE
Kernel: add no-secret client activation planner

### DIFF
--- a/kernel/api/workcell-plan.mjs
+++ b/kernel/api/workcell-plan.mjs
@@ -1,0 +1,58 @@
+// Ops-gated, no-mutation client activation planner.
+// It validates one client manifest and returns only names/checklists; secret values are never read.
+
+import crypto from 'node:crypto'
+
+import { buildProvisionPlan, validateClientManifest } from '../workcell-provision.mjs'
+
+function constantTimeEqual(a, b) {
+  const left = crypto.createHash('sha256').update(String(a)).digest()
+  const right = crypto.createHash('sha256').update(String(b)).digest()
+  return crypto.timingSafeEqual(left, right)
+}
+
+export async function handleWorkcellPlan(request = {}, options = {}) {
+  const env = options.env || process.env
+  const opsKey = String(options.opsKey ?? env.SUPERMEGA_OPS_KEY ?? '').trim()
+  if (!opsKey) return { status: 503, json: { ok: false, reason: 'ops_key_not_configured' } }
+  if (!constantTimeEqual(String(request.headers?.['x-ops-key'] || ''), opsKey)) {
+    return { status: 401, json: { ok: false, reason: 'unauthorized' } }
+  }
+  if (String(request.method || '').toUpperCase() !== 'POST') {
+    return { status: 405, json: { ok: false, reason: 'method_not_allowed' } }
+  }
+
+  const body = request.body && typeof request.body === 'object' && !Array.isArray(request.body)
+    ? request.body
+    : {}
+  try {
+    const manifest = validateClientManifest(body.manifest)
+    const plan = buildProvisionPlan(manifest, {
+      scope: body.scope,
+      env: {},
+      randomBytes: options.randomBytes,
+    })
+    return {
+      status: 200,
+      json: {
+        ok: true,
+        mode: 'plan',
+        mutation: false,
+        secretValuesAccepted: false,
+        manifest,
+        plan,
+      },
+    }
+  } catch (error) {
+    return {
+      status: 400,
+      json: { ok: false, reason: String(error?.message || 'workcell_plan_invalid').slice(0, 200) },
+    }
+  }
+}
+
+export default async function handler(req, res) {
+  const result = await handleWorkcellPlan({ method: req.method, headers: req.headers, body: req.body })
+  res.setHeader('Cache-Control', 'no-store')
+  res.status(result.status).json(result.json)
+}

--- a/kernel/api/workcell-plan.test.mjs
+++ b/kernel/api/workcell-plan.test.mjs
@@ -1,0 +1,61 @@
+import { readFile } from 'node:fs/promises'
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+
+import { handleWorkcellPlan } from './workcell-plan.mjs'
+
+const KEY = 'ops-secret'
+const request = {
+  method: 'POST',
+  headers: { 'x-ops-key': KEY },
+  body: {
+    scope: 'swanhtet01s-projects',
+    manifest: {
+      version: 1,
+      clientSlug: 'acme-trading',
+      clientName: 'Acme Trading',
+      workcells: ['owner-command'],
+      timeZone: 'Asia/Yangon',
+      currency: 'MMK',
+      lookbackHours: 24,
+      clickupListId: '123456789',
+      deliveryUtc: '01:30',
+    },
+  },
+}
+
+test('activation planner is ops-gated and method-restricted', async () => {
+  assert.equal((await handleWorkcellPlan(request, { env: {} })).status, 503)
+  assert.equal((await handleWorkcellPlan({ ...request, headers: {} }, { opsKey: KEY })).status, 401)
+  assert.equal((await handleWorkcellPlan({ ...request, method: 'GET' }, { opsKey: KEY })).status, 405)
+})
+
+test('activation planner returns a normalized no-secret plan without mutation', async () => {
+  const result = await handleWorkcellPlan(request, {
+    opsKey: KEY,
+    randomBytes: () => Buffer.from('not-returned'),
+  })
+  assert.equal(result.status, 200)
+  assert.equal(result.json.mode, 'plan')
+  assert.equal(result.json.mutation, false)
+  assert.equal(result.json.secretValuesAccepted, false)
+  assert.equal(result.json.manifest.projectName, 'supermega-wc-acme-trading')
+  assert.equal(result.json.plan.confirmation, 'PROVISION supermega-wc-acme-trading')
+  assert.ok(result.json.plan.missingSecretInputs.includes('SUPERMEGA_NEW_CLIENT_SUPABASE_URL'))
+  assert.equal(result.json.plan.sourceDirectory, null)
+  assert.doesNotMatch(JSON.stringify(result.json), /not-returned|ops-secret/)
+})
+
+test('activation planner preserves canonical manifest validation', async () => {
+  const invalid = await handleWorkcellPlan({
+    ...request,
+    body: { ...request.body, manifest: { ...request.body.manifest, workcells: ['invented'] } },
+  }, { opsKey: KEY })
+  assert.equal(invalid.status, 400)
+  assert.match(invalid.json.reason, /manifest_unknown_workcell/)
+})
+
+test('planner runtime cannot enter the mutating provision path', async () => {
+  const source = await readFile(new URL('./workcell-plan.mjs', import.meta.url), 'utf8')
+  assert.doesNotMatch(source, /applyProvisionPlan|vercel deploy|vercel env|child_process/)
+})

--- a/kernel/public/index.html
+++ b/kernel/public/index.html
@@ -79,6 +79,17 @@
   .workcell-output h3{font-size:18px;margin-bottom:8px}.workcell-output .metrics{display:grid;grid-template-columns:repeat(auto-fit,minmax(170px,1fr));gap:8px;margin:12px 0}
   .workcell-output .metric{border-top:1px solid var(--line);padding-top:8px}.workcell-output .metric b{display:block}.workcell-output .metric small{color:var(--muted)}
   .workcell-output ol{padding-left:22px}.workcell-output li{margin:8px 0}.workcell-output .owner-action{border-left:3px solid var(--accent);padding:9px 12px;background:var(--accent-soft)}
+  .workcell-toolbar{display:flex;align-items:flex-start;justify-content:space-between;gap:16px;margin-bottom:14px}.workcell-toolbar h2{font-size:20px}.workcell-toolbar button{min-height:44px;white-space:nowrap}
+  .activation{border:1px solid rgba(59,130,246,.32);border-radius:8px;background:rgba(59,130,246,.055);padding:18px;margin-bottom:16px}
+  .activation-head{display:flex;align-items:flex-start;justify-content:space-between;gap:14px;margin-bottom:16px}.activation-head h3{font-size:17px}.activation-head .badge{display:inline-block;margin-top:6px}
+  .activation-close{width:44px;height:44px;padding:0;font-size:22px;line-height:1}.activation-fields{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:12px}
+  .activation-fields .field{margin:0}.activation-fields input,.activation-fields select{min-height:44px}.activation-actions{display:flex;align-items:center;gap:12px;margin-top:16px}.activation-actions button{min-height:44px}
+  .activation-result{border-top:1px solid var(--line);margin-top:18px;padding-top:18px;scroll-margin-top:120px}.activation-summary{display:flex;gap:8px;flex-wrap:wrap;margin-bottom:14px}
+  .activation-output{display:grid;grid-template-columns:minmax(0,1.15fr) minmax(260px,.85fr);gap:18px}.activation-output h4{font-family:Inter,sans-serif;font-size:11px;letter-spacing:.08em;text-transform:uppercase;color:var(--muted);margin:0 0 8px}
+  .activation-code{display:block;min-height:96px;max-height:290px;margin:0;padding:13px;border:1px solid var(--line);border-radius:8px;background:var(--deep);color:var(--ink);overflow:auto;white-space:pre-wrap;word-break:break-word;font:12px/1.55 Consolas,"Courier New",monospace}
+  .activation-commands{display:grid;gap:8px;margin-top:12px}.activation-command{padding:10px 12px;border-left:3px solid var(--accent);background:var(--deep);overflow:auto;white-space:nowrap;font:12px/1.5 Consolas,"Courier New",monospace}
+  .activation-inputs{display:grid;gap:7px}.activation-inputs code{display:block;padding:8px 10px;border:1px solid var(--line);border-radius:8px;background:var(--deep);font-size:11px;overflow-wrap:anywhere}
+  .activation-result .row{margin-top:12px}.activation-result .row button{min-height:44px}
   .loading-pulse{color:var(--muted);font-size:13px;padding:24px 0;text-align:center;animation:pulse 1.2s ease-in-out infinite}
   @keyframes pulse{0%,100%{opacity:.5}50%{opacity:1}}
   .err-banner{background:rgba(248,113,113,.09);border:1px solid rgba(248,113,113,.35);border-radius:8px;padding:14px 16px;color:var(--bad);font-size:13px}
@@ -86,7 +97,10 @@
     header{display:grid;grid-template-columns:max-content max-content minmax(0,1fr);gap:8px 10px;padding:12px 16px}
     .brand{grid-column:1/-1;white-space:nowrap}.grow{display:none}.key{grid-column:1/-1;max-width:none}
     nav{padding:14px 16px 0}main{padding:18px 16px 70px}
-    .cols{grid-template-columns:1fr}.two{grid-template-columns:1fr}
+    .cols{grid-template-columns:1fr}.two{grid-template-columns:1fr}.activation-fields{grid-template-columns:repeat(2,minmax(0,1fr))}.activation-output{grid-template-columns:1fr}
+  }
+  @media(max-width:520px){
+    .workcell-toolbar{align-items:stretch;flex-direction:column}.workcell-toolbar button{width:100%}.activation{padding:15px}.activation-fields{grid-template-columns:1fr}.activation-actions{align-items:stretch;flex-direction:column}.activation-actions button{width:100%}
   }
 </style>
 </head>
@@ -124,6 +138,38 @@
   </section>
 
   <section id="view-workcells" hidden>
+    <div class="workcell-toolbar">
+      <div><h2>Operator workcells</h2><div class="muted">Cash, pipeline, and owner command</div></div>
+      <button class="primary" id="activationOpen" type="button">New client plan</button>
+    </div>
+    <div class="activation" id="activationPanel" hidden>
+      <div class="activation-head">
+        <div><h3>Client activation</h3><span class="badge">no secret fields</span></div>
+        <button class="activation-close" id="activationClose" type="button" aria-label="Close client activation" title="Close">×</button>
+      </div>
+      <form id="activationForm">
+        <div class="activation-fields">
+          <div class="field"><label for="activationClientName">Client name</label><input id="activationClientName" autocomplete="organization" required /></div>
+          <div class="field"><label for="activationClientSlug">Deployment slug</label><input id="activationClientSlug" autocomplete="off" pattern="[a-z0-9][a-z0-9\-]{1,39}" required /></div>
+          <div class="field"><label for="activationWorkcell">Workcell</label><select id="activationWorkcell"><option value="owner-command">Owner Command</option><option value="cash-close">Cash Close</option><option value="pipeline-control">Pipeline Control</option></select></div>
+          <div class="field" id="activationClickupField"><label for="activationClickup">ClickUp List ID</label><input id="activationClickup" inputmode="numeric" pattern="[0-9]{1,32}" required /></div>
+          <div class="field"><label for="activationTimeZone">Time zone</label><input id="activationTimeZone" value="Asia/Yangon" required /></div>
+          <div class="field"><label for="activationCurrency">Currency</label><input id="activationCurrency" value="MMK" maxlength="8" required /></div>
+          <div class="field"><label for="activationDelivery">Daily delivery (UTC)</label><input id="activationDelivery" type="time" value="01:30" required /></div>
+          <div class="field"><label for="activationLookback">Lookback hours</label><input id="activationLookback" type="number" min="1" max="168" value="24" required /></div>
+          <div class="field"><label for="activationScope">Vercel scope</label><input id="activationScope" value="swanhtet01s-projects" autocomplete="off" required /></div>
+        </div>
+        <div class="activation-actions"><button class="primary" id="activationGenerate" type="submit">Generate activation plan</button><span class="muted" id="activationState" role="status" aria-live="polite"></span></div>
+      </form>
+      <div class="activation-result" id="activationResult" hidden>
+        <div class="activation-summary" id="activationSummary"></div>
+        <div class="activation-output">
+          <div><h4>Client manifest</h4><pre class="activation-code" id="activationManifest"></pre><div class="activation-commands"><code class="activation-command" id="activationPlanCommand"></code><code class="activation-command" id="activationApplyCommand"></code></div></div>
+          <div><h4>Credential inputs</h4><div class="activation-inputs" id="activationInputs"></div></div>
+        </div>
+        <div class="row"><button type="button" id="activationCopyManifest">Copy manifest</button><button type="button" id="activationDownloadManifest">Download manifest</button><button type="button" id="activationCopyInputs">Copy input list</button></div>
+      </div>
+    </div>
     <div id="workcellGrid" class="workcell-grid"><div class="loading-pulse">Loading workcells...</div></div>
     <div id="workcellOut" class="workcell-output" role="status" aria-live="polite"></div>
   </section>
@@ -421,6 +467,75 @@ const WORKCELL_MISSING={
   'tool:work_tasks_read':'Connect ClickUp',
   'input:WORKCELL_CLICKUP_LIST_ID':'Choose a ClickUp list',
   unknown_workcell:'Unknown workcell'
+}
+let activationSlugEdited=false, activationManifest=null, activationPlan=null
+const activationSlug=(value)=>{
+  const slug=String(value||'').toLowerCase().normalize('NFKD').replace(/[^a-z0-9]+/g,'-').replace(/^-+|-+$/g,'').slice(0,40)
+  return slug.length>1?slug:'client'
+}
+function syncActivationInputs(){
+  const needsClickUp=$('#activationWorkcell').value!=='cash-close'
+  $('#activationClickupField').hidden=!needsClickUp
+  $('#activationClickup').required=needsClickUp
+  $('#activationClickup').disabled=!needsClickUp
+}
+async function copyActivationText(value,message){
+  try{await navigator.clipboard.writeText(value);toast(message)}
+  catch{
+    const area=document.createElement('textarea');area.value=value;area.style.position='fixed';area.style.opacity='0';document.body.appendChild(area);area.select();document.execCommand('copy');area.remove();toast(message)
+  }
+}
+function renderActivationPlan(response){
+  activationManifest=response.manifest
+  activationPlan=response.plan
+  const manifestText=JSON.stringify(activationManifest,null,2)
+  const fileName=`${activationManifest.clientSlug}.json`
+  const manifestPath=`workcells/${fileName}`
+  const planCommand=`npm run workcell:provision -- --manifest ${manifestPath} --scope ${activationPlan.scope}`
+  const applyCommand=`npm run workcell:provision -- --apply --manifest ${manifestPath} --scope ${activationPlan.scope} --confirm "${activationPlan.confirmation}"`
+  $('#activationManifest').textContent=manifestText
+  $('#activationPlanCommand').textContent=`Plan: ${planCommand}`
+  $('#activationApplyCommand').textContent=`Apply: ${applyCommand}`
+  $('#activationInputs').innerHTML=(activationPlan.requiredSecretInputs||[]).map(name=>`<code>${esc(name)}</code>`).join('')
+  $('#activationSummary').innerHTML=`<span class="badge on">plan ready</span><span class="badge">${esc(activationPlan.projectName)}</span><span class="badge">${esc(activationPlan.cron.utc)} UTC daily</span><span class="badge">${esc(activationPlan.workcells.join(', '))}</span>`
+  $('#activationResult').hidden=false
+  $('#activationState').textContent='Plan ready'
+  $('#activationResult').scrollIntoView({behavior:'smooth',block:'nearest'})
+}
+$('#activationOpen').onclick=()=>{$('#activationPanel').hidden=false;syncActivationInputs();$('#activationClientName').focus()}
+$('#activationClose').onclick=()=>{$('#activationPanel').hidden=true;$('#activationOpen').focus()}
+$('#activationClientName').addEventListener('input',event=>{if(!activationSlugEdited)$('#activationClientSlug').value=activationSlug(event.currentTarget.value)})
+$('#activationClientSlug').addEventListener('input',()=>{activationSlugEdited=true})
+$('#activationWorkcell').addEventListener('change',syncActivationInputs)
+$('#activationForm').addEventListener('submit',async event=>{
+  event.preventDefault()
+  if(!event.currentTarget.reportValidity())return
+  const button=$('#activationGenerate');button.disabled=true;button.textContent='Generating...';$('#activationState').textContent='Validating client boundary...'
+  const selected=$('#activationWorkcell').value
+  const manifest={
+    version:1,
+    clientSlug:$('#activationClientSlug').value.trim(),
+    clientName:$('#activationClientName').value.trim(),
+    workcells:[selected],
+    timeZone:$('#activationTimeZone').value.trim(),
+    currency:$('#activationCurrency').value.trim(),
+    lookbackHours:Number($('#activationLookback').value),
+    clickupListId:selected==='cash-close'?'':$('#activationClickup').value.trim(),
+    deliveryUtc:$('#activationDelivery').value,
+  }
+  try{
+    const response=await api('POST','/api/workcell-plan',{scope:$('#activationScope').value.trim(),manifest})
+    if(!response.ok){$('#activationState').textContent=response.reason||'Plan failed';return}
+    renderActivationPlan(response)
+  }catch(error){$('#activationState').textContent=String(error.message||'Network error').slice(0,120)}
+  finally{button.disabled=false;button.textContent='Generate activation plan'}
+})
+$('#activationCopyManifest').onclick=()=>activationManifest&&copyActivationText(JSON.stringify(activationManifest,null,2),'Manifest copied')
+$('#activationCopyInputs').onclick=()=>activationPlan&&copyActivationText((activationPlan.requiredSecretInputs||[]).join('\n'),'Input list copied')
+$('#activationDownloadManifest').onclick=()=>{
+  if(!activationManifest)return
+  const blob=new Blob([`${JSON.stringify(activationManifest,null,2)}\n`],{type:'application/json'})
+  const url=URL.createObjectURL(blob);const link=document.createElement('a');link.href=url;link.download=`${activationManifest.clientSlug}.json`;link.click();setTimeout(()=>URL.revokeObjectURL(url),0)
 }
 function renderWorkcellOutput(r){
   const out=$('#workcellOut')

--- a/kernel/vercel.json
+++ b/kernel/vercel.json
@@ -9,6 +9,7 @@
     "api/operator.mjs": { "maxDuration": 45 },
     "api/brief.mjs": { "maxDuration": 45 },
     "api/crew.mjs": { "maxDuration": 45 },
+    "api/workcell-plan.mjs": { "maxDuration": 10 },
     "api/workcells.mjs": { "maxDuration": 45 }
   },
   "crons": [
@@ -22,6 +23,7 @@
     { "src": "/api/operator", "dest": "/api/operator" },
     { "src": "/api/brief", "dest": "/api/brief" },
     { "src": "/api/crew", "dest": "/api/crew" },
+    { "src": "/api/workcell-plan", "dest": "/api/workcell-plan" },
     { "src": "/api/workcells", "dest": "/api/workcells" },
     { "src": "/api/(.*)", "dest": "/api/index" },
     { "src": "/status", "dest": "/status.html" },

--- a/kernel/workcell-ui-contract.test.mjs
+++ b/kernel/workcell-ui-contract.test.mjs
@@ -14,11 +14,28 @@ test('console exposes the configured workcell activation flow with mobile-safe c
   assert.match(html, /\.brand\{grid-column:1\/-1;white-space:nowrap\}/)
 })
 
+test('console builds a canonical client activation plan without collecting credentials', async () => {
+  const html = await readFile(new URL('./public/index.html', import.meta.url), 'utf8')
+  assert.match(html, /id="activationOpen"/)
+  assert.match(html, /id="activationForm"/)
+  assert.match(html, /api\('POST','\/api\/workcell-plan',\{scope:\$\('#activationScope'\)\.value\.trim\(\),manifest\}\)/)
+  assert.match(html, /id="activationDownloadManifest"/)
+  assert.match(html, /activationPlan\.requiredSecretInputs/)
+  assert.match(html, /\.activation-fields input,\.activation-fields select\{min-height:44px\}/)
+  assert.match(html, /@media\(max-width:520px\)/)
+  const panel = html.match(/<div class="activation" id="activationPanel"[\s\S]*?<div id="workcellGrid"/)?.[0] || ''
+  assert.ok(panel)
+  assert.doesNotMatch(panel, /type="password"|name="[^"]*(?:secret|token|key)/i)
+})
+
 test('Vercel serves the guarded workcell function before the generic API route', async () => {
   const config = JSON.parse(await readFile(new URL('./vercel.json', import.meta.url), 'utf8'))
   assert.equal(config.functions['api/workcells.mjs'].maxDuration, 45)
+  assert.equal(config.functions['api/workcell-plan.mjs'].maxDuration, 10)
+  const planRoute = config.routes.findIndex((route) => route.src === '/api/workcell-plan')
   const workcellRoute = config.routes.findIndex((route) => route.src === '/api/workcells')
   const catchAll = config.routes.findIndex((route) => route.src === '/api/(.*)')
+  assert.ok(planRoute >= 0 && planRoute < catchAll)
   assert.ok(workcellRoute >= 0 && workcellRoute < catchAll)
   assert.deepEqual(config.crons, [{ path: '/api/brief', schedule: '30 1 * * *' }])
 })


### PR DESCRIPTION
## What changed

- adds an ops-gated `POST /api/workcell-plan` endpoint backed by the canonical provisioner manifest validation
- adds a responsive Client activation tool inside the Workcells console
- generates a normalized client manifest, exact project/cron, plan/apply commands, and the complete client-scoped credential-name checklist
- supports manifest copy/download and input-list copy without accepting or storing provider credentials
- routes the planner before the generic API catch-all

## Product impact

An operator can now turn a customer name, selected workcell, timezone, delivery time, currency, and ClickUp list into a deployment-ready activation pack. The operator no longer needs to hand-edit JSON or infer environment variable names.

## Safety

- planner is ops-gated
- plan endpoint passes an empty environment to the canonical planner and never reads existing provider credentials
- no secret/token/key input exists in the activation panel
- endpoint exposes no apply/deploy/env mutation path
- browser validation stops incomplete forms before the API
- actual provisioning remains a separate exact-confirmation CLI step

## Verification

- `npm run verify`
- 99 unit/product tests
- brand contract
- 69 connectors / 953 adversarial calls / 0 violations
- 5 crews / 74 checks / 0 violations
- rendered Edge QA at 1280x900 and 390x844
- one valid plan call per flow, invalid form made zero calls
- 11/11 credential-name inputs, zero credential fields
- clipboard and JSON download verified
- zero overflow, zero sub-44px controls, zero browser errors
