### PR TITLE
Kernel: add reviewed Agent Company work orders

### DIFF
--- a/kernel/README.md
+++ b/kernel/README.md
@@ -14,8 +14,8 @@ broader system boundaries.
 | `workcells.mjs` + `workcell-run.mjs` | Cash Close, Pipeline Control, and Owner Command products | live |
 | `owner-evidence.mjs` + `api/owner-evidence.mjs` | Reviewed LINE/Viber evidence preview, immutable storage, and bounded read | live |
 | `approval-actions.mjs` + `api/approvals.mjs` | Immutable owner approval and idempotent ClickUp execution | live |
-| `crews/` + `crew-run.mjs` | Contract-enforced, draft-only multi-role tasks | 5 live |
-| `agent-company.mjs` + `api/agent-company.mjs` | Bounded supervisor cycles across the fixed crew roster | live |
+| `crews/` + `crew-run.mjs` | Contract-enforced, draft-only multi-role tasks | 8 live |
+| `agent-company.mjs` + `agent-company-work-orders.mjs` | Bounded supervisor cycles and durable reviewed delegation | live |
 | `public/` + `api/` | Ops console, status, workcell activation, and scheduled delivery | live |
 
 ## Gateway
@@ -56,7 +56,7 @@ The agent receives only the bounded read tool and cannot write to the inbox.
 
 ## Agent Company Cycles
 
-`POST /api/agent-company` is the protected manager layer over the five validated crews. Callers must
+`POST /api/agent-company` is the protected manager layer over the eight validated crews. Callers must
 choose `action: "plan"` or `action: "run"`, a stable client and cycle id, one or two allowlisted
 specialists, and separate evidence for each specialist. A plan reports the exact role-call budget
 before any model call. A run atomically claims the cycle in durable storage, then executes the crews
@@ -68,6 +68,22 @@ traceable envelope and returns drafts only; every external side effect remains b
 approval path. Reusing a claimed cycle id is blocked to prevent duplicate spend.
 Completed specialist and final envelopes are also stored under the claimed run id, so an idempotent
 replay can return a finished result or expose the recoverable partial results without spending again.
+
+For durable delegation, the same endpoint accepts four additional explicit actions:
+
+- `work-order-create` validates and stores the exact cycle plan without a model call.
+- `work-order-list` returns up to 40 client-bound order summaries, filtered in the store by kind and
+  client. Raw queued evidence is never returned.
+- `work-order-get` returns assignments, budgets, byte counts, evidence fingerprints, and any result.
+- `work-order-run` requires the saved 64-character plan hash and exact `RUN <workOrderId>`
+  confirmation, then reuses `runCompanyCycle`; there is no second runner or recursive delegation.
+
+The work-order id is deterministic for one client and cycle. Re-creating the same exact plan replays
+the saved order, while changed evidence under the same cycle id is a conflict. Dispatch first saves
+the `running` state, so storage failure blocks model spend. A concurrent or lost-response retry hits
+the cycle runner's durable claim and either returns the saved result or reports the existing run.
+Queued evidence remains inside the service-role-only cache record and is replaced by fingerprints
+after a terminal dispatch state.
 
 ## Core Environment
 
@@ -96,6 +112,8 @@ in recovery instead of being retried blindly.
 - The default cron is one daily UTC schedule. Each isolated client deployment sets its own UTC time.
 - Agent Company cycles are synchronous waves capped at two specialists and eight planned role calls.
   Failed or partial waves require a new explicit cycle id; there is no automatic retry or hidden loop.
+- Planned work orders retain their bounded evidence in the protected cache until dispatch. There is
+  no unattended dispatcher or retention sweeper; an owner still reviews and dispatches each order.
 
 ## Next
 

