### PR TITLE
CI: run public health without repository checkout

### DIFF
--- a/.github/workflows/supermega-public-live-health.yml
+++ b/.github/workflows/supermega-public-live-health.yml
@@ -26,15 +26,18 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Checkout
-        uses: actions/checkout@v5
-        with:
-          persist-credentials: false
-
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 
+      - name: Fetch checker from the triggering commit
+        run: |
+          curl --fail --silent --show-error --location \
+            --proto '=https' --proto-redir '=https' \
+            --retry 3 --retry-all-errors \
+            "https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/${GITHUB_SHA}/tools/check_public_live_health.py" \
+            --output "${RUNNER_TEMP}/check_public_live_health.py"
+
       - name: Check current public funnel
-        run: python tools/check_public_live_health.py
+        run: python "${RUNNER_TEMP}/check_public_live_health.py"


### PR DESCRIPTION
Fix the failed #16 self-test caused by this repository's old unregistered gitlink. The read-only monitor no longer checks out the repository; it downloads `tools/check_public_live_health.py` from the exact immutable `GITHUB_SHA` over HTTPS into runner temp and executes it with Python 3.12.

The exact raw-commit download path and all 9 live checks passed locally. No credential, form submission, or external write is involved.