### PR TITLE
Kernel: exclude test code from Vercel deploys

### DIFF
--- a/kernel/.vercelignore
+++ b/kernel/.vercelignore
@@ -1,0 +1,3 @@
+**/*.test.mjs
+.playwright-cli/
+output/

--- a/kernel/workcell-ui-contract.test.mjs
+++ b/kernel/workcell-ui-contract.test.mjs
@@ -56,3 +56,10 @@ test('Vercel serves the guarded workcell function before the generic API route',
   assert.ok(approvalRoute >= 0 && approvalRoute < catchAll)
   assert.deepEqual(config.crons, [{ path: '/api/brief', schedule: '30 1 * * *' }])
 })
+
+test('Vercel upload excludes test suites and browser QA artifacts', async () => {
+  const ignore = await readFile(new URL('./.vercelignore', import.meta.url), 'utf8')
+  assert.match(ignore, /^\*\*\/\*\.test\.mjs$/m)
+  assert.match(ignore, /^\.playwright-cli\/$/m)
+  assert.match(ignore, /^output\/$/m)
+})


### PR DESCRIPTION
## What changed

- adds a kernel `.vercelignore` for all `*.test.mjs` and browser QA artifacts
- adds a contract test that locks the deployment boundary

## Why

Production build inspection after #30 showed files under `kernel/api/*.test.mjs` were being emitted as serverless functions. Test code must not be part of the runtime function surface.

## Validation

- `npm run verify`: 116 tests passed
- 69 connectors / 973 adversarial calls / 0 violations
- 5 crews / 74 checks / 0 violations
- `vercel build --prod`: 13 runtime functions, zero `.test.func` outputs