### PR TITLE
Site: make inbound leads reach the sales console

### DIFF
--- a/.github/workflows/supermega-deploy.yml
+++ b/.github/workflows/supermega-deploy.yml
@@ -1,22 +1,27 @@
-name: SuperMega Platform — Build & Deploy
+name: SuperMega Public - Build and Deploy
 
-# Autonomous deploy pipeline for supermega-platform (supermega.dev).
-# Triggers on push to main or the console/kernel-fixes branch.
-# Requires VERCEL_TOKEN secret in GitHub repo settings.
-# Set via: Settings → Secrets and variables → Actions → New repository secret
-#   VERCEL_TOKEN  — from vercel.com/account/tokens (scope: full account)
+# The live public site is released from the canonical public branch, not main.
+# Project IDs are non-secret and lock prebuilt deploys to supermega-public.
 on:
   push:
     branches:
-      - main
-      - 'console/**'
+      - codex/public-enterprise-site
   workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: supermega-public-production
+  cancel-in-progress: false
 
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
-    # Only auto-deploy main; feature branches build + verify but don't promote to prod
-    environment: ${{ github.ref == 'refs/heads/main' && 'production' || 'preview' }}
+    environment: production
+    env:
+      VERCEL_ORG_ID: team_wI4l7ZgSxcEztQPSlCCYVeJ5
+      VERCEL_PROJECT_ID: prj_Yaf0cZYbiFXcLkMcKaAm4alPWMhR
 
     steps:
       - name: Checkout
@@ -28,17 +33,12 @@ jobs:
           node-version: 22
 
       - name: Build public output
-        working-directory: .
-        run: node tools/create_public_vercel_output.mjs
+        run: npm run public:build
 
-      - name: Verify build gate
-        working-directory: .
-        run: node tools/verify_public_vercel_output.mjs
+      - name: Verify full public gate
+        run: npm run public:verify
 
-      - name: Deploy to Vercel (production)
-        if: github.ref == 'refs/heads/main'
-        run: npx vercel deploy --prebuilt --prod --yes --token=${{ secrets.VERCEL_TOKEN }}
-
-      - name: Deploy to Vercel (preview)
-        if: github.ref != 'refs/heads/main'
-        run: npx vercel deploy --prebuilt --yes --token=${{ secrets.VERCEL_TOKEN }}
+      - name: Deploy canonical public production
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: npx vercel deploy --prebuilt --prod --yes --token="$VERCEL_TOKEN"

--- a/api/contact-submissions.js
+++ b/api/contact-submissions.js
@@ -1981,6 +1981,98 @@ async function postLeadWebhook({ record }) {
   }
 }
 
