### PR TITLE
Monitor the live Shop brand bundle

### DIFF
--- a/tools/check_public_live_health.py
+++ b/tools/check_public_live_health.py
@@ -10,11 +10,12 @@ import time
 import urllib.error
 import urllib.request
 from dataclasses import dataclass
+from html.parser import HTMLParser
 from typing import Any
-from urllib.parse import urljoin
+from urllib.parse import urljoin, urlparse
 
 
-USER_AGENT = "supermega-portfolio-live-health/4.0"
+USER_AGENT = "supermega-portfolio-live-health/4.1"
 
 
 class NoRedirect(urllib.request.HTTPRedirectHandler):
@@ -28,6 +29,35 @@ class HttpResult:
     status: int
     headers: dict[str, str]
     body: bytes
+
+
+class ModuleScriptParser(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__()
+        self.sources: list[str] = []
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        if tag != "script":
+            return
+        values = dict(attrs)
+        if values.get("type") == "module" and values.get("src"):
+            self.sources.append(str(values["src"]))
+
+
+def app_module_url(body: str, app_url: str) -> str | None:
+    parser = ModuleScriptParser()
+    parser.feed(body)
+    app = urlparse(app_url)
+    for source in parser.sources:
+        resolved = urlparse(urljoin(app_url, source))
+        if (
+            resolved.scheme == "https"
+            and resolved.netloc == app.netloc
+            and resolved.path.startswith("/assets/")
+            and resolved.path.endswith(".js")
+        ):
+            return resolved.geturl()
+    return None
 
 
 def fetch(url: str, *, timeout: float, attempts: int, follow_redirects: bool = True) -> HttpResult:
@@ -193,10 +223,13 @@ def run(
     if status_response.status != 200 or mismatches:
         failures.append(api_result)
 
+    app_home_body = ""
     for route in ("home", "factory"):
         url = urljoin(app_url, route)
         response = fetch(url, timeout=timeout, attempts=attempts)
         body = response.body.decode("utf-8", errors="replace")
+        if route == "home":
+            app_home_body = body
         missing = [token for token in ['<title>Shop - SuperMega</title>', '<div id="root"></div>', 'type="module"'] if token not in body]
         result = {
             "kind": "app_route",
@@ -209,6 +242,26 @@ def run(
         results.append(result)
         if response.status != 200 or len(response.body) < 1000 or missing:
             failures.append(result)
+
+    module_url = app_module_url(app_home_body, app_url)
+    module_response = fetch(module_url, timeout=timeout, attempts=attempts) if module_url else None
+    module_body = module_response.body.decode("utf-8", errors="replace") if module_response else ""
+    module_result = {
+        "kind": "shop_brand_bundle",
+        "url": module_url or app_url,
+        "status": module_response.status if module_response else 0,
+        "bytes": len(module_response.body) if module_response else 0,
+        "missing": [] if module_url else ["same-origin /assets/*.js module"],
+        "unexpected": [token for token in ("MegaOS", "Mega OS") if token in module_body],
+    }
+    results.append(module_result)
+    if (
+        module_response is None
+        or module_response.status != 200
+        or len(module_response.body) < 1000
+        or module_result["unexpected"]
+    ):
+        failures.append(module_result)
 
     app_health_url = urljoin(app_url, "api/health")
     app_health_response = fetch(app_health_url, timeout=timeout, attempts=attempts)

--- a/tools/test_public_live_health.py
+++ b/tools/test_public_live_health.py
@@ -56,7 +56,7 @@ def healthy_responses() -> dict[str, checker.HttpResult]:
     app_shell = page(
         "<title>Shop - SuperMega</title>",
         '<div id="root"></div>',
-        'type="module"',
+        '<script type="module" crossorigin src="/assets/index-current.js"></script>',
     )
     console = page(
         "<title>SuperMega Console</title>",
@@ -129,6 +129,9 @@ def healthy_responses() -> dict[str, checker.HttpResult]:
         ),
         f"{APP}home": result(f"{APP}home", app_shell),
         f"{APP}factory": result(f"{APP}factory", app_shell),
+        f"{APP}assets/index-current.js": result(
+            f"{APP}assets/index-current.js", "Shop" + ("x" * 1400)
+        ),
         f"{APP}api/health": result(f"{APP}api/health", app_health),
         CONSOLE: result(CONSOLE, console),
         f"{CONSOLE}api/status": result(f"{CONSOLE}api/status", kernel_status),
@@ -152,10 +155,10 @@ class PortfolioHealthTest(unittest.TestCase):
         with patch.object(checker, "fetch", side_effect=fake_fetch):
             return checker.run(BASE, WWW, APP, CONSOLE, timeout=1, attempts=1)
 
-    def test_healthy_portfolio_passes_all_fifteen_checks(self):
+    def test_healthy_portfolio_passes_all_sixteen_checks(self):
         report = self.run_report(healthy_responses())
         self.assertEqual(report["status"], "ready")
-        self.assertEqual(report["checks"], 15)
+        self.assertEqual(report["checks"], 16)
         self.assertEqual(report["failures"], [])
 
     def test_missing_plant_link_fails_public_page(self):
@@ -182,6 +185,17 @@ class PortfolioHealthTest(unittest.TestCase):
         self.assertEqual(report["status"], "error")
         health_failure = next(item for item in report["failures"] if item["kind"] == "app_health")
         self.assertIn("proof.productionCloudDurability", health_failure["mismatches"])
+
+    def test_retired_megaos_name_fails_shop_bundle(self):
+        for retired_name in ("MegaOS", "Mega OS"):
+            with self.subTest(retired_name=retired_name):
+                responses = healthy_responses()
+                asset_url = f"{APP}assets/index-current.js"
+                responses[asset_url] = result(asset_url, f"Shop {retired_name}" + ("x" * 1400))
+                report = self.run_report(responses)
+                self.assertEqual(report["status"], "error")
+                failure = next(item for item in report["failures"] if item["kind"] == "shop_brand_bundle")
+                self.assertEqual(failure["unexpected"], [retired_name])
 
     def test_missing_review_gate_fails_agent_company_page(self):
         responses = healthy_responses()


### PR DESCRIPTION
## Summary
- parse the live Shop HTML with the standard HTML parser and resolve only its same-origin `/assets/*.js` module
- add a sixteenth read-only portfolio check that rejects the retired customer labels `MegaOS` and `Mega OS`
- preserve lowercase `megaos.*` compatibility identifiers and avoid any app mutation

## Proof
- 9 deterministic monitor regressions passed, including both retired spellings
- direct production sweep passed 16/16 checks
- current Shop bundle: 573,708 bytes, zero retired customer-brand matches
- no account, customer data, model call, provider action, external write, lead, payment, schema, domain, or pricing change