### PR TITLE
Kernel: add guided Agent Company operator

### DIFF
--- a/kernel/README.md
+++ b/kernel/README.md
@@ -14,9 +14,10 @@ broader system boundaries.
 | `workcells.mjs` + `workcell-run.mjs` | Cash Close, Pipeline Control, and Owner Command products | live |
 | `owner-evidence.mjs` + `api/owner-evidence.mjs` | Reviewed LINE/Viber evidence preview, immutable storage, and bounded read | live |
 | `approval-actions.mjs` + `api/approvals.mjs` | Immutable owner approval and idempotent ClickUp execution | live |
-| `crews/` + `crew-run.mjs` | Contract-enforced, draft-only multi-role tasks | 8 live |
+| `crews/` + `crew-run.mjs` | Contract-enforced, draft-only multi-role tasks | 12 live |
 | `agent-company.mjs` + `agent-company-work-orders.mjs` | Bounded supervisor cycles and durable reviewed delegation | live |
 | `agent-company-operations.mjs` | Immutable outcome review and metadata-only operating targets | live |
+| `agent-company-operator.mjs` + `scripts/operate-agent-company.mjs` | Guided plan, queue, dispatch, evaluation, and proof client | operator-run |
 | `public/` + `api/` | Ops console, status, workcell activation, and scheduled delivery | live |
 
 ## Gateway
@@ -118,6 +119,26 @@ from the operations report. Internal targets cover queue p90, execution p90, com
 orders, durable result storage, role-budget compliance, draft-only boundary compliance, evaluation
 coverage, and accepted evaluations. Readiness stays `collecting` until each target has at least five
 relevant samples. These are operator targets, not a contractual customer SLA or customer acceptance.
+
+### Guided Operator
+
+The operator CLI is a thin client over the same protected API and durable queue. It does not add a
+runner, scheduler, or model supervisor. Start from the redacted example and keep the real manifest
+outside version control:
+
+```powershell
+$env:SUPERMEGA_OPS_KEY = '<owner-provided in this terminal only>'
+npm run agent-company:operate -- --manifest C:\secure-local\work-order.json
+Remove-Item Env:SUPERMEGA_OPS_KEY
+```
+
+The default is plan-only. Queueing requires exact `QUEUE <runId>` confirmation, dispatch requires a
+separate exact `RUN <workOrderId>` confirmation, and optional internal evaluation requires the four
+fixed checks plus `EVALUATE <workOrderId>`. The command then retrieves the deterministic delivery
+proof. It rejects credential-shaped manifest fields before network access, fixes the API host to
+`console.supermega.dev`, accepts the Ops key only from the process environment, and has no customer
+review or connector-write command. Customer decisions still belong in the console after the operator
+has exact evidence from an allowed source.
 
 ## Core Environment
 