+function opsIntakeTarget() {
+  return envText('SUPERMEGA_OPS_INTAKE_URL') || 'https://supermega-machine.vercel.app/api/intake'
+}
+
+function isSafeOpsIntakeUrl(value) {
+  try {
+    const url = new URL(value)
+    return (
+      url.protocol === 'https:' &&
+      url.hostname === 'supermega-machine.vercel.app' &&
+      url.pathname === '/api/intake' &&
+      !url.search &&
+      !url.hash
+    )
+  } catch {
+    return false
+  }
+}
+
+function opsIntakeStatus() {
+  const target = opsIntakeTarget()
+  const configured = Boolean(envText('SUPERMEGA_INTAKE_SECRET'))
+  return {
+    status: configured && isSafeOpsIntakeUrl(target) ? 'ready' : 'needs_configuration',
+    target,
+    contract: 'body_secret',
+  }
+}
+
+async function forwardOpsIntake({ record }) {
+  const intakeSecret = envText('SUPERMEGA_INTAKE_SECRET')
+  if (!intakeSecret) return { status: 'skipped', reason: 'ops_intake_not_configured' }
+
+  const target = opsIntakeTarget()
+  if (!isSafeOpsIntakeUrl(target)) {
+    return { status: 'skipped', reason: 'unsafe_ops_intake_url' }
+  }
+
+  const workflow = truncate([
+    record.template_id ? `Template: ${record.template_id}` : '',
+    record.starter_kit_url ? `Starter kit: ${record.starter_kit_url}` : '',
+    record.requested_package ? `Package: ${record.requested_package}` : '',
+    record.first_proof_target ? `First proof: ${record.first_proof_target}` : '',
+    record.price_hint ? `Price hint: ${record.price_hint}` : '',
+    record.entitlement_free_core ? `Free core entitlement: ${record.entitlement_free_core}` : '',
+    record.entitlement_paid_pilot ? `Paid pilot entitlement: ${record.entitlement_paid_pilot}` : '',
+    record.entitlement_premium ? `Premium maintained entitlement: ${record.entitlement_premium}` : '',
+    record.entitlement_gated_hands ? `Gated hands entitlement: ${record.entitlement_gated_hands}` : '',
+    record.entitlement_gate ? `Entitlement gate: ${record.entitlement_gate}` : '',
+    record.goal || '',
+    record.data || '',
+  ].filter(Boolean).join('\n'), 2400)
+
+  try {
+    const response = await fetch(target, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        Authorization: `Bearer ${intakeSecret}`,
+      },
+      signal: AbortSignal.timeout(8000),
+      body: JSON.stringify({
+        secret: intakeSecret,
+        source: 'website',
+        external_id: record.lead_id,
+        name: record.name,
+        email: record.email,
+        phone: record.phone,
+        company: record.company,
+        business_type: record.template_source_category || record.product_area || record.requested_package || 'inbound',
+        template_id: record.template_id,
+        starter_kit_url: record.starter_kit_url,
+        price_hint: record.price_hint,
+        workflow,
+      }),
+    })
+    const body = await response.json().catch(() => ({}))
+    if (!response.ok || body.ok === false) {
+      return { status: 'error', reason: `ops_intake_${response.status}`, target }
+    }
+    return {
+      status: 'ready',
+      target,
+      lead_id: text(body.lead_id) || null,
+      duplicate: body.duplicate === true,
+      fit_score: Number.isFinite(Number(body.fit_score)) ? Number(body.fit_score) : null,
+    }
+  } catch (error) {
+    return { status: 'error', reason: text(error?.message) || 'ops_intake_failed', target }
+  }
+}
+
 // Build the concise CEO lead-alert text, then push it via the shared Telegram helper.
 // Best-effort: the helper never throws and skips cleanly when TELEGRAM_* isn't configured.
 function telegramLeadMessage(record) {
@@ -2084,6 +2176,7 @@ async function handler(req, res) {
         pipeline_actions: pipelineActionStatus(),
         pipeline_actions_table: 'supermega_pipeline_actions',
         deskpos_pipeline: deskposPipelineStatus(),
+        ops_intake: opsIntakeStatus(),
         primary_datastore: datastore.datastoreStatus(),
         fallback_queue: fallbackQueueStatus(),
         management_mode: databaseConfigured() ? 'database_queue' : 'email_fallback',
@@ -2158,9 +2251,10 @@ async function handler(req, res) {
   const firstProofTask = buildFirstProofTaskPayload(record)
   const ledger = await saveLeadLedger({ record })
   const pipelineAction = await savePipelineAction({ record })
-  const [webhook, deskposPipeline] = await Promise.all([
+  const [webhook, deskposPipeline, opsIntake] = await Promise.all([
     postLeadWebhook({ record }),
     forwardDeskposPipeline({ record }),
+    forwardOpsIntake({ record }),
   ])
   const [delivery, confirmation, telegram, sheets] = await Promise.all([
     sendEmail({ record }),
@@ -2168,50 +2262,6 @@ async function handler(req, res) {
     notifyTelegram({ record }),
     appendToGoogleSheet({ record }),
   ])
-
-  // Forward to the Ops pipeline so the lead appears in the machine console
-  // Fire-and-forget: doesn't block or affect the response
-  ;(async () => {
-    const intakeSecret = text(process.env.SUPERMEGA_INTAKE_SECRET)
-    const intakeUrl = text(process.env.SUPERMEGA_OPS_INTAKE_URL) || 'https://supermega-machine.vercel.app/api/intake'
-    if (!intakeSecret) return
-    if (intakeUrl && !intakeUrl.startsWith('https://supermega-machine.vercel.app')) return
-    try {
-      await fetch(intakeUrl, {
-        method: 'POST',
-        headers: { 'content-type': 'application/json', 'Authorization': `Bearer ${intakeSecret}` },
-        signal: AbortSignal.timeout(5000),
-        body: JSON.stringify({
-          source: 'website',
-          external_id: record.lead_id,
-          name: record.name,
-          email: record.email,
-          phone: record.phone,
-          company: record.company,
-          business_type: record.template_source_category || record.product_area || record.requested_package || 'inbound',
-          template_id: record.template_id,
-          starter_kit_url: record.starter_kit_url,
-          price_hint: record.price_hint,
-          workflow: truncate([
-            record.template_id ? `Template: ${record.template_id}` : '',
-            record.starter_kit_url ? `Starter kit: ${record.starter_kit_url}` : '',
-            record.requested_package ? `Package: ${record.requested_package}` : '',
-            record.first_proof_target ? `First proof: ${record.first_proof_target}` : '',
-            record.price_hint ? `Price hint: ${record.price_hint}` : '',
-            record.entitlement_free_core ? `Free core entitlement: ${record.entitlement_free_core}` : '',
-            record.entitlement_paid_pilot ? `Paid pilot entitlement: ${record.entitlement_paid_pilot}` : '',
-            record.entitlement_premium ? `Premium maintained entitlement: ${record.entitlement_premium}` : '',
-            record.entitlement_gated_hands ? `Gated hands entitlement: ${record.entitlement_gated_hands}` : '',
-            record.entitlement_gate ? `Entitlement gate: ${record.entitlement_gate}` : '',
-            record.goal || goal || '',
-            record.data || '',
-          ].filter(Boolean).join('\n'), 2400),
-        }),
-      })
-    } catch (err) {
-      console.error('[contact-submissions] ops_intake_failed', err && err.message)
-    }
-  })().catch(() => {})
 
   // Email is a notification layer — only fail hard if the lead was not saved anywhere
   const leadSaved = ledger.status === 'ready' || pipelineAction.status === 'ready'
@@ -2270,6 +2320,7 @@ async function handler(req, res) {
     ledger,
     pipeline_action: pipelineAction,
     deskpos_pipeline: deskposPipeline,
+    ops_intake: opsIntake,
     webhook,
     confirmation,
     telegram,
@@ -2285,6 +2336,7 @@ async function handler(req, res) {
           : 'email_fallback',
       datastore: pipelineAction.adapter || ledger.adapter || 'email_fallback',
       deskpos: deskposPipeline,
+      ops_intake: opsIntake,
       workspace_id: 'public-site',
       lead_id: leadId,
       task_id: taskId,
@@ -2312,6 +2364,9 @@ handler.__test = {
   pipelineActionPayload,
   telegramLeadMessage,
   operatorConsoleUrl,
+  forwardOpsIntake,
+  isSafeOpsIntakeUrl,
+  opsIntakeStatus,
 }
 
 module.exports = handler

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "vercel:deploy": "npx vercel deploy --prebuilt -y",
     "vercel:deploy:prod": "npx vercel deploy --prebuilt --prod -y",
     "public:build": "node tools/create_public_vercel_output.mjs",
-    "public:verify": "node tools/verify_public_vercel_artifact_budget.mjs && node tools/verify_public_vercel_output.mjs && node tools/test_connector_resilience.mjs",
+    "public:verify": "node tools/verify_public_vercel_artifact_budget.mjs && node tools/verify_public_vercel_output.mjs && node tools/verify_contact_ops_intake_handoff.mjs && node tools/test_connector_resilience.mjs",
     "_public:verify:RETIRED": "source-to-screen/workcell/intake/contact-order + operator-retainer contracts retired 2026-07-09 — they enforced the discontinued 'source-to-screen / AI Workcell' model the founder removed. Kept only artifact-budget + vercel-output structural checks.",
     "deploy:public:prod": "node tools/create_public_vercel_output.mjs && npm run public:verify && npx vercel deploy --prebuilt --prod -y",
     "kernel:verify": "npm --prefix kernel run verify",

--- a/tools/verify_contact_ops_intake_handoff.mjs
+++ b/tools/verify_contact_ops_intake_handoff.mjs
@@ -1,0 +1,85 @@
+import assert from 'node:assert/strict'
+import { createRequire } from 'node:module'
+
+const require = createRequire(import.meta.url)
+const handler = require('../api/contact-submissions.js')
+const { forwardOpsIntake, isSafeOpsIntakeUrl, opsIntakeStatus } = handler.__test
+
+assert.equal(typeof forwardOpsIntake, 'function')
+assert.equal(isSafeOpsIntakeUrl('https://supermega-machine.vercel.app/api/intake'), true)
+assert.equal(isSafeOpsIntakeUrl('https://supermega-machine.vercel.app.evil.example/api/intake'), false)
+assert.equal(isSafeOpsIntakeUrl('https://supermega-machine.vercel.app/api/intake?redirect=1'), false)
+
+const originalFetch = globalThis.fetch
+const originalSecret = process.env.SUPERMEGA_INTAKE_SECRET
+const originalUrl = process.env.SUPERMEGA_OPS_INTAKE_URL
+const calls = []
+const secret = 'contract-test-secret'
+
+try {
+  process.env.SUPERMEGA_INTAKE_SECRET = secret
+  delete process.env.SUPERMEGA_OPS_INTAKE_URL
+  globalThis.fetch = async (url, options) => {
+    calls.push({ url, options })
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({ ok: true, lead_id: 'OPS-LEAD-1', fit_score: 84 }),
+    }
+  }
+
+  assert.deepEqual(opsIntakeStatus(), {
+    status: 'ready',
+    target: 'https://supermega-machine.vercel.app/api/intake',
+    contract: 'body_secret',
+  })
+
+  const result = await forwardOpsIntake({
+    record: {
+      lead_id: 'LEAD-PUBLIC-1',
+      name: 'Test Buyer',
+      email: 'buyer@example.com',
+      phone: '+959000000000',
+      company: 'Example Co',
+      requested_package: 'General enquiry',
+      product_area: 'Operations',
+      goal: 'Replace a manual daily reconciliation task.',
+    },
+  })
+
+  assert.equal(calls.length, 1)
+  assert.equal(calls[0].url, 'https://supermega-machine.vercel.app/api/intake')
+  assert.equal(calls[0].options.method, 'POST')
+  assert.equal(calls[0].options.headers.Authorization, `Bearer ${secret}`)
+  const payload = JSON.parse(calls[0].options.body)
+  assert.equal(payload.secret, secret)
+  assert.equal(payload.external_id, 'LEAD-PUBLIC-1')
+  assert.equal(payload.source, 'website')
+  assert.match(payload.workflow, /manual daily reconciliation/i)
+  assert.deepEqual(result, {
+    status: 'ready',
+    target: 'https://supermega-machine.vercel.app/api/intake',
+    lead_id: 'OPS-LEAD-1',
+    duplicate: false,
+    fit_score: 84,
+  })
+  assert.equal(JSON.stringify(result).includes(secret), false)
+
+  process.env.SUPERMEGA_OPS_INTAKE_URL = 'https://supermega-machine.vercel.app.evil.example/api/intake'
+  const unsafe = await forwardOpsIntake({ record: {} })
+  assert.deepEqual(unsafe, { status: 'skipped', reason: 'unsafe_ops_intake_url' })
+  assert.equal(calls.length, 1)
+
+  delete process.env.SUPERMEGA_INTAKE_SECRET
+  delete process.env.SUPERMEGA_OPS_INTAKE_URL
+  const missing = await forwardOpsIntake({ record: {} })
+  assert.deepEqual(missing, { status: 'skipped', reason: 'ops_intake_not_configured' })
+} finally {
+  globalThis.fetch = originalFetch
+  if (originalSecret === undefined) delete process.env.SUPERMEGA_INTAKE_SECRET
+  else process.env.SUPERMEGA_INTAKE_SECRET = originalSecret
+  if (originalUrl === undefined) delete process.env.SUPERMEGA_OPS_INTAKE_URL
+  else process.env.SUPERMEGA_OPS_INTAKE_URL = originalUrl
+}
+
+console.log('contact_ops_intake_handoff=ready')


### PR DESCRIPTION
## What changed
- align the public contact bridge with the active Ops intake contract (`body.secret`)
- await and report the bounded Ops handoff instead of dropping a fire-and-forget request
- lock the intake URL to the exact production host/path and keep secret material out of results
- add a deterministic no-network contract test to `public:verify`
- move public auto-deploy ownership from `main` to `codex/public-enterprise-site` and pin the `supermega-public` Vercel project

## Verification
- `npm run public:build`
- `npm run public:verify`
- 28 files / 0.25 MB
- 3 public functions
- 66 connectors / 923 adversarial calls / 0 violations

No test lead, customer record, payment, provider write, or live intake submission was created.