### PR TITLE
Kernel: prove Agent Company planner readiness

### DIFF
--- a/kernel/api/status.mjs
+++ b/kernel/api/status.mjs
@@ -1,16 +1,72 @@
 // SUPERMEGA kernel — PUBLIC status surface. GET /api/status returns a secret-safe, at-a-glance
 // health snapshot of the whole platform brain so an operator can confirm it's working WITHOUT the
 // ops key: data-spine reachability, connector inventory (counts + registration faults), AI provider
-// failover chain, and money-layer configuration booleans. No secret VALUES, no PII, no per-connector
-// detail (that stays behind /api/integrations + the ops key). 200 when healthy, 503 when not.
+// failover chain, Agent Company plan-only readiness, and money-layer configuration booleans. No
+// secret VALUES, PII, evidence, assignments, or per-connector detail. 200 when healthy, 503 when not.
+import {
+  MAX_CYCLE_AGENTS,
+  MAX_CYCLE_ROLE_BUDGET,
+  planCompanyCycle,
+} from '../agent-company.mjs'
 import connectors, { registrationErrors } from '../connectors/index.mjs'
 import gateway from '../gateway.mjs'
 import store from '../store.mjs'
 
 const env = (name) => Boolean(String(process.env[name] || '').trim())
-const withTimeout = (p, ms, fallback) => Promise.race([p, new Promise((r) => setTimeout(() => r(fallback), ms))])
+const withTimeout = async (promise, ms, fallback) => {
+  let timer
+  try {
+    return await Promise.race([
+      promise,
+      new Promise((resolve) => { timer = setTimeout(() => resolve(fallback), ms) }),
+    ])
+  } finally {
+    clearTimeout(timer)
+  }
+}
 