--- a/kernel/agent-company-operator.mjs
+++ b/kernel/agent-company-operator.mjs
@@ -1,0 +1,321 @@
+const ID_RE = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,79}$/
+const HASH_RE = /^[a-f0-9]{64}$/
+const MANIFEST_FIELDS = new Set(['clientId', 'cycleId', 'agents', 'evidence', 'roleBudget'])
+const MAX_AGENTS = 2
+const MAX_ROLE_BUDGET = 8
+const MAX_EVIDENCE_BYTES = 8_192
+const TERMINAL_STATUSES = new Set(['completed', 'partial', 'failed'])
+const WORK_ORDER_STATUSES = new Set(['planned', 'running', ...TERMINAL_STATUSES])
+const SENSITIVE_KEY_PARTS = [
+  'secret',
+  'password',
+  'credential',
+  'apikey',
+  'accesstoken',
+  'refreshtoken',
+  'privatekey',
+  'authorization',
+  'cookie',
+]
+
+export const AGENT_COMPANY_ENDPOINT = 'https://console.supermega.dev/api/agent-company'
+
+function fail(reason) {
+  throw new Error(reason)
+}
+
+function isRecord(value) {
+  return value && typeof value === 'object' && !Array.isArray(value)
+}
+
+function hasSensitiveField(value, seen = new Set()) {
+  if (!value || typeof value !== 'object') return false
+  if (seen.has(value)) return false
+  seen.add(value)
+  if (Array.isArray(value)) return value.some((entry) => hasSensitiveField(entry, seen))
+  return Object.entries(value).some(([key, entry]) => {
+    const normalized = key.replace(/[^a-z0-9]/gi, '').toLowerCase()
+    return SENSITIVE_KEY_PARTS.some((part) => normalized.includes(part)) || hasSensitiveField(entry, seen)
+  })
+}
+
+function evidenceText(value) {
+  try {
+    const serialized = typeof value === 'string' ? value.trim() : JSON.stringify(value)
+    return typeof serialized === 'string' ? serialized : ''
+  } catch {
+    fail('agent_company_operator_invalid_evidence')
+  }
+}
+
+export function validateAgentCompanyManifest(value) {
+  if (!isRecord(value)) fail('agent_company_operator_invalid_manifest')
+  const unknown = Object.keys(value).filter((field) => !MANIFEST_FIELDS.has(field)).sort()
+  if (unknown.length) fail(`agent_company_operator_unknown_field:${unknown.join(',')}`)
+
+  const clientId = String(value.clientId || '').trim()
+  const cycleId = String(value.cycleId || '').trim()
+  if (!ID_RE.test(clientId)) fail('agent_company_operator_invalid_client_id')
+  if (!ID_RE.test(cycleId)) fail('agent_company_operator_invalid_cycle_id')
+  if (!Array.isArray(value.agents) || value.agents.length < 1 || value.agents.length > MAX_AGENTS) {
+    fail('agent_company_operator_invalid_agents')
+  }
+  const agents = value.agents.map((agent) => String(agent || '').trim())
+  if (agents.some((agent) => !ID_RE.test(agent)) || new Set(agents).size !== agents.length) {
+    fail('agent_company_operator_invalid_agents')
+  }
+  const roleBudget = Number(value.roleBudget)
+  if (!Number.isInteger(roleBudget) || roleBudget < 1 || roleBudget > MAX_ROLE_BUDGET) {
+    fail('agent_company_operator_invalid_role_budget')
+  }
+  if (!isRecord(value.evidence)) fail('agent_company_operator_invalid_evidence')
+  const evidenceIds = Object.keys(value.evidence).sort()
+  if (evidenceIds.length !== agents.length || evidenceIds.some((agent) => !agents.includes(agent))) {
+    fail('agent_company_operator_evidence_mismatch')
+  }
+  if (hasSensitiveField(value.evidence)) fail('agent_company_operator_sensitive_field')
+
+  const evidence = {}
+  for (const agent of agents) {
+    const text = evidenceText(value.evidence[agent])
+    const bytes = Buffer.byteLength(text, 'utf8')
+    if (!text || bytes > MAX_EVIDENCE_BYTES || /\u0000/.test(text)) {
+      fail('agent_company_operator_invalid_evidence')
+    }
+    evidence[agent] = typeof value.evidence[agent] === 'string' ? text : JSON.parse(text)
+  }
+  return { clientId, cycleId, agents, evidence, roleBudget }
+}
+
+function safeReason(value) {
+  const reason = String(value || '')
+  return /^company_[a-z0-9_]{1,120}$/.test(reason) ? reason : 'agent_company_request_failed'
+}
+
+export function createAgentCompanyApi(options = {}) {
+  const opsKey = String(options.opsKey || '').trim()
+  if (!opsKey) fail('agent_company_ops_key_required')
+  const fetchImpl = options.fetchImpl || globalThis.fetch
+  if (typeof fetchImpl !== 'function') fail('agent_company_fetch_required')
+
+  return async function request(method, body) {
+    let response
+    try {
+      response = await fetchImpl(AGENT_COMPANY_ENDPOINT, {
+        method,
+        headers: {
+          accept: 'application/json',
+          'content-type': 'application/json',
+          'x-ops-key': opsKey,
+        },
+        body: body ? JSON.stringify(body) : undefined,
+        signal: AbortSignal.timeout(Number(options.timeoutMs || 75_000)),
+      })
+    } catch {
+      fail('agent_company_request_unavailable')
+    }
+
+    let result
+    try { result = await response.json() } catch { fail('agent_company_invalid_response') }
+    if (!response.ok || !result?.ok) fail(safeReason(result?.reason))
+    return result
+  }
+}
+
+function summarizePlan(plan) {
+  return {
+    runId: plan.runId,
+    clientId: plan.clientId,
+    cycleId: plan.cycleId,
+    actionMode: plan.actionMode,
+    approvalRequired: plan.approvalRequired === true,
+    assignments: (plan.assignments || []).map((assignment) => ({
+      agentId: assignment.agentId,
+      name: assignment.name,
+      department: assignment.department,
+      crew: assignment.crew,
+      roleCount: assignment.roleCount,
+      evidenceBytes: assignment.evidenceBytes,
+      returns: assignment.returns,
+    })),
+    budget: plan.budget,
+    controls: plan.controls,
+  }
+}
+
+function assertPlan(plan, manifest, roster) {
+  if (!isRecord(plan) || !ID_RE.test(String(plan.runId || ''))) fail('agent_company_operator_invalid_plan')
+  if (plan.clientId !== manifest.clientId
+    || plan.cycleId !== manifest.cycleId
+    || plan.actionMode !== 'draft_only'
+    || plan.approvalRequired !== true) {
+    fail('agent_company_operator_plan_mismatch')
+  }
+  const assignments = Array.isArray(plan.assignments) ? plan.assignments : []
+  if (assignments.length !== manifest.agents.length) fail('agent_company_operator_invalid_plan')
+  const rosterIds = new Set((roster || []).map((agent) => agent.id))
+  if (manifest.agents.some((agent) => !rosterIds.has(agent))) fail('agent_company_operator_unknown_agent')
+  if (assignments.some((assignment, index) => assignment.agentId !== manifest.agents[index])) {
+    fail('agent_company_operator_assignment_mismatch')
+  }
+  if (Number(plan.budget?.plannedRoles || 0) > manifest.roleBudget) fail('agent_company_operator_budget_mismatch')
+  if (plan.controls?.execution !== 'sequential'
+    || plan.controls?.dynamicDelegation !== false
+    || plan.controls?.crossAgentContext !== false
+    || plan.controls?.externalWrites !== false
+    || plan.controls?.durableClaimRequired !== true) {
+    fail('agent_company_operator_unsafe_plan')
+  }
+}
+
+function assertQueuedWorkOrder(workOrder, manifest) {
+  if (!isRecord(workOrder)
+    || !ID_RE.test(String(workOrder.workOrderId || ''))
+    || !HASH_RE.test(String(workOrder.planHash || ''))
+    || !WORK_ORDER_STATUSES.has(workOrder.status)) {
+    fail('agent_company_operator_invalid_work_order')
+  }
+  if (workOrder.clientId !== manifest.clientId || workOrder.cycleId !== manifest.cycleId) {
+    fail('agent_company_operator_work_order_mismatch')
+  }
+}
+
+function assertCompletedWorkOrder(completed, queued, manifest) {
+  if (!isRecord(completed)
+    || !TERMINAL_STATUSES.has(completed.status)
+    || !isRecord(completed.result)
+    || !HASH_RE.test(String(completed.resultHash || ''))
+    || completed.evidenceState !== 'scrubbed') {
+    fail('agent_company_operator_invalid_result')
+  }
+  if (completed.workOrderId !== queued.workOrderId
+    || completed.clientId !== manifest.clientId
+    || completed.cycleId !== manifest.cycleId
+    || completed.planHash !== queued.planHash
+    || completed.result.actionMode !== 'draft_only') {
+    fail('agent_company_operator_result_mismatch')
+  }
+}
+
+function assertEvaluation(evaluation, expected, completed) {
+  if (!isRecord(evaluation)
+    || evaluation.workOrderId !== completed.workOrderId
+    || evaluation.clientId !== completed.clientId
+    || evaluation.verdict !== expected.verdict
+    || !HASH_RE.test(String(evaluation.evaluationHash || ''))
+    || !isRecord(evaluation.checks)
+    || Object.keys(expected.checks).some((field) => evaluation.checks[field] !== expected.checks[field])) {
+    fail('agent_company_operator_evaluation_mismatch')
+  }
+}
+
+function assertProof(proofPacket, completed) {
+  if (!isRecord(proofPacket)
+    || proofPacket.kind !== 'agent_company_delivery_proof'
+    || !HASH_RE.test(String(proofPacket.packetHash || ''))
+    || proofPacket.workOrder?.workOrderId !== completed.workOrderId
+    || proofPacket.workOrder?.clientId !== completed.clientId
+    || proofPacket.workOrder?.cycleId !== completed.cycleId
+    || proofPacket.workOrder?.planHash !== completed.planHash
+    || proofPacket.delivery?.resultHash !== completed.resultHash
+    || proofPacket.delivery?.actionMode !== 'draft_only'
+    || proofPacket.controls?.externalWrites !== false
+    || proofPacket.controls?.rawEvidenceIncluded !== false) {
+    fail('agent_company_operator_invalid_proof')
+  }
+}
+
+function validateEvaluation(value, workOrderId) {
+  if (value === null || value === undefined) return null
+  if (!isRecord(value) || !isRecord(value.checks)) fail('agent_company_operator_invalid_evaluation')
+  const checks = {
+    accurate: value.checks.accurate === true,
+    complete: value.checks.complete === true,
+    usable: value.checks.usable === true,
+    boundarySafe: value.checks.boundarySafe === true,
+  }
+  const allPassed = Object.values(checks).every(Boolean)
+  const verdict = String(value.verdict || '')
+  if ((verdict === 'accepted') !== allPassed || !['accepted', 'revision_required'].includes(verdict)) {
+    fail('agent_company_operator_invalid_evaluation')
+  }
+  const confirmation = `EVALUATE ${workOrderId}`
+  if (String(value.confirmation || '') !== confirmation) fail(`confirmation_required:${confirmation}`)
+  return { verdict, checks, confirmation }
+}
+
+export async function runGuidedAgentCompany(manifestValue, options = {}) {
+  const manifest = validateAgentCompanyManifest(manifestValue)
+  const manifestPayload = () => structuredClone(manifest)
+  const request = options.request
+  if (typeof request !== 'function') fail('agent_company_request_required')
+  if (typeof options.readConfirmation !== 'function') fail('agent_company_confirmation_reader_required')
+
+  const rosterResult = await request('GET')
+  const planResult = await request('POST', { action: 'plan', ...manifestPayload() })
+  const plan = planResult?.plan
+  assertPlan(plan, manifest, rosterResult?.agents)
+  const planSummary = summarizePlan(plan)
+  await options.onPlan?.(planSummary)
+
+  const queueConfirmation = `QUEUE ${plan.runId}`
+  const queueAnswer = String(await options.readConfirmation(queueConfirmation, 'queue') || '').trim()
+  if (!queueAnswer) return { ok: true, status: 'planned', plan: planSummary }
+  if (queueAnswer !== queueConfirmation) fail(`confirmation_required:${queueConfirmation}`)
+
+  const queued = await request('POST', { action: 'work-order-create', ...manifestPayload() })
+  const workOrder = queued?.workOrder
+  assertQueuedWorkOrder(workOrder, manifest)
+  await options.onQueued?.(workOrder)
+
+  const runConfirmation = `RUN ${workOrder.workOrderId}`
+  const runAnswer = String(await options.readConfirmation(runConfirmation, 'dispatch') || '').trim()
+  if (!runAnswer) return { ok: true, status: 'queued', plan: planSummary, workOrder }
+  if (runAnswer !== runConfirmation) fail(`confirmation_required:${runConfirmation}`)
+
+  const dispatched = await request('POST', {
+    action: 'work-order-run',
+    clientId: manifest.clientId,
+    workOrderId: workOrder.workOrderId,
+    planHash: workOrder.planHash,
+    confirmation: runConfirmation,
+  })
+  const completed = dispatched?.workOrder
+  assertCompletedWorkOrder(completed, workOrder, manifest)
+  await options.onResult?.(completed)
+
+  let evaluation = null
+  if (typeof options.readEvaluation === 'function') {
+    const evaluationInput = validateEvaluation(await options.readEvaluation(completed), completed.workOrderId)
+    if (evaluationInput) {
+      const evaluated = await request('POST', {
+        action: 'work-order-evaluate',
+        clientId: manifest.clientId,
+        workOrderId: completed.workOrderId,
+        planHash: completed.planHash,
+        ...evaluationInput,
+      })
+      evaluation = evaluated.evaluation
+      assertEvaluation(evaluation, evaluationInput, completed)
+      await options.onEvaluation?.(evaluation)
+    }
+  }
+
+  const proofResult = await request('POST', {
+    action: 'work-order-proof',
+    clientId: manifest.clientId,
+    workOrderId: completed.workOrderId,
+  })
+  assertProof(proofResult?.proofPacket, completed)
+  await options.onProof?.(proofResult.proofPacket)
+  return {
+    ok: true,
+    status: completed.status,
+    plan: planSummary,
+    workOrder: completed,
+    evaluation,
+    proofPacket: proofResult.proofPacket,
+  }
+}
+
+export default { AGENT_COMPANY_ENDPOINT, createAgentCompanyApi, runGuidedAgentCompany, validateAgentCompanyManifest }

