### PR TITLE
Kernel: guide secure client activation

### DIFF
--- a/kernel/package.json
+++ b/kernel/package.json
@@ -8,6 +8,7 @@
     "connector:resilience": "node ../tools/test_connector_resilience.mjs",
     "crew:resilience": "node ../tools/test_crew_resilience.mjs",
     "workcell:provision": "node scripts/provision-workcell-client.mjs",
+    "workcell:activate": "node scripts/activate-workcell-client.mjs",
     "verify": "npm test && npm run brand:verify && npm run connector:resilience && npm run crew:resilience",
     "deploy:prod": "npm run verify && npx vercel deploy --prod -y"
   },

--- a/kernel/public/index.html
+++ b/kernel/public/index.html
@@ -180,10 +180,10 @@
       <div class="activation-result" id="activationResult" hidden>
         <div class="activation-summary" id="activationSummary"></div>
         <div class="activation-output">
-          <div><h4>Client manifest</h4><pre class="activation-code" id="activationManifest"></pre><div class="activation-commands"><code class="activation-command" id="activationPlanCommand"></code><code class="activation-command" id="activationApplyCommand"></code></div></div>
+          <div><h4>Client manifest</h4><pre class="activation-code" id="activationManifest"></pre><div class="activation-commands"><code class="activation-command" id="activationGuidedCommand"></code><code class="activation-command" id="activationPlanCommand"></code><code class="activation-command" id="activationApplyCommand"></code></div></div>
           <div><h4>Credential inputs</h4><div class="activation-inputs" id="activationInputs"></div></div>
         </div>
-        <div class="row"><button type="button" id="activationCopyManifest">Copy manifest</button><button type="button" id="activationDownloadManifest">Download manifest</button><button type="button" id="activationCopyInputs">Copy input list</button></div>
+        <div class="row"><button type="button" id="activationCopyManifest">Copy manifest</button><button type="button" id="activationDownloadManifest">Download manifest</button><button type="button" id="activationCopyGuided">Copy guided command</button><button type="button" id="activationCopyInputs">Copy input list</button></div>
       </div>
     </div>
     <div id="workcellGrid" class="workcell-grid"><div class="loading-pulse">Loading workcells...</div></div>
@@ -500,7 +500,7 @@ const WORKCELL_MISSING={
   'input:WORKCELL_CLICKUP_LIST_ID':'Choose a ClickUp list',
   unknown_workcell:'Unknown workcell'
 }
