### PR TITLE
Ops: monitor live Agent Company portfolio

### DIFF
--- a/.github/workflows/supermega-public-live-health.yml
+++ b/.github/workflows/supermega-public-live-health.yml
@@ -1,9 +1,16 @@
-name: SuperMega Public Live Health
+name: SuperMega Portfolio Live Health
 
-# Default-branch, read-only production monitor. The public release itself is
-# owned by codex/public-enterprise-site; this workflow only checks live truth.
+# Default-branch, read-only production monitor for the public front door,
+# Shop and Plant app, and protected AI Agent Solutions control plane.
 on:
   push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/supermega-public-live-health.yml
+      - tools/check_public_live_health.py
+      - tools/test_public_live_health.py
+  pull_request:
     branches:
       - main
     paths:
@@ -19,7 +26,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: supermega-public-live-health
+  group: supermega-portfolio-live-health
   cancel-in-progress: true
 
 jobs:
@@ -33,17 +40,19 @@ jobs:
           python-version: '3.12'
 
       - name: Fetch checker from the triggering commit
+        env:
+          SOURCE_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
         run: |
           curl --fail --silent --show-error --location \
             --proto '=https' --proto-redir '=https' \
             --retry 3 --retry-all-errors \
-            "https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/${GITHUB_SHA}/tools/check_public_live_health.py" \
+            "https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/${SOURCE_SHA}/tools/check_public_live_health.py" \
             --output "${RUNNER_TEMP}/check_public_live_health.py"
 
           curl --fail --silent --show-error --location \
             --proto '=https' --proto-redir '=https' \
             --retry 3 --retry-all-errors \
-            "https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/${GITHUB_SHA}/tools/test_public_live_health.py" \
+            "https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/${SOURCE_SHA}/tools/test_public_live_health.py" \
             --output "${RUNNER_TEMP}/test_public_live_health.py"
 
       - name: Test portfolio health checker

--- a/tools/check_public_live_health.py
+++ b/tools/check_public_live_health.py
@@ -14,7 +14,7 @@ from typing import Any
 from urllib.parse import urljoin
 
 
-USER_AGENT = "supermega-portfolio-live-health/3.0"
+USER_AGENT = "supermega-portfolio-live-health/4.0"
 
 
 class NoRedirect(urllib.request.HTTPRedirectHandler):
@@ -76,10 +76,19 @@ def nested_value(payload: dict[str, Any], path: str) -> Any:
     return value
 
 
-def run(base_url: str, www_url: str, app_url: str, *, timeout: float, attempts: int) -> dict[str, Any]:
+def run(
+    base_url: str,
+    www_url: str,
+    app_url: str,
+    console_url: str,
+    *,
+    timeout: float,
+    attempts: int,
+) -> dict[str, Any]:
     base_url = base_url.rstrip("/") + "/"
     www_url = www_url.rstrip("/") + "/"
     app_url = app_url.rstrip("/") + "/"
+    console_url = console_url.rstrip("/") + "/"
     failures: list[dict[str, Any]] = []
     results: list[dict[str, Any]] = []
 
