### PR TITLE
Kernel: import public Workcell activation manifests

### DIFF
--- a/kernel/public/index.html
+++ b/kernel/public/index.html
@@ -82,6 +82,7 @@
   .workcell-toolbar{display:flex;align-items:flex-start;justify-content:space-between;gap:16px;margin-bottom:14px}.workcell-toolbar h2{font-size:20px}.workcell-toolbar button{min-height:44px;white-space:nowrap}
   .activation{border:1px solid rgba(59,130,246,.32);border-radius:8px;background:rgba(59,130,246,.055);padding:18px;margin-bottom:16px}
   .activation-head{display:flex;align-items:flex-start;justify-content:space-between;gap:14px;margin-bottom:16px}.activation-head h3{font-size:17px}.activation-head .badge{display:inline-block;margin-top:6px}
+  .activation-import{display:flex;align-items:flex-end;gap:12px;padding:0 0 16px;margin-bottom:16px;border-bottom:1px solid var(--line)}.activation-import .field{flex:1;margin:0}.activation-import input{min-height:44px}.activation-import button{min-height:44px;white-space:nowrap}
   .activation-close{width:44px;height:44px;padding:0;font-size:22px;line-height:1}.activation-fields{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:12px}
   .activation-fields .field{margin:0}.activation-fields input,.activation-fields select{min-height:44px}.activation-actions{display:flex;align-items:center;gap:12px;margin-top:16px}.activation-actions button{min-height:44px}
   .activation-result{border-top:1px solid var(--line);margin-top:18px;padding-top:18px;scroll-margin-top:120px}.activation-summary{display:flex;gap:8px;flex-wrap:wrap;margin-bottom:14px}
@@ -108,7 +109,7 @@
     .cols{grid-template-columns:1fr}.two{grid-template-columns:1fr}.activation-fields{grid-template-columns:repeat(2,minmax(0,1fr))}.activation-output{grid-template-columns:1fr}
   }
   @media(max-width:520px){
-    .workcell-toolbar,.approval-toolbar{align-items:stretch;flex-direction:column}.workcell-toolbar button,.approval-toolbar button{width:100%}.activation{padding:15px}.activation-fields{grid-template-columns:1fr}.activation-actions{align-items:stretch;flex-direction:column}.activation-actions button{width:100%}
+    .workcell-toolbar,.approval-toolbar{align-items:stretch;flex-direction:column}.workcell-toolbar button,.approval-toolbar button{width:100%}.activation{padding:15px}.activation-import{align-items:stretch;flex-direction:column}.activation-import button{width:100%}.activation-fields{grid-template-columns:1fr}.activation-actions{align-items:stretch;flex-direction:column}.activation-actions button{width:100%}
     .workcell .wc-actions{align-items:stretch;flex-direction:column}.workcell .wc-actions button{width:100%}.approval-head{align-items:flex-start}.approval-details{grid-template-columns:1fr;gap:2px}.approval-details dd{margin-bottom:9px}.approval-actions{align-items:stretch;flex-direction:column}.approval-confirm{margin:0}.approval-actions button{width:100%}
   }
 </style>
@@ -157,6 +158,10 @@
         <div><h3>Client activation</h3><span class="badge">no secret fields</span></div>
         <button class="activation-close" id="activationClose" type="button" aria-label="Close client activation" title="Close">×</button>
       </div>
+      <div class="activation-import">
+        <div class="field"><label for="activationManifestFile">Handoff manifest JSON</label><input id="activationManifestFile" type="file" accept=".json,application/json" /></div>
+        <button id="activationImportManifest" type="button">Import manifest</button>
+      </div>
       <form id="activationForm">
         <div class="activation-fields">
           <div class="field"><label for="activationClientName">Client name</label><input id="activationClientName" autocomplete="organization" required /></div>
