### PR TITLE
Kernel: add reviewed Agent Company console

### DIFF
--- a/kernel/agent-company-ui-contract.test.mjs
+++ b/kernel/agent-company-ui-contract.test.mjs
@@ -1,0 +1,60 @@
+import { readFile } from 'node:fs/promises'
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+
+const readConsole = () => readFile(new URL('./public/index.html', import.meta.url), 'utf8')
+
+test('console exposes one plan-first Agent Company workspace', async () => {
+  const html = await readConsole()
+  assert.match(html, /data-view="company"/)
+  assert.match(html, /id="view-company"/)
+  assert.match(html, /api\('GET','\/api\/agent-company'\)/)
+  assert.match(html, /api\('POST','\/api\/agent-company',\{action:'plan',\.\.\.input\}\)/)
+  assert.match(html, /api\('POST','\/api\/agent-company',\{action:'run',\.\.\.companyDraft\.input\}\)/)
+  assert.match(html, /I reviewed this exact client, evidence, assignments, and budget/)
+  assert.match(html, /id="companyRunButton" type="button" disabled/)
+  assert.match(html, /if\(companyDraft\)invalidateCompanyPlan\('Inputs changed\. Plan the cycle again\.'\)/)
+  assert.match(html, /Result unavailable\. Checking again is idempotent\./)
+  assert.match(html, /if\(location\.hash==='\#company'\)/)
+  assert.match(html, /companyRoster=\[\]\s+invalidateCompanyPlan\(\)\s+loadProtectedState\(\)/)
+})
+
+test('Agent Company UI accepts bounded evidence but no credential or action fields', async () => {
+  const html = await readConsole()
+  const panel = html.match(/<section id="view-company"[\s\S]*?<section id="view-workcells"/)?.[0] || ''
+  assert.ok(panel)
+  assert.match(panel, /id="companyRoleBudget" type="number" min="1" max="8"/)
+  assert.match(html, /data-company-check type="checkbox"/)
+  assert.match(html, /data-company-evidence maxlength="12000" disabled/)
+  assert.match(html, /\.company-agent:not\(\.selected\) \.company-evidence\{display:none\}/)
+  assert.doesNotMatch(panel, /type="password"|name="[^"]*(?:secret|token|key)|Apply|Execute|Send/i)
+  assert.doesNotMatch(html, /setInterval\(loadCompanyAgents|eval\s*\(/)
+})
+
+test('Agent Company controls remain touch-safe and collapse to one column', async () => {
+  const html = await readConsole()
+  assert.match(html, /\.key\{max-width:180px;min-height:44px\}/)
+  assert.match(html, /nav button\{min-height:44px/)
+  assert.match(html, /\.company-agent-choice\{[^}]*min-height:44px/)
+  assert.match(html, /\.company-confirm\{[^}]*min-height:44px/)
+  assert.match(html, /\.company-actions button\{min-height:44px\}/)
+  assert.match(html, /\.company-plan-actions button\{min-height:44px\}/)
+  assert.match(html, /\.company-new-cycle\{min-height:44px\}/)
+  assert.match(html, /\.company-agent\{grid-template-columns:1fr\}/)
+  assert.match(html, /\.company-scope\{grid-template-columns:1fr\}/)
+})
+
+test('Agent Company API route is a dedicated function before the catch-all', async () => {
+  const config = JSON.parse(await readFile(new URL('./vercel.json', import.meta.url), 'utf8'))
+  assert.equal(config.functions['api/agent-company.mjs'].maxDuration, 60)
+  const companyRoute = config.routes.findIndex((route) => route.src === '/api/agent-company')
+  const catchAll = config.routes.findIndex((route) => route.src === '/api/(.*)')
+  assert.ok(companyRoute >= 0 && companyRoute < catchAll)
+})
+
+test('console inline scripts parse after Agent Company wiring', async () => {
+  const html = await readConsole()
+  const scripts = [...html.matchAll(/<script>([\s\S]*?)<\/script>/g)].map((match) => match[1])
+  assert.ok(scripts.length)
+  for (const source of scripts) assert.doesNotThrow(() => new Function(source))
+})

--- a/kernel/public/index.html
+++ b/kernel/public/index.html
@@ -19,11 +19,11 @@
   .grow{flex:1}
   input,textarea,select,button{font:inherit;color:var(--ink)}
   input,textarea,select{width:100%;border:1px solid var(--line);border-radius:8px;background:var(--field);padding:9px 11px;outline:none}
-  input:focus,textarea:focus{border-color:var(--accent);box-shadow:0 0 0 3px var(--accent-soft)}.key{max-width:180px}
+  input:focus,textarea:focus{border-color:var(--accent);box-shadow:0 0 0 3px var(--accent-soft)}.key{max-width:180px;min-height:44px}
   button{cursor:pointer;border:1px solid var(--line);border-radius:8px;background:var(--surf);padding:8px 14px;font-weight:600}
   button.primary{background:var(--accent);color:#fff;border-color:var(--accent)}button.primary:hover{background:var(--accent-2)}button.sm{padding:5px 10px;font-size:12px}button:disabled{opacity:.5;cursor:wait}
   nav{display:flex;gap:6px;padding:14px 22px 0;flex-wrap:wrap}
-  nav button{border-radius:8px 8px 0 0;border-bottom:0;background:transparent;border-color:transparent;color:var(--muted)}
+  nav button{min-height:44px;border-radius:8px 8px 0 0;border-bottom:0;background:transparent;border-color:transparent;color:var(--muted)}
   nav button.active{background:var(--surf);border-color:var(--line);color:var(--ink)}
   main{padding:18px 22px 70px;max-width:1180px}
   .panel{background:var(--surf);border:1px solid var(--line);border-radius:8px;padding:18px;box-shadow:var(--shadow)}
@@ -92,6 +92,14 @@
   .activation-commands{display:grid;gap:8px;margin-top:12px}.activation-command{padding:10px 12px;border-left:3px solid var(--accent);background:var(--deep);overflow:auto;white-space:nowrap;font:12px/1.5 Consolas,"Courier New",monospace}
   .activation-inputs{display:grid;gap:7px}.activation-inputs code{display:block;padding:8px 10px;border:1px solid var(--line);border-radius:8px;background:var(--deep);font-size:11px;overflow-wrap:anywhere}
   .activation-result .row{margin-top:12px}.activation-result .row button{min-height:44px}
+  .company-toolbar{display:flex;align-items:flex-start;justify-content:space-between;gap:16px;margin-bottom:18px}.company-toolbar h2{font-size:20px}.company-toolbar .badge{align-self:flex-start;white-space:nowrap}
+  .company-scope{display:grid;grid-template-columns:minmax(180px,1.2fr) minmax(180px,1fr) minmax(120px,.45fr);gap:12px;padding:0 0 18px;border-bottom:1px solid var(--line)}.company-scope .field{margin:0}.company-scope input{min-height:44px}
+  .company-roster{display:grid;gap:10px;margin-top:16px}.company-agent{display:grid;grid-template-columns:minmax(220px,.75fr) minmax(280px,1.25fr);gap:18px;align-items:start;padding:15px 0;border-bottom:1px solid var(--line)}.company-agent:last-child{border-bottom:0}.company-agent:not(.selected){grid-template-columns:1fr}.company-agent:not(.selected) .company-evidence{display:none}.company-agent.selected{padding:15px;background:var(--accent-soft);border:1px solid rgba(59,130,246,.28);border-radius:8px}
+  .company-agent-choice{display:flex;align-items:flex-start;gap:11px;min-height:44px;margin:0;color:var(--ink)}.company-agent-choice input{width:20px;height:20px;margin:2px 0 0;flex:0 0 auto}.company-agent-name{display:block;font-family:"Space Grotesk",Inter,sans-serif;font-size:16px}.company-agent-outcome{display:block;color:var(--muted);font-size:12.5px;font-weight:400;margin-top:5px}.company-agent-meta{display:flex;gap:6px;flex-wrap:wrap;margin-top:9px}
+  .company-evidence{margin:0}.company-evidence textarea{min-height:112px;resize:vertical}.company-evidence textarea:disabled{opacity:.5}.company-actions{display:flex;align-items:center;gap:12px;margin-top:18px}.company-actions button{min-height:44px}
+  .company-plan{border-left:3px solid var(--accent);background:var(--accent-soft);padding:16px 18px;margin-top:18px;scroll-margin-top:120px}.company-plan-head{display:flex;align-items:flex-start;justify-content:space-between;gap:14px}.company-plan-head h3{font-size:17px}.company-plan-summary{display:flex;gap:7px;flex-wrap:wrap;margin:12px 0}.company-run-id{font-family:ui-monospace,SFMono-Regular,Consolas,monospace;font-size:11px;color:var(--muted);overflow-wrap:anywhere}
+  .company-assignments{display:grid;gap:8px;margin:14px 0}.company-assignment{display:grid;grid-template-columns:minmax(180px,.7fr) minmax(0,1.3fr);gap:12px;padding:11px 0;border-top:1px solid var(--line)}.company-assignment b{display:block}.company-assignment .roles{color:var(--muted);font-size:12px;overflow-wrap:anywhere}.company-confirm{display:flex;align-items:flex-start;gap:9px;min-height:44px;margin:0}.company-confirm input{width:20px;height:20px;margin:1px 0 0;flex:0 0 auto}.company-plan-actions{display:flex;align-items:center;gap:12px;border-top:1px solid var(--line);padding-top:14px}.company-plan-actions button{min-height:44px}
+  .company-results{margin-top:20px}.company-results-head{display:flex;align-items:flex-start;justify-content:space-between;gap:14px;margin-bottom:12px}.company-results-head h3{font-size:18px}.company-result-list{display:grid;gap:10px}.company-result{border:1px solid var(--line);border-radius:8px;background:var(--surf);padding:15px}.company-result-head{display:flex;align-items:center;justify-content:space-between;gap:12px}.company-result pre{max-height:340px;margin:12px 0 0;padding:12px;border:1px solid var(--line);border-radius:8px;background:var(--deep);overflow:auto;white-space:pre-wrap;overflow-wrap:anywhere;font:12px/1.55 Consolas,"Courier New",monospace}.company-result .err-banner{margin-top:10px}.company-new-cycle{min-height:44px}
   .approval-toolbar{display:flex;align-items:flex-start;justify-content:space-between;gap:16px;margin-bottom:14px}.approval-toolbar h2{font-size:20px}.approval-toolbar button{min-height:44px}
   .approval-summary{display:flex;gap:7px;flex-wrap:wrap;margin-bottom:14px}.approval-list{display:grid;gap:12px}
   .approval-card{border:1px solid var(--line);border-radius:8px;background:var(--surf);padding:17px}.approval-head{display:flex;align-items:flex-start;justify-content:space-between;gap:12px;margin-bottom:13px}
@@ -107,10 +115,10 @@
     header{display:grid;grid-template-columns:max-content max-content minmax(0,1fr);gap:8px 10px;padding:12px 16px}
     .brand{grid-column:1/-1;white-space:nowrap}.grow{display:none}.key{grid-column:1/-1;max-width:none}
     nav{padding:14px 16px 0}main{padding:18px 16px 70px}
-    .cols{grid-template-columns:1fr}.two{grid-template-columns:1fr}.activation-fields,.owner-evidence-fields{grid-template-columns:repeat(2,minmax(0,1fr))}.activation-output{grid-template-columns:1fr}.owner-evidence-fields .evidence-text{grid-column:1/-1}
+    .cols{grid-template-columns:1fr}.two{grid-template-columns:1fr}.activation-fields,.owner-evidence-fields{grid-template-columns:repeat(2,minmax(0,1fr))}.activation-output{grid-template-columns:1fr}.owner-evidence-fields .evidence-text{grid-column:1/-1}.company-agent{grid-template-columns:1fr}.company-scope{grid-template-columns:repeat(2,minmax(0,1fr))}.company-scope .field:last-child{grid-column:1/-1}
   }
   @media(max-width:520px){
-    .workcell-toolbar,.approval-toolbar,.owner-evidence-head{align-items:stretch;flex-direction:column}.workcell-toolbar button,.approval-toolbar button{width:100%}.activation{padding:15px}.activation-import{align-items:stretch;flex-direction:column}.activation-import button{width:100%}.activation-fields,.owner-evidence-fields{grid-template-columns:1fr}.activation-actions,.owner-evidence-actions{align-items:stretch;flex-direction:column}.activation-actions button,.owner-evidence-actions button{width:100%}.owner-evidence-fields .evidence-text{grid-column:1}.owner-evidence-confirm{align-items:flex-start}
+    .workcell-toolbar,.approval-toolbar,.owner-evidence-head,.company-toolbar,.company-plan-head,.company-results-head{align-items:stretch;flex-direction:column}.workcell-toolbar button,.approval-toolbar button{width:100%}.activation{padding:15px}.activation-import{align-items:stretch;flex-direction:column}.activation-import button{width:100%}.activation-fields,.owner-evidence-fields,.company-scope{grid-template-columns:1fr}.company-scope .field:last-child{grid-column:1}.activation-actions,.owner-evidence-actions,.company-actions,.company-plan-actions{align-items:stretch;flex-direction:column}.activation-actions button,.owner-evidence-actions button,.company-actions button,.company-plan-actions button,.company-new-cycle{width:100%}.owner-evidence-fields .evidence-text{grid-column:1}.owner-evidence-confirm{align-items:flex-start}.company-assignment{grid-template-columns:1fr;gap:5px}.company-agent.selected{padding:13px}
     .workcell .wc-actions{align-items:stretch;flex-direction:column}.workcell .wc-actions button{width:100%}.approval-head{align-items:flex-start}.approval-details{grid-template-columns:1fr;gap:2px}.approval-details dd{margin-bottom:9px}.approval-actions{align-items:stretch;flex-direction:column}.approval-confirm{margin:0}.approval-actions button{width:100%}
   }
 </style>
@@ -130,6 +138,7 @@
   <button data-view="outreach">Outreach</button>
   <button data-view="deal">Run a deal</button>
   <button data-view="operator">Ask</button>
+  <button data-view="company">Company</button>
   <button data-view="workcells">Workcells</button>
   <button data-view="approvals">Approvals</button>
   <button data-view="connectors">Connectors</button>
@@ -147,6 +156,30 @@
   <section id="view-connectors" hidden>
     <div id="connGrid" class="conn-grid"><div class="loading-pulse">Loading connectors…</div></div>
     <p class="muted" style="font-size:12px">Each connector is a live integration. "Configured" = env var present; "OK" = health probe passed. Set missing env vars in the Vercel project settings.</p>
+  </section>
+
+  <section id="view-company" hidden>
+    <div class="company-toolbar">
+      <div><h2>Agent company</h2><div class="muted">Plan and run one bounded specialist wave</div></div>
+      <span class="badge">draft only</span>
+    </div>
+    <form id="companyForm">
+      <div class="company-scope">
+        <div class="field"><label for="companyClientId">Client ID</label><input id="companyClientId" autocomplete="off" pattern="[A-Za-z0-9][A-Za-z0-9._:\-]{0,79}" required /></div>
+        <div class="field"><label for="companyCycleId">Cycle ID</label><input id="companyCycleId" autocomplete="off" pattern="[A-Za-z0-9][A-Za-z0-9._:\-]{0,79}" required /></div>
+        <div class="field"><label for="companyRoleBudget">Role-call budget</label><input id="companyRoleBudget" type="number" min="1" max="8" value="8" required /></div>
+      </div>
+      <div class="company-roster" id="companyRoster"><div class="loading-pulse">Loading specialists...</div></div>
+      <div class="company-actions"><button class="primary" id="companyPlanButton" type="submit">Plan cycle</button><span class="muted" id="companyState" role="status" aria-live="polite"></span></div>
+    </form>
+    <div class="company-plan" id="companyPlan" hidden>
+      <div class="company-plan-head"><div><h3>Reviewed plan</h3><div class="muted">Exact assignments and budget before model spend</div></div><span class="badge on">plan ready</span></div>
+      <div class="company-plan-summary" id="companyPlanSummary"></div>
+      <div class="company-run-id" id="companyRunId"></div>
+      <div class="company-assignments" id="companyAssignments"></div>
+      <div class="company-plan-actions"><label class="company-confirm"><input id="companyConfirm" type="checkbox" /> I reviewed this exact client, evidence, assignments, and budget</label><button class="primary" id="companyRunButton" type="button" disabled>Run reviewed cycle</button></div>
+    </div>
+    <div class="company-results" id="companyResults" role="status" aria-live="polite"></div>
   </section>
 
   <section id="view-workcells" hidden>
@@ -282,16 +315,30 @@ const usd=(n)=>'$'+Number(n||0).toLocaleString()
 const getOpsKey=()=>$('#opsKey').value.trim()
 const hasOpsKey=()=>getOpsKey().length>0
 let dealLead=null, lastPacket=null
+let companyRoster=[], companyDraft=null, companyAgentLimit=2
+
+function nextCompanyCycleId(){
+  const now=new Date(),iso=now.toISOString()
+  return `${iso.slice(0,10)}-${iso.slice(11,16).replace(':','')}-${Date.now().toString(36).slice(-5)}`
+}
+$('#companyClientId').value=localStorage.getItem('sm.company.client')||''
+$('#companyCycleId').value=nextCompanyCycleId()
 
 $('#opsKey').value=localStorage.getItem('sm.ops')||''
 $('#opsKey').addEventListener('change',()=>{
   const key=getOpsKey()
   if(key)localStorage.setItem('sm.ops',key);else localStorage.removeItem('sm.ops')
+  companyRoster=[]
+  invalidateCompanyPlan()
   loadProtectedState()
   const activeView=document.querySelector('nav button.active')?.dataset.view
   if(activeView==='workcells'){
     if(key)loadWorkcells()
     else $('#workcellGrid').innerHTML='<div class="empty">Enter the ops passcode to load live workcell status.</div>'
+  }
+  if(activeView==='company'){
+    if(key)loadCompanyAgents()
+    else $('#companyRoster').innerHTML='<div class="empty">Enter the ops passcode to load the specialist roster.</div>'
   }
 })
 $('#opsKey').addEventListener('keydown',(event)=>{if(event.key==='Enter')event.currentTarget.blur()})
@@ -317,13 +364,162 @@ async function runOperator(){
 $('#op-run').onclick=runOperator
 $('#op-goal').addEventListener('keydown',e=>{if(e.key==='Enter')runOperator()})
 
+function invalidateCompanyPlan(message=''){
+  companyDraft=null
+  $('#companyPlan').hidden=true
+  $('#companyConfirm').checked=false
+  $('#companyConfirm').disabled=false
+  $('#companyRunButton').disabled=true
+  $('#companyRunButton').textContent='Run reviewed cycle'
+  if(message)$('#companyState').textContent=message
+}
+function syncCompanyAgent(row,checkbox){
+  const selected=checkbox.checked
+  row.classList.toggle('selected',selected)
+  const evidence=row.querySelector('[data-company-evidence]')
+  evidence.disabled=!selected
+  evidence.required=selected
+}
+function renderCompanyRoster(agents=[]){
+  companyRoster=agents
+  const box=$('#companyRoster')
+  box.innerHTML=agents.length?agents.map(agent=>`<div class="company-agent" data-company-agent="${esc(agent.id)}">
+    <label class="company-agent-choice" for="company-agent-${esc(agent.id)}"><input id="company-agent-${esc(agent.id)}" data-company-check type="checkbox" /><span><span class="company-agent-name">${esc(agent.name)}</span><span class="company-agent-outcome">${esc(agent.outcome)}</span><span class="company-agent-meta"><span class="badge">${esc(agent.department)}</span><span class="badge">${esc(agent.crew)}</span></span></span></label>
+    <div class="company-evidence"><label for="company-evidence-${esc(agent.id)}">Evidence for ${esc(agent.name)}</label><textarea id="company-evidence-${esc(agent.id)}" data-company-evidence maxlength="12000" disabled></textarea></div>
+  </div>`).join(''):'<div class="empty">No specialists are available.</div>'
+  box.querySelectorAll('[data-company-agent]').forEach(row=>{
+    const checkbox=row.querySelector('[data-company-check]')
+    syncCompanyAgent(row,checkbox)
+    checkbox.addEventListener('change',()=>{
+      const selected=box.querySelectorAll('[data-company-check]:checked')
+      if(selected.length>companyAgentLimit){checkbox.checked=false;toast(`Choose up to ${companyAgentLimit} specialists`)}
+      syncCompanyAgent(row,checkbox)
+      invalidateCompanyPlan('Selection changed. Plan the cycle again.')
+    })
+  })
+}
+async function loadCompanyAgents(){
+  const box=$('#companyRoster')
+  if(!hasOpsKey()){box.innerHTML='<div class="empty">Enter the ops passcode to load the specialist roster.</div>';return}
+  if(companyRoster.length)return
+  box.innerHTML='<div class="loading-pulse">Loading specialists...</div>'
+  let response
+  try{response=await api('GET','/api/agent-company')}
+  catch(error){box.innerHTML=`<div class="err-banner">Could not load specialists: ${esc(String(error.message||'network error'))}</div>`;return}
+  if(!response.ok){box.innerHTML=`<div class="err-banner">${esc(response.reason||'Could not load specialists')}</div>`;return}
+  companyAgentLimit=Number(response.limits&&response.limits.maxAgents)||2
+  const maxBudget=Number(response.limits&&response.limits.maxRoleBudget)||8
+  $('#companyRoleBudget').max=String(maxBudget)
+  if(Number($('#companyRoleBudget').value)>maxBudget)$('#companyRoleBudget').value=String(maxBudget)
+  renderCompanyRoster(response.agents||[])
+  $('#companyState').textContent=`${(response.agents||[]).length} specialists available`
+}
+function companyCycleInput(){
+  const agents=[],evidence={}
+  $('#companyRoster').querySelectorAll('[data-company-agent]').forEach(row=>{
+    const checkbox=row.querySelector('[data-company-check]')
+    if(!checkbox.checked)return
+    const agentId=row.dataset.companyAgent
+    agents.push(agentId)
+    evidence[agentId]=row.querySelector('[data-company-evidence]').value.trim()
+  })
+  return {
+    clientId:$('#companyClientId').value.trim(),
+    cycleId:$('#companyCycleId').value.trim(),
+    agents,
+    evidence,
+    roleBudget:Number($('#companyRoleBudget').value),
+  }
+}
+function renderCompanyPlan(plan,input){
+  companyDraft={input:JSON.parse(JSON.stringify(input)),plan}
+  $('#companyPlanSummary').innerHTML=`<span class="badge on">${plan.budget.selectedAgents} specialists</span><span class="badge">${plan.budget.plannedRoles} / ${plan.budget.roleLimit} role calls</span><span class="badge">${esc(plan.controls.execution)}</span><span class="badge">no writes</span>`
+  $('#companyRunId').textContent=`Run ID: ${plan.runId}`
+  $('#companyAssignments').innerHTML=(plan.assignments||[]).map(assignment=>`<div class="company-assignment"><div><b>${esc(assignment.name)}</b><span class="muted">${esc(assignment.department)} / ${esc(assignment.crew)}</span></div><div class="roles">${esc((assignment.roles||[]).map(role=>`${role.title} (${role.tier})`).join(' -> '))}<br />Returns: ${esc((assignment.returns||[]).join(', '))}</div></div>`).join('')
+  $('#companyConfirm').checked=false
+  $('#companyRunButton').disabled=true
+  $('#companyPlan').hidden=false
+  $('#companyResults').innerHTML=''
+  $('#companyState').textContent='Plan ready. Review before running.'
+  $('#companyPlan').scrollIntoView({behavior:'smooth',block:'nearest'})
+}
+function companyStatusBadge(status){
+  const tone=status==='completed'?' on':status==='failed'?' off':''
+  return `<span class="badge${tone}">${esc(status||'unknown')}</span>`
+}
+function renderCompanyResults(response){
+  const results=Array.isArray(response.results)?response.results:Array.isArray(response.recoveredResults)?response.recoveredResults:[]
+  const status=response.status||(response.ok?'completed':'failed')
+  const budget=response.budget||{}
+  const summary=[
+    companyStatusBadge(status),
+    response.replayed?'<span class="badge">saved replay</span>':'',
+    response.durableResultStored?'<span class="badge on">result stored</span>':'',
+    Number.isFinite(budget.usedRoleCalls)?`<span class="badge">${budget.usedRoleCalls} role calls used</span>`:'',
+  ].filter(Boolean).join('')
+  const list=results.length?results.map(result=>{
+    const output=result.output===undefined?'':JSON.stringify(result.output,null,2)
+    const problem=result.reason?`<div class="err-banner">${esc(result.reason)}${result.role?` / ${esc(result.role)}`:''}</div>`:''
+    return `<article class="company-result"><div class="company-result-head"><div><b>${esc(result.agentId)}</b><div class="muted">${esc(result.department||'')} / ${esc(result.crew||'')}</div></div>${companyStatusBadge(result.status)}</div>${problem}${output?`<pre>${esc(output)}</pre>`:''}</article>`
+  }).join(''):`<div class="err-banner">${esc(response.reason||'No specialist result was returned.')}</div>`
+  $('#companyResults').innerHTML=`<div class="company-results-head"><div><h3>Cycle result</h3><div class="company-plan-summary">${summary}</div><div class="company-run-id">${esc(response.runId||'')}</div></div><button class="company-new-cycle" id="companyNewCycle" type="button">New cycle</button></div><div class="company-result-list">${list}</div>`
+  $('#companyNewCycle').onclick=startNewCompanyCycle
+  $('#companyResults').scrollIntoView({behavior:'smooth',block:'nearest'})
+}
+function startNewCompanyCycle(){
+  $('#companyCycleId').value=nextCompanyCycleId()
+  $('#companyRoster').querySelectorAll('[data-company-agent]').forEach(row=>{
+    const checkbox=row.querySelector('[data-company-check]');checkbox.checked=false;syncCompanyAgent(row,checkbox)
+    row.querySelector('[data-company-evidence]').value=''
+  })
+  invalidateCompanyPlan()
+  $('#companyResults').innerHTML=''
+  $('#companyState').textContent='New cycle ready'
+  $('#companyClientId').focus()
+}
+$('#companyForm').addEventListener('input',event=>{
+  if(event.target.id==='companyClientId')localStorage.setItem('sm.company.client',event.target.value.trim())
+  if(companyDraft)invalidateCompanyPlan('Inputs changed. Plan the cycle again.')
+})
+$('#companyForm').addEventListener('submit',async event=>{
+  event.preventDefault()
+  const input=companyCycleInput()
+  if(!input.agents.length){toast('Choose at least one specialist');return}
+  if(!event.currentTarget.reportValidity())return
+  const button=$('#companyPlanButton');button.disabled=true;button.textContent='Planning...';$('#companyState').textContent='Validating assignments and budget...'
+  try{
+    const response=await api('POST','/api/agent-company',{action:'plan',...input})
+    if(!response.ok){invalidateCompanyPlan(response.reason||'Plan failed');return}
+    renderCompanyPlan(response,input)
+  }catch(error){invalidateCompanyPlan(String(error.message||'Plan failed').slice(0,120))}
+  finally{button.disabled=false;button.textContent='Plan cycle'}
+})
+$('#companyConfirm').addEventListener('change',event=>{$('#companyRunButton').disabled=!event.currentTarget.checked||!companyDraft})
+$('#companyRunButton').addEventListener('click',async()=>{
+  if(!companyDraft||!$('#companyConfirm').checked)return
+  const button=$('#companyRunButton');button.disabled=true;$('#companyConfirm').disabled=true;button.textContent='Running...';$('#companyState').textContent='Running specialists sequentially...'
+  try{
+    const response=await api('POST','/api/agent-company',{action:'run',...companyDraft.input})
+    renderCompanyResults(response)
+    $('#companyState').textContent=response.ok?'Cycle complete':response.reason||'Cycle returned a partial result'
+  }catch(error){
+    $('#companyResults').innerHTML=`<div class="err-banner">${esc(String(error.message||'Run failed').slice(0,120))}</div>`
+    $('#companyState').textContent='Result unavailable. Checking again is idempotent.'
+  }finally{
+    $('#companyConfirm').disabled=false
+    button.disabled=!$('#companyConfirm').checked
+    button.textContent='Check saved result'
+  }
+})
+
 document.querySelectorAll('nav button').forEach(b=>b.onclick=()=>{
   document.querySelectorAll('nav button').forEach(x=>x.classList.toggle('active',x===b))
-  for(const v of ['overview','leads','pipeline','outreach','deal','operator','workcells','approvals','connectors']) $('#view-'+v).hidden=v!==b.dataset.view
+  for(const v of ['overview','leads','pipeline','outreach','deal','operator','company','workcells','approvals','connectors']) $('#view-'+v).hidden=v!==b.dataset.view
   if(b.dataset.view==='overview')loadOverview()
   if(b.dataset.view==='pipeline')loadProjects()
   if(b.dataset.view==='leads')loadLeads()
   if(b.dataset.view==='outreach')loadOutreach()
+  if(b.dataset.view==='company')loadCompanyAgents()
   if(b.dataset.view==='workcells')loadWorkcells()
   if(b.dataset.view==='approvals')loadApprovals()
   if(b.dataset.view==='connectors')loadConnectors()
@@ -855,10 +1051,16 @@ async function refresh(){
   $('#aiBadge').textContent='ai: '+(r.aiConfigured?'on':'off')
   $('#aiBadge').className='badge '+(r.aiConfigured?'on':'off')
 }
-if(location.hash==='#activation'){
+if(location.hash==='#company'){
+  const companyTab=document.querySelector('nav button[data-view="company"]')
+  document.querySelectorAll('nav button').forEach(button=>button.classList.toggle('active',button===companyTab))
+  for(const view of ['overview','leads','pipeline','outreach','deal','operator','company','workcells','approvals','connectors']) $('#view-'+view).hidden=view!=='company'
+  if(hasOpsKey())loadCompanyAgents()
+  else $('#companyRoster').innerHTML='<div class="empty">Enter the ops passcode to load the specialist roster.</div>'
+}else if(location.hash==='#activation'){
   const workcellsTab=document.querySelector('nav button[data-view="workcells"]')
   document.querySelectorAll('nav button').forEach(button=>button.classList.toggle('active',button===workcellsTab))
-  for(const view of ['overview','leads','pipeline','outreach','deal','operator','workcells','approvals','connectors']) $('#view-'+view).hidden=view!=='workcells'
+  for(const view of ['overview','leads','pipeline','outreach','deal','operator','company','workcells','approvals','connectors']) $('#view-'+view).hidden=view!=='workcells'
   openActivationPanel('#activationManifestFile')
   if(hasOpsKey())loadWorkcells()
   else $('#workcellGrid').innerHTML='<div class="empty">Enter the ops passcode to load live workcell status.</div>'


### PR DESCRIPTION
## What changed
- adds one protected Company workspace for the fixed five-specialist Agent Company roster
- requires client/cycle scope and isolated evidence per selected specialist
- plans first, displays exact assignments and role-call budget, invalidates stale plans, and requires explicit review before run
- renders durable/replayed/partial result envelopes without exposing credential or provider action fields
- raises console passcode/navigation and new workflow targets to the 44px interaction floor

## Verification
- kernel verify: 164 tests passed
- connector resilience: 69 connectors / 993 calls / 0 violations
- crew resilience: 5 crews / 74 checks / 0 violations
- Edge QA: 1280x900 and 390x844, zero failed requests/errors/overflow/undersized visible controls

## Evidence boundary
Browser QA used mocked read-only roster/plan/run responses with redacted fixture evidence. No real model call, provider action, client record, payment, approval, or customer data was created or changed.