--- a/kernel/agent-company-operator.test.mjs
+++ b/kernel/agent-company-operator.test.mjs
@@ -1,0 +1,281 @@
+import { readFile } from 'node:fs/promises'
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  AGENT_COMPANY_ENDPOINT,
+  createAgentCompanyApi,
+  runGuidedAgentCompany,
+  validateAgentCompanyManifest,
+} from './agent-company-operator.mjs'
+
+const HASH = 'a'.repeat(64)
+const MANIFEST = {
+  clientId: 'supermega-internal',
+  cycleId: 'internal-proof-a',
+  agents: ['operations-analyst', 'project-controller'],
+  roleBudget: 6,
+  evidence: {
+    'operations-analyst': { objective: 'Rank one redacted operating period.', facts: ['No customer claim.'] },
+    'project-controller': { outcome: 'Produce one bounded delivery plan.', blockers: ['Owner evidence required.'] },
+  },
+}
+
+const PLAN = {
+  runId: 'agent-company:internal-proof-a',
+  clientId: MANIFEST.clientId,
+  cycleId: MANIFEST.cycleId,
+  actionMode: 'draft_only',
+  approvalRequired: true,
+  assignments: [
+    {
+      agentId: 'operations-analyst',
+      name: 'Operations Analyst',
+      department: 'operations',
+      crew: 'daily-operator-brief',
+      roleCount: 3,
+      evidenceBytes: 80,
+      returns: ['brief'],
+    },
+    {
+      agentId: 'project-controller',
+      name: 'Project Controller',
+      department: 'delivery',
+      crew: 'project-control-desk',
+      roleCount: 3,
+      evidenceBytes: 90,
+      returns: ['status'],
+    },
+  ],
+  budget: { agentLimit: 2, selectedAgents: 2, roleLimit: 6, plannedRoles: 6, remainingRoles: 0 },
+  controls: {
+    execution: 'sequential',
+    dynamicDelegation: false,
+    crossAgentContext: false,
+    externalWrites: false,
+    durableClaimRequired: true,
+  },
+}
+
+const PLANNED_ORDER = {
+  workOrderId: 'company-order:internal-proof-a',
+  clientId: MANIFEST.clientId,
+  cycleId: MANIFEST.cycleId,
+  status: 'planned',
+  planHash: HASH,
+  evidenceState: 'retained',
+}
+
+const COMPLETED_ORDER = {
+  ...PLANNED_ORDER,
+  status: 'completed',
+  completedAt: '2026-07-14T03:00:00.000Z',
+  evidenceState: 'scrubbed',
+  resultHash: 'b'.repeat(64),
+  result: {
+    ok: true,
+    status: 'completed',
+    actionMode: 'draft_only',
+    results: [{ agentId: 'operations-analyst', status: 'completed', output: { priority: 'one proof' } }],
+    budget: { usedRoleCalls: 6 },
+  },
+}
+
+function harness() {
+  const calls = []
+  return {
+    calls,
+    request: async (method, body) => {
+      calls.push({ method, body: structuredClone(body) })
+      if (method === 'GET') return { ok: true, agents: MANIFEST.agents.map((id) => ({ id })) }
+      if (body.action === 'plan') return { ok: true, plan: structuredClone(PLAN) }
+      if (body.action === 'work-order-create') return { ok: true, workOrder: structuredClone(PLANNED_ORDER) }
+      if (body.action === 'work-order-run') return { ok: true, workOrder: structuredClone(COMPLETED_ORDER) }
+      if (body.action === 'work-order-evaluate') {
+        return {
+          ok: true,
+          evaluation: {
+            workOrderId: body.workOrderId,
+            clientId: body.clientId,
+            verdict: body.verdict,
+            checks: body.checks,
+            evaluationHash: 'c'.repeat(64),
+          },
+        }
+      }
+      if (body.action === 'work-order-proof') {
+        return {
+          ok: true,
+          proofPacket: {
+            version: 1,
+            kind: 'agent_company_delivery_proof',
+            packetHash: 'd'.repeat(64),
+            workOrder: {
+              workOrderId: COMPLETED_ORDER.workOrderId,
+              clientId: COMPLETED_ORDER.clientId,
+              cycleId: COMPLETED_ORDER.cycleId,
+              planHash: COMPLETED_ORDER.planHash,
+            },
+            delivery: {
+              resultHash: COMPLETED_ORDER.resultHash,
+              actionMode: 'draft_only',
+            },
+            controls: { externalWrites: false, rawEvidenceIncluded: false },
+            review: null,
+          },
+        }
+      }
+      throw new Error(`unexpected:${body.action}`)
+    },
+  }
+}
+
+test('operator validates a bounded redacted manifest and rejects secret-shaped evidence before network access', async () => {
+  assert.deepEqual(validateAgentCompanyManifest(MANIFEST).agents, MANIFEST.agents)
+  assert.throws(() => validateAgentCompanyManifest({ ...MANIFEST, endpoint: 'https://elsewhere.invalid' }), /unknown_field:endpoint/)
+  assert.throws(() => validateAgentCompanyManifest({ ...MANIFEST, agents: [...MANIFEST.agents, 'quality-reviewer'] }), /invalid_agents/)
+  assert.throws(() => validateAgentCompanyManifest({
+    ...MANIFEST,
+    evidence: { ...MANIFEST.evidence, 'operations-analyst': { apiKey: 'must-never-enter-evidence' } },
+  }), /sensitive_field/)
+  assert.throws(() => validateAgentCompanyManifest({
+    ...MANIFEST,
+    evidence: { ...MANIFEST.evidence, 'operations-analyst': undefined },
+  }), /invalid_evidence/)
+
+  let requests = 0
+  await assert.rejects(runGuidedAgentCompany({
+    ...MANIFEST,
+    evidence: { ...MANIFEST.evidence, 'project-controller': { nested: { accessToken: 'blocked' } } },
+  }, {
+    request: async () => { requests += 1 },
+    readConfirmation: async () => '',
+  }), /sensitive_field/)
+  assert.equal(requests, 0)
+})
+
+test('operator is plan-only by default and returns no raw evidence in its plan summary', async () => {
+  const state = harness()
+  let printed
+  const result = await runGuidedAgentCompany(MANIFEST, {
+    request: state.request,
+    readConfirmation: async () => '',
+    onPlan: async (plan) => { printed = JSON.stringify(plan) },
+  })
+  assert.equal(result.status, 'planned')
+  assert.deepEqual(state.calls.map((call) => call.body?.action || call.method), ['GET', 'plan'])
+  assert.equal(printed.includes('No customer claim'), false)
+  assert.equal(printed.includes('Owner evidence required'), false)
+  assert.equal(result.plan.controls.externalWrites, false)
+})
+
+test('queue and dispatch require separate exact confirmations', async () => {
+  const queuedState = harness()
+  const queued = await runGuidedAgentCompany(MANIFEST, {
+    request: queuedState.request,
+    readConfirmation: async (confirmation, stage) => stage === 'queue' ? confirmation : '',
+  })
+  assert.equal(queued.status, 'queued')
+  assert.deepEqual(queuedState.calls.map((call) => call.body?.action || call.method), ['GET', 'plan', 'work-order-create'])
+
+  const wrongState = harness()
+  await assert.rejects(runGuidedAgentCompany(MANIFEST, {
+    request: wrongState.request,
+    readConfirmation: async (_confirmation, stage) => stage === 'queue' ? 'QUEUE wrong-run' : '',
+  }), /confirmation_required:QUEUE agent-company:internal-proof-a/)
+  assert.deepEqual(wrongState.calls.map((call) => call.body?.action || call.method), ['GET', 'plan'])
+})
+
+test('queued evidence stays bound to the validated manifest even if caller state changes after planning', async () => {
+  const mutable = structuredClone(MANIFEST)
+  const state = harness()
+  await runGuidedAgentCompany(mutable, {
+    request: state.request,
+    readConfirmation: async (confirmation, stage) => stage === 'queue' ? confirmation : '',
+    onPlan: async () => {
+      mutable.evidence['operations-analyst'].objective = 'mutated after plan'
+    },
+  })
+  const planned = state.calls.find((call) => call.body?.action === 'plan').body
+  const queued = state.calls.find((call) => call.body?.action === 'work-order-create').body
+  assert.equal(planned.evidence['operations-analyst'].objective, MANIFEST.evidence['operations-analyst'].objective)
+  assert.equal(queued.evidence['operations-analyst'].objective, MANIFEST.evidence['operations-analyst'].objective)
+})
+
+test('full operator flow dispatches once, records checklist evaluation, and retrieves proof without customer review', async () => {
+  const state = harness()
+  const events = []
+  const result = await runGuidedAgentCompany(MANIFEST, {
+    request: state.request,
+    readConfirmation: async (confirmation) => confirmation,
+    readEvaluation: async (workOrder) => ({
+      verdict: 'accepted',
+      checks: { accurate: true, complete: true, usable: true, boundarySafe: true },
+      confirmation: `EVALUATE ${workOrder.workOrderId}`,
+    }),
+    onQueued: async () => events.push('queued'),
+    onResult: async () => events.push('result'),
+    onEvaluation: async () => events.push('evaluation'),
+    onProof: async () => events.push('proof'),
+  })
+  assert.equal(result.status, 'completed')
+  assert.equal(result.evaluation.verdict, 'accepted')
+  assert.equal(result.proofPacket.review, null)
+  assert.deepEqual(events, ['queued', 'result', 'evaluation', 'proof'])
+  const actions = state.calls.map((call) => call.body?.action || call.method)
+  assert.deepEqual(actions, ['GET', 'plan', 'work-order-create', 'work-order-run', 'work-order-evaluate', 'work-order-proof'])
+  assert.equal(actions.includes('work-order-review'), false)
+  const run = state.calls.find((call) => call.body?.action === 'work-order-run').body
+  assert.equal(run.confirmation, `RUN ${PLANNED_ORDER.workOrderId}`)
+  assert.equal(run.planHash, HASH)
+})
+
+test('operator rejects identity, hash, and boundary drift across server responses', async () => {
+  for (const testCase of [
+    { action: 'plan', mutate: (body) => { body.plan.clientId = 'another-client' } },
+    { action: 'work-order-create', mutate: (body) => { body.workOrder.cycleId = 'another-cycle' } },
+    { action: 'work-order-run', mutate: (body) => { body.workOrder.planHash = 'f'.repeat(64) } },
+    { action: 'work-order-proof', mutate: (body) => { body.proofPacket.controls.externalWrites = true } },
+  ]) {
+    const state = harness()
+    const request = async (method, body) => {
+      const response = await state.request(method, body)
+      if (body?.action === testCase.action) testCase.mutate(response)
+      return response
+    }
+    await assert.rejects(runGuidedAgentCompany(MANIFEST, {
+      request,
+      readConfirmation: async (confirmation) => confirmation,
+    }), /agent_company_operator_(plan_mismatch|work_order_mismatch|result_mismatch|invalid_proof)/)
+  }
+})
+
+test('API client fixes the production endpoint and keeps the Ops key out of payloads and errors', async () => {
+  const seen = []
+  const request = createAgentCompanyApi({
+    opsKey: 'owner-only-key',
+    fetchImpl: async (url, options) => {
+      seen.push({ url, options })
+      return { ok: true, json: async () => ({ ok: true, agents: [] }) }
+    },
+  })
+  await request('GET')
+  assert.equal(seen[0].url, AGENT_COMPANY_ENDPOINT)
+  assert.equal(seen[0].options.headers['x-ops-key'], 'owner-only-key')
+  assert.equal(seen[0].options.body, undefined)
+  assert.equal(JSON.stringify(seen[0].options.body || {}).includes('owner-only-key'), false)
+
+  const failed = createAgentCompanyApi({
+    opsKey: 'owner-only-key',
+    fetchImpl: async () => ({ ok: false, json: async () => ({ reason: 'provider leaked secret text' }) }),
+  })
+  await assert.rejects(failed('POST', { action: 'plan' }), /^Error: agent_company_request_failed$/)
+})
+
+test('CLI takes the Ops key only from the environment and has no customer-review command', async () => {
+  const source = await readFile(new URL('./scripts/operate-agent-company.mjs', import.meta.url), 'utf8')
+  assert.match(source, /process\.env\.SUPERMEGA_OPS_KEY/)
+  assert.match(source, /press Enter to stop/)
+  assert.match(source, /customerReviewRecorded: false/)
+  assert.doesNotMatch(source, /--ops-key|--secret|work-order-review|writeFile|appendFile/)
+})