-export async function buildStatus() {
+const AGENT_COMPANY_PROBE = Object.freeze({
+  clientId: 'status-self-test',
+  cycleId: 'status-self-test',
+  agents: ['operations-analyst'],
+  evidence: {
+    'operations-analyst': 'Synthetic status probe. No customer data, account access, or credentials.',
+  },
+  roleBudget: MAX_CYCLE_ROLE_BUDGET,
+})
+
+async function agentCompanyStatus(plan) {
+  let result
+  try { result = await withTimeout(plan(AGENT_COMPANY_PROBE), 1000, null) }
+  catch { result = null }
+  const plannerReady = Boolean(
+    result?.ok
+      && result.mode === 'plan'
+      && result.actionMode === 'draft_only'
+      && result.approvalRequired === true
+      && result.assignments?.length === 1
+      && result.budget?.selectedAgents === 1
+      && result.budget?.plannedRoles > 0
+      && result.budget.plannedRoles <= MAX_CYCLE_ROLE_BUDGET
+      && result.controls?.execution === 'sequential'
+      && result.controls.dynamicDelegation === false
+      && result.controls.crossAgentContext === false
+      && result.controls.externalWrites === false
+      && result.controls.durableClaimRequired === true
+  )
+  return {
+    plannerReady,
+    actionMode: plannerReady ? 'draft_only' : 'unavailable',
+    maxAgents: MAX_CYCLE_AGENTS,
+    maxRoleBudget: MAX_CYCLE_ROLE_BUDGET,
+    probeMode: 'plan_only',
+    modelRequest: false,
+    durableClaimCreated: false,
+    externalWrites: plannerReady ? false : null,
+  }
+}
+
+export async function buildStatus(options = {}) {
   const t0 = Date.now()
 
   // Data spine reachability (bounded so a hung DB can't hang the probe).
@@ -28,6 +84,9 @@ export async function buildStatus() {
   // AI gateway provider chain (env-derived, cheap).
   const providers = gateway.providerChain().map((p) => p.name)
 
+  // Fixed synthetic plan only: no model call, durable claim, provider write, or secret.
+  const agentCompany = await agentCompanyStatus(options.planCompanyCycle || planCompanyCycle)
+
   const money = {
     stripe_configured: env('STRIPE_SECRET_KEY'),
     stripe_webhook_configured: env('STRIPE_WEBHOOK_SECRET'),
@@ -35,7 +94,7 @@ export async function buildStatus() {
     wavepay_configured: env('WAVEPAY_SECRET_KEY') || env('WAVEPAY_MERCHANT_ID'),
   }
 
-  const ok = Boolean(db.ok) && regErrors === 0
+  const ok = Boolean(db.ok) && regErrors === 0 && agentCompany.plannerReady
   return {
     ok,
     service: 'supermega-kernel',
@@ -43,6 +102,7 @@ export async function buildStatus() {
     db,
     connectors: { total: list.length, configured, registrationErrors: regErrors, byCategory },
     ai: { providers, primary: providers[0] || null, failover: providers.length > 1 },
+    agentCompany,
     money,
     latency_ms: Date.now() - t0,
   }

--- a/kernel/api/status.test.mjs
+++ b/kernel/api/status.test.mjs
@@ -1,4 +1,5 @@
 // Public status surface — shape + secret-safety. `node --test`.
+import { readFile } from 'node:fs/promises'
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
 import { buildStatus } from './status.mjs'
@@ -10,9 +11,43 @@ test('buildStatus returns a complete, secret-safe snapshot', async () => {
   assert.ok(s.connectors.total > 0, 'connectors are registered')
   assert.ok('configured' in s.connectors && 'registrationErrors' in s.connectors)
   assert.ok(Array.isArray(s.ai.providers))
+  assert.deepEqual(s.agentCompany, {
+    plannerReady: true,
+    actionMode: 'draft_only',
+    maxAgents: 2,
+    maxRoleBudget: 8,
+    probeMode: 'plan_only',
+    modelRequest: false,
+    durableClaimCreated: false,
+    externalWrites: false,
+  })
   assert.ok('stripe_configured' in s.money && 'stripe_webhook_configured' in s.money)
   assert.equal(typeof s.latency_ms, 'number')
   // Never leak a secret value through the public surface.
   const blob = JSON.stringify(s)
   assert.equal(/sk_(live|test)_|whsec_|Bearer |SUPABASE_SERVICE/.test(blob), false, 'no secret material in the payload')
+})
+
+test('planner failure makes public health fail closed without leaking the reason', async () => {
+  const s = await buildStatus({
+    planCompanyCycle: async () => ({ ok: false, reason: 'private_planner_failure_detail' }),
+  })
+  assert.equal(s.ok, false)
+  assert.deepEqual(s.agentCompany, {
+    plannerReady: false,
+    actionMode: 'unavailable',
+    maxAgents: 2,
+    maxRoleBudget: 8,
+    probeMode: 'plan_only',
+    modelRequest: false,
+    durableClaimCreated: false,
+    externalWrites: null,
+  })
+  assert.doesNotMatch(JSON.stringify(s), /private_planner_failure_detail/)
+})
+
+test('public status imports only the Agent Company planner, never its runner', async () => {
+  const source = await readFile(new URL('./status.mjs', import.meta.url), 'utf8')
+  assert.match(source, /planCompanyCycle/)
+  assert.doesNotMatch(source, /runCompanyCycle|SUPERMEGA_OPS_KEY|x-ops-key|gateway\.complete/)
 })


### PR DESCRIPTION
## Summary
- run a fixed synthetic Agent Company plan inside the public read-only status endpoint
- expose only bounded planner-readiness metadata, never evidence, prompts, assignments, secrets, model output, or claims
- fail overall status closed when the planner probe cannot produce the required draft-only approval boundary
- clear status timeout timers after completion

## Proof
- `npm run verify`: 166 tests passed
- connector resilience: 69 connectors / 993 adversarial calls / 0 violations
- crew resilience: 5 crews / 74 checks / 0 violations
- the probe is plan-only: no model request, durable claim, provider action, or external write