-let activationSlugEdited=false, activationManifest=null, activationPlan=null
+let activationSlugEdited=false, activationManifest=null, activationPlan=null, activationGuidedCommand=''
 const activationSlug=(value)=>{
   const slug=String(value||'').toLowerCase().normalize('NFKD').replace(/[^a-z0-9]+/g,'-').replace(/^-+|-+$/g,'').slice(0,40)
   return slug.length>1?slug:'client'
@@ -529,6 +529,7 @@ function populateActivationManifest(manifest){
   activationSlugEdited=true
   activationManifest=null
   activationPlan=null
+  activationGuidedCommand=''
   $('#activationResult').hidden=true
   syncActivationInputs()
 }
@@ -568,9 +569,12 @@ function renderActivationPlan(response){
   const manifestText=JSON.stringify(activationManifest,null,2)
   const fileName=`${activationManifest.clientSlug}.json`
   const manifestPath=`workcells/${fileName}`
+  const guidedCommand=`npm run workcell:activate -- --manifest ${manifestPath} --scope ${activationPlan.scope}`
   const planCommand=`npm run workcell:provision -- --manifest ${manifestPath} --scope ${activationPlan.scope}`
   const applyCommand=`npm run workcell:provision -- --apply --manifest ${manifestPath} --scope ${activationPlan.scope} --confirm "${activationPlan.confirmation}"`
+  activationGuidedCommand=guidedCommand
   $('#activationManifest').textContent=manifestText
+  $('#activationGuidedCommand').textContent=`Guided: ${guidedCommand}`
   $('#activationPlanCommand').textContent=`Plan: ${planCommand}`
   $('#activationApplyCommand').textContent=`Apply: ${applyCommand}`
   $('#activationInputs').innerHTML=(activationPlan.requiredSecretInputs||[]).map(name=>`<code>${esc(name)}</code>`).join('')
@@ -610,6 +614,7 @@ $('#activationForm').addEventListener('submit',async event=>{
   finally{button.disabled=false;button.textContent='Generate activation plan'}
 })
 $('#activationCopyManifest').onclick=()=>activationManifest&&copyActivationText(JSON.stringify(activationManifest,null,2),'Manifest copied')
+$('#activationCopyGuided').onclick=()=>activationGuidedCommand&&copyActivationText(activationGuidedCommand,'Guided command copied')
 $('#activationCopyInputs').onclick=()=>activationPlan&&copyActivationText((activationPlan.requiredSecretInputs||[]).join('\n'),'Input list copied')
 $('#activationDownloadManifest').onclick=()=>{
   if(!activationManifest)return

--- a/kernel/scripts/activate-workcell-client.mjs
+++ b/kernel/scripts/activate-workcell-client.mjs
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+
+import { readFile } from 'node:fs/promises'
+import { stdin, stdout } from 'node:process'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { TerminalPrompt } from '../terminal-prompt.mjs'
+import { runGuidedActivation } from '../workcell-guided-activation.mjs'
+
+const KERNEL_DIR = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+
+function parseArgs(argv) {
+  const out = { allowExisting: false, allowDirtySource: false, keepTemp: false }
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index]
+    if (arg === '--allow-existing') out.allowExisting = true
+    else if (arg === '--allow-dirty-source') out.allowDirtySource = true
+    else if (arg === '--keep-temp') out.keepTemp = true
+    else if (arg === '--help' || arg === '-h') out.help = true
+    else if (['--manifest', '--scope', '--source'].includes(arg)) {
+      const value = argv[index + 1]
+      if (!value || value.startsWith('--')) throw new Error(`argument_value_required:${arg}`)
+      out[arg.slice(2)] = value
+      index += 1
+    } else throw new Error(`unknown_argument:${arg}`)
+  }
+  return out
+}
+
+function help() {
+  return [
+    'SuperMega guided client activation',
+    '',
+    '  npm run workcell:activate -- --manifest <client.json> --scope <vercel-team>',
+    '',
+    'The command masks every client input, keeps values only in this process, prints a value-free',
+    'plan, requires the exact project confirmation, and reuses the fail-closed provisioner.',
+  ].join('\n')
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2))
+  if (args.help) { stdout.write(`${help()}\n`); return }
+  if (!args.manifest) throw new Error('manifest_path_required')
+  const scope = args.scope || process.env.VERCEL_SCOPE
+  if (!scope) throw new Error('vercel_scope_required')
+  const manifest = JSON.parse(await readFile(resolve(args.manifest), 'utf8'))
+  const prompt = new TerminalPrompt(stdin, stdout)
+  prompt.assertInteractive()
+
+  stdout.write('Client values are masked and remain in memory only. Nothing changes before exact confirmation.\n')
+  const result = await runGuidedActivation(manifest, {
+    scope,
+    sourceDirectory: resolve(args.source || KERNEL_DIR),
+    allowExisting: args.allowExisting,
+    allowDirtySource: args.allowDirtySource,
+    keepTemp: args.keepTemp,
+    chooseInput: (group) => prompt.choose(group),
+    readSecret: ({ label, inputName, bootstrapOnly }) => prompt.read(
+      `${label}${bootstrapOnly ? ' (not deployed)' : ''} [${inputName}]: `,
+      { masked: true },
+    ),
+    confirmBootstrap: async () => {
+      const answer = (await prompt.read('Bootstrap the client schema now? [Y/n]: ')).trim().toLowerCase()
+      if (!answer || answer === 'y' || answer === 'yes') return true
+      if (answer === 'n' || answer === 'no') return false
+      throw new Error('guided_bootstrap_choice_invalid')
+    },
+    onPlan: (plan) => stdout.write(`${JSON.stringify({ ok: true, mode: 'guided_plan', ...plan }, null, 2)}\n`),
+    readConfirmation: (confirmation) => prompt.read(`Type ${confirmation} to activate: `),
+  })
+  stdout.write(`${JSON.stringify(result, null, 2)}\n`)
+}
+
+main().catch((error) => {
+  process.stderr.write(`${JSON.stringify({ ok: false, reason: String(error?.message || 'activation_failed').slice(0, 500) })}\n`)
+  process.exitCode = 1
+})

