### PR TITLE
CI: keep public health checkout read only

### DIFF
--- a/.github/workflows/supermega-public-live-health.yml
+++ b/.github/workflows/supermega-public-live-health.yml
@@ -28,6 +28,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - name: Setup Python
         uses: actions/setup-python@v6


### PR DESCRIPTION
Set `persist-credentials: false` on the read-only health workflow. It does not need repository writes, and this avoids checkout's auth-cleanup traversal of the repository's old unregistered gitlink. Local 9/9 live checks still pass; the path-scoped trigger will self-test after merge.