### PR TITLE
CI: move public health actions to Node 24

### DIFF
--- a/.github/workflows/supermega-public-live-health.yml
+++ b/.github/workflows/supermega-public-live-health.yml
@@ -27,10 +27,10 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 


### PR DESCRIPTION
Update the read-only public health workflow to official `actions/checkout@v5` and `actions/setup-python@v6`, whose current tags use the supported Node 24 runner. The checker still passes 9/9 live checks locally and the path-scoped push trigger will self-test this change after merge.