### PR TITLE
Monitor the current Shop, Plant, and agent portfolio

### DIFF
--- a/.github/workflows/supermega-public-live-health.yml
+++ b/.github/workflows/supermega-public-live-health.yml
@@ -9,6 +9,7 @@ on:
     paths:
       - .github/workflows/supermega-public-live-health.yml
       - tools/check_public_live_health.py
+      - tools/test_public_live_health.py
   workflow_dispatch:
   schedule:
     # 08:15 Asia/Rangoon daily.
@@ -39,5 +40,15 @@ jobs:
             "https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/${GITHUB_SHA}/tools/check_public_live_health.py" \
             --output "${RUNNER_TEMP}/check_public_live_health.py"
 
-      - name: Check current public funnel
+          curl --fail --silent --show-error --location \
+            --proto '=https' --proto-redir '=https' \
+            --retry 3 --retry-all-errors \
+            "https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/${GITHUB_SHA}/tools/test_public_live_health.py" \
+            --output "${RUNNER_TEMP}/test_public_live_health.py"
+
+      - name: Test portfolio health checker
+        working-directory: ${{ runner.temp }}
+        run: python -m unittest -v test_public_live_health.py
+
+      - name: Check current public portfolio
         run: python "${RUNNER_TEMP}/check_public_live_health.py"

--- a/tools/check_public_live_health.py
+++ b/tools/check_public_live_health.py
@@ -14,7 +14,7 @@ from typing import Any
 from urllib.parse import urljoin
 
 
-USER_AGENT = "supermega-public-live-health/2.0"
+USER_AGENT = "supermega-portfolio-live-health/3.0"
 
 
 class NoRedirect(urllib.request.HTTPRedirectHandler):
@@ -76,36 +76,70 @@ def nested_value(payload: dict[str, Any], path: str) -> Any:
     return value
 
 
-def run(base_url: str, www_url: str, *, timeout: float, attempts: int) -> dict[str, Any]:
+def run(base_url: str, www_url: str, app_url: str, *, timeout: float, attempts: int) -> dict[str, Any]:
     base_url = base_url.rstrip("/") + "/"
     www_url = www_url.rstrip("/") + "/"
+    app_url = app_url.rstrip("/") + "/"
     failures: list[dict[str, Any]] = []
     results: list[dict[str, Any]] = []
 
     page_checks = [
-        (base_url, ["<title>SuperMega | Open Shop or try a demo</title>", "Open Shop", "Try demo", "Contact"]),
-        (www_url, ["<title>SuperMega | Open Shop or try a demo</title>", "Open Shop", "Try demo", "Contact"]),
+        (
+            base_url,
+            [
+                "<title>supermega.dev | Shop, Plant and AI Agent Solutions</title>",
+                '<h1 id="portfolio-heading">Shop. Plant. AI Agent Solutions.</h1>',
+                "https://app.supermega.dev/?demo=shop",
+                "https://app.supermega.dev/?demo=plant",
+                "/contact/?from=ai-agent-solution",
+                "external actions approval-gated",
+                "data-public-status",
+            ],
+        ),
+        (
+            www_url,
+            [
+                "<title>supermega.dev | Shop, Plant and AI Agent Solutions</title>",
+                '<h1 id="portfolio-heading">Shop. Plant. AI Agent Solutions.</h1>',
+                "https://app.supermega.dev/?demo=shop",
+                "https://app.supermega.dev/?demo=plant",
+                "/contact/?from=ai-agent-solution",
+                "external actions approval-gated",
+                "data-public-status",
+            ],
+        ),
         (
             urljoin(base_url, "contact/"),
             [
-                "Tell us what needs to work better.",
+                "<title>Contact | supermega.dev</title>",
+                "What needs to work better?",
                 'action="/api/contact-submissions"',
                 'name="name"',
                 'name="email"',
                 'name="company"',
                 'name="goal"',
+                "No account or data connection is made before you approve it.",
             ],
         ),
-        (urljoin(base_url, "privacy/"), ["<title>Privacy | SuperMega</title>", "Only the details needed to reply."]),
+        (urljoin(base_url, "privacy/"), ["<title>Privacy | supermega.dev</title>", "Only the details needed to reply."]),
     ]
 
     for url, tokens in page_checks:
         response = fetch(url, timeout=timeout, attempts=attempts)
         body = response.body.decode("utf-8", errors="replace")
         missing = [token for token in tokens if token not in body]