--- a/kernel/terminal-prompt.mjs
+++ b/kernel/terminal-prompt.mjs
@@ -1,0 +1,60 @@
+import readline from 'node:readline'
+
+export class TerminalPrompt {
+  constructor(input, output) {
+    this.input = input
+    this.output = output
+  }
+
+  assertInteractive() {
+    if (!this.input?.isTTY || !this.output?.isTTY || typeof this.input.setRawMode !== 'function') {
+      throw new Error('interactive_terminal_required')
+    }
+  }
+
+  read(prompt, { masked = false } = {}) {
+    this.assertInteractive()
+    this.output.write(prompt)
+    readline.emitKeypressEvents(this.input)
+    const previousRawMode = Boolean(this.input.isRaw)
+    this.input.setRawMode(true)
+    this.input.resume()
+    let value = ''
+
+    return new Promise((resolveValue, reject) => {
+      const finish = (error) => {
+        this.input.off('keypress', onKeypress)
+        this.input.setRawMode(previousRawMode)
+        this.output.write('\n')
+        if (error) reject(error)
+        else resolveValue(value)
+      }
+      const onKeypress = (text, key = {}) => {
+        if (key.ctrl && key.name === 'c') { finish(new Error('activation_cancelled')); return }
+        if (key.name === 'return' || key.name === 'enter') { finish(); return }
+        if (key.name === 'backspace') {
+          if (value) { value = value.slice(0, -1); this.output.write('\b \b') }
+          return
+        }
+        if (key.ctrl || key.meta || !text || /[\r\n]/.test(text)) return
+        if (value.length + text.length > 20_000) return
+        value += text
+        this.output.write(masked ? '*'.repeat([...text].length) : text)
+      }
+      this.input.on('keypress', onKeypress)
+    })
+  }
+
+  async choose(group) {
+    this.output.write(`\n${group.label}:\n`)
+    group.inputNames.forEach((inputName, index) => this.output.write(`  ${index + 1}. ${inputName}\n`))
+    const answer = (await this.read('Choose input [1]: ')).trim()
+    const index = answer ? Number(answer) - 1 : 0
+    if (!Number.isInteger(index) || index < 0 || index >= group.inputNames.length) {
+      throw new Error(`guided_input_choice_invalid:${group.target}`)
+    }
+    return group.inputNames[index]
+  }
+}
+
+export default TerminalPrompt