--- a/kernel/agent-company-ui-contract.test.mjs
+++ b/kernel/agent-company-ui-contract.test.mjs
@@ -13,10 +13,25 @@ test('console exposes one plan-first Agent Company workspace', async () => {
   assert.match(html, /api\('POST','\/api\/agent-company',\{action:'run',\.\.\.companyDraft\.input\}\)/)
   assert.match(html, /I reviewed this exact client, evidence, assignments, and budget/)
   assert.match(html, /id="companyRunButton" type="button" disabled/)
+  assert.match(html, /id="companyQueueButton" type="button" disabled/)
   assert.match(html, /if\(companyDraft\)invalidateCompanyPlan\('Inputs changed\. Plan the cycle again\.'\)/)
   assert.match(html, /Result unavailable\. Checking again is idempotent\./)
   assert.match(html, /if\(location\.hash==='\#company'\)/)
-  assert.match(html, /companyRoster=\[\]\s+invalidateCompanyPlan\(\)\s+loadProtectedState\(\)/)
+  assert.match(html, /companyRoster=\[\]\s+companyWorkOrders=\[\]\s+invalidateCompanyPlan\(\)/)
+})
+
+test('Agent Company console queues and dispatches only exact reviewed work orders', async () => {
+  const html = await readConsole()
+  assert.match(html, /action:'work-order-create',\.\.\.companyDraft\.input/)
+  assert.match(html, /action:'work-order-list',clientId,limit:20/)
+  assert.match(html, /action:'work-order-get',clientId,workOrderId/)
+  assert.match(html, /action:'work-order-run',clientId:order\.clientId,workOrderId:order\.workOrderId,planHash:order\.planHash,confirmation:`RUN \$\{order\.workOrderId\}`/)
+  assert.match(html, /I reviewed this stored plan, evidence fingerprints, assignments, and budget/)
+  assert.match(html, /Work order queued\. No model call was made\./)
+  assert.match(html, /renderCompanyWorkOrderDetail\(response\.workOrder\)/)
+  assert.match(html, /companyWorkOrders=\[\]\s+invalidateCompanyPlan\(\)/)
+  assert.match(html, /invalidateCompanyPlan\(\)\s+\$\('#companyOrderDetail'\)\.hidden=true\s+\$\('#companyOrderDetail'\)\.innerHTML=''\s+\$\('#companyResults'\)\.innerHTML=''/)
+  assert.doesNotMatch(html, /order\.input|workOrder\.input/)
 })
 
 test('Agent Company UI accepts bounded evidence but no credential or action fields', async () => {
@@ -40,8 +55,12 @@ test('Agent Company controls remain touch-safe and collapse to one column', asyn
   assert.match(html, /\.company-actions button\{min-height:44px\}/)
   assert.match(html, /\.company-plan-actions button\{min-height:44px\}/)
   assert.match(html, /\.company-new-cycle\{min-height:44px\}/)
+  assert.match(html, /\.company-work-orders-head button\{min-height:44px\}/)
+  assert.match(html, /\.company-order-actions button\{min-height:44px\}/)
+  assert.match(html, /\.company-order-confirm\{[^}]*min-height:44px/)
   assert.match(html, /\.company-agent\{grid-template-columns:1fr\}/)
   assert.match(html, /\.company-scope\{grid-template-columns:1fr\}/)
+  assert.match(html, /\.company-assignment,\.company-order-row\{grid-template-columns:1fr/)
 })
 
 test('Agent Company API route is a dedicated function before the catch-all', async () => {

--- a/kernel/agent-company-work-orders.mjs
+++ b/kernel/agent-company-work-orders.mjs
@@ -1,0 +1,303 @@
+// Durable, reviewed work orders for the bounded Agent Company cycle runner.
+// This layer queues exact plans; it does not invent agents or add another execution engine.
+
+import { createHash, timingSafeEqual } from 'node:crypto'
+
+import { planCompanyCycle, runCompanyCycle } from './agent-company.mjs'
+import {
+  claimActivity,
+  getCachedResponse,
+  listActivity,
+  putCachedResponse,
+  releaseActivityClaim,
+} from './store.mjs'
+
+export const MAX_COMPANY_WORK_ORDERS = 40
+
+const ID_RE = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,79}$/
+const FINAL_STATUSES = new Set(['completed', 'partial', 'blocked', 'failed'])
+const CREATE_FIELDS = new Set(['clientId', 'cycleId', 'agents', 'evidence', 'roleBudget'])
+const LIST_FIELDS = new Set(['clientId', 'limit'])
+const GET_FIELDS = new Set(['clientId', 'workOrderId'])
+const RUN_FIELDS = new Set(['clientId', 'workOrderId', 'planHash', 'confirmation'])
+
+const failure = (reason, extra = {}) => ({ ok: false, reason, ...extra })
+const isRecord = (value) => value && typeof value === 'object' && !Array.isArray(value)
+const recordKey = (workOrderId) => `company-work-order-record:${workOrderId}`
+
+function onlyFields(input, allowed) {
+  if (!isRecord(input)) return failure('company_work_order_invalid_request')
+  const fields = Object.keys(input).filter((field) => !allowed.has(field)).sort()
+  return fields.length ? failure('company_work_order_unknown_field', { fields }) : { ok: true }
+}
+
+function normalizeId(value, reason) {
+  const normalized = String(value || '').trim()
+  return ID_RE.test(normalized) ? normalized : failure(reason)
+}
+
+function stableStringify(value) {
+  if (value === null || typeof value !== 'object') return JSON.stringify(value)
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(',')}]`
+  return `{${Object.keys(value).sort().map((key) => `${JSON.stringify(key)}:${stableStringify(value[key])}`).join(',')}}`
+}
+
+function sha256(value) {
+  return createHash('sha256').update(String(value)).digest('hex')
+}
+
+function sameHash(left, right) {
+  if (!/^[a-f0-9]{64}$/.test(String(left)) || !/^[a-f0-9]{64}$/.test(String(right))) return false
+  return timingSafeEqual(Buffer.from(String(left), 'hex'), Buffer.from(String(right), 'hex'))
+}
+
+function evidenceText(value) {
+  return typeof value === 'string' ? value.trim() : JSON.stringify(value)
+}
+
+function normalizeStoredInput(input, plan) {
+  const evidence = {}
+  for (const assignment of plan.assignments) evidence[assignment.agentId] = evidenceText(input.evidence[assignment.agentId])
+  return {
+    clientId: plan.clientId,
+    cycleId: plan.cycleId,
+    agents: plan.assignments.map((assignment) => assignment.agentId),
+    evidence,
+    roleBudget: plan.budget.roleLimit,
+  }
+}
+
+function publicWorkOrder(record, { includeResult = true } = {}) {
+  const result = includeResult && isRecord(record.result) ? record.result : undefined
+  return {
+    workOrderId: record.workOrderId,
+    clientId: record.clientId,
+    cycleId: record.cycleId,
+    status: record.status,
+    planHash: record.planHash,
+    createdAt: record.createdAt,
+    updatedAt: record.updatedAt,
+    completedAt: record.completedAt || null,
+    plan: record.plan,
+    evidence: record.plan.assignments.map((assignment) => ({
+      agentId: assignment.agentId,
+      bytes: assignment.evidenceBytes,
+      digest: record.evidenceDigests[assignment.agentId],
+    })),
+    ...(result ? { result } : {}),
+  }
+}
+
+async function readWorkOrder(workOrderId, options = {}) {
+  const read = options.getWorkOrder || getCachedResponse
+  try {
+    const record = await read(recordKey(workOrderId))
+    return isRecord(record) && record.workOrderId === workOrderId ? record : null
+  } catch {
+    return null
+  }
+}
+
+export async function createCompanyWorkOrder(input, options = {}) {
+  const fields = onlyFields(input, CREATE_FIELDS)
+  if (!fields.ok) return fields
+  const planCycle = options.planCompanyCycle || planCompanyCycle
+  const plan = await planCycle(input)
+  if (!plan.ok) return plan
+
+  let storedInput
+  try { storedInput = normalizeStoredInput(input, plan) }
+  catch { return failure('company_work_order_invalid_evidence') }
+  const planHash = sha256(stableStringify(storedInput))
+  const workOrderId = `company-order:${String(plan.runId).split(':').pop()}`
+  const evidenceDigests = Object.fromEntries(
+    Object.entries(storedInput.evidence).map(([agentId, evidence]) => [agentId, sha256(evidence)]),
+  )
+
+  const reserve = options.claimActivity || claimActivity
+  const release = options.releaseActivityClaim || releaseActivityClaim
+  const save = options.putWorkOrder || putCachedResponse
+  const requireDurableClaim = options.requireDurableClaim !== false
+  let claim
+  try {
+    claim = await reserve({
+      id: workOrderId,
+      kind: 'agent_company_work_order',
+      summary: `${plan.assignments.length} specialists queued for cycle ${plan.cycleId}`,
+      ref: plan.clientId,
+    })
+  } catch {
+    claim = { fresh: false, durable: false }
+  }
+  if (!claim?.fresh) {
+    if (!claim?.durable) return failure('company_work_order_store_unavailable', { status: 'blocked' })
+    const existing = await readWorkOrder(workOrderId, options)
+    if (!existing) return failure('company_work_order_already_claimed', { status: 'duplicate', workOrderId })
+    if (!sameHash(existing.planHash, planHash)) {
+      return failure('company_work_order_conflict', { status: 'conflict', workOrderId })
+    }
+    return { ok: true, mode: 'work_order_create', replayed: true, workOrder: publicWorkOrder(existing) }
+  }
+  if (requireDurableClaim && !claim.durable) {
+    try { await release(workOrderId) } catch { /* no evidence was persisted */ }
+    return failure('company_work_order_durable_claim_required', { status: 'blocked', workOrderId })
+  }
+
+  const now = String(options.now?.() || new Date().toISOString())
+  const record = {
+    version: 1,
+    workOrderId,
+    clientId: plan.clientId,
+    cycleId: plan.cycleId,
+    status: 'planned',
+    planHash,
+    createdAt: now,
+    updatedAt: now,
+    plan,
+    evidenceDigests,
+    input: storedInput,
+  }
+  let stored = false
+  try { stored = Boolean(await save(recordKey(workOrderId), record)) }
+  catch { stored = false }
+  if (!stored) {
+    try { await release(workOrderId) } catch { /* allow an explicit retry */ }
+    return failure('company_work_order_store_unavailable', { status: 'blocked', workOrderId })
+  }
+  return { ok: true, mode: 'work_order_create', replayed: false, workOrder: publicWorkOrder(record) }
+}
+
+export async function getCompanyWorkOrder(input, options = {}) {
+  const fields = onlyFields(input, GET_FIELDS)
+  if (!fields.ok) return fields
+  const clientId = normalizeId(input.clientId, 'company_invalid_client_id')
+  if (isRecord(clientId)) return clientId
+  const workOrderId = normalizeId(input.workOrderId, 'company_work_order_invalid_id')
+  if (isRecord(workOrderId)) return workOrderId
+  const record = await readWorkOrder(workOrderId, options)
+  if (!record || record.clientId !== clientId) return failure('company_work_order_not_found')
+  return { ok: true, mode: 'work_order_get', workOrder: publicWorkOrder(record) }
+}
+
+export async function listCompanyWorkOrders(input, options = {}) {
+  const fields = onlyFields(input, LIST_FIELDS)
+  if (!fields.ok) return fields
+  const clientId = normalizeId(input.clientId, 'company_invalid_client_id')
+  if (isRecord(clientId)) return clientId
+  const requestedLimit = input.limit === undefined ? 20 : Number(input.limit)
+  if (!Number.isInteger(requestedLimit) || requestedLimit < 1 || requestedLimit > MAX_COMPANY_WORK_ORDERS) {
+    return failure('company_work_order_invalid_limit', { maxWorkOrders: MAX_COMPANY_WORK_ORDERS })
+  }
+  const readActivity = options.listActivity || listActivity
+  let activity
+  try {
+    activity = await readActivity(requestedLimit, {
+      kind: 'agent_company_work_order',
+      ref: clientId,
+    })
+  }
+  catch { return failure('company_work_order_store_unavailable', { status: 'blocked' }) }
+
+  const workOrders = []
+  for (const item of Array.isArray(activity) ? activity : []) {
+    if (item.kind !== 'agent_company_work_order' || item.ref !== clientId) continue
+    const record = await readWorkOrder(String(item.id || ''), options)
+    if (!record || record.clientId !== clientId) continue
+    workOrders.push(publicWorkOrder(record, { includeResult: false }))
+    if (workOrders.length >= requestedLimit) break
+  }
+  return { ok: true, mode: 'work_order_list', clientId, workOrders }
+}
+
+export async function runCompanyWorkOrder(input, options = {}) {
+  const fields = onlyFields(input, RUN_FIELDS)
+  if (!fields.ok) return fields
+  const clientId = normalizeId(input.clientId, 'company_invalid_client_id')
+  if (isRecord(clientId)) return clientId
+  const workOrderId = normalizeId(input.workOrderId, 'company_work_order_invalid_id')
+  if (isRecord(workOrderId)) return workOrderId
+  const record = await readWorkOrder(workOrderId, options)
+  if (!record || record.clientId !== clientId) return failure('company_work_order_not_found')
+  if (!sameHash(input.planHash, record.planHash)) {
+    return failure('company_work_order_plan_mismatch', { status: 'conflict', workOrderId })
+  }
+  if (String(input.confirmation || '') !== `RUN ${workOrderId}`) {
+    return failure('company_work_order_confirmation_required', {
+      workOrderId,
+      confirmation: `RUN ${workOrderId}`,
+    })
+  }
+  if (FINAL_STATUSES.has(record.status) && isRecord(record.result)) {
+    return {
+      ok: true,
+      mode: 'work_order_run',
+      replayed: true,
+      workOrder: publicWorkOrder(record),
+      cycleResult: record.result,
+    }
+  }
+  if (!isRecord(record.input)) return failure('company_work_order_input_unavailable', { status: 'blocked', workOrderId })
+
+  const save = options.putWorkOrder || putCachedResponse
+  const now = () => String(options.now?.() || new Date().toISOString())
+  const running = { ...record, status: 'running', updatedAt: now() }
+  let runningStored = false
+  try { runningStored = Boolean(await save(recordKey(workOrderId), running)) }
+  catch { runningStored = false }
+  if (!runningStored) return failure('company_work_order_store_unavailable', { status: 'blocked', workOrderId })
+
+  const execute = options.runCompanyCycle || runCompanyCycle
+  let result
+  try { result = await execute(record.input) }
+  catch { result = failure('company_work_order_dispatch_failed', { status: 'failed' }) }
+
+  if (result.reason === 'company_claim_unavailable' || result.reason === 'company_durable_claim_required') {
+    const retryable = { ...running, status: 'planned', updatedAt: now(), lastDispatch: { reason: result.reason } }
+    try { await save(recordKey(workOrderId), retryable) } catch { /* next read reports running */ }
+    return failure(result.reason, { status: 'blocked', workOrderId, workOrder: publicWorkOrder(retryable) })
+  }
+  if (result.reason === 'company_cycle_already_claimed') {
+    const latest = await readWorkOrder(workOrderId, options) || running
+    return failure('company_work_order_running', {
+      status: 'duplicate',
+      workOrderId,
+      recoveredResults: result.recoveredResults || [],
+      workOrder: publicWorkOrder(latest),
+    })
+  }
+
+  const status = FINAL_STATUSES.has(result.status) ? result.status : (result.ok ? 'completed' : 'failed')
+  const finished = {
+    ...running,
+    status,
+    updatedAt: now(),
+    completedAt: now(),
+    input: null,
+    result,
+  }
+  let finalStored = false
+  try { finalStored = Boolean(await save(recordKey(workOrderId), finished)) }
+  catch { finalStored = false }
+  if (!finalStored) {
+    return failure('company_work_order_state_unavailable', {
+      status: 'recovery_required',
+      workOrderId,
+      cycleResult: result,
+      workOrder: publicWorkOrder(finished),
+    })
+  }
+  return {
+    ok: true,
+    mode: 'work_order_run',
+    replayed: Boolean(result.replayed),
+    workOrder: publicWorkOrder(finished),
+    cycleResult: result,
+  }
+}
+
+export default {
+  createCompanyWorkOrder,
+  getCompanyWorkOrder,
+  listCompanyWorkOrders,
+  runCompanyWorkOrder,
+}

--- a/kernel/agent-company-work-orders.test.mjs
+++ b/kernel/agent-company-work-orders.test.mjs
@@ -1,0 +1,216 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  createCompanyWorkOrder,
+  getCompanyWorkOrder,
+  listCompanyWorkOrders,
+  runCompanyWorkOrder,
+} from './agent-company-work-orders.mjs'
+
+const work = (patch = {}) => ({
+  clientId: 'client-acme',
+  cycleId: 'queue-2026-07-14-a',
+  agents: ['sales-qualifier', 'quality-reviewer'],
+  evidence: {
+    'sales-qualifier': { problem: 'Manual close takes two days', buyer: 'Owner' },
+    'quality-reviewer': 'Review draft v2 against acceptance rules A and B.',
+  },
+  roleBudget: 6,
+  ...patch,
+})
+
+function harness() {
+  const records = new Map()
+  const claims = new Map()
+  const activity = []
+  return {
+    records,
+    activity,
+    options: {
+      claimActivity: async (row) => {
+        if (claims.has(row.id)) return { fresh: false, durable: true }
+        claims.set(row.id, row)
+        activity.unshift({ ...row, at: '2026-07-14T00:00:00.000Z' })
+        return { fresh: true, durable: true }
+      },
+      releaseActivityClaim: async (id) => claims.delete(id),
+      putWorkOrder: async (key, payload) => { records.set(key, structuredClone(payload)); return true },
+      getWorkOrder: async (key) => records.get(key) || null,
+      listActivity: async () => activity,
+      now: () => '2026-07-14T00:00:00.000Z',
+    },
+  }
+}
+
+test('creation durably queues one exact reviewed plan without running a model', async () => {
+  const state = harness()
+  let runs = 0
+  const result = await createCompanyWorkOrder(work(), {
+    ...state.options,
+    runCompanyCycle: async () => { runs += 1; return { ok: true } },
+  })
+  assert.equal(result.ok, true)
+  assert.equal(result.mode, 'work_order_create')
+  assert.equal(result.workOrder.status, 'planned')
+  assert.match(result.workOrder.workOrderId, /^company-order:[a-f0-9]{40}$/)
+  assert.match(result.workOrder.planHash, /^[a-f0-9]{64}$/)
+  assert.equal(result.workOrder.plan.assignments.length, 2)
+  assert.equal(result.workOrder.plan.budget.plannedRoles, 6)
+  assert.equal(result.workOrder.evidence.length, 2)
+  assert.match(result.workOrder.evidence[0].digest, /^[a-f0-9]{64}$/)
+  assert.equal('input' in result.workOrder, false)
+  assert.equal(JSON.stringify(result).includes('Manual close takes two days'), false)
+  assert.equal(runs, 0)
+})
+
+test('duplicate creation replays the same order and rejects changed evidence for one cycle id', async () => {
+  const state = harness()
+  const first = await createCompanyWorkOrder(work(), state.options)
+  const replay = await createCompanyWorkOrder(work(), state.options)
+  assert.equal(replay.ok, true)
+  assert.equal(replay.replayed, true)
+  assert.equal(replay.workOrder.workOrderId, first.workOrder.workOrderId)
+
+  const conflict = await createCompanyWorkOrder(work({
+    evidence: { ...work().evidence, 'sales-qualifier': 'Different evidence under the same cycle.' },
+  }), state.options)
+  assert.equal(conflict.ok, false)
+  assert.equal(conflict.reason, 'company_work_order_conflict')
+})
+
+test('creation fails closed when the queue claim or record is not durable', async () => {
+  let released = ''
+  const nonDurable = await createCompanyWorkOrder(work(), {
+    claimActivity: async () => ({ fresh: true, durable: false }),
+    releaseActivityClaim: async (id) => { released = id; return true },
+  })
+  assert.equal(nonDurable.reason, 'company_work_order_durable_claim_required')
+  assert.match(released, /^company-order:/)
+
+  let releasedAfterWrite = ''
+  const failedWrite = await createCompanyWorkOrder(work(), {
+    claimActivity: async () => ({ fresh: true, durable: true }),
+    putWorkOrder: async () => null,
+    releaseActivityClaim: async (id) => { releasedAfterWrite = id; return true },
+  })
+  assert.equal(failedWrite.reason, 'company_work_order_store_unavailable')
+  assert.match(releasedAfterWrite, /^company-order:/)
+})
+
+test('list and get remain client-bound and never return queued raw evidence', async () => {
+  const state = harness()
+  const created = await createCompanyWorkOrder(work(), state.options)
+  state.activity.unshift({ id: 'company-order:other', kind: 'agent_company_work_order', ref: 'client-other' })
+
+  let activityFilter
+  state.options.listActivity = async (limit, filter) => {
+    activityFilter = { limit, filter }
+    return state.activity.filter((item) => item.kind === filter.kind && item.ref === filter.ref).slice(0, limit)
+  }
+
+  const list = await listCompanyWorkOrders({ clientId: 'client-acme', limit: 10 }, state.options)
+  assert.equal(list.ok, true)
+  assert.equal(list.workOrders.length, 1)
+  assert.equal(list.workOrders[0].workOrderId, created.workOrder.workOrderId)
+  assert.deepEqual(activityFilter, { limit: 10, filter: { kind: 'agent_company_work_order', ref: 'client-acme' } })
+  assert.equal('result' in list.workOrders[0], false)
+  assert.equal(JSON.stringify(list).includes('Manual close takes two days'), false)
+
+  const fetched = await getCompanyWorkOrder({
+    clientId: 'client-acme',
+    workOrderId: created.workOrder.workOrderId,
+  }, state.options)
+  assert.equal(fetched.ok, true)
+  assert.equal(JSON.stringify(fetched).includes('Manual close takes two days'), false)
+  const wrongClient = await getCompanyWorkOrder({
+    clientId: 'client-other',
+    workOrderId: created.workOrder.workOrderId,
+  }, state.options)
+  assert.equal(wrongClient.reason, 'company_work_order_not_found')
+})
+
+test('dispatch is bound to the saved fingerprint and exact confirmation', async () => {
+  const state = harness()
+  const created = await createCompanyWorkOrder(work(), state.options)
+  const args = {
+    clientId: 'client-acme',
+    workOrderId: created.workOrder.workOrderId,
+    planHash: created.workOrder.planHash,
+    confirmation: `RUN ${created.workOrder.workOrderId}`,
+  }
+  assert.equal((await runCompanyWorkOrder({ ...args, planHash: '0'.repeat(64) }, state.options)).reason, 'company_work_order_plan_mismatch')
+  assert.equal((await runCompanyWorkOrder({ ...args, confirmation: 'RUN something-else' }, state.options)).reason, 'company_work_order_confirmation_required')
+
+  let received
+  const result = await runCompanyWorkOrder(args, {
+    ...state.options,
+    runCompanyCycle: async (input) => {
+      received = input
+      return {
+        ok: true,
+        mode: 'run',
+        status: 'completed',
+        runId: created.workOrder.plan.runId,
+        clientId: input.clientId,
+        cycleId: input.cycleId,
+        results: [{ ok: true, status: 'completed', agentId: 'sales-qualifier', output: { fit: 'strong' } }],
+        budget: { usedRoleCalls: 3 },
+      }
+    },
+  })
+  assert.equal(result.ok, true)
+  assert.equal(result.workOrder.status, 'completed')
+  assert.equal(received.clientId, 'client-acme')
+  assert.deepEqual(received.agents, ['sales-qualifier', 'quality-reviewer'])
+  assert.match(received.evidence['sales-qualifier'], /Manual close/)
+  assert.equal(JSON.stringify(result.workOrder).includes('Manual close takes two days'), false)
+  const saved = [...state.records.values()].find((row) => row.workOrderId === created.workOrder.workOrderId)
+  assert.equal(saved.input, null)
+  assert.equal(saved.result.status, 'completed')
+})
+
+test('completed dispatches replay without another specialist call', async () => {
+  const state = harness()
+  const created = await createCompanyWorkOrder(work(), state.options)
+  const args = {
+    clientId: 'client-acme',
+    workOrderId: created.workOrder.workOrderId,
+    planHash: created.workOrder.planHash,
+    confirmation: `RUN ${created.workOrder.workOrderId}`,
+  }
+  let runs = 0
+  const options = {
+    ...state.options,
+    runCompanyCycle: async () => { runs += 1; return { ok: true, status: 'completed', results: [] } },
+  }
+  assert.equal((await runCompanyWorkOrder(args, options)).ok, true)
+  const replay = await runCompanyWorkOrder(args, options)
+  assert.equal(replay.ok, true)
+  assert.equal(replay.replayed, true)
+  assert.equal(runs, 1)
+})
+
+test('dispatch never spends when the running state cannot be persisted', async () => {
+  const state = harness()
+  const created = await createCompanyWorkOrder(work(), state.options)
+  let runs = 0
+  const result = await runCompanyWorkOrder({
+    clientId: 'client-acme',
+    workOrderId: created.workOrder.workOrderId,
+    planHash: created.workOrder.planHash,
+    confirmation: `RUN ${created.workOrder.workOrderId}`,
+  }, {
+    ...state.options,
+    putWorkOrder: async () => null,
+    runCompanyCycle: async () => { runs += 1; return { ok: true, status: 'completed' } },
+  })
+  assert.equal(result.reason, 'company_work_order_store_unavailable')
+  assert.equal(runs, 0)
+})
+
+test('work-order actions reject unknown fields and unbounded listing', async () => {
+  assert.equal((await createCompanyWorkOrder({ ...work(), execute: true })).reason, 'company_work_order_unknown_field')
+  assert.equal((await listCompanyWorkOrders({ clientId: 'client-acme', limit: 41 })).reason, 'company_work_order_invalid_limit')
+  assert.equal((await runCompanyWorkOrder({ clientId: 'client-acme', workOrderId: 'x', planHash: 'x', confirmation: 'x', action: true })).reason, 'company_work_order_unknown_field')
+})

--- a/kernel/agent-company.mjs
+++ b/kernel/agent-company.mjs
@@ -52,6 +52,27 @@ export const AGENT_ROSTER = Object.freeze([
     crew: 'source-to-screen-pilot',
     outcome: 'Builds one source-traced proof and a human approval packet.',
   }),
+  Object.freeze({
+    id: 'sales-qualifier',
+    name: 'Sales Qualifier',
+    department: 'growth',
+    crew: 'lead-qualification-desk',
+    outcome: 'Qualifies one opportunity from evidence and drafts the smallest useful next step.',
+  }),
+  Object.freeze({
+    id: 'delivery-planner',
+    name: 'Delivery Planner',
+    department: 'delivery',
+    crew: 'delivery-planning-desk',
+    outcome: 'Turns an accepted outcome into milestones, dependencies, and objective acceptance checks.',
+  }),
+  Object.freeze({
+    id: 'quality-reviewer',
+    name: 'Quality Reviewer',
+    department: 'assurance',
+    crew: 'quality-review-desk',
+    outcome: 'Audits a deliverable against sources and acceptance rules before owner release.',
+  }),
 ])
 
 const ROSTER_BY_ID = new Map(AGENT_ROSTER.map((agent) => [agent.id, agent]))

--- a/kernel/agent-company.test.mjs
+++ b/kernel/agent-company.test.mjs
@@ -23,10 +23,14 @@ const cycle = (patch = {}) => ({
 
 test('agent roster is fixed, bounded, and backed by validated crews', async () => {
   const roster = listCompanyAgents()
-  assert.equal(roster.length, 5)
+  assert.equal(roster.length, 8)
   assert.equal(MAX_CYCLE_AGENTS, 2)
   assert.equal(MAX_CYCLE_ROLE_BUDGET, 8)
   assert.equal(new Set(roster.map((agent) => agent.id)).size, roster.length)
+  assert.deepEqual(
+    roster.slice(-3).map((agent) => agent.id),
+    ['sales-qualifier', 'delivery-planner', 'quality-reviewer'],
+  )
   const plan = await planCompanyCycle(cycle())
   assert.equal(plan.ok, true)
   assert.equal(plan.actionMode, 'draft_only')

--- a/kernel/api/agent-company.mjs
+++ b/kernel/api/agent-company.mjs
@@ -9,6 +9,13 @@ import {
   planCompanyCycle,
   runCompanyCycle,
 } from '../agent-company.mjs'
+import {
+  createCompanyWorkOrder,
+  getCompanyWorkOrder,
+  listCompanyWorkOrders,
+  MAX_COMPANY_WORK_ORDERS,
+  runCompanyWorkOrder,
+} from '../agent-company-work-orders.mjs'
 
 function constantTimeEqual(a, b) {
   const left = crypto.createHash('sha256').update(String(a)).digest()
@@ -18,8 +25,21 @@ function constantTimeEqual(a, b) {
 
 function statusFor(result) {
   if (result.ok) return 200
-  if (result.reason === 'company_cycle_already_claimed') return 409
-  if (result.reason === 'company_claim_unavailable' || result.reason === 'company_durable_claim_required') return 503
+  if (result.reason === 'company_work_order_not_found') return 404
+  if ([
+    'company_cycle_already_claimed',
+    'company_work_order_already_claimed',
+    'company_work_order_conflict',
+    'company_work_order_plan_mismatch',
+    'company_work_order_running',
+  ].includes(result.reason)) return 409
+  if ([
+    'company_claim_unavailable',
+    'company_durable_claim_required',
+    'company_work_order_durable_claim_required',
+    'company_work_order_state_unavailable',
+    'company_work_order_store_unavailable',
+  ].includes(result.reason)) return 503
   if (result.reason === 'company_role_budget_exceeded') return 422
   if (result.status === 'failed') return 502
   return 400
@@ -42,6 +62,12 @@ export async function handleAgentCompany(request = {}, options = {}) {
         actionMode: 'draft_only',
         agents: listCompanyAgents(),
         limits: { maxAgents: MAX_CYCLE_AGENTS, maxRoleBudget: MAX_CYCLE_ROLE_BUDGET },
+        workOrders: {
+          enabled: true,
+          maxList: MAX_COMPANY_WORK_ORDERS,
+          explicitDispatch: true,
+          rawEvidenceReturned: false,
+        },
       },
     }
   }
@@ -52,7 +78,14 @@ export async function handleAgentCompany(request = {}, options = {}) {
     : {}
   const action = String(body.action || '').trim()
   delete body.action
-  if (action !== 'plan' && action !== 'run') {
+  if (![
+    'plan',
+    'run',
+    'work-order-create',
+    'work-order-list',
+    'work-order-get',
+    'work-order-run',
+  ].includes(action)) {
     return { status: 400, json: { ok: false, reason: 'company_invalid_action' } }
   }
   const configuredClientId = String(options.clientId ?? env.SUPERMEGA_CLIENT_ID ?? '').trim()
@@ -62,7 +95,16 @@ export async function handleAgentCompany(request = {}, options = {}) {
 
   const plan = options.planCompanyCycle || planCompanyCycle
   const run = options.runCompanyCycle || runCompanyCycle
-  const result = action === 'plan' ? await plan(body) : await run(body)
+  const createOrder = options.createCompanyWorkOrder || createCompanyWorkOrder
+  const listOrders = options.listCompanyWorkOrders || listCompanyWorkOrders
+  const getOrder = options.getCompanyWorkOrder || getCompanyWorkOrder
+  const runOrder = options.runCompanyWorkOrder || runCompanyWorkOrder
+  const result = action === 'plan' ? await plan(body)
+    : action === 'run' ? await run(body)
+      : action === 'work-order-create' ? await createOrder(body)
+        : action === 'work-order-list' ? await listOrders(body)
+          : action === 'work-order-get' ? await getOrder(body)
+            : await runOrder(body)
   return { status: statusFor(result), json: result }
 }
 

--- a/kernel/api/agent-company.test.mjs
+++ b/kernel/api/agent-company.test.mjs
@@ -30,9 +30,12 @@ test('GET returns the protected fixed roster and hard limits', async () => {
   const result = await handleAgentCompany(request({ method: 'GET', body: undefined }), { opsKey: KEY })
   assert.equal(result.status, 200)
   assert.equal(result.json.actionMode, 'draft_only')
-  assert.equal(result.json.agents.length, 5)
+  assert.equal(result.json.agents.length, 8)
   assert.equal(result.json.limits.maxAgents, 2)
   assert.equal(result.json.limits.maxRoleBudget, 8)
+  assert.equal(result.json.workOrders.enabled, true)
+  assert.equal(result.json.workOrders.explicitDispatch, true)
+  assert.equal(result.json.workOrders.rawEvidenceReturned, false)
 })
 
 test('POST plans without claiming a run or accepting an implicit action', async () => {
@@ -65,6 +68,52 @@ test('POST run maps duplicate and unavailable durable claims cleanly', async () 
     runCompanyCycle: async () => ({ ok: false, reason: 'company_durable_claim_required', status: 'blocked' }),
   })
   assert.equal(blocked.status, 503)
+})
+
+test('protected work-order actions delegate to the durable queue contract', async () => {
+  const calls = []
+  const options = {
+    opsKey: KEY,
+    createCompanyWorkOrder: async (body) => { calls.push(['create', body]); return { ok: true, mode: 'work_order_create' } },
+    listCompanyWorkOrders: async (body) => { calls.push(['list', body]); return { ok: true, mode: 'work_order_list' } },
+    getCompanyWorkOrder: async (body) => { calls.push(['get', body]); return { ok: true, mode: 'work_order_get' } },
+    runCompanyWorkOrder: async (body) => { calls.push(['run', body]); return { ok: true, mode: 'work_order_run' } },
+  }
+  const actions = [
+    ['work-order-create', validBody],
+    ['work-order-list', { clientId: 'client-acme', limit: 10 }],
+    ['work-order-get', { clientId: 'client-acme', workOrderId: 'company-order:abc' }],
+    ['work-order-run', { clientId: 'client-acme', workOrderId: 'company-order:abc', planHash: 'a'.repeat(64), confirmation: 'RUN company-order:abc' }],
+  ]
+  for (const [action, body] of actions) {
+    const result = await handleAgentCompany(request({ body: { ...body, action } }), options)
+    assert.equal(result.status, 200)
+  }
+  assert.deepEqual(calls.map(([name]) => name), ['create', 'list', 'get', 'run'])
+  assert.equal(calls.every(([, body]) => !('action' in body)), true)
+})
+
+test('work-order API maps isolation, conflicts, and unavailable storage without leaking through GET', async () => {
+  const mismatch = await handleAgentCompany(request({
+    body: { action: 'work-order-list', clientId: 'client-other', limit: 10 },
+  }), { opsKey: KEY, clientId: 'client-acme' })
+  assert.equal(mismatch.status, 403)
+
+  const conflict = await handleAgentCompany(request({
+    body: { action: 'work-order-run', clientId: 'client-acme' },
+  }), {
+    opsKey: KEY,
+    runCompanyWorkOrder: async () => ({ ok: false, reason: 'company_work_order_plan_mismatch' }),
+  })
+  assert.equal(conflict.status, 409)
+
+  const unavailable = await handleAgentCompany(request({
+    body: { action: 'work-order-create', clientId: 'client-acme' },
+  }), {
+    opsKey: KEY,
+    createCompanyWorkOrder: async () => ({ ok: false, reason: 'company_work_order_store_unavailable' }),
+  })
+  assert.equal(unavailable.status, 503)
 })
 
 test('API runtime has no connector, approval execution, or process-launch path', async () => {

--- a/kernel/crews/README.md
+++ b/kernel/crews/README.md
@@ -102,6 +102,9 @@ Adding a task is: **write or forge one JSON → it's registered, gated, runnable
 The separate ops-gated `../api/agent-company.mjs` manager runs bounded multi-crew cycles. It accepts
 only the fixed roster, isolates evidence per specialist, budgets role calls before execution, claims
 one durable cycle id, and returns draft-only partial results without cross-agent context or writes.
+`../agent-company-work-orders.mjs` adds durable reviewed delegation around that same runner: exact
+plan fingerprints, no-spend queue creation, client-filtered listing, explicit dispatch, and
+duplicate-safe recovery. It never exposes queued raw evidence in list or detail responses.
 
 ## Shipped crews
 
@@ -112,3 +115,6 @@ one durable cycle id, and returns draft-only partial results without cross-agent
 | `daily-operator-brief` | all | any trade's day numbers → actions ranked by money-at-stake + tomorrow's risk |
 | `reconcile-premium` | pro | MMQR/KBZPay/WavePay ↔ POS reconciliation with LIVE intra-day shortfall flagging by staff/shift; free tier keeps the end-of-day close |
 | `source-to-screen-pilot` | pilot | the paid upgrade from a free browser-only draft → one source-traced first proof + owner approval queue |
+| `lead-qualification-desk` | all | approved lead facts → fit decision, proof step, open questions, and owner-reviewed follow-up draft |
+| `delivery-planning-desk` | all | accepted outcome → milestones, dependencies, owner inputs, and objective acceptance checks |
+| `quality-review-desk` | all | draft + sources + acceptance rules → proof-linked ship, revise, or block recommendation |

--- a/kernel/crews/delivery-planning-desk.json
+++ b/kernel/crews/delivery-planning-desk.json
@@ -1,0 +1,48 @@
+{
+  "slug": "delivery-planning-desk",
+  "name": "Delivery Planning Desk",
+  "version": 1,
+  "description": "Converts an accepted outcome and source pack into a bounded delivery plan with dependencies, owner inputs, and objective acceptance checks.",
+  "intake": {
+    "accepts": [
+      "accepted outcome",
+      "scope notes",
+      "approved source inventory",
+      "delivery constraints",
+      "acceptance rules"
+    ],
+    "description": "An owner-approved delivery brief. Missing dependencies remain blockers rather than invented assumptions."
+  },
+  "roles": [
+    {
+      "id": "intake",
+      "title": "Intake",
+      "tier": "bulk",
+      "goal": "Normalize the accepted outcome, scope boundary, approved sources, constraints, and acceptance rules. Flag every unresolved input."
+    },
+    {
+      "id": "plan-builder",
+      "title": "Delivery Planner",
+      "tier": "reason",
+      "goal": "Build the smallest sequenced milestone plan that can prove the accepted outcome. Bind each milestone to dependencies, owner inputs, and an observable completion condition."
+    },
+    {
+      "id": "boundary-reviewer",
+      "title": "Boundary Reviewer",
+      "tier": "bulk",
+      "goal": "Check the plan for scope drift, hidden writes, missing approvals, unsupported dates, and vague acceptance language. Keep external actions blocked until separately approved."
+    }
+  ],
+  "output_contract": {
+    "format": "json",
+    "fields": [
+      "milestones",
+      "dependencies",
+      "owner_inputs",
+      "acceptance_tests",
+      "delivery_risks",
+      "blocked_actions"
+    ],
+    "description": "A bounded delivery packet with objective proof gates and no implicit external execution."
+  }
+}

--- a/kernel/crews/lead-qualification-desk.json
+++ b/kernel/crews/lead-qualification-desk.json
@@ -1,0 +1,47 @@
+{
+  "slug": "lead-qualification-desk",
+  "name": "Lead Qualification Desk",
+  "version": 1,
+  "description": "Turns owner-approved lead notes into an evidence-backed fit decision, open questions, and a draft next step for any service business.",
+  "intake": {
+    "accepts": [
+      "lead notes",
+      "discovery answers",
+      "business requirements",
+      "budget and timing evidence"
+    ],
+    "description": "Owner-approved prospect facts only. Treat all claims as unverified until supported by the supplied evidence."
+  },
+  "roles": [
+    {
+      "id": "intake",
+      "title": "Intake",
+      "tier": "bulk",
+      "goal": "Normalize the prospect, stated problem, buyer, timing, budget evidence, and missing facts. Never infer a budget, authority, or commitment."
+    },
+    {
+      "id": "qualifier",
+      "title": "Qualification Analyst",
+      "tier": "reason",
+      "goal": "Score problem fit, urgency, evidence quality, and delivery risk. Separate supported facts from assumptions and identify the smallest proof that can advance the deal."
+    },
+    {
+      "id": "next-step-writer",
+      "title": "Next Step Writer",
+      "tier": "bulk",
+      "goal": "Draft one concise owner-reviewable follow-up with unanswered questions and a bounded proof proposal. Do not send, promise delivery, quote an unapproved price, or claim acceptance."
+    }
+  ],
+  "output_contract": {
+    "format": "json",
+    "fields": [
+      "fit",
+      "supported_facts",
+      "open_questions",
+      "proof_step",
+      "follow_up_draft",
+      "blocked_claims"
+    ],
+    "description": "A qualification packet that preserves evidence boundaries and leaves every external message as an owner-reviewed draft."
+  }
+}

--- a/kernel/crews/quality-review-desk.json
+++ b/kernel/crews/quality-review-desk.json
@@ -1,0 +1,48 @@
+{
+  "slug": "quality-review-desk",
+  "name": "Quality Review Desk",
+  "version": 1,
+  "description": "Reviews an AI or human-produced deliverable against its sources and acceptance rules before an owner decides whether it can ship.",
+  "intake": {
+    "accepts": [
+      "draft deliverable",
+      "source trace",
+      "acceptance rules",
+      "test evidence",
+      "known limitations"
+    ],
+    "description": "The exact draft, approved sources, and acceptance evidence. A missing source or test is a finding, not permission to guess."
+  },
+  "roles": [
+    {
+      "id": "intake",
+      "title": "Intake",
+      "tier": "bulk",
+      "goal": "Normalize the deliverable, source trace, acceptance rules, tests, and declared limitations. Reject ambiguous versions and missing review targets."
+    },
+    {
+      "id": "evidence-auditor",
+      "title": "Evidence Auditor",
+      "tier": "reason",
+      "goal": "Test important claims against supplied sources, find contradictions and unsupported conclusions, and grade each acceptance rule as pass, fail, or unproven."
+    },
+    {
+      "id": "release-reviewer",
+      "title": "Release Reviewer",
+      "tier": "bulk",
+      "goal": "Produce a concise ship, revise, or block recommendation with exact remediation. Never approve on the owner's behalf or conceal an unproven check."
+    }
+  ],
+  "output_contract": {
+    "format": "json",
+    "fields": [
+      "verdict",
+      "acceptance_results",
+      "findings",
+      "source_gaps",
+      "remediation",
+      "release_boundary"
+    ],
+    "description": "A proof-linked quality packet whose release recommendation remains advisory until owner approval."
+  }
+}

--- a/kernel/public/index.html
+++ b/kernel/public/index.html
@@ -100,6 +100,7 @@
   .company-plan{border-left:3px solid var(--accent);background:var(--accent-soft);padding:16px 18px;margin-top:18px;scroll-margin-top:120px}.company-plan-head{display:flex;align-items:flex-start;justify-content:space-between;gap:14px}.company-plan-head h3{font-size:17px}.company-plan-summary{display:flex;gap:7px;flex-wrap:wrap;margin:12px 0}.company-run-id{font-family:ui-monospace,SFMono-Regular,Consolas,monospace;font-size:11px;color:var(--muted);overflow-wrap:anywhere}
   .company-assignments{display:grid;gap:8px;margin:14px 0}.company-assignment{display:grid;grid-template-columns:minmax(180px,.7fr) minmax(0,1.3fr);gap:12px;padding:11px 0;border-top:1px solid var(--line)}.company-assignment b{display:block}.company-assignment .roles{color:var(--muted);font-size:12px;overflow-wrap:anywhere}.company-confirm{display:flex;align-items:flex-start;gap:9px;min-height:44px;margin:0}.company-confirm input{width:20px;height:20px;margin:1px 0 0;flex:0 0 auto}.company-plan-actions{display:flex;align-items:center;gap:12px;border-top:1px solid var(--line);padding-top:14px}.company-plan-actions button{min-height:44px}
   .company-results{margin-top:20px}.company-results-head{display:flex;align-items:flex-start;justify-content:space-between;gap:14px;margin-bottom:12px}.company-results-head h3{font-size:18px}.company-result-list{display:grid;gap:10px}.company-result{border:1px solid var(--line);border-radius:8px;background:var(--surf);padding:15px}.company-result-head{display:flex;align-items:center;justify-content:space-between;gap:12px}.company-result pre{max-height:340px;margin:12px 0 0;padding:12px;border:1px solid var(--line);border-radius:8px;background:var(--deep);overflow:auto;white-space:pre-wrap;overflow-wrap:anywhere;font:12px/1.55 Consolas,"Courier New",monospace}.company-result .err-banner{margin-top:10px}.company-new-cycle{min-height:44px}
+  .company-work-orders{min-width:0;border-top:1px solid var(--line);margin-top:24px;padding-top:20px}.company-work-orders-head{display:flex;align-items:flex-start;justify-content:space-between;gap:14px;margin-bottom:12px}.company-work-orders-head h3{font-size:18px}.company-work-orders-head button{min-height:44px}.company-order-list{display:grid;gap:8px;min-width:0}.company-order-row{display:grid;grid-template-columns:minmax(0,1fr) auto;gap:14px;align-items:center;width:100%;min-width:0;min-height:64px;padding:11px 13px;text-align:left;background:var(--surf-2)}.company-order-row:hover{border-color:rgba(59,130,246,.5)}.company-order-name{display:block;font-weight:700;overflow-wrap:anywhere}.company-order-meta{display:flex;gap:6px;flex-wrap:wrap;margin-top:6px}.company-order-detail{min-width:0;border-left:3px solid var(--accent);background:var(--accent-soft);padding:16px 18px;margin-top:14px}.company-order-detail-head{display:flex;align-items:flex-start;justify-content:space-between;gap:14px;min-width:0}.company-order-detail-head>*{min-width:0}.company-order-detail-head .muted{overflow-wrap:anywhere}.company-order-detail-head h4{font-family:"Space Grotesk",Inter,sans-serif;font-size:16px;margin:0}.company-order-detail .company-assignments{margin-bottom:8px}.company-order-fingerprint{font:11px/1.5 Consolas,"Courier New",monospace;color:var(--muted);overflow-wrap:anywhere}.company-order-actions{display:flex;align-items:center;gap:12px;border-top:1px solid var(--line);padding-top:14px;margin-top:14px}.company-order-actions button{min-height:44px}.company-order-confirm{display:flex;align-items:flex-start;gap:9px;min-height:44px;margin:0}.company-order-confirm input{width:20px;height:20px;margin:1px 0 0;flex:0 0 auto}
   .approval-toolbar{display:flex;align-items:flex-start;justify-content:space-between;gap:16px;margin-bottom:14px}.approval-toolbar h2{font-size:20px}.approval-toolbar button{min-height:44px}
   .approval-summary{display:flex;gap:7px;flex-wrap:wrap;margin-bottom:14px}.approval-list{display:grid;gap:12px}
   .approval-card{border:1px solid var(--line);border-radius:8px;background:var(--surf);padding:17px}.approval-head{display:flex;align-items:flex-start;justify-content:space-between;gap:12px;margin-bottom:13px}
@@ -118,7 +119,7 @@
     .cols{grid-template-columns:1fr}.two{grid-template-columns:1fr}.activation-fields,.owner-evidence-fields{grid-template-columns:repeat(2,minmax(0,1fr))}.activation-output{grid-template-columns:1fr}.owner-evidence-fields .evidence-text{grid-column:1/-1}.company-agent{grid-template-columns:1fr}.company-scope{grid-template-columns:repeat(2,minmax(0,1fr))}.company-scope .field:last-child{grid-column:1/-1}
   }
   @media(max-width:520px){
-    .workcell-toolbar,.approval-toolbar,.owner-evidence-head,.company-toolbar,.company-plan-head,.company-results-head{align-items:stretch;flex-direction:column}.workcell-toolbar button,.approval-toolbar button{width:100%}.activation{padding:15px}.activation-import{align-items:stretch;flex-direction:column}.activation-import button{width:100%}.activation-fields,.owner-evidence-fields,.company-scope{grid-template-columns:1fr}.company-scope .field:last-child{grid-column:1}.activation-actions,.owner-evidence-actions,.company-actions,.company-plan-actions{align-items:stretch;flex-direction:column}.activation-actions button,.owner-evidence-actions button,.company-actions button,.company-plan-actions button,.company-new-cycle{width:100%}.owner-evidence-fields .evidence-text{grid-column:1}.owner-evidence-confirm{align-items:flex-start}.company-assignment{grid-template-columns:1fr;gap:5px}.company-agent.selected{padding:13px}
+    .workcell-toolbar,.approval-toolbar,.owner-evidence-head,.company-toolbar,.company-plan-head,.company-results-head,.company-work-orders-head,.company-order-detail-head{align-items:stretch;flex-direction:column}.workcell-toolbar button,.approval-toolbar button,.company-work-orders-head button{width:100%}.activation{padding:15px}.activation-import{align-items:stretch;flex-direction:column}.activation-import button{width:100%}.activation-fields,.owner-evidence-fields,.company-scope{grid-template-columns:1fr}.company-scope .field:last-child{grid-column:1}.activation-actions,.owner-evidence-actions,.company-actions,.company-plan-actions,.company-order-actions{align-items:stretch;flex-direction:column}.activation-actions button,.owner-evidence-actions button,.company-actions button,.company-plan-actions button,.company-order-actions button,.company-new-cycle{width:100%}.owner-evidence-fields .evidence-text{grid-column:1}.owner-evidence-confirm{align-items:flex-start}.company-assignment,.company-order-row{grid-template-columns:1fr;gap:5px}.company-agent.selected{padding:13px}.company-order-row .badge{justify-self:start}
     .workcell .wc-actions{align-items:stretch;flex-direction:column}.workcell .wc-actions button{width:100%}.approval-head{align-items:flex-start}.approval-details{grid-template-columns:1fr;gap:2px}.approval-details dd{margin-bottom:9px}.approval-actions{align-items:stretch;flex-direction:column}.approval-confirm{margin:0}.approval-actions button{width:100%}
   }
 </style>
@@ -177,9 +178,14 @@
       <div class="company-plan-summary" id="companyPlanSummary"></div>
       <div class="company-run-id" id="companyRunId"></div>
       <div class="company-assignments" id="companyAssignments"></div>
-      <div class="company-plan-actions"><label class="company-confirm"><input id="companyConfirm" type="checkbox" /> I reviewed this exact client, evidence, assignments, and budget</label><button class="primary" id="companyRunButton" type="button" disabled>Run reviewed cycle</button></div>
+      <div class="company-plan-actions"><label class="company-confirm"><input id="companyConfirm" type="checkbox" /> I reviewed this exact client, evidence, assignments, and budget</label><button id="companyQueueButton" type="button" disabled>Queue work order</button><button class="primary" id="companyRunButton" type="button" disabled>Run reviewed cycle</button></div>
     </div>
     <div class="company-results" id="companyResults" role="status" aria-live="polite"></div>
+    <section class="company-work-orders" aria-labelledby="companyWorkOrdersTitle">
+      <div class="company-work-orders-head"><div><h3 id="companyWorkOrdersTitle">Work orders</h3><div class="muted">Durable reviewed plans for this client</div></div><button id="companyQueueRefresh" type="button">Refresh queue</button></div>
+      <div class="company-order-list" id="companyOrderList"><div class="empty">Set a client ID to load its queue.</div></div>
+      <div class="company-order-detail" id="companyOrderDetail" hidden></div>
+    </section>
   </section>
 
   <section id="view-workcells" hidden>
@@ -315,7 +321,7 @@ const usd=(n)=>'$'+Number(n||0).toLocaleString()
 const getOpsKey=()=>$('#opsKey').value.trim()
 const hasOpsKey=()=>getOpsKey().length>0
 let dealLead=null, lastPacket=null
-let companyRoster=[], companyDraft=null, companyAgentLimit=2
+let companyRoster=[], companyDraft=null, companyAgentLimit=2, companyWorkOrders=[]
 
 function nextCompanyCycleId(){
   const now=new Date(),iso=now.toISOString()
@@ -329,7 +335,11 @@ $('#opsKey').addEventListener('change',()=>{
   const key=getOpsKey()
   if(key)localStorage.setItem('sm.ops',key);else localStorage.removeItem('sm.ops')
   companyRoster=[]
+  companyWorkOrders=[]
   invalidateCompanyPlan()
+  $('#companyOrderDetail').hidden=true
+  $('#companyOrderDetail').innerHTML=''
+  $('#companyResults').innerHTML=''
   loadProtectedState()
   const activeView=document.querySelector('nav button.active')?.dataset.view
   if(activeView==='workcells'){
@@ -337,8 +347,12 @@ $('#opsKey').addEventListener('change',()=>{
     else $('#workcellGrid').innerHTML='<div class="empty">Enter the ops passcode to load live workcell status.</div>'
   }
   if(activeView==='company'){
-    if(key)loadCompanyAgents()
-    else $('#companyRoster').innerHTML='<div class="empty">Enter the ops passcode to load the specialist roster.</div>'
+    if(key){loadCompanyAgents();loadCompanyWorkOrders()}
+    else{
+      $('#companyRoster').innerHTML='<div class="empty">Enter the ops passcode to load the specialist roster.</div>'
+      $('#companyOrderList').innerHTML='<div class="empty">Enter the ops passcode to load work orders.</div>'
+      $('#companyState').textContent='Locked'
+    }
   }
 })
 $('#opsKey').addEventListener('keydown',(event)=>{if(event.key==='Enter')event.currentTarget.blur()})
@@ -371,6 +385,8 @@ function invalidateCompanyPlan(message=''){
   $('#companyConfirm').disabled=false
   $('#companyRunButton').disabled=true
   $('#companyRunButton').textContent='Run reviewed cycle'
+  $('#companyQueueButton').disabled=true
+  $('#companyQueueButton').textContent='Queue work order'
   if(message)$('#companyState').textContent=message
 }
 function syncCompanyAgent(row,checkbox){
@@ -438,6 +454,7 @@ function renderCompanyPlan(plan,input){
   $('#companyAssignments').innerHTML=(plan.assignments||[]).map(assignment=>`<div class="company-assignment"><div><b>${esc(assignment.name)}</b><span class="muted">${esc(assignment.department)} / ${esc(assignment.crew)}</span></div><div class="roles">${esc((assignment.roles||[]).map(role=>`${role.title} (${role.tier})`).join(' -> '))}<br />Returns: ${esc((assignment.returns||[]).join(', '))}</div></div>`).join('')
   $('#companyConfirm').checked=false
   $('#companyRunButton').disabled=true
+  $('#companyQueueButton').disabled=true
   $('#companyPlan').hidden=false
   $('#companyResults').innerHTML=''
   $('#companyState').textContent='Plan ready. Review before running.'
@@ -466,6 +483,74 @@ function renderCompanyResults(response){
   $('#companyNewCycle').onclick=startNewCompanyCycle
   $('#companyResults').scrollIntoView({behavior:'smooth',block:'nearest'})
 }
+function renderCompanyWorkOrderList(orders=[]){
+  companyWorkOrders=orders
+  const box=$('#companyOrderList')
+  box.innerHTML=orders.length?orders.map(order=>{
+    const names=(order.plan&&order.plan.assignments||[]).map(item=>item.name).join(', ')
+    const created=order.createdAt?new Date(order.createdAt).toLocaleString():''
+    return `<button class="company-order-row" type="button" data-company-order="${esc(order.workOrderId)}"><span><span class="company-order-name">${esc(order.cycleId)}</span><span class="muted">${esc(names||'No assignments')} / ${esc(created)}</span><span class="company-order-meta"><span class="badge">${esc(order.plan&&order.plan.budget&&order.plan.budget.plannedRoles||0)} role calls</span><span class="badge">${esc((order.plan&&order.plan.assignments||[]).length)} specialists</span></span></span>${companyStatusBadge(order.status)}</button>`
+  }).join(''):'<div class="empty">No work orders for this client.</div>'
+  box.querySelectorAll('[data-company-order]').forEach(button=>button.addEventListener('click',()=>openCompanyWorkOrder(button.dataset.companyOrder)))
+}
+async function loadCompanyWorkOrders(){
+  const box=$('#companyOrderList'),clientId=$('#companyClientId').value.trim()
+  $('#companyOrderDetail').hidden=true
+  if(!hasOpsKey()){box.innerHTML='<div class="empty">Enter the ops passcode to load work orders.</div>';return}
+  if(!clientId){box.innerHTML='<div class="empty">Set a client ID to load its queue.</div>';return}
+  box.innerHTML='<div class="loading-pulse">Loading work orders...</div>'
+  let response
+  try{response=await api('POST','/api/agent-company',{action:'work-order-list',clientId,limit:20})}
+  catch(error){box.innerHTML=`<div class="err-banner">Could not load work orders: ${esc(String(error.message||'network error'))}</div>`;return}
+  if(!response.ok){box.innerHTML=`<div class="err-banner">${esc(response.reason||'Could not load work orders')}</div>`;return}
+  renderCompanyWorkOrderList(response.workOrders||[])
+}
+function renderCompanyWorkOrderDetail(order){
+  const box=$('#companyOrderDetail'),plan=order.plan||{},assignments=plan.assignments||[],budget=plan.budget||{}
+  const assignmentHtml=assignments.map(assignment=>`<div class="company-assignment"><div><b>${esc(assignment.name)}</b><span class="muted">${esc(assignment.department)} / ${esc(assignment.crew)}</span></div><div class="roles">${esc((assignment.roles||[]).map(role=>`${role.title} (${role.tier})`).join(' -> '))}<br />Evidence: ${esc(assignment.evidenceBytes)} bytes</div></div>`).join('')
+  const evidenceHtml=(order.evidence||[]).map(item=>`<div class="company-order-fingerprint">${esc(item.agentId)}: ${esc(item.digest)} (${esc(item.bytes)} bytes)</div>`).join('')
+  const canDispatch=order.status==='planned'||order.status==='running'
+  const actions=canDispatch?`<div class="company-order-actions"><label class="company-order-confirm"><input id="companyOrderConfirm" type="checkbox" /> I reviewed this stored plan, evidence fingerprints, assignments, and budget</label><button class="primary" id="companyOrderRun" type="button" disabled>${order.status==='running'?'Check saved result':'Dispatch work order'}</button></div>`:order.result?'<div class="company-order-actions"><button id="companyOrderResult" type="button">Open cycle result</button></div>':''
+  box.innerHTML=`<div class="company-order-detail-head"><div><h4>${esc(order.cycleId)}</h4><div class="muted">${esc(order.workOrderId)}</div></div>${companyStatusBadge(order.status)}</div><div class="company-plan-summary"><span class="badge">${esc(assignments.length)} specialists</span><span class="badge">${esc(budget.plannedRoles||0)} / ${esc(budget.roleLimit||0)} role calls</span><span class="badge">no writes</span></div><div class="company-order-fingerprint">Plan: ${esc(order.planHash)}</div><div class="company-assignments">${assignmentHtml}</div>${evidenceHtml}${actions}`
+  box.hidden=false
+  const confirm=$('#companyOrderConfirm'),run=$('#companyOrderRun')
+  if(confirm&&run){confirm.addEventListener('change',()=>{run.disabled=!confirm.checked});run.addEventListener('click',()=>runQueuedCompanyWorkOrder(order))}
+  $('#companyOrderResult')?.addEventListener('click',()=>renderCompanyResults(order.result))
+  box.scrollIntoView({behavior:'smooth',block:'nearest'})
+}
+async function openCompanyWorkOrder(workOrderId){
+  const clientId=$('#companyClientId').value.trim(),box=$('#companyOrderDetail')
+  box.hidden=false;box.innerHTML='<div class="loading-pulse">Loading work order...</div>'
+  let response
+  try{response=await api('POST','/api/agent-company',{action:'work-order-get',clientId,workOrderId})}
+  catch(error){box.innerHTML=`<div class="err-banner">${esc(String(error.message||'Could not load work order'))}</div>`;return}
+  if(!response.ok){box.innerHTML=`<div class="err-banner">${esc(response.reason||'Could not load work order')}</div>`;return}
+  renderCompanyWorkOrderDetail(response.workOrder)
+}
+async function queueReviewedCompanyWorkOrder(){
+  if(!companyDraft||!$('#companyConfirm').checked)return
+  const button=$('#companyQueueButton');button.disabled=true;button.textContent='Queueing...';$('#companyState').textContent='Saving the exact plan without model spend...'
+  try{
+    const response=await api('POST','/api/agent-company',{action:'work-order-create',...companyDraft.input})
+    if(!response.ok){$('#companyState').textContent=response.reason||'Work order was not queued';return}
+    $('#companyState').textContent=response.replayed?'Saved work order loaded':'Work order queued. No model call was made.'
+    await loadCompanyWorkOrders()
+    renderCompanyWorkOrderDetail(response.workOrder)
+  }catch(error){$('#companyState').textContent=String(error.message||'Queue unavailable').slice(0,120)}
+  finally{button.disabled=!$('#companyConfirm').checked||!companyDraft;button.textContent='Queue work order'}
+}
+async function runQueuedCompanyWorkOrder(order){
+  const button=$('#companyOrderRun')
+  if(!button||!$('#companyOrderConfirm')?.checked)return
+  button.disabled=true;button.textContent='Dispatching...';$('#companyState').textContent='Dispatching the saved plan through the bounded runner...'
+  let response
+  try{response=await api('POST','/api/agent-company',{action:'work-order-run',clientId:order.clientId,workOrderId:order.workOrderId,planHash:order.planHash,confirmation:`RUN ${order.workOrderId}`})}
+  catch(error){$('#companyState').textContent=String(error.message||'Dispatch unavailable').slice(0,120);button.disabled=false;button.textContent='Check saved result';return}
+  if(response.cycleResult)renderCompanyResults(response.cycleResult)
+  $('#companyState').textContent=response.ok?'Work order finished':response.reason||'Work order is still running'
+  await loadCompanyWorkOrders()
+  if(response.workOrder)renderCompanyWorkOrderDetail(response.workOrder)
+}
 function startNewCompanyCycle(){
   $('#companyCycleId').value=nextCompanyCycleId()
   $('#companyRoster').querySelectorAll('[data-company-agent]').forEach(row=>{
@@ -478,9 +563,16 @@ function startNewCompanyCycle(){
   $('#companyClientId').focus()
 }
 $('#companyForm').addEventListener('input',event=>{
-  if(event.target.id==='companyClientId')localStorage.setItem('sm.company.client',event.target.value.trim())
+  if(event.target.id==='companyClientId'){
+    localStorage.setItem('sm.company.client',event.target.value.trim())
+    companyWorkOrders=[]
+    $('#companyOrderDetail').hidden=true
+    $('#companyOrderList').innerHTML='<div class="empty">Client changed. Refresh the queue.</div>'
+  }
   if(companyDraft)invalidateCompanyPlan('Inputs changed. Plan the cycle again.')
 })
+$('#companyClientId').addEventListener('change',loadCompanyWorkOrders)
+$('#companyQueueRefresh').addEventListener('click',loadCompanyWorkOrders)
 $('#companyForm').addEventListener('submit',async event=>{
   event.preventDefault()
   const input=companyCycleInput()
@@ -494,7 +586,12 @@ $('#companyForm').addEventListener('submit',async event=>{
   }catch(error){invalidateCompanyPlan(String(error.message||'Plan failed').slice(0,120))}
   finally{button.disabled=false;button.textContent='Plan cycle'}
 })
-$('#companyConfirm').addEventListener('change',event=>{$('#companyRunButton').disabled=!event.currentTarget.checked||!companyDraft})
+$('#companyConfirm').addEventListener('change',event=>{
+  const disabled=!event.currentTarget.checked||!companyDraft
+  $('#companyRunButton').disabled=disabled
+  $('#companyQueueButton').disabled=disabled
+})
+$('#companyQueueButton').addEventListener('click',queueReviewedCompanyWorkOrder)
 $('#companyRunButton').addEventListener('click',async()=>{
   if(!companyDraft||!$('#companyConfirm').checked)return
   const button=$('#companyRunButton');button.disabled=true;$('#companyConfirm').disabled=true;button.textContent='Running...';$('#companyState').textContent='Running specialists sequentially...'
@@ -519,7 +616,7 @@ document.querySelectorAll('nav button').forEach(b=>b.onclick=()=>{
   if(b.dataset.view==='pipeline')loadProjects()
   if(b.dataset.view==='leads')loadLeads()
   if(b.dataset.view==='outreach')loadOutreach()
-  if(b.dataset.view==='company')loadCompanyAgents()
+  if(b.dataset.view==='company'){loadCompanyAgents();loadCompanyWorkOrders()}
   if(b.dataset.view==='workcells')loadWorkcells()
   if(b.dataset.view==='approvals')loadApprovals()
   if(b.dataset.view==='connectors')loadConnectors()
@@ -1055,8 +1152,11 @@ if(location.hash==='#company'){
   const companyTab=document.querySelector('nav button[data-view="company"]')
   document.querySelectorAll('nav button').forEach(button=>button.classList.toggle('active',button===companyTab))
   for(const view of ['overview','leads','pipeline','outreach','deal','operator','company','workcells','approvals','connectors']) $('#view-'+view).hidden=view!=='company'
-  if(hasOpsKey())loadCompanyAgents()
-  else $('#companyRoster').innerHTML='<div class="empty">Enter the ops passcode to load the specialist roster.</div>'
+  if(hasOpsKey()){loadCompanyAgents();loadCompanyWorkOrders()}
+  else{
+    $('#companyRoster').innerHTML='<div class="empty">Enter the ops passcode to load the specialist roster.</div>'
+    $('#companyOrderList').innerHTML='<div class="empty">Enter the ops passcode to load work orders.</div>'
+  }
 }else if(location.hash==='#activation'){
   const workcellsTab=document.querySelector('nav button[data-view="workcells"]')
   document.querySelectorAll('nav button').forEach(button=>button.classList.toggle('active',button===workcellsTab))

--- a/kernel/store.mjs
+++ b/kernel/store.mjs
@@ -297,10 +297,32 @@ export async function releaseActivityClaim(id) {
     return false
   }
 }
-export async function listActivity(limit = 30) {
-  if (mode === 'supabase') return rest('GET', `supermega_console_activity?order=at.desc&limit=${limit}`)
-  if (mode === 'postgres') { await ensurePgTables(); return q('select * from supermega_console_activity order by at desc limit $1', [limit]) }
-  return [...mem.activity.values()].sort((a, b) => String(b.at).localeCompare(String(a.at))).slice(0, limit)
+export async function listActivity(limit = 30, filter = {}) {
+  const boundedLimit = Math.min(200, Math.max(1, Number.isInteger(Number(limit)) ? Number(limit) : 30))
+  const kind = String(filter?.kind || '').trim().slice(0, 80)
+  const ref = String(filter?.ref || '').trim().slice(0, 160)
+  if (mode === 'supabase') {
+    const query = [
+      kind ? `kind=eq.${encodeURIComponent(kind)}` : '',
+      ref ? `ref=eq.${encodeURIComponent(ref)}` : '',
+      'order=at.desc',
+      `limit=${boundedLimit}`,
+    ].filter(Boolean).join('&')
+    return rest('GET', `supermega_console_activity?${query}`)
+  }
+  if (mode === 'postgres') {
+    await ensurePgTables()
+    const where = []
+    const values = []
+    if (kind) { values.push(kind); where.push(`kind=$${values.length}`) }
+    if (ref) { values.push(ref); where.push(`ref=$${values.length}`) }
+    values.push(boundedLimit)
+    return q(`select * from supermega_console_activity${where.length ? ` where ${where.join(' and ')}` : ''} order by at desc limit $${values.length}`, values)
+  }
+  let rows = [...mem.activity.values()]
+  if (kind) rows = rows.filter((row) => row.kind === kind)
+  if (ref) rows = rows.filter((row) => row.ref === ref)
+  return rows.sort((a, b) => String(b.at).localeCompare(String(a.at))).slice(0, boundedLimit)
 }
 
 // ---------- per-tenant token ledger (monthly window) + AI response cache ----------


### PR DESCRIPTION
## What changed
- Expands the fixed Agent Company roster from five to eight specialists with Sales Qualifier, Delivery Planner, and Quality Reviewer desks.
- Adds a durable, client-bound work-order queue that saves reviewed evidence without model spend.
- Binds dispatch to the saved plan SHA-256 and exact `RUN <workOrderId>` confirmation.
- Reuses the existing bounded cycle runner; no second orchestrator, recursive delegation, connector write, or unattended loop.
- Keeps raw queued evidence out of API envelopes and scrubs it after terminal completion.
- Adds responsive queue/list/detail/recovery UI and clears rendered private state when Ops identity changes.
- Documents recovery behavior and the current honest limit: no unattended dispatcher or retention sweeper yet.

## Verification
- `npm run verify`
  - 177 tests passed
  - brand contract passed
  - 69 connectors / 993 adversarial calls / 0 violations
  - 8 crews / 116 resilience checks / 0 violations
- `vercel build --prod`
  - 15 runtime functions
  - work-order runtime and queue UI bundled
  - 0 test/spec builds
- Local Edge QA at desktop and 390x844:
  - max-two-agent limit enforced
  - evidence edits invalidate saved plans
  - queueing performs no model call
  - exact reviewed dispatch contract emitted
  - completed replay does not spend twice
  - zero horizontal overflow, undersized visible controls, or console errors
  - identity reset clears loaded queue/result state

## Evidence boundary
Browser QA used deterministic redacted fixtures. No real customer evidence, model run, connector/provider write, payment, lead, or production work order was created.