-        result = {"kind": "page", "url": url, "status": response.status, "bytes": len(response.body), "missing": missing}
+        forbidden = ["MegaOS", "DeskPOS", ">Studio<", "Try demo", "https://demo.supermega.dev/"] if url in (base_url, www_url) else []
+        unexpected = [token for token in forbidden if token in body]
+        result = {
+            "kind": "page",
+            "url": url,
+            "status": response.status,
+            "bytes": len(response.body),
+            "missing": missing,
+            "unexpected": unexpected,
+        }
         results.append(result)
-        if response.status != 200 or len(response.body) < 1000 or missing:
+        if response.status != 200 or len(response.body) < 1000 or missing or unexpected:
             failures.append(result)
 
     for path in ("products/", "pricing/", "ai-agents/", "offers/"):
@@ -134,8 +168,6 @@ def run(base_url: str, www_url: str, *, timeout: float, attempts: int) -> dict[s
         "ops_intake.status": "ready",
         "ops_intake.target": "https://supermega-machine.vercel.app/api/intake",
         "ops_intake.contract": "body_secret",
-        "deskpos_pipeline.status": "ready",
-        "deskpos_pipeline.target": "https://pos.supermega.dev/api/pipeline-leads",
     }
     mismatches = {
         path: {"expected": expected, "actual": nested_value(status_payload, path)}
@@ -152,6 +184,61 @@ def run(base_url: str, www_url: str, *, timeout: float, attempts: int) -> dict[s
     if status_response.status != 200 or mismatches:
         failures.append(api_result)
 
+    for route in ("home", "factory"):
+        url = urljoin(app_url, route)
+        response = fetch(url, timeout=timeout, attempts=attempts)
+        body = response.body.decode("utf-8", errors="replace")
+        missing = [token for token in ['<title>Shop - SuperMega</title>', '<div id="root"></div>', 'type="module"'] if token not in body]
+        result = {
+            "kind": "app_route",
+            "route": route,
+            "url": url,
+            "status": response.status,
+            "bytes": len(response.body),
+            "missing": missing,
+        }
+        results.append(result)
+        if response.status != 200 or len(response.body) < 1000 or missing:
+            failures.append(result)
+
+    app_health_url = urljoin(app_url, "api/health")
+    app_health_response = fetch(app_health_url, timeout=timeout, attempts=attempts)
+    try:
+        app_health_payload = json.loads(app_health_response.body.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        app_health_payload = {}
+
+    expected_app_health = {
+        "ok": True,
+        "status": "ready",
+        "service": "supermega-product-app",
+        "contractVersion": 1,
+        "portfolio.products": ["shop", "plant"],
+        "portfolio.demos.shop.entry": "/?demo=shop",
+        "portfolio.demos.shop.route": "/home",
+        "portfolio.demos.plant.entry": "/?demo=plant",
+        "portfolio.demos.plant.route": "/factory",
+        "portfolio.agentSolutions.intake": "https://supermega.dev/contact/?from=ai-agent-solution",
+        "portfolio.agentSolutions.externalActions": "approval-gated",
+        "proof.workingDemos": True,
+        "proof.productionCloudDurability": "not-asserted",
+        "proof.realCustomerAcceptance": "not-asserted",
+    }
+    app_health_mismatches = {
+        path: {"expected": expected, "actual": nested_value(app_health_payload, path)}
+        for path, expected in expected_app_health.items()
+        if nested_value(app_health_payload, path) != expected
+    }
+    app_health_result = {
+        "kind": "app_health",
+        "url": app_health_url,
+        "status": app_health_response.status,
+        "mismatches": app_health_mismatches,
+    }
+    results.append(app_health_result)
+    if app_health_response.status != 200 or app_health_mismatches:
+        failures.append(app_health_result)
+
     return {
         "status": "ready" if not failures else "error",
         "checks": len(results),
@@ -164,6 +251,7 @@ def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--base-url", default="https://supermega.dev")
     parser.add_argument("--www-url", default="https://www.supermega.dev")
+    parser.add_argument("--app-url", default="https://app.supermega.dev")
     parser.add_argument("--timeout", type=float, default=30.0)
     parser.add_argument("--attempts", type=int, default=3)
     args = parser.parse_args()
@@ -171,7 +259,7 @@ def main() -> int:
         parser.error("timeout and attempts must be positive")
 
     try:
-        report = run(args.base_url, args.www_url, timeout=args.timeout, attempts=args.attempts)
+        report = run(args.base_url, args.www_url, args.app_url, timeout=args.timeout, attempts=args.attempts)
     except Exception as error:  # Keep Actions output concise and secret-free.
         report = {"status": "error", "reason": str(error)}
 

--- a/tools/test_public_live_health.py
+++ b/tools/test_public_live_health.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Deterministic tests for the read-only SuperMega portfolio monitor."""
+
+from __future__ import annotations
+
+import copy
+import json
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import check_public_live_health as checker
+
+
+BASE = "https://public.example/"
+WWW = "https://www.example/"
+APP = "https://app.example/"
+
+
+def result(url: str, body: str | dict, *, status: int = 200, headers: dict[str, str] | None = None):
+    encoded = json.dumps(body).encode() if isinstance(body, dict) else body.encode()
+    return checker.HttpResult(url=url, status=status, headers=headers or {}, body=encoded)
+
+
+def page(*tokens: str) -> str:
+    return "<!doctype html>" + "\n".join(tokens) + ("x" * 1400)
+
+
+def healthy_responses() -> dict[str, checker.HttpResult]:
+    home = page(
+        "<title>supermega.dev | Shop, Plant and AI Agent Solutions</title>",
+        '<h1 id="portfolio-heading">Shop. Plant. AI Agent Solutions.</h1>',
+        "https://app.supermega.dev/?demo=shop",
+        "https://app.supermega.dev/?demo=plant",
+        "/contact/?from=ai-agent-solution",
+        "external actions approval-gated",
+        "data-public-status",
+    )
+    contact = page(
+        "<title>Contact | supermega.dev</title>",
+        "What needs to work better?",
+        'action="/api/contact-submissions"',
+        'name="name"',
+        'name="email"',
+        'name="company"',
+        'name="goal"',
+        "No account or data connection is made before you approve it.",
+    )
+    privacy = page(
+        "<title>Privacy | supermega.dev</title>",
+        "Only the details needed to reply.",
+    )
+    app_shell = page(
+        "<title>Shop - SuperMega</title>",
+        '<div id="root"></div>',
+        'type="module"',
+    )
+    contact_status = {
+        "status": "ready",
+        "lead_ledger": "configured",
+        "pipeline_actions": "configured",
+        "primary_datastore": {"status": "configured"},
+        "fallback_queue": {"status": "ready", "email_delivery": "configured"},
+        "ops_intake": {
+            "status": "ready",
+            "target": "https://supermega-machine.vercel.app/api/intake",
+            "contract": "body_secret",
+        },
+    }
+    app_health = {
+        "ok": True,
+        "status": "ready",
+        "service": "supermega-product-app",
+        "contractVersion": 1,
+        "portfolio": {
+            "products": ["shop", "plant"],
+            "demos": {
+                "shop": {"entry": "/?demo=shop", "route": "/home"},
+                "plant": {"entry": "/?demo=plant", "route": "/factory"},
+            },
+            "agentSolutions": {
+                "intake": "https://supermega.dev/contact/?from=ai-agent-solution",
+                "externalActions": "approval-gated",
+            },
+        },
+        "proof": {
+            "workingDemos": True,
+            "productionCloudDurability": "not-asserted",
+            "realCustomerAcceptance": "not-asserted",
+        },
+    }
+
+    responses = {
+        BASE: result(BASE, home),
+        WWW: result(WWW, home),
+        f"{BASE}contact/": result(f"{BASE}contact/", contact),
+        f"{BASE}privacy/": result(f"{BASE}privacy/", privacy),
+        f"{BASE}api/contact-submissions/status": result(
+            f"{BASE}api/contact-submissions/status", contact_status
+        ),
+        f"{APP}home": result(f"{APP}home", app_shell),
+        f"{APP}factory": result(f"{APP}factory", app_shell),
+        f"{APP}api/health": result(f"{APP}api/health", app_health),
+    }
+    for path in ("products/", "pricing/", "ai-agents/", "offers/"):
+        url = f"{BASE}{path}"
+        responses[url] = result(url, "", status=308, headers={"Location": "/"})
+    return responses
+
+
+class PortfolioHealthTest(unittest.TestCase):
+    def run_report(self, responses: dict[str, checker.HttpResult]):
+        def fake_fetch(url: str, **_kwargs):
+            return responses[url]
+
+        with patch.object(checker, "fetch", side_effect=fake_fetch):
+            return checker.run(BASE, WWW, APP, timeout=1, attempts=1)
+
+    def test_healthy_portfolio_passes_all_twelve_checks(self):
+        report = self.run_report(healthy_responses())
+        self.assertEqual(report["status"], "ready")
+        self.assertEqual(report["checks"], 12)
+        self.assertEqual(report["failures"], [])
+
+    def test_missing_plant_link_fails_public_page(self):
+        responses = healthy_responses()
+        responses[BASE] = result(BASE, responses[BASE].body.decode().replace("https://app.supermega.dev/?demo=plant", ""))
+        report = self.run_report(responses)
+        self.assertEqual(report["status"], "error")
+        self.assertTrue(any(item["kind"] == "page" and item["url"] == BASE for item in report["failures"]))
+
+    def test_retired_product_name_fails_public_page(self):
+        responses = healthy_responses()
+        responses[BASE] = result(BASE, responses[BASE].body.decode() + "DeskPOS")
+        report = self.run_report(responses)
+        self.assertEqual(report["status"], "error")
+        failure = next(item for item in report["failures"] if item["kind"] == "page" and item["url"] == BASE)
+        self.assertIn("DeskPOS", failure["unexpected"])
+
+    def test_unproven_cloud_claim_fails_health_contract(self):
+        responses = healthy_responses()
+        payload = copy.deepcopy(json.loads(responses[f"{APP}api/health"].body))
+        payload["proof"]["productionCloudDurability"] = "ready"
+        responses[f"{APP}api/health"] = result(f"{APP}api/health", payload)
+        report = self.run_report(responses)
+        self.assertEqual(report["status"], "error")
+        health_failure = next(item for item in report["failures"] if item["kind"] == "app_health")
+        self.assertIn("proof.productionCloudDurability", health_failure["mismatches"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed
- replaces stale `Open Shop or try a demo` assertions with the live Shop, Plant, and AI Agent Solutions contract
- checks both public aliases, Contact, Privacy, four retired routes, conversion status, Shop `/home`, Plant `/factory`, and `app.supermega.dev/api/health`
- removes the separate DeskPOS lead endpoint as a core portfolio dependency
- fails if MegaOS, DeskPOS, Studio, or the retired generic demo path returns to the public homepage
- preserves honest boundaries by requiring cloud durability and real customer acceptance to remain `not-asserted` until separately proven
- downloads and runs an offline regression suite before every live scheduled check

## Verification
- 4 offline regression tests pass
- Python bytecode compilation passes
- live production checker passes 12/12 with no failures
- checker remains read-only: no form submission, account, provider, payment, or datastore mutation

The workflow runs on relevant `main` pushes, manual dispatch, and daily at 08:15 Asia/Rangoon.