@@ -239,6 +248,91 @@ def run(base_url: str, www_url: str, app_url: str, *, timeout: float, attempts: 
     if app_health_response.status != 200 or app_health_mismatches:
         failures.append(app_health_result)
 
+    console_page_response = fetch(console_url, timeout=timeout, attempts=attempts)
+    console_page_body = console_page_response.body.decode("utf-8", errors="replace")
+    console_page_tokens = [
+        "<title>SuperMega Console</title>",
+        'data-view="company"',
+        'id="view-company"',
+        "Plan and run one bounded specialist wave",
+        "I reviewed this exact client, evidence, assignments, and budget",
+        "api('POST','/api/agent-company',{action:'plan',...input})",
+        "api('POST','/api/agent-company',{action:'run',...companyDraft.input})",
+    ]
+    console_page_missing = [token for token in console_page_tokens if token not in console_page_body]
+    console_page_result = {
+        "kind": "agent_company_page",
+        "url": console_url,
+        "status": console_page_response.status,
+        "bytes": len(console_page_response.body),
+        "missing": console_page_missing,
+    }
+    results.append(console_page_result)
+    if console_page_response.status != 200 or len(console_page_response.body) < 1000 or console_page_missing:
+        failures.append(console_page_result)
+
+    kernel_status_url = urljoin(console_url, "api/status")
+    kernel_status_response = fetch(kernel_status_url, timeout=timeout, attempts=attempts)
+    try:
+        kernel_status_payload = json.loads(kernel_status_response.body.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        kernel_status_payload = {}
+    expected_kernel_status = {
+        "ok": True,
+        "service": "supermega-kernel",
+        "db.ok": True,
+        "db.mode": "supabase",
+        "connectors.total": 69,
+        "connectors.registrationErrors": 0,
+        "ai.primary": "anthropic",
+    }
+    kernel_status_mismatches = {
+        path: {"expected": expected, "actual": nested_value(kernel_status_payload, path)}
+        for path, expected in expected_kernel_status.items()
+        if nested_value(kernel_status_payload, path) != expected
+    }
+    configured_connectors = nested_value(kernel_status_payload, "connectors.configured")
+    if not isinstance(configured_connectors, int) or configured_connectors < 1:
+        kernel_status_mismatches["connectors.configured"] = {
+            "expected": "integer >= 1",
+            "actual": configured_connectors,
+        }
+    providers = nested_value(kernel_status_payload, "ai.providers")
+    if not isinstance(providers, list) or "anthropic" not in providers:
+        kernel_status_mismatches["ai.providers"] = {
+            "expected": "contains anthropic",
+            "actual": providers,
+        }
+    kernel_status_result = {
+        "kind": "agent_company_status",
+        "url": kernel_status_url,
+        "status": kernel_status_response.status,
+        "mismatches": kernel_status_mismatches,
+    }
+    results.append(kernel_status_result)
+    if kernel_status_response.status != 200 or kernel_status_mismatches:
+        failures.append(kernel_status_result)
+
+    company_guard_url = urljoin(console_url, "api/agent-company")
+    company_guard_response = fetch(company_guard_url, timeout=timeout, attempts=attempts)
+    try:
+        company_guard_payload = json.loads(company_guard_response.body.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        company_guard_payload = {}
+    company_guard_result = {
+        "kind": "agent_company_guard",
+        "url": company_guard_url,
+        "status": company_guard_response.status,
+        "reason": company_guard_payload.get("reason"),
+    }
+    results.append(company_guard_result)
+    if (
+        company_guard_response.status != 401
+        or company_guard_payload.get("ok") is not False
+        or company_guard_payload.get("reason") != "unauthorized"
+    ):
+        failures.append(company_guard_result)
+
     return {
         "status": "ready" if not failures else "error",
         "checks": len(results),
@@ -252,6 +346,7 @@ def main() -> int:
     parser.add_argument("--base-url", default="https://supermega.dev")
     parser.add_argument("--www-url", default="https://www.supermega.dev")
     parser.add_argument("--app-url", default="https://app.supermega.dev")
+    parser.add_argument("--console-url", default="https://console.supermega.dev")
     parser.add_argument("--timeout", type=float, default=30.0)
     parser.add_argument("--attempts", type=int, default=3)
     args = parser.parse_args()
@@ -259,7 +354,14 @@ def main() -> int:
         parser.error("timeout and attempts must be positive")
 
     try:
-        report = run(args.base_url, args.www_url, args.app_url, timeout=args.timeout, attempts=args.attempts)
+        report = run(
+            args.base_url,
+            args.www_url,
+            args.app_url,
+            args.console_url,
+            timeout=args.timeout,
+            attempts=args.attempts,
+        )
     except Exception as error:  # Keep Actions output concise and secret-free.
         report = {"status": "error", "reason": str(error)}
 

--- a/tools/test_public_live_health.py
+++ b/tools/test_public_live_health.py
@@ -17,6 +17,7 @@ import check_public_live_health as checker
 BASE = "https://public.example/"
 WWW = "https://www.example/"
 APP = "https://app.example/"
+CONSOLE = "https://console.example/"
 
 
 def result(url: str, body: str | dict, *, status: int = 200, headers: dict[str, str] | None = None):
@@ -57,6 +58,15 @@ def healthy_responses() -> dict[str, checker.HttpResult]:
         '<div id="root"></div>',
         'type="module"',
     )
+    console = page(
+        "<title>SuperMega Console</title>",
+        'data-view="company"',
+        'id="view-company"',
+        "Plan and run one bounded specialist wave",
+        "I reviewed this exact client, evidence, assignments, and budget",
+        "api('POST','/api/agent-company',{action:'plan',...input})",
+        "api('POST','/api/agent-company',{action:'run',...companyDraft.input})",
+    )
     contact_status = {
         "status": "ready",
         "lead_ledger": "configured",
@@ -91,6 +101,13 @@ def healthy_responses() -> dict[str, checker.HttpResult]:
             "realCustomerAcceptance": "not-asserted",
         },
     }
+    kernel_status = {
+        "ok": True,
+        "service": "supermega-kernel",
+        "db": {"ok": True, "mode": "supabase"},
+        "connectors": {"total": 69, "configured": 12, "registrationErrors": 0},
+        "ai": {"providers": ["anthropic"], "primary": "anthropic"},
+    }
 
     responses = {
         BASE: result(BASE, home),
@@ -103,6 +120,13 @@ def healthy_responses() -> dict[str, checker.HttpResult]:
         f"{APP}home": result(f"{APP}home", app_shell),
         f"{APP}factory": result(f"{APP}factory", app_shell),
         f"{APP}api/health": result(f"{APP}api/health", app_health),
+        CONSOLE: result(CONSOLE, console),
+        f"{CONSOLE}api/status": result(f"{CONSOLE}api/status", kernel_status),
+        f"{CONSOLE}api/agent-company": result(
+            f"{CONSOLE}api/agent-company",
+            {"ok": False, "reason": "unauthorized"},
+            status=401,
+        ),
     }
     for path in ("products/", "pricing/", "ai-agents/", "offers/"):
         url = f"{BASE}{path}"
@@ -116,12 +140,12 @@ class PortfolioHealthTest(unittest.TestCase):
             return responses[url]
 
         with patch.object(checker, "fetch", side_effect=fake_fetch):
-            return checker.run(BASE, WWW, APP, timeout=1, attempts=1)
+            return checker.run(BASE, WWW, APP, CONSOLE, timeout=1, attempts=1)
 
-    def test_healthy_portfolio_passes_all_twelve_checks(self):
+    def test_healthy_portfolio_passes_all_fifteen_checks(self):
         report = self.run_report(healthy_responses())
         self.assertEqual(report["status"], "ready")
-        self.assertEqual(report["checks"], 12)
+        self.assertEqual(report["checks"], 15)
         self.assertEqual(report["failures"], [])
 
     def test_missing_plant_link_fails_public_page(self):
@@ -148,6 +172,43 @@ class PortfolioHealthTest(unittest.TestCase):
         self.assertEqual(report["status"], "error")
         health_failure = next(item for item in report["failures"] if item["kind"] == "app_health")
         self.assertIn("proof.productionCloudDurability", health_failure["mismatches"])
+
+    def test_missing_review_gate_fails_agent_company_page(self):
+        responses = healthy_responses()
+        responses[CONSOLE] = result(
+            CONSOLE,
+            responses[CONSOLE].body.decode().replace(
+                "I reviewed this exact client, evidence, assignments, and budget", ""
+            ),
+        )
+        report = self.run_report(responses)
+        self.assertEqual(report["status"], "error")
+        failure = next(item for item in report["failures"] if item["kind"] == "agent_company_page")
+        self.assertIn(
+            "I reviewed this exact client, evidence, assignments, and budget",
+            failure["missing"],
+        )
+
+    def test_kernel_registration_fault_fails_agent_company_status(self):
+        responses = healthy_responses()
+        payload = copy.deepcopy(json.loads(responses[f"{CONSOLE}api/status"].body))
+        payload["connectors"]["registrationErrors"] = 1
+        responses[f"{CONSOLE}api/status"] = result(f"{CONSOLE}api/status", payload)
+        report = self.run_report(responses)
+        self.assertEqual(report["status"], "error")
+        failure = next(item for item in report["failures"] if item["kind"] == "agent_company_status")
+        self.assertIn("connectors.registrationErrors", failure["mismatches"])
+
+    def test_unprotected_agent_company_endpoint_fails_guard(self):
+        responses = healthy_responses()
+        responses[f"{CONSOLE}api/agent-company"] = result(
+            f"{CONSOLE}api/agent-company",
+            {"ok": True, "agents": []},
+        )
+        report = self.run_report(responses)
+        self.assertEqual(report["status"], "error")
+        failure = next(item for item in report["failures"] if item["kind"] == "agent_company_guard")
+        self.assertEqual(failure["status"], 200)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What changed
- renames the scheduled job to SuperMega Portfolio Live Health
- adds read-only checks for the live Agent Company console workspace
- verifies the kernel reports healthy Supabase, Anthropic, 69 registered connectors, and zero registration errors
- proves `/api/agent-company` remains `401 unauthorized` without an Ops passcode
- expands deterministic regressions from four to seven and the live contract from 12 to 15 checks

## Verification
- `python -m unittest -v tools.test_public_live_health`: 7 passed
- Python compile: passed
- direct production run: 15/15 checks passed

## Evidence boundary
The checker performs GET requests only. It sends no passcode, contact form, model request, customer evidence, provider action, or database mutation. Availability and configuration are not customer acceptance or revenue proof.