### PR TITLE
site: remove retired contact catalog fields

### DIFF
--- a/tools/create_public_vercel_output.mjs
+++ b/tools/create_public_vercel_output.mjs
@@ -316,10 +316,6 @@ const contactHtml = documentHtml({
     </div>
   </section>
   <form class="contact-form" action="/api/contact-submissions" data-sm-contact-form method="post">
-    <input type="hidden" name="workflow" value="General enquiry" />
-    <input type="hidden" name="first_output" value="General enquiry" />
-    <input type="hidden" name="requested_package" value="General enquiry" />
-    <input type="hidden" name="product_area" value="General enquiry" />
     <input type="hidden" name="source_url" value="https://supermega.dev/contact/" />
     <input type="hidden" name="page_path" value="/contact/" />
     <input type="hidden" name="referrer" value="" />

--- a/tools/verify_public_vercel_output.mjs
+++ b/tools/verify_public_vercel_output.mjs
@@ -91,7 +91,18 @@ for (const required of [
 for (const required of ['action="/api/contact-submissions"', 'name="name"', 'name="email"', 'name="company"', 'name="goal"', 'No account or data connection is made before you approve it.']) {
   if (!contact.includes(required)) fail('contact_surface_contract_missing', { required })
 }
-for (const forbidden of ['placeholder="Drive folder', 'placeholder="Example:', 'Upload files', 'Source link or system', 'custom AI worker']) {
+for (const forbidden of [
+  'placeholder="Drive folder',
+  'placeholder="Example:',
+  'Upload files',
+  'Source link or system',
+  'custom AI worker',
+  'name="workflow"',
+  'name="first_output"',
+  'name="requested_package"',
+  'name="product_area"',
+  'General enquiry',
+]) {
   if (contact.includes(forbidden)) fail('contact_surface_keeps_retired_intake', { forbidden })
 }
 


### PR DESCRIPTION
Completes the public-front-door simplification by removing the four hidden catalog-shaped contact fields (`workflow`, `first_output`, `requested_package`, and `product_area`). The public form now sends only buyer-entered identity/context plus neutral source and UTM attribution.

The existing handler keeps its safe generic defaults and continues to derive routing from the buyer's actual note; no Ops endpoint, pricing, or Claude-owned demo/factory file changes are included.

Validation: clean dependency install, `npm run public:build`, `npm run public:verify` (29 files / 0.29 MB; 66 connectors / 923 adversarial calls / 0 violations), static generated-form absence check, and syntax checks.