### PR TITLE
CI: self-test the public health monitor

### DIFF
--- a/.github/workflows/supermega-public-live-health.yml
+++ b/.github/workflows/supermega-public-live-health.yml
@@ -3,6 +3,12 @@ name: SuperMega Public Live Health
 # Default-branch, read-only production monitor. The public release itself is
 # owned by codex/public-enterprise-site; this workflow only checks live truth.
 on:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/supermega-public-live-health.yml
+      - tools/check_public_live_health.py
   workflow_dispatch:
   schedule:
     # 08:15 Asia/Rangoon daily.


### PR DESCRIPTION
Run the read-only public health workflow when its own checker or workflow changes on `main`, in addition to the daily schedule and manual dispatch. This makes the merged workflow prove its real GitHub runner path without broadening execution to unrelated kernel commits.

Local 9/9 live checks passed. No form submission or external write was performed.