--- a/kernel/workcell-guided-activation.mjs
+++ b/kernel/workcell-guided-activation.mjs
@@ -1,0 +1,115 @@
+import {
+  applyProvisionPlan,
+  buildProvisionPlan,
+  requiredSecretGroups,
+  validateClientManifest,
+} from './workcell-provision.mjs'
+
+export const GUIDED_BOOTSTRAP_INPUT = 'SUPERMEGA_NEW_CLIENT_SUPABASE_DB_URL'
+
+const INPUT_LABELS = Object.freeze({
+  SUPERMEGA_OPS_KEY: 'Client console passcode',
+  'ANTHROPIC_API_KEY|CLAUDE_API_KEY|OPENROUTER_API_KEY': 'AI provider key',
+  SUPABASE_URL: 'Client Supabase URL',
+  SUPABASE_SERVICE_ROLE_KEY: 'Client Supabase service-role key',
+  TELEGRAM_BOT_TOKEN: 'Client Telegram bot token',
+  TELEGRAM_ALERT_CHAT_ID: 'Owner Telegram chat ID',
+  PAYPAL_CLIENT_ID: 'Client PayPal ID',
+  PAYPAL_CLIENT_SECRET: 'Client PayPal secret',
+  'PIPEDRIVE_ACCESS_TOKEN|PIPEDRIVE_API_TOKEN': 'Client Pipedrive token',
+  'CLICKUP_ACCESS_TOKEN|CLICKUP_API_TOKEN': 'Client ClickUp token',
+})
+
+function inputValue(value, inputName) {
+  if (typeof value !== 'string' || !value.trim()) throw new Error(`guided_input_required:${inputName}`)
+  if (value.length > 20_000 || /[\r\n]/.test(value)) throw new Error(`guided_input_invalid:${inputName}`)
+  return value
+}
+
+function scrubEnvironment(env) {
+  for (const inputName of Object.keys(env)) {
+    env[inputName] = ''
+    delete env[inputName]
+  }
+}
+
+export function guidedInputGroups(manifestInput) {
+  return requiredSecretGroups(validateClientManifest(manifestInput)).map((group) => ({
+    target: group.target,
+    label: INPUT_LABELS[group.target] || group.target,
+    inputNames: group.sources.map((source) => source.name),
+  }))
+}
+
+export async function collectGuidedEnvironment(manifestInput, options = {}) {
+  const groups = guidedInputGroups(manifestInput)
+  if (typeof options.readSecret !== 'function') throw new Error('guided_secret_reader_required')
+  const env = Object.create(null)
+
+  try {
+    for (const group of groups) {
+      let inputName = group.inputNames[0]
+      if (group.inputNames.length > 1) {
+        if (typeof options.chooseInput !== 'function') throw new Error(`guided_input_choice_required:${group.target}`)
+        inputName = await options.chooseInput(group)
+        if (!group.inputNames.includes(inputName)) throw new Error(`guided_input_choice_invalid:${group.target}`)
+      }
+      env[inputName] = inputValue(await options.readSecret({ ...group, inputName }), inputName)
+    }
+
+    const bootstrap = typeof options.confirmBootstrap === 'function'
+      ? await options.confirmBootstrap({ inputName: GUIDED_BOOTSTRAP_INPUT, defaultValue: true })
+      : true
+    if (bootstrap !== true && bootstrap !== false) throw new Error('guided_bootstrap_choice_invalid')
+    if (bootstrap) {
+      env[GUIDED_BOOTSTRAP_INPUT] = inputValue(await options.readSecret({
+        target: 'SUPABASE_DB_URL',
+        label: 'Temporary client database URL for schema bootstrap',
+        inputNames: [GUIDED_BOOTSTRAP_INPUT],
+        inputName: GUIDED_BOOTSTRAP_INPUT,
+        bootstrapOnly: true,
+      }), GUIDED_BOOTSTRAP_INPUT)
+    }
+    return env
+  } catch (error) {
+    scrubEnvironment(env)
+    throw error
+  }
+}
+
+export async function runGuidedActivation(manifestInput, options = {}) {
+  const manifest = validateClientManifest(manifestInput)
+  const env = await collectGuidedEnvironment(manifest, options)
+  try {
+    const plan = buildProvisionPlan(manifest, {
+      scope: options.scope,
+      env,
+      sourceDirectory: options.sourceDirectory,
+      randomBytes: options.randomBytes,
+    })
+    if (plan.missingSecrets.length) throw new Error(`missing_secrets:${plan.missingSecrets.join(',')}`)
+    if (typeof options.onPlan === 'function') await options.onPlan(plan)
+    if (typeof options.readConfirmation !== 'function') throw new Error('guided_confirmation_reader_required')
+    const confirmation = await options.readConfirmation(plan.confirmation)
+    if (confirmation !== plan.confirmation) throw new Error(`confirmation_required:${plan.confirmation}`)
+    const apply = options.apply || applyProvisionPlan
+    return await apply(manifest, {
+      scope: options.scope,
+      env,
+      sourceDirectory: options.sourceDirectory,
+      confirm: confirmation,
+      allowExisting: options.allowExisting,
+      allowDirtySource: options.allowDirtySource,
+      keepTemp: options.keepTemp,
+    })
+  } finally {
+    scrubEnvironment(env)
+  }
+}
+
+export default {
+  GUIDED_BOOTSTRAP_INPUT,
+  guidedInputGroups,
+  collectGuidedEnvironment,
+  runGuidedActivation,
+}