@@ -167,6 +172,7 @@
           <div class="field"><label for="activationCurrency">Currency</label><input id="activationCurrency" value="MMK" maxlength="8" required /></div>
           <div class="field"><label for="activationDelivery">Daily delivery (UTC)</label><input id="activationDelivery" type="time" value="01:30" required /></div>
           <div class="field"><label for="activationLookback">Lookback hours</label><input id="activationLookback" type="number" min="1" max="168" value="24" required /></div>
+          <div class="field"><label for="activationTokenCap">Token cap</label><input id="activationTokenCap" type="number" min="10000" max="5000000" value="150000" required /></div>
           <div class="field"><label for="activationScope">Vercel scope</label><input id="activationScope" value="swanhtet01s-projects" autocomplete="off" required /></div>
         </div>
         <div class="activation-actions"><button class="primary" id="activationGenerate" type="submit">Generate activation plan</button><span class="muted" id="activationState" role="status" aria-live="polite"></span></div>
@@ -243,6 +249,7 @@
   </section>
 </main>
 <div class="toast" id="toast"></div>
+<script src="/workcell-manifest-import.js"></script>
 <script>
 const $=(s)=>document.querySelector(s)
 const esc=(s)=>String(s==null?'':s).replace(/[&<>"']/g,(c)=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]))
@@ -257,6 +264,11 @@ $('#opsKey').addEventListener('change',()=>{
   const key=getOpsKey()
   if(key)localStorage.setItem('sm.ops',key);else localStorage.removeItem('sm.ops')
   loadProtectedState()
+  const activeView=document.querySelector('nav button.active')?.dataset.view
+  if(activeView==='workcells'){
+    if(key)loadWorkcells()
+    else $('#workcellGrid').innerHTML='<div class="empty">Enter the ops passcode to load live workcell status.</div>'
+  }
 })
 $('#opsKey').addEventListener('keydown',(event)=>{if(event.key==='Enter')event.currentTarget.blur()})
 
@@ -499,6 +511,51 @@ function syncActivationInputs(){
   $('#activationClickup').required=needsClickUp
   $('#activationClickup').disabled=!needsClickUp
 }
+function openActivationPanel(focusSelector='#activationClientName'){
+  $('#activationPanel').hidden=false
+  syncActivationInputs()
+  $(focusSelector).focus()
+}
+function populateActivationManifest(manifest){
+  $('#activationClientName').value=manifest.clientName
+  $('#activationClientSlug').value=manifest.clientSlug
+  $('#activationWorkcell').value=manifest.workcells[0]
+  $('#activationClickup').value=manifest.clickupListId
+  $('#activationTimeZone').value=manifest.timeZone
+  $('#activationCurrency').value=manifest.currency
+  $('#activationDelivery').value=manifest.deliveryUtc
+  $('#activationLookback').value=String(manifest.lookbackHours)
+  $('#activationTokenCap').value=String(manifest.tokenCap)
+  activationSlugEdited=true
+  activationManifest=null
+  activationPlan=null
+  $('#activationResult').hidden=true
+  syncActivationInputs()
+}
+async function importActivationManifestFile(){
+  const input=$('#activationManifestFile')
+  const file=input.files&&input.files[0]
+  if(!file){$('#activationState').textContent='Choose a manifest JSON file';input.focus();return}
+  if(file.size>65536){$('#activationState').textContent='Manifest file is too large';input.value='';return}
+  const button=$('#activationImportManifest')
+  button.disabled=true
+  button.textContent='Importing...'
+  try{
+    const manifest=SuperMegaManifestImport.parseActivationManifest(await file.text())
+    populateActivationManifest(manifest)
+    const needsClickUp=manifest.workcells[0]!=='cash-close'&&!manifest.clickupListId
+    $('#activationState').textContent=needsClickUp
+      ? 'Manifest imported. Add the client-owned ClickUp List ID.'
+      : 'Manifest imported. Generate the plan to validate it.'
+    $(needsClickUp?'#activationClickup':'#activationGenerate').focus()
+  }catch(error){
+    $('#activationState').textContent=`Import failed: ${String(error&&error.code||'manifest_invalid').slice(0,80)}`
+  }finally{
+    input.value=''
+    button.disabled=false
+    button.textContent='Import manifest'
+  }
+}
 async function copyActivationText(value,message){
   try{await navigator.clipboard.writeText(value);toast(message)}
   catch{
@@ -522,8 +579,9 @@ function renderActivationPlan(response){
   $('#activationState').textContent='Plan ready'
   $('#activationResult').scrollIntoView({behavior:'smooth',block:'nearest'})
 }
-$('#activationOpen').onclick=()=>{$('#activationPanel').hidden=false;syncActivationInputs();$('#activationClientName').focus()}
+$('#activationOpen').onclick=()=>openActivationPanel()
 $('#activationClose').onclick=()=>{$('#activationPanel').hidden=true;$('#activationOpen').focus()}
+$('#activationImportManifest').onclick=importActivationManifestFile
 $('#activationClientName').addEventListener('input',event=>{if(!activationSlugEdited)$('#activationClientSlug').value=activationSlug(event.currentTarget.value)})
 $('#activationClientSlug').addEventListener('input',()=>{activationSlugEdited=true})
 $('#activationWorkcell').addEventListener('change',syncActivationInputs)
@@ -542,6 +600,7 @@ $('#activationForm').addEventListener('submit',async event=>{
     lookbackHours:Number($('#activationLookback').value),
     clickupListId:selected==='cash-close'?'':$('#activationClickup').value.trim(),
     deliveryUtc:$('#activationDelivery').value,
+    tokenCap:Number($('#activationTokenCap').value),
   }
   try{
     const response=await api('POST','/api/workcell-plan',{scope:$('#activationScope').value.trim(),manifest})
@@ -685,6 +744,14 @@ async function refresh(){
   $('#modeBadge').title=r.dbError||''
   $('#aiBadge').textContent='ai: '+(r.aiConfigured?'on':'off')
   $('#aiBadge').className='badge '+(r.aiConfigured?'on':'off')
+}
+if(location.hash==='#activation'){
+  const workcellsTab=document.querySelector('nav button[data-view="workcells"]')
+  document.querySelectorAll('nav button').forEach(button=>button.classList.toggle('active',button===workcellsTab))
+  for(const view of ['overview','leads','pipeline','outreach','deal','operator','workcells','approvals','connectors']) $('#view-'+view).hidden=view!=='workcells'
+  openActivationPanel('#activationManifestFile')
+  if(hasOpsKey())loadWorkcells()
+  else $('#workcellGrid').innerHTML='<div class="empty">Enter the ops passcode to load live workcell status.</div>'
 }
 loadProtectedState()
 </script>

--- a/kernel/public/workcell-manifest-import.js
+++ b/kernel/public/workcell-manifest-import.js
@@ -1,0 +1,101 @@
+(function attachWorkcellManifestImport(root) {
+  'use strict'
+
+  const ALLOWED_KEYS = new Set([
+    'version',
+    'clientSlug',
+    'clientName',
+    'clientId',
+    'projectName',
+    'workcells',
+    'timeZone',
+    'currency',
+    'lookbackHours',
+    'clickupListId',
+    'deliveryUtc',
+    'tokenCap',
+  ])
+  const WORKCELLS = new Set(['cash-close', 'pipeline-control', 'owner-command'])
+  const CLIENT_SLUG_RE = /^[a-z0-9][a-z0-9-]{1,39}$/
+  const CLICKUP_LIST_RE = /^\d{1,32}$/
+  const DELIVERY_UTC_RE = /^(?:[01]\d|2[0-3]):[0-5]\d$/
+  const CONTROL_CHARACTER_RE = /[\u0000-\u001f\u007f]/
+
+  function fail(reason) {
+    const error = new Error(reason)
+    error.code = reason
+    throw error
+  }
+
+  function boundedText(value, max, reason) {
+    const candidate = String(value == null ? '' : value).trim()
+    if (!candidate || candidate.length > max || CONTROL_CHARACTER_RE.test(candidate)) fail(reason)
+    return candidate
+  }
+
+  function boundedInteger(value, min, max, reason) {
+    const candidate = Number(value)
+    if (!Number.isInteger(candidate) || candidate < min || candidate > max) fail(reason)
+    return candidate
+  }
+
+  function parseActivationManifest(input) {
+    let parsed = input
+    if (typeof input === 'string') {
+      if (!input.trim() || input.length > 65_536) fail('manifest_file_invalid_size')
+      try { parsed = JSON.parse(input) } catch { fail('manifest_json_invalid') }
+    }
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) fail('manifest_object_required')
+
+    for (const key of Object.keys(parsed)) {
+      if (!ALLOWED_KEYS.has(key)) fail(`manifest_unexpected_field:${key}`)
+    }
+    if (Number(parsed.version) !== 1) fail('manifest_version_must_be_1')
+
+    const clientSlug = boundedText(parsed.clientSlug, 40, 'manifest_invalid_client_slug').toLowerCase()
+    if (!CLIENT_SLUG_RE.test(clientSlug)) fail('manifest_invalid_client_slug')
+    const clientName = boundedText(parsed.clientName, 120, 'manifest_client_name_required')
+    const expectedClientId = `workcell-${clientSlug}`
+    const clientId = parsed.clientId == null || parsed.clientId === ''
+      ? expectedClientId
+      : boundedText(parsed.clientId, 80, 'manifest_invalid_client_id')
+    if (clientId !== expectedClientId) fail('manifest_client_id_mismatch')
+    const expectedProjectName = `supermega-wc-${clientSlug}`
+    const projectName = parsed.projectName == null || parsed.projectName === ''
+      ? expectedProjectName
+      : boundedText(parsed.projectName, 100, 'manifest_invalid_project_name')
+    if (projectName !== expectedProjectName) fail('manifest_project_name_mismatch')
+
+    if (!Array.isArray(parsed.workcells) || parsed.workcells.length !== 1) fail('manifest_one_workcell_required')
+    const workcell = boundedText(parsed.workcells[0], 60, 'manifest_unknown_workcell').toLowerCase()
+    if (!WORKCELLS.has(workcell)) fail(`manifest_unknown_workcell:${workcell}`)
+
+    const timeZone = boundedText(parsed.timeZone || 'Asia/Yangon', 80, 'manifest_invalid_time_zone')
+    try { new Intl.DateTimeFormat('en-US', { timeZone }).format(new Date(0)) } catch { fail('manifest_invalid_time_zone') }
+    const currency = boundedText(parsed.currency || 'MMK', 8, 'manifest_invalid_currency').toUpperCase()
+    if (!/^[A-Z]{3,8}$/.test(currency)) fail('manifest_invalid_currency')
+    const lookbackHours = boundedInteger(parsed.lookbackHours == null ? 24 : parsed.lookbackHours, 1, 168, 'manifest_invalid_lookback_hours')
+    const clickupListId = String(parsed.clickupListId == null ? '' : parsed.clickupListId).trim()
+    if (clickupListId && !CLICKUP_LIST_RE.test(clickupListId)) fail('manifest_invalid_clickup_list_id')
+    const deliveryUtc = String(parsed.deliveryUtc || '01:30').trim()
+    if (!DELIVERY_UTC_RE.test(deliveryUtc)) fail('manifest_invalid_delivery_utc')
+    const tokenCap = boundedInteger(parsed.tokenCap == null ? 150_000 : parsed.tokenCap, 10_000, 5_000_000, 'manifest_invalid_token_cap')
+
+    return {
+      version: 1,
+      clientSlug,
+      clientName,
+      clientId,
+      projectName,
+      workcells: [workcell],
+      timeZone,
+      currency,
+      lookbackHours,
+      clickupListId,
+      deliveryUtc,
+      tokenCap,
+    }
+  }
+
+  root.SuperMegaManifestImport = Object.freeze({ parseActivationManifest })
+})(globalThis)

--- a/kernel/workcell-manifest-import.test.mjs
+++ b/kernel/workcell-manifest-import.test.mjs
@@ -1,0 +1,82 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import { test } from 'node:test'
+import vm from 'node:vm'
+
+async function loadParser() {
+  const source = await readFile(new URL('./public/workcell-manifest-import.js', import.meta.url), 'utf8')
+  const context = vm.createContext({ Intl, Date, JSON, Object, Set, Error, Number, String })
+  vm.runInContext(source, context, { filename: 'workcell-manifest-import.js' })
+  return context.SuperMegaManifestImport.parseActivationManifest
+}
+
+function manifest(workcell = 'cash-close') {
+  return {
+    version: 1,
+    clientSlug: 'acme-trading',
+    clientName: 'Acme Trading',
+    clientId: 'workcell-acme-trading',
+    projectName: 'supermega-wc-acme-trading',
+    workcells: [workcell],
+    timeZone: 'Asia/Yangon',
+    currency: 'MMK',
+    lookbackHours: 24,
+    clickupListId: workcell === 'cash-close' ? '' : '123456789',
+    deliveryUtc: '01:30',
+    tokenCap: 150000,
+  }
+}
+
+test('browser manifest parser accepts each fixed workcell without credential values', async () => {
+  const parse = await loadParser()
+  for (const workcell of ['cash-close', 'pipeline-control', 'owner-command']) {
+    const parsed = parse(JSON.stringify(manifest(workcell)))
+    assert.equal(parsed.workcells[0], workcell)
+    assert.equal(parsed.clientId, 'workcell-acme-trading')
+    assert.equal(parsed.projectName, 'supermega-wc-acme-trading')
+    assert.equal(parsed.tokenCap, 150000)
+    assert.equal(Object.hasOwn(parsed, 'credentials'), false)
+    assert.equal(Object.hasOwn(parsed, 'secrets'), false)
+  }
+})
+
+test('browser manifest parser derives canonical optional identifiers', async () => {
+  const parse = await loadParser()
+  const input = manifest('cash-close')
+  delete input.clientId
+  delete input.projectName
+  const parsed = parse(input)
+  assert.equal(parsed.clientId, 'workcell-acme-trading')
+  assert.equal(parsed.projectName, 'supermega-wc-acme-trading')
+})
+
+test('browser manifest parser accepts an incomplete ClickUp handoff for operator completion', async () => {
+  const parse = await loadParser()
+  for (const workcell of ['pipeline-control', 'owner-command']) {
+    const parsed = parse({ ...manifest(workcell), clickupListId: '' })
+    assert.equal(parsed.workcells[0], workcell)
+    assert.equal(parsed.clickupListId, '')
+  }
+})
+
+test('browser manifest parser rejects wrappers, secret fields, and boundary changes', async () => {
+  const parse = await loadParser()
+  assert.throws(() => parse({ manifest_draft: manifest() }), /manifest_unexpected_field:manifest_draft/)
+  assert.throws(() => parse({ ...manifest(), credentials: { token: 'secret' } }), /manifest_unexpected_field:credentials/)
+  assert.throws(() => parse({ ...manifest(), apiKey: 'secret' }), /manifest_unexpected_field:apiKey/)
+  assert.throws(() => parse({ ...manifest(), projectName: 'shared-console' }), /manifest_project_name_mismatch/)
+  assert.throws(() => parse({ ...manifest(), clientId: 'other-client' }), /manifest_client_id_mismatch/)
+  assert.throws(() => parse({ ...manifest(), workcells: ['cash-close', 'owner-command'] }), /manifest_one_workcell_required/)
+  assert.throws(() => parse({ ...manifest(), workcells: ['invented'] }), /manifest_unknown_workcell:invented/)
+  assert.throws(() => parse({ ...manifest('pipeline-control'), clickupListId: '../other-list' }), /manifest_invalid_clickup_list_id/)
+  assert.throws(() => parse({ ...manifest(), clientName: 'Acme\u001b[2J' }), /manifest_client_name_required/)
+  assert.throws(() => parse('{broken'), /manifest_json_invalid/)
+})
+
+test('browser manifest parser rejects values the server would normalize unexpectedly', async () => {
+  const parse = await loadParser()
+  assert.throws(() => parse({ ...manifest(), timeZone: 'Mars/Olympus' }), /manifest_invalid_time_zone/)
+  assert.throws(() => parse({ ...manifest(), lookbackHours: 999 }), /manifest_invalid_lookback_hours/)
+  assert.throws(() => parse({ ...manifest(), tokenCap: 1 }), /manifest_invalid_token_cap/)
+  assert.throws(() => parse({ ...manifest(), deliveryUtc: '25:00' }), /manifest_invalid_delivery_utc/)
+})

--- a/kernel/workcell-ui-contract.test.mjs
+++ b/kernel/workcell-ui-contract.test.mjs
@@ -34,12 +34,25 @@ test('console builds a canonical client activation plan without collecting crede
   assert.match(html, /id="activationForm"/)
   assert.match(html, /api\('POST','\/api\/workcell-plan',\{scope:\$\('#activationScope'\)\.value\.trim\(\),manifest\}\)/)
   assert.match(html, /id="activationDownloadManifest"/)
+  assert.match(html, /src="\/workcell-manifest-import\.js"/)
+  assert.match(html, /id="activationManifestFile" type="file" accept="\.json,application\/json"/)
+  assert.match(html, /id="activationImportManifest"/)
+  assert.match(html, /SuperMegaManifestImport\.parseActivationManifest\(await file\.text\(\)\)/)
+  assert.match(html, /Manifest imported\. Add the client-owned ClickUp List ID\./)
+  assert.match(html, /id="activationTokenCap" type="number" min="10000" max="5000000"/)
+  assert.match(html, /tokenCap:Number\(\$\('#activationTokenCap'\)\.value\)/)
+  assert.match(html, /if\(location\.hash==='\#activation'\)/)
+  assert.match(html, /Enter the ops passcode to load live workcell status\./)
+  assert.match(html, /if\(activeView==='workcells'\)/)
   assert.match(html, /activationPlan\.requiredSecretInputs/)
   assert.match(html, /\.activation-fields input,\.activation-fields select\{min-height:44px\}/)
   assert.match(html, /@media\(max-width:520px\)/)
   const panel = html.match(/<div class="activation" id="activationPanel"[\s\S]*?<div id="workcellGrid"/)?.[0] || ''
   assert.ok(panel)
   assert.doesNotMatch(panel, /type="password"|name="[^"]*(?:secret|token|key)/i)
+  const importFunction = html.match(/async function importActivationManifestFile\(\)\{[\s\S]*?\n\}/)?.[0] || ''
+  assert.ok(importFunction)
+  assert.doesNotMatch(importFunction, /\bapi\s*\(|fetch\s*\(/)
 })
 
 test('Vercel serves the guarded workcell function before the generic API route', async () => {


### PR DESCRIPTION
## What changed
- adds a strict browser-side parser for the manifest downloaded from the public Workcell order handoff
- adds a JSON import control and `#activation` deep link to the ops-gated Workcells planner
- preserves token cap and all canonical manifest fields without accepting credential values
- accepts intentionally incomplete Pipeline Control / Owner Command handoffs, focuses the required ClickUp List ID, and leaves server plan validation as the next gate
- replaces the locked deep-link loading placeholder with a truthful passcode state and refreshes Workcells after key entry

## Boundaries
- import is local-only and performs no API/fetch call
- unexpected fields, wrappers, secret/credential fields, mismatched client/project identity, invented workcells, control characters, and invalid ranges are rejected
- provisioning apply remains the separate exact-confirmation CLI

## Verification
- `npm --prefix kernel run verify`
- 124 tests passed
- 69 connectors / 973 adversarial calls / 0 violations
- 5 crews / 74 checks / 0 violations
- Edge QA at 1280x900 and 390x844: valid and incomplete manifests import, 44px controls, zero overflow/errors, no secret fields or import network request