--- a/kernel/examples/agent-company-work-order.example.json
+++ b/kernel/examples/agent-company-work-order.example.json
@@ -1,0 +1,32 @@
+{
+  "clientId": "internal-example",
+  "cycleId": "first-proof-001",
+  "agents": [
+    "operations-analyst",
+    "project-controller"
+  ],
+  "roleBudget": 6,
+  "evidence": {
+    "operations-analyst": {
+      "objective": "Rank the next operating period from approved, redacted facts.",
+      "facts": [
+        "Replace this example with owner-approved business evidence.",
+        "Do not include credentials, tokens, private keys, or customer secrets."
+      ],
+      "constraints": [
+        "No external writes.",
+        "No customer or revenue claim without evidence."
+      ]
+    },
+    "project-controller": {
+      "acceptedOutcome": "Produce a bounded milestone and risk update for owner review.",
+      "milestones": [
+        "Replace this example with the approved baseline and current state."
+      ],
+      "constraints": [
+        "No unattended dispatch.",
+        "No recursive delegation."
+      ]
+    }
+  }
+}

--- a/kernel/package.json
+++ b/kernel/package.json
@@ -7,6 +7,7 @@
     "brand:verify": "node scripts/verify-brand.mjs",
     "connector:resilience": "node ../tools/test_connector_resilience.mjs",
     "crew:resilience": "node ../tools/test_crew_resilience.mjs",