--- a/kernel/workcell-guided-activation.test.mjs
+++ b/kernel/workcell-guided-activation.test.mjs
@@ -1,0 +1,170 @@
+import { readFile } from 'node:fs/promises'
+import { EventEmitter } from 'node:events'
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  GUIDED_BOOTSTRAP_INPUT,
+  collectGuidedEnvironment,
+  guidedInputGroups,
+  runGuidedActivation,
+} from './workcell-guided-activation.mjs'
+import { TerminalPrompt } from './terminal-prompt.mjs'
+
+const MANIFEST = {
+  version: 1,
+  clientSlug: 'guided-owner',
+  clientName: 'Guided Owner',
+  workcells: ['owner-command'],
+  timeZone: 'Asia/Yangon',
+  currency: 'MMK',
+  lookbackHours: 24,
+  clickupListId: '123456789',
+  deliveryUtc: '01:30',
+  tokenCap: 150000,
+}
+
+function valueFor(inputName) {
+  if (inputName === 'SUPERMEGA_NEW_CLIENT_SUPABASE_URL') return 'https://client-project.supabase.co'
+  if (inputName === GUIDED_BOOTSTRAP_INPUT) {
+    return 'postgresql://postgres:bootstrap-password@db.client-project.supabase.co:5432/postgres?sslmode=require'
+  }
+  return `secret-value-for-${inputName}`
+}
+
+class FakeInput extends EventEmitter {
+  constructor() {
+    super()
+    this.isTTY = true
+    this.isRaw = false
+    this.rawModes = []
+  }
+
+  setRawMode(value) {
+    this.isRaw = Boolean(value)
+    this.rawModes.push(this.isRaw)
+  }
+
+  resume() {}
+}
+
+class FakeOutput {
+  constructor() {
+    this.isTTY = true
+    this.chunks = []
+  }
+
+  write(value) {
+    this.chunks.push(String(value))
+  }
+}
+
+test('guided inputs derive only client-scoped names for the selected workcell', () => {
+  const groups = guidedInputGroups(MANIFEST)
+  assert.ok(groups.length >= 8)
+  assert.ok(groups.every((group) => group.inputNames.every((name) => name.startsWith('SUPERMEGA_NEW_CLIENT_'))))
+  assert.ok(groups.some((group) => group.inputNames.includes('SUPERMEGA_NEW_CLIENT_CLICKUP_ACCESS_TOKEN')))
+  assert.ok(groups.some((group) => group.inputNames.includes('SUPERMEGA_NEW_CLIENT_PAYPAL_CLIENT_SECRET')))
+  assert.ok(groups.some((group) => group.inputNames.includes('SUPERMEGA_NEW_CLIENT_PIPEDRIVE_ACCESS_TOKEN')))
+})
+
+test('guided collector chooses one alias per group and keeps bootstrap separate', async () => {
+  const requested = []
+  const env = await collectGuidedEnvironment(MANIFEST, {
+    chooseInput: async (group) => group.inputNames.at(-1),
+    readSecret: async ({ inputName }) => { requested.push(inputName); return valueFor(inputName) },
+    confirmBootstrap: async () => true,
+  })
+  assert.equal(Object.getPrototypeOf(env), null)
+  assert.equal(env.SUPERMEGA_NEW_CLIENT_OPENROUTER_API_KEY, valueFor('SUPERMEGA_NEW_CLIENT_OPENROUTER_API_KEY'))
+  assert.equal(env.SUPERMEGA_NEW_CLIENT_ANTHROPIC_API_KEY, undefined)
+  assert.equal(env[GUIDED_BOOTSTRAP_INPUT], valueFor(GUIDED_BOOTSTRAP_INPUT))
+  assert.equal(requested.at(-1), GUIDED_BOOTSTRAP_INPUT)
+  assert.ok(Object.keys(env).every((name) => name.startsWith('SUPERMEGA_NEW_CLIENT_')))
+})
+
+test('guided activation prints a value-free plan, requires exact confirmation, and scrubs inputs', async () => {
+  const secretValues = []
+  let planOutput = ''
+  let applyCalls = 0
+  let appliedEnvironment
+  const result = await runGuidedActivation(MANIFEST, {
+    scope: 'test-team',
+    sourceDirectory: 'C:\\clean-kernel',
+    chooseInput: async (group) => group.inputNames[0],
+    readSecret: async ({ inputName }) => {
+      const value = valueFor(inputName)
+      secretValues.push(value)
+      return value
+    },
+    confirmBootstrap: async () => true,
+    onPlan: async (plan) => { planOutput = JSON.stringify(plan) },
+    readConfirmation: async (confirmation) => confirmation,
+    apply: async (_manifest, options) => {
+      applyCalls += 1
+      appliedEnvironment = options.env
+      assert.equal(options.confirm, 'PROVISION supermega-wc-guided-owner')
+      assert.equal(options.env.SUPERMEGA_NEW_CLIENT_SUPABASE_URL, 'https://client-project.supabase.co')
+      return { ok: true, projectName: 'supermega-wc-guided-owner' }
+    },
+  })
+  assert.equal(result.ok, true)
+  assert.equal(applyCalls, 1)
+  for (const value of secretValues) assert.equal(planOutput.includes(value), false)
+  assert.deepEqual(Object.keys(appliedEnvironment), [])
+})
+
+test('guided activation stops before apply on wrong confirmation', async () => {
+  let applyCalls = 0
+  await assert.rejects(
+    runGuidedActivation(MANIFEST, {
+      scope: 'test-team',
+      chooseInput: async (group) => group.inputNames[0],
+      readSecret: async ({ inputName }) => valueFor(inputName),
+      confirmBootstrap: async () => true,
+      readConfirmation: async () => 'PROVISION wrong-project',
+      apply: async () => { applyCalls += 1 },
+    }),
+    /confirmation_required:PROVISION supermega-wc-guided-owner/,
+  )
+  assert.equal(applyCalls, 0)
+})
+
+test('terminal prompt masks values, supports correction, and restores raw mode', async () => {
+  const input = new FakeInput()
+  const output = new FakeOutput()
+  const prompt = new TerminalPrompt(input, output)
+  const reading = prompt.read('Masked input: ', { masked: true })
+  input.emit('keypress', 'x', {})
+  input.emit('keypress', 'y', {})
+  input.emit('keypress', '', { name: 'backspace' })
+  input.emit('keypress', 'z', {})
+  input.emit('keypress', '\r', { name: 'return' })
+  assert.equal(await reading, 'xz')
+  const transcript = output.chunks.join('')
+  assert.equal(transcript.includes('xz'), false)
+  assert.match(transcript, /\*\*\x08 \x08\*/)
+  assert.deepEqual(input.rawModes, [true, false])
+  assert.equal(input.listenerCount('keypress'), 0)
+})
+
+test('terminal prompt cancels without leaving raw mode enabled', async () => {
+  const input = new FakeInput()
+  const output = new FakeOutput()
+  const prompt = new TerminalPrompt(input, output)
+  const reading = prompt.read('Masked input: ', { masked: true })
+  input.emit('keypress', '', { name: 'c', ctrl: true })
+  await assert.rejects(reading, /activation_cancelled/)
+  assert.equal(input.isRaw, false)
+  assert.equal(input.listenerCount('keypress'), 0)
+})
+
+test('guided CLI masks client values and never exports them to process environment or arguments', async () => {
+  const source = await readFile(new URL('./scripts/activate-workcell-client.mjs', import.meta.url), 'utf8')
+  const terminalSource = await readFile(new URL('./terminal-prompt.mjs', import.meta.url), 'utf8')
+  assert.match(source, /\{ masked: true \}/)
+  assert.match(source, /remain in memory only/)
+  assert.match(terminalSource, /interactive_terminal_required/)
+  assert.match(terminalSource, /masked \? '\*'\.repeat/)
+  assert.doesNotMatch(source, /process\.env\[[^\]]*SUPERMEGA_NEW_CLIENT|process\.env\s*=|writeFile|appendFile|--token|--secret/)
+})

