### PR TITLE
Site: turn fixed-workcell leads into activation handoffs

### DIFF
--- a/api/contact-submissions.js
+++ b/api/contact-submissions.js
@@ -321,7 +321,70 @@ function recommendedNextStep(record) {
   return 'Reply asking for the first messy workflow, current tools, and the team that owns it.'
 }
 
+const runtimeWorkcellCatalog = {
+  'cash-close': {
+    template_id: 'cash-close',
+    package_name: 'Cash Close',
+    product_area: 'Custom Solutions & AI Agents',
+    delivery_lane: 'cash_close_workcell',
+    keywords: ['cash close', 'cash', 'paypal', 'settlement', 'fees', 'net receipts', 'reconcile'],
+    first_proof_target: 'One read-only cash-close preview with gross receipts, fees, net cash, transaction count, exceptions, and source trace.',
+    source_requests: [
+      'PayPal account owner and one settlement window; load credentials only during isolated provisioning, never in this form or email',
+      'agreed close window and reporting timezone',
+      'owner who reviews the first proof',
+    ],
+    sales_motion: 'Prove one read-only close, then provision an isolated daily Cash Close deployment after owner acceptance.',
+    modules: ['paypal_settlement_read', 'cash_close_reconciliation', 'fee_and_net_summary', 'exception_queue', 'source_trace'],
+    requires_clickup_list: false,
+    provider_secret_inputs: ['SUPERMEGA_NEW_CLIENT_PAYPAL_CLIENT_ID', 'SUPERMEGA_NEW_CLIENT_PAYPAL_CLIENT_SECRET'],
+  },
+  'pipeline-control': {
+    template_id: 'pipeline-control',
+    package_name: 'Pipeline Control',
+    product_area: 'Custom Solutions & AI Agents',
+    delivery_lane: 'pipeline_control_workcell',
+    keywords: ['pipeline control', 'pipeline', 'pipedrive', 'clickup', 'deal', 'revenue risk', 'delivery queue'],
+    first_proof_target: 'One read-only revenue-control preview with ranked risks, exact deal and task evidence, and one owner action.',
+    source_requests: [
+      'Pipedrive account owner and pipeline scope; load credentials only during isolated provisioning, never in this form or email',
+      'ClickUp workspace owner and the exact delivery list ID',
+      'owner who approves any proposed ClickUp task',
+    ],
+    sales_motion: 'Prove one read-only revenue-risk brief, then provision an isolated scheduled Pipeline Control deployment after owner acceptance.',
+    modules: ['pipedrive_open_deals_read', 'clickup_work_queue_read', 'revenue_risk_ranking', 'evidence_matching', 'approval_only_task_draft'],
+    requires_clickup_list: true,
+    provider_secret_inputs: [
+      'SUPERMEGA_NEW_CLIENT_PIPEDRIVE_ACCESS_TOKEN|SUPERMEGA_NEW_CLIENT_PIPEDRIVE_API_TOKEN',
+      'SUPERMEGA_NEW_CLIENT_CLICKUP_ACCESS_TOKEN|SUPERMEGA_NEW_CLIENT_CLICKUP_API_TOKEN',
+    ],
+  },
+  'owner-command': {
+    template_id: 'owner-command',
+    package_name: 'Owner Command',
+    product_area: 'Custom Solutions & AI Agents',
+    delivery_lane: 'owner_command_workcell',
+    keywords: ['owner command', 'owner brief', 'daily command', 'paypal', 'pipedrive', 'clickup', 'cash', 'pipeline', 'delivery'],
+    first_proof_target: 'One read-only owner brief that leads with money at stake, cites exact source numbers, lists exceptions, and proposes one owner action.',
+    source_requests: [
+      'PayPal and Pipedrive account owners; load credentials only during isolated provisioning, never in this form or email',
+      'ClickUp workspace owner and the exact delivery list ID',
+      'daily delivery time, reporting timezone, and owner reviewer',
+    ],
+    sales_motion: 'Prove one source-traced owner brief, then provision an isolated daily Owner Command deployment after owner acceptance.',
+    modules: ['paypal_settlement_read', 'pipedrive_open_deals_read', 'clickup_work_queue_read', 'owner_command_brief', 'approval_only_task_draft'],
+    requires_clickup_list: true,
+    provider_secret_inputs: [
+      'SUPERMEGA_NEW_CLIENT_PAYPAL_CLIENT_ID',
+      'SUPERMEGA_NEW_CLIENT_PAYPAL_CLIENT_SECRET',
+      'SUPERMEGA_NEW_CLIENT_PIPEDRIVE_ACCESS_TOKEN|SUPERMEGA_NEW_CLIENT_PIPEDRIVE_API_TOKEN',
+      'SUPERMEGA_NEW_CLIENT_CLICKUP_ACCESS_TOKEN|SUPERMEGA_NEW_CLIENT_CLICKUP_API_TOKEN',
+    ],
+  },
+}
+
 const solutionRouteCatalog = [
+  ...Object.values(runtimeWorkcellCatalog),
   {
     template_id: 'deskpos-quickstart',
     package_name: 'Shop Quickstart',
@@ -414,6 +477,7 @@ function buildSolutionRoute(record = {}) {
   const matchedKeywords = winner?.matched_keywords || []
   const fitScore = Math.max(20, Math.min(100, winner?.score || 20))
   const templateId = explicitTemplate || route.template_id
+  const runtimeWorkcell = runtimeWorkcellCatalog[templateId] || null
   const requestedPackage = text(record.requested_package)
   const publicPackage = text(record.public_package)
   const genericPackage = /^(first output request|first useful output|general enquiry|general inquiry|custom supermega template)$/i
@@ -423,7 +487,7 @@ function buildSolutionRoute(record = {}) {
       ? requestedPackage
       : route.package_name
   const firstProofTarget = text(record.first_proof_target) || text(record.first_output) || route.first_proof_target
-  const starterKitUrl = text(record.starter_kit_url) || `/site/agent-templates/${templateId}.json`
+  const starterKitUrl = text(record.starter_kit_url) || (runtimeWorkcell ? '' : `/site/agent-templates/${templateId}.json`)
   const priceHint = text(record.price_hint) || 'quote after first proof review'
   const status = fitScore >= 55 || explicitTemplate ? 'route_ready' : 'needs_operator_review'
   const sourceRequests = route.source_requests
@@ -487,11 +551,125 @@ function buildSolutionRoute(record = {}) {
     sales_motion: route.sales_motion,
     delivery_path: deliveryPath,
     service_model: 'managed_ai_workcell',
+    runtime_workcell_slug: runtimeWorkcell?.template_id || null,
+    provisioner_handoff_supported: Boolean(runtimeWorkcell),
     enterprise_controls: ['source_trace', 'role_separation', 'approval_queue', 'value_ledger'],
     approval_boundary: 'owner approval before send/write/payment actions',
     external_action_state: 'blocked_until_owner_approval',
     connector_write_state: 'blocked_until_owner_approval',
     payment_action_state: 'blocked_until_owner_approval',
+    real_mrr_delta: 0,
+    packet,
+  }
+}
+
+function runtimeWorkcellClientSlug(record = {}) {
+  let base = text(record.company || record.name || 'client')
+  try { base = base.normalize('NFKD') } catch { /* use source text */ }
+  base = base
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+  if (base.length < 3) base = 'client'
+  const identity = text(record.lead_id || record.email || record.company || record.name || 'pending-client')
+  const suffix = crypto.createHash('sha256').update(identity).digest('hex').slice(0, 6)
+  return `${base.slice(0, 33).replace(/-+$/g, '')}-${suffix}`
+}
+
+function buildRuntimeWorkcellActivationHandoff(record = {}, solutionRoute = {}, intakeJob = {}) {
+  const runtime = runtimeWorkcellCatalog[text(record.template_id || solutionRoute.runtime_workcell_slug)]
+  if (!runtime) return null
+
+  const clientSlug = runtimeWorkcellClientSlug(record)
+  const projectName = `supermega-wc-${clientSlug}`
+  const manifestFile = `workcells/${clientSlug}.json`
+  const missingManifestFields = runtime.requires_clickup_list ? ['clickupListId'] : []
+  const sharedSecretInputs = [
+    'SUPERMEGA_NEW_CLIENT_OPS_KEY',
+    'SUPERMEGA_NEW_CLIENT_ANTHROPIC_API_KEY|SUPERMEGA_NEW_CLIENT_CLAUDE_API_KEY|SUPERMEGA_NEW_CLIENT_OPENROUTER_API_KEY',
+    'SUPERMEGA_NEW_CLIENT_SUPABASE_URL',
+    'SUPERMEGA_NEW_CLIENT_SUPABASE_SERVICE_ROLE_KEY',
+    'SUPERMEGA_NEW_CLIENT_TELEGRAM_BOT_TOKEN',
+    'SUPERMEGA_NEW_CLIENT_TELEGRAM_ALERT_CHAT_ID|SUPERMEGA_NEW_CLIENT_TELEGRAM_CHAT_ID',
+  ]
+  const requiredSecretInputs = [...sharedSecretInputs, ...runtime.provider_secret_inputs]
+  const optionalBootstrapInputs = [
+    'SUPERMEGA_NEW_CLIENT_SUPABASE_DB_URL',
+    'SUPERMEGA_NEW_CLIENT_CRON_SECRET',
+  ]
+  const manifestDraft = {
+    version: 1,
+    clientSlug,
+    clientName: truncate(record.company || record.name || 'Client', 120).replace(/[\u0000-\u001f\u007f]/g, ' ').replace(/\s+/g, ' ').trim() || 'Client',
+    clientId: `workcell-${clientSlug}`,
+    projectName,
+    workcells: [runtime.template_id],
+    timeZone: 'Asia/Yangon',
+    currency: 'MMK',
+    lookbackHours: 24,
+    clickupListId: '',
+    deliveryUtc: '01:30',
+    tokenCap: 150000,
+  }
+  const status = missingManifestFields.length ? 'needs_manifest_inputs' : 'needs_client_credentials'
+  const operatorSteps = [
+    'Confirm the buyer accepted the first proof and approved isolated activation.',
+    ...(runtime.requires_clickup_list ? ['Collect the exact client-owned ClickUp list ID and place it in the manifest draft.'] : []),
+    'Create or confirm the client-owned Supabase project; never reuse the shared console or another client project.',
+    'Load every required credential through the isolated provisioning environment, never through the public form, email, logs, or the manifest file.',
+    `Run the plan command and review the normalized manifest, missing inputs, project target, and schedule before applying.`,
+    `Apply only with the exact confirmation PROVISION ${projectName}.`,
+    'Use client-owned test data for the first authenticated read-only run and keep every proposed write in the Approval Inbox.',
+  ]
+  const packet = [
+    `# ${runtime.package_name} isolated activation handoff`,
+    '',
+    `Status: ${status}`,
+    `Lead: ${record.lead_id || 'not set'}`,
+    `Runtime workcell: ${runtime.template_id}`,
+    `Manifest file: ${manifestFile}`,
+    `Project: ${projectName}`,
+    `Apply allowed: false`,
+    '',
+    '## Missing manifest fields',
+    ...(missingManifestFields.length ? missingManifestFields.map((item) => `- ${item}`) : ['- none']),
+    '',
+    '## Required secret input names',
+    ...requiredSecretInputs.map((item) => `- ${item}`),
+    '',
+    '## Bootstrap-only optional inputs',
+    ...optionalBootstrapInputs.map((item) => `- ${item}`),
+    '',
+    '## Operator steps',
+    ...operatorSteps.map((item, index) => `${index + 1}. ${item}`),
+    '',
+    '## Boundary',
+    '- No credential value belongs in this packet or manifest.',
+    '- No project creation, schema write, provider action, send, or payment occurs from intake.',
+    '- Apply remains blocked until client-owned inputs and exact owner confirmation are present.',
+  ].join('\n')
+
+  return {
+    status,
+    handoff_type: 'isolated_workcell_provisioner',
+    runtime_workcell_slug: runtime.template_id,
+    lead_id: record.lead_id || '',
+    manifest_file: manifestFile,
+    manifest_draft: manifestDraft,
+    missing_manifest_fields: missingManifestFields,
+    required_secret_input_names: requiredSecretInputs,
+    optional_bootstrap_input_names: optionalBootstrapInputs,
+    plan_command: `npm run workcell:provision -- --manifest ${manifestFile} --scope <vercel-team>`,
+    apply_command: `npm run workcell:provision -- --apply --manifest ${manifestFile} --scope <vercel-team> --confirm "PROVISION ${projectName}"`,
+    exact_apply_confirmation: `PROVISION ${projectName}`,
+    provisioner_source: 'kernel/workcell-provision.mjs',
+    schema_source: 'kernel/supabase/workcell-client.sql',
+    operator_steps: operatorSteps,
+    intake_status: intakeJob.status || null,
+    manifest_ready: missingManifestFields.length === 0,
+    credentials_present: false,
+    apply_allowed: false,
+    external_action_state: 'blocked_until_owner_approval_and_client_inputs',
     real_mrr_delta: 0,
     packet,
   }
@@ -514,6 +692,8 @@ function recordWithSolutionRoute(record, solutionRoute) {
 function implementationModulesForRoute(solutionRoute = {}) {
   const lane = text(solutionRoute.delivery_lane)
   const defaults = ['buyer_goal', 'approved_sources', 'source_trace', 'first_proof', 'approval_queue', 'delivery_packet']
+  const runtime = runtimeWorkcellCatalog[text(solutionRoute.runtime_workcell_slug || solutionRoute.template_id)]
+  if (runtime) return [...new Set([...defaults, ...runtime.modules])]
   const byLane = {
     pos_launch_workcell: ['business_profile', 'catalog', 'staff_roles', 'checkout_or_booking', 'payment_proof', 'receipt', 'daily_close'],
     chat_to_ledger_workcell: ['chat_sources', 'customer_match', 'order_ledger', 'open_balance_queue', 'delivery_queue', 'approval_only_followups'],
@@ -934,6 +1114,7 @@ function buildPilotCrewRunSheet(sourceToScreenOrder) {
 function buildIntakeJob(record, acceptanceTests = []) {
   const templateName = record.public_package || record.requested_package || record.template_id || 'Custom SUPERMEGA template'
   const sourceToScreenOrder = buildSourceToScreenOrder(record)
+  const runtimeWorkcell = runtimeWorkcellCatalog[text(record.template_id)] || null
   const proofTarget = sourceToScreenOrder?.proof_target || record.first_proof_target || record.first_output || record.requested_package || 'First useful output'
   const sourceManifest = [
     {
@@ -954,9 +1135,9 @@ function buildIntakeJob(record, acceptanceTests = []) {
       workcell_id: sourceToScreenOrder.workcell_id,
     }] : []),
     {
-      source_type: 'starter_kit',
-      status: record.starter_kit_url ? 'provided' : 'missing',
-      value: record.starter_kit_url || (record.template_id ? `/site/agent-templates/${record.template_id}.json` : 'SELECT_TEMPLATE_STARTER_KIT'),
+      source_type: runtimeWorkcell ? 'runtime_contract' : 'starter_kit',
+      status: record.starter_kit_url || runtimeWorkcell ? 'provided' : 'missing',
+      value: record.starter_kit_url || (runtimeWorkcell ? `runtime-workcell:${runtimeWorkcell.template_id}` : (record.template_id ? `/site/agent-templates/${record.template_id}.json` : 'SELECT_TEMPLATE_STARTER_KIT')),
     },
     {
       source_type: 'approval_boundary',
@@ -1235,12 +1416,14 @@ function buildOwnerOnboardingAlert(record, sourcePackRequest) {
 function buildFirstProofTaskPayload(record) {
   const solutionRoute = buildSolutionRoute(record)
   const routedRecord = recordWithSolutionRoute(record, solutionRoute)
+  const runtimeWorkcell = runtimeWorkcellCatalog[text(routedRecord.template_id)] || null
   const sourceToScreenOrder = buildSourceToScreenOrder(routedRecord)
   const acceptanceTests = listFromText(routedRecord.acceptance_tests)
   const proofTarget = sourceToScreenOrder?.proof_target || routedRecord.first_proof_target || routedRecord.first_output || routedRecord.requested_package || 'First useful output'
-  const starterKitUrl = routedRecord.starter_kit_url || (routedRecord.template_id ? `/site/agent-templates/${routedRecord.template_id}.json` : '')
+  const starterKitUrl = routedRecord.starter_kit_url || (!runtimeWorkcell && routedRecord.template_id ? `/site/agent-templates/${routedRecord.template_id}.json` : '')
   const templateName = routedRecord.public_package || routedRecord.requested_package || routedRecord.template_id || 'Custom SUPERMEGA template'
   const intakeJob = buildIntakeJob(routedRecord, acceptanceTests)
+  const workcellActivationHandoff = buildRuntimeWorkcellActivationHandoff(routedRecord, solutionRoute, intakeJob)
   const clientKickoffPack = buildClientKickoffPack(routedRecord, intakeJob)
   const implementationBlueprintPack = buildImplementationBlueprintPack(routedRecord, solutionRoute, intakeJob)
   const sourcePackRequest = buildContactSourcePackRequest(routedRecord)
@@ -1259,6 +1442,7 @@ function buildFirstProofTaskPayload(record) {
     sourceToScreenOrder?.source_hash ? `Source hash: ${sourceToScreenOrder.source_hash}.` : '',
     `First proof: ${proofTarget}.`,
     starterKitUrl ? `Starter kit: ${starterKitUrl}.` : '',
+    workcellActivationHandoff ? `Activation handoff: ${workcellActivationHandoff.status}; ${workcellActivationHandoff.manifest_file}.` : '',
     sourceSummary ? `Sources: ${sourceSummary}.` : 'Sources: request the minimum sample sources before building.',
     `Boundary: ${routedRecord.automation_boundary || 'Approval required before external sends, connector writes, payment actions, or live record edits.'}`,
   ].filter(Boolean).join('\n')
@@ -1280,6 +1464,7 @@ function buildFirstProofTaskPayload(record) {
     intake_job: intakeJob,
     client_kickoff_pack: clientKickoffPack,
     implementation_blueprint_pack: implementationBlueprintPack,
+    workcell_activation_handoff: workcellActivationHandoff,
     source_pack_request: sourcePackRequest,
     source_pack_request_packet: sourcePackRequest.client_message,
     source_pack_request_json: JSON.stringify(sourcePackRequest, null, 2),
@@ -1364,6 +1549,7 @@ function pipelineActionPayload(record) {
       source_to_screen_order: firstProofTask.source_to_screen_order,
       pilot_crew_run_sheet: firstProofTask.pilot_crew_run_sheet,
       implementation_blueprint_pack: firstProofTask.implementation_blueprint_pack,
+      workcell_activation_handoff: firstProofTask.workcell_activation_handoff,
       source_pack_request: firstProofTask.source_pack_request,
       source_pack_request_packet: firstProofTask.source_pack_request_packet,
       source_pack_request_json: firstProofTask.source_pack_request_json,
@@ -2121,6 +2307,7 @@ async function handler(req, res) {
 
 handler.__test = {
   buildSolutionRoute,
+  buildRuntimeWorkcellActivationHandoff,
   buildImplementationBlueprintPack,
   buildFirstProofTaskPayload,
   buildClientKickoffPack,

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "vercel:deploy": "npx vercel deploy --prebuilt -y",
     "vercel:deploy:prod": "npx vercel deploy --prebuilt --prod -y",
     "public:build": "node tools/create_public_vercel_output.mjs",
-    "public:verify": "node tools/verify_public_vercel_artifact_budget.mjs && node tools/verify_public_vercel_output.mjs && node tools/verify_public_runtime_workcells_contract.mjs && node tools/test_connector_resilience.mjs",
+    "public:verify": "node tools/verify_public_vercel_artifact_budget.mjs && node tools/verify_public_vercel_output.mjs && node tools/verify_public_runtime_workcells_contract.mjs && node tools/verify_runtime_workcell_activation_handoff_contract.mjs && node tools/test_connector_resilience.mjs",
     "_public:verify:RETIRED": "source-to-screen/workcell/intake/contact-order + operator-retainer contracts retired 2026-07-09 — they enforced the discontinued 'source-to-screen / AI Workcell' model the founder removed. Kept only artifact-budget + vercel-output structural checks.",
     "deploy:public:prod": "node tools/create_public_vercel_output.mjs && npm run public:verify && npx vercel deploy --prebuilt --prod -y",
     "kernel:verify": "npm --prefix kernel run verify",

--- a/tools/verify_runtime_workcell_activation_handoff_contract.mjs
+++ b/tools/verify_runtime_workcell_activation_handoff_contract.mjs
@@ -1,0 +1,192 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import { resolve } from 'node:path'
+
+const require = createRequire(import.meta.url)
+const handler = require('../api/contact-submissions.js')
+const bundledContactPath = resolve(process.cwd(), '.vercel/output/functions/api/contact-submissions.js.func/api/contact-submissions.js')
+const bundledContact = readFileSync(bundledContactPath, 'utf8')
+const bundledHandler = require(bundledContactPath)
+const {
+  buildSolutionRoute,
+  buildRuntimeWorkcellActivationHandoff,
+  buildFirstProofTaskPayload,
+  pipelineActionPayload,
+} = handler.__test || {}
+
+for (const [name, fn] of Object.entries({
+  buildSolutionRoute,
+  buildRuntimeWorkcellActivationHandoff,
+  buildFirstProofTaskPayload,
+  pipelineActionPayload,
+})) {
+  assert.equal(typeof fn, 'function', `${name}_not_exported`)
+}
+
+const cases = [
+  {
+    slug: 'cash-close',
+    name: 'Cash Close',
+    lane: 'cash_close_workcell',
+    status: 'needs_client_credentials',
+    clickupRequired: false,
+    providerInputs: ['SUPERMEGA_NEW_CLIENT_PAYPAL_CLIENT_ID', 'SUPERMEGA_NEW_CLIENT_PAYPAL_CLIENT_SECRET'],
+  },
+  {
+    slug: 'pipeline-control',
+    name: 'Pipeline Control',
+    lane: 'pipeline_control_workcell',
+    status: 'needs_manifest_inputs',
+    clickupRequired: true,
+    providerInputs: [
+      'SUPERMEGA_NEW_CLIENT_PIPEDRIVE_ACCESS_TOKEN|SUPERMEGA_NEW_CLIENT_PIPEDRIVE_API_TOKEN',
+      'SUPERMEGA_NEW_CLIENT_CLICKUP_ACCESS_TOKEN|SUPERMEGA_NEW_CLIENT_CLICKUP_API_TOKEN',
+    ],
+  },
+  {
+    slug: 'owner-command',
+    name: 'Owner Command',
+    lane: 'owner_command_workcell',
+    status: 'needs_manifest_inputs',
+    clickupRequired: true,
+    providerInputs: [
+      'SUPERMEGA_NEW_CLIENT_PAYPAL_CLIENT_ID',
+      'SUPERMEGA_NEW_CLIENT_PAYPAL_CLIENT_SECRET',
+      'SUPERMEGA_NEW_CLIENT_PIPEDRIVE_ACCESS_TOKEN|SUPERMEGA_NEW_CLIENT_PIPEDRIVE_API_TOKEN',
+      'SUPERMEGA_NEW_CLIENT_CLICKUP_ACCESS_TOKEN|SUPERMEGA_NEW_CLIENT_CLICKUP_API_TOKEN',
+    ],
+  },
+]
+
+const sharedInputs = [
+  'SUPERMEGA_NEW_CLIENT_OPS_KEY',
+  'SUPERMEGA_NEW_CLIENT_ANTHROPIC_API_KEY|SUPERMEGA_NEW_CLIENT_CLAUDE_API_KEY|SUPERMEGA_NEW_CLIENT_OPENROUTER_API_KEY',
+  'SUPERMEGA_NEW_CLIENT_SUPABASE_URL',
+  'SUPERMEGA_NEW_CLIENT_SUPABASE_SERVICE_ROLE_KEY',
+  'SUPERMEGA_NEW_CLIENT_TELEGRAM_BOT_TOKEN',
+  'SUPERMEGA_NEW_CLIENT_TELEGRAM_ALERT_CHAT_ID|SUPERMEGA_NEW_CLIENT_TELEGRAM_CHAT_ID',
+]
+
+for (const token of [
+  "'cash-close': {",
+  "'pipeline-control': {",
+  "'owner-command': {",
+  'buildRuntimeWorkcellActivationHandoff',
+  "handoff_type: 'isolated_workcell_provisioner'",
+  'workcell_activation_handoff: firstProofTask.workcell_activation_handoff',
+  'apply_allowed: false',
+]) {
+  assert.ok(bundledContact.includes(token), `bundled_contact_missing:${token}`)
+}
+assert.equal(typeof bundledHandler.__test?.buildRuntimeWorkcellActivationHandoff, 'function', 'bundled_handoff_helper_not_executable')
+
+for (const [index, item] of cases.entries()) {
+  const record = {
+    lead_id: `LEAD-RUNTIME-${index + 1}`,
+    task_id: `TASK-RUNTIME-${index + 1}`,
+    company: index === 1 ? 'Mingalar Distribution & Trading Co.' : 'Acme Regional Trading',
+    name: 'Owner',
+    email: 'owner@example.com',
+    template_id: item.slug,
+    public_package: item.name,
+    requested_package: item.name,
+    product_area: 'Custom Solutions & AI Agents',
+    first_output: item.name,
+    first_proof_target: `Accepted ${item.name} first proof`,
+    acceptance_tests: 'Uses approved sources | Shows exact source trace | Keeps writes approval-only',
+    launch_blockers: 'No owner reviewer | No client-owned source access',
+    automation_boundary: 'No external send, write, payment, or provider action without owner approval.',
+    price_hint: index === 0 ? 'From 8,000,000 MMK' : 'From 13,000,000 MMK',
+    goal: `Prove ${item.name} from client-owned sources.`,
+    source_links: 'Approved source inventory only; no credentials.',
+    owner: 'Revenue Pod',
+  }
+
+  const route = buildSolutionRoute(record)
+  assert.equal(route.template_id, item.slug)
+  assert.equal(route.package_name, item.name)
+  assert.equal(route.delivery_lane, item.lane)
+  assert.equal(route.runtime_workcell_slug, item.slug)
+  assert.equal(route.provisioner_handoff_supported, true)
+  assert.equal(route.starter_kit_url, '')
+  assert.ok(route.source_requests.every((request) => !/send|paste|email.+credential/i.test(request)))
+  assert.ok(route.source_requests.some((request) => /never in this form or email/i.test(request)))
+
+  const task = buildFirstProofTaskPayload(record)
+  const handoff = task.workcell_activation_handoff
+  assert.ok(handoff)
+  assert.equal(task.solution_route.delivery_lane, item.lane)
+  assert.equal(task.starter_kit_url, '')
+  assert.equal(task.intake_job.source_manifest.some((source) => source.source_type === 'runtime_contract' && source.value === `runtime-workcell:${item.slug}`), true)
+  assert.doesNotMatch(JSON.stringify(task), new RegExp(`/site/agent-templates/${item.slug}\\.json`))
+
+  assert.equal(handoff.status, item.status)
+  assert.equal(handoff.handoff_type, 'isolated_workcell_provisioner')
+  assert.equal(handoff.runtime_workcell_slug, item.slug)
+  assert.equal(handoff.manifest_draft.version, 1)
+  assert.ok(handoff.manifest_draft.clientName.length <= 120)
+  assert.doesNotMatch(handoff.manifest_draft.clientName, /[\u0000-\u001f\u007f]/)
+  assert.match(handoff.manifest_draft.clientSlug, /^[a-z0-9][a-z0-9-]{1,38}[a-z0-9]$/)
+  assert.equal(handoff.manifest_draft.clientId, `workcell-${handoff.manifest_draft.clientSlug}`)
+  assert.equal(handoff.manifest_draft.projectName, `supermega-wc-${handoff.manifest_draft.clientSlug}`)
+  assert.deepEqual(handoff.manifest_draft.workcells, [item.slug])
+  assert.equal(handoff.manifest_draft.timeZone, 'Asia/Yangon')
+  assert.equal(handoff.manifest_draft.currency, 'MMK')
+  assert.equal(handoff.manifest_draft.lookbackHours, 24)
+  assert.equal(handoff.manifest_draft.deliveryUtc, '01:30')
+  assert.equal(handoff.manifest_draft.tokenCap, 150000)
+  assert.deepEqual(handoff.missing_manifest_fields, item.clickupRequired ? ['clickupListId'] : [])
+  assert.equal(handoff.manifest_ready, !item.clickupRequired)
+  assert.equal(handoff.credentials_present, false)
+  assert.equal(handoff.apply_allowed, false)
+  assert.equal(handoff.real_mrr_delta, 0)
+  assert.equal(handoff.exact_apply_confirmation, `PROVISION ${handoff.manifest_draft.projectName}`)
+  assert.match(handoff.plan_command, new RegExp(`--manifest workcells/${handoff.manifest_draft.clientSlug}\\.json`))
+  assert.match(handoff.apply_command, /--apply/)
+  assert.match(handoff.apply_command, new RegExp(`--confirm "PROVISION ${handoff.manifest_draft.projectName}"`))
+  assert.deepEqual(handoff.required_secret_input_names, [...sharedInputs, ...item.providerInputs])
+  assert.deepEqual(handoff.optional_bootstrap_input_names, ['SUPERMEGA_NEW_CLIENT_SUPABASE_DB_URL', 'SUPERMEGA_NEW_CLIENT_CRON_SECRET'])
+  assert.equal(Object.prototype.hasOwnProperty.call(handoff, 'secrets'), false)
+  assert.equal(Object.prototype.hasOwnProperty.call(handoff.manifest_draft, 'secret'), false)
+  assert.match(handoff.packet, /Apply allowed: false/)
+  assert.match(handoff.packet, /No credential value belongs in this packet or manifest/)
+
+  const action = pipelineActionPayload(record)
+  assert.deepEqual(action.payload.workcell_activation_handoff, handoff)
+  assert.deepEqual(action.payload.first_proof_task.workcell_activation_handoff, handoff)
+}
+
+const unsupported = buildRuntimeWorkcellActivationHandoff({ template_id: 'document-extraction-ledger' }, {}, {})
+assert.equal(unsupported, null)
+
+const bundledProof = bundledHandler.__test.buildFirstProofTaskPayload({
+  lead_id: 'LEAD-BUNDLED-PROOF',
+  task_id: 'TASK-BUNDLED-PROOF',
+  template_id: 'owner-command',
+  public_package: 'Owner Command',
+  requested_package: 'Owner Command',
+  company: 'Bundled Contract Client',
+  name: 'Owner',
+  email: 'owner@example.com',
+  first_proof_target: 'One owner brief from approved sources.',
+})
+assert.equal(bundledProof.solution_route.delivery_lane, 'owner_command_workcell')
+assert.equal(bundledProof.workcell_activation_handoff.runtime_workcell_slug, 'owner-command')
+assert.equal(bundledProof.workcell_activation_handoff.apply_allowed, false)
+
+const sanitized = buildRuntimeWorkcellActivationHandoff({
+  lead_id: 'LEAD-SANITIZE',
+  template_id: 'cash-close',
+  company: `${'Very Long Client Name '.repeat(12)}\nInjected`,
+}, { runtime_workcell_slug: 'cash-close' }, {})
+assert.ok(sanitized.manifest_draft.clientName.length <= 120)
+assert.doesNotMatch(sanitized.manifest_draft.clientName, /[\u0000-\u001f\u007f]/)
+assert.match(sanitized.manifest_draft.clientSlug, /^[a-z0-9][a-z0-9-]{1,38}[a-z0-9]$/)
+
+console.log(JSON.stringify({
+  ok: true,
+  contract: 'runtime_workcell_activation_handoff',
+  workcells: cases.map((item) => item.slug),
+  mutation: false,
+}, null, 2))


### PR DESCRIPTION
## What
- route Cash Close, Pipeline Control, and Owner Command through exact runtime delivery lanes instead of legacy keyword fallbacks
- attach a deterministic, no-secret provisioner manifest draft to the existing pipeline action
- list required setup input names and keep apply blocked until client-owned inputs and exact owner confirmation exist
- remove phantom starter-kit URLs for runtime workcells

## Proof
- `npm run public:build`
- `npm run public:verify` (202 files / 11.78 MB; 66 connectors / 923 adversarial calls / 0 violations)
- generated Vercel contact function executes the activation helper
- legacy contact proof and Source-to-Screen contracts still pass

## Boundary
Pure routing and packet generation only. No form submission, lead mutation, project creation, schema write, credential access, provider action, or revenue claim.