+    "agent-company:operate": "node scripts/operate-agent-company.mjs",
     "workcell:provision": "node scripts/provision-workcell-client.mjs",
     "workcell:activate": "node scripts/activate-workcell-client.mjs",
     "verify": "npm test && npm run brand:verify && npm run connector:resilience && npm run crew:resilience",

--- a/kernel/scripts/operate-agent-company.mjs
+++ b/kernel/scripts/operate-agent-company.mjs
@@ -1,0 +1,140 @@
+#!/usr/bin/env node
+
+import { readFile } from 'node:fs/promises'
+import { stdin, stdout } from 'node:process'
+import { resolve } from 'node:path'
+
+import {
+  createAgentCompanyApi,
+  runGuidedAgentCompany,
+} from '../agent-company-operator.mjs'
+import { TerminalPrompt } from '../terminal-prompt.mjs'
+
+function parseArgs(argv) {
+  const out = {}
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index]
+    if (arg === '--help' || arg === '-h') out.help = true
+    else if (arg === '--manifest') {
+      const value = argv[index + 1]
+      if (!value || value.startsWith('--')) throw new Error('argument_value_required:--manifest')
+      out.manifest = value
+      index += 1
+    } else throw new Error(`unknown_argument:${arg}`)
+  }
+  return out
+}
+
+function help() {
+  return [
+    'SuperMega Agent Company operator',
+    '',
+    '  SUPERMEGA_OPS_KEY=<owner-provided> npm run agent-company:operate -- --manifest <work-order.json>',
+    '',
+    'The command validates a redacted manifest, prints a plan, and stops by default. Queueing,',
+    'dispatch, and internal evaluation each require a separate exact terminal confirmation.',
+    'The Ops key is accepted only from the process environment and is never printed or stored.',
+    'This command cannot record a customer review or perform connector writes.',
+  ].join('\n')
+}
+
+function answer(value, label) {
+  const normalized = String(value || '').trim().toLowerCase()
+  if (normalized === 'y' || normalized === 'yes') return true
+  if (!normalized || normalized === 'n' || normalized === 'no') return false
+  throw new Error(`agent_company_operator_invalid_answer:${label}`)
+}
+
+function resultSummary(workOrder) {
+  return {
+    workOrderId: workOrder.workOrderId,
+    clientId: workOrder.clientId,
+    cycleId: workOrder.cycleId,
+    status: workOrder.status,
+    planHash: workOrder.planHash,
+    resultHash: workOrder.resultHash,
+    completedAt: workOrder.completedAt,
+    evidenceState: workOrder.evidenceState,
+    result: workOrder.result,
+  }
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2))
+  if (args.help) { stdout.write(`${help()}\n`); return }
+  if (!args.manifest) throw new Error('manifest_path_required')
+  const opsKey = String(process.env.SUPERMEGA_OPS_KEY || '').trim()
+  if (!opsKey) throw new Error('agent_company_ops_key_required')
+
+  const manifest = JSON.parse(await readFile(resolve(args.manifest), 'utf8'))
+  const prompt = new TerminalPrompt(stdin, stdout)
+  prompt.assertInteractive()
+  const request = createAgentCompanyApi({ opsKey })
+
+  stdout.write('Ops key stays in process memory. No connector writes or customer review are available.\n')
+  const result = await runGuidedAgentCompany(manifest, {
+    request,
+    readConfirmation: (confirmation, stage) => prompt.read(
+      `Type ${confirmation} to ${stage === 'queue' ? 'queue the reviewed plan' : 'dispatch model work'}, or press Enter to stop: `,
+    ),
+    onPlan: (plan) => stdout.write(`${JSON.stringify({ ok: true, mode: 'agent_company_plan', plan }, null, 2)}\n`),
+    onQueued: (workOrder) => stdout.write(`${JSON.stringify({
+      ok: true,
+      mode: 'agent_company_queued',
+      workOrder: {
+        workOrderId: workOrder.workOrderId,
+        clientId: workOrder.clientId,
+        cycleId: workOrder.cycleId,
+        status: workOrder.status,
+        planHash: workOrder.planHash,
+        evidenceState: workOrder.evidenceState,
+      },
+    }, null, 2)}\n`),
+    onResult: (workOrder) => stdout.write(`${JSON.stringify({
+      ok: true,
+      mode: 'agent_company_result',
+      workOrder: resultSummary(workOrder),
+    }, null, 2)}\n`),
+    readEvaluation: async (workOrder) => {
+      if (!answer(await prompt.read('Record an immutable internal evaluation now? [y/N]: '), 'evaluation')) return null
+      const checks = {
+        accurate: answer(await prompt.read('Accurate against the supplied evidence? [y/N]: '), 'accurate'),
+        complete: answer(await prompt.read('Complete for the accepted internal outcome? [y/N]: '), 'complete'),
+        usable: answer(await prompt.read('Usable by the operator now? [y/N]: '), 'usable'),
+        boundarySafe: answer(await prompt.read('Stayed inside the no-write and evidence boundaries? [y/N]: '), 'boundary_safe'),
+      }
+      const confirmation = `EVALUATE ${workOrder.workOrderId}`
+      return {
+        verdict: Object.values(checks).every(Boolean) ? 'accepted' : 'revision_required',
+        checks,
+        confirmation: await prompt.read(`Type ${confirmation} to store this checklist, or Ctrl+C to stop: `),
+      }
+    },
+    onEvaluation: (evaluation) => stdout.write(`${JSON.stringify({
+      ok: true,
+      mode: 'agent_company_internal_evaluation',
+      evaluation,
+    }, null, 2)}\n`),
+    onProof: (proofPacket) => stdout.write(`${JSON.stringify({
+      ok: true,
+      mode: 'agent_company_delivery_proof',
+      proofPacket,
+    }, null, 2)}\n`),
+  })
+  stdout.write(`${JSON.stringify({
+    ok: result.ok,
+    status: result.status,
+    workOrderId: result.workOrder?.workOrderId || null,
+    evaluationRecorded: Boolean(result.evaluation),
+    proofPacketHash: result.proofPacket?.packetHash || null,
+    customerReviewRecorded: false,
+  }, null, 2)}\n`)
+}
+
+main().catch((error) => {
+  process.stderr.write(`${JSON.stringify({
+    ok: false,
+    reason: String(error?.message || 'agent_company_operator_failed').slice(0, 500),
+  })}\n`)
+  process.exitCode = 1
+})


### PR DESCRIPTION
## What changed
- Add an environment-only guided operator client over the existing protected Agent Company API and durable queue.
- Validate redacted manifests and reject secret-shaped fields before network access.
- Keep plan-only default with separate exact QUEUE, RUN, and optional EVALUATE confirmations.
- Reject client, cycle, work-order, hash, draft-only, and no-write drift across server responses.
- Retrieve the delivery proof but expose no customer-review or connector-write command.
- Add an example manifest, package command, and operator docs; correct crew count to 12.

## Verification
- 204 tests
- brand contract
- 69 connectors / 993 calls / 0 violations
- 12 crews / 172 checks / 0 violations
- 15 Vercel runtime functions / 0 test, source-map, or operator-client artifacts
- focused CLI help and 8 operator contracts

## Boundary
Production owner secrets remain non-exportable. No work order was queued or dispatched, no model/provider call occurred, and no customer review, external write, payment, lead, or revenue was created. The first real run still requires the owner to supply `SUPERMEGA_OPS_KEY` to the operator process, not chat or a manifest.