--- a/kernel/workcell-ui-contract.test.mjs
+++ b/kernel/workcell-ui-contract.test.mjs
@@ -45,6 +45,10 @@ test('console builds a canonical client activation plan without collecting crede
   assert.match(html, /Enter the ops passcode to load live workcell status\./)
   assert.match(html, /if\(activeView==='workcells'\)/)
   assert.match(html, /activationPlan\.requiredSecretInputs/)
+  assert.match(html, /id="activationGuidedCommand"/)
+  assert.match(html, /id="activationCopyGuided"/)
+  assert.match(html, /npm run workcell:activate -- --manifest/)
+  assert.match(html, /copyActivationText\(activationGuidedCommand,'Guided command copied'\)/)
   assert.match(html, /\.activation-fields input,\.activation-fields select\{min-height:44px\}/)
   assert.match(html, /@media\(max-width:520px\)/)
   const panel = html.match(/<div class="activation" id="activationPanel"[\s\S]*?<div id="workcellGrid"/)?.[0] || ''

--- a/kernel/workcells/README.md
+++ b/kernel/workcells/README.md
@@ -112,6 +112,19 @@ environment:
 npm run workcell:provision -- --apply --manifest <client.json> --scope <vercel-team> --confirm "PROVISION <project-name>"
 ```
 
+For the normal first-client path, use the guided command instead of manually exporting those inputs:
+
+```text
+npm run workcell:activate -- --manifest <client.json> --scope <vercel-team>
+```
+
+It requires an interactive terminal, masks every client value, stores nothing on disk or in
+`process.env`, prints the same value-free plan, and asks for the exact project confirmation before
+calling the provisioner. Schema bootstrap is offered by default; its database URL remains
+bootstrap-only and is scrubbed with the other inputs when the command exits. The low-level
+`workcell:provision` command remains the auditable non-interactive path for controlled CI or
+preloaded secure environments.
+
 Apply refuses dirty source and an existing project by default. `--allow-existing` is the explicit
 upgrade path. Before touching Vercel, it validates/applies the optional bootstrap transaction,
 checks the full shape of all four tables, inserts the same delivery claim twice to prove duplicate


### PR DESCRIPTION
## Product change
- adds `npm run workcell:activate` as the normal first-client onboarding path
- prompts for only the selected Workcell's client-scoped inputs
- masks every value and keeps it out of files, process environment, arguments, and printed plans
- offers one-command client schema bootstrap, then requires the exact project confirmation
- reuses the existing fail-closed provision/deploy/live-verification path
- exposes and copies the guided command from the Workcells activation panel

## Verification
- 131 kernel tests passed
- 69 connectors / 973 adversarial calls / 0 violations
- 5 crews / 74 checks / 0 violations
- masked terminal behavior, cancellation, raw-mode restoration, value-free plan, exact confirmation, and environment scrubbing are tested
- Edge 390x844: guided command rendered/copied, controls >=44px, zero overflow, zero credential fields, zero console errors

No client, provider, schema, project, payment, or revenue mutation was performed.