### PR TITLE
Ops: monitor the agent first-proof funnel

### DIFF
--- a/tools/check_public_live_health.py
+++ b/tools/check_public_live_health.py
@@ -15,7 +15,7 @@ from typing import Any
 from urllib.parse import urljoin, urlparse
 
 
-USER_AGENT = "supermega-portfolio-live-health/4.1"
+USER_AGENT = "supermega-portfolio-live-health/4.2"
 
 
 class NoRedirect(urllib.request.HTTPRedirectHandler):
@@ -121,6 +121,7 @@ def run(
     console_url = console_url.rstrip("/") + "/"
     failures: list[dict[str, Any]] = []
     results: list[dict[str, Any]] = []
+    agent_intake_url = urljoin(base_url, "contact/?from=ai-agent-solution")
 
     page_checks = [
         (
@@ -160,6 +161,23 @@ def run(
                 "No account or data connection is made before you approve it.",
             ],
         ),
+        (
+            agent_intake_url,
+            [
+                "search.get('from')==='ai-agent-solution'",
+                "document.title='AI Agent Solution | supermega.dev'",
+                "What should your agent handle every week?",
+                "Request an agent proof",
+                "What does your team repeat?",
+                "Request first proof",
+                "one redacted sample and one reviewed output",
+                'action="/api/contact-submissions"',
+                'name="name"',
+                'name="email"',
+                'name="company"',
+                'name="goal"',
+            ],
+        ),
         (urljoin(base_url, "privacy/"), ["<title>Privacy | supermega.dev</title>", "Only the details needed to reply."]),
     ]
 
@@ -167,10 +185,25 @@ def run(
         response = fetch(url, timeout=timeout, attempts=attempts)
         body = response.body.decode("utf-8", errors="replace")
         missing = [token for token in tokens if token not in body]
-        forbidden = ["MegaOS", "DeskPOS", ">Studio<", "Try demo", "https://demo.supermega.dev/"] if url in (base_url, www_url) else []
+        if url in (base_url, www_url):
+            forbidden = ["MegaOS", "DeskPOS", ">Studio<", "Try demo", "https://demo.supermega.dev/"]
+        elif url == agent_intake_url:
+            forbidden = [
+                "MegaOS",
+                "DeskPOS",
+                'name="workflow"',
+                'name="requested_package"',
+                'name="product_area"',
+                'name="template_id"',
+                'name="source_links"',
+                "/site/agent-templates/",
+                "General enquiry",
+            ]
+        else:
+            forbidden = []
         unexpected = [token for token in forbidden if token in body]
         result = {
-            "kind": "page",
+            "kind": "agent_intake_page" if url == agent_intake_url else "page",
             "url": url,
             "status": response.status,
             "bytes": len(response.body),

--- a/tools/test_public_live_health.py
+++ b/tools/test_public_live_health.py
@@ -18,6 +18,7 @@ BASE = "https://public.example/"
 WWW = "https://www.example/"
 APP = "https://app.example/"
 CONSOLE = "https://console.example/"
+AGENT_INTAKE = f"{BASE}contact/?from=ai-agent-solution"
 
 
 def result(url: str, body: str | dict, *, status: int = 200, headers: dict[str, str] | None = None):
@@ -48,6 +49,20 @@ def healthy_responses() -> dict[str, checker.HttpResult]:
         'name="company"',
         'name="goal"',
         "No account or data connection is made before you approve it.",
+    )
+    agent_contact = page(
+        "search.get('from')==='ai-agent-solution'",
+        "document.title='AI Agent Solution | supermega.dev'",
+        "What should your agent handle every week?",
+        "Request an agent proof",
+        "What does your team repeat?",
+        "Request first proof",
+        "one redacted sample and one reviewed output",
+        'action="/api/contact-submissions"',
+        'name="name"',
+        'name="email"',
+        'name="company"',
+        'name="goal"',
     )
     privacy = page(
         "<title>Privacy | supermega.dev</title>",
@@ -131,6 +146,7 @@ def healthy_responses() -> dict[str, checker.HttpResult]:
         BASE: result(BASE, home),
         WWW: result(WWW, home),
         f"{BASE}contact/": result(f"{BASE}contact/", contact),
+        AGENT_INTAKE: result(AGENT_INTAKE, agent_contact),
         f"{BASE}privacy/": result(f"{BASE}privacy/", privacy),
         f"{BASE}api/contact-submissions/status": result(
             f"{BASE}api/contact-submissions/status", contact_status
@@ -163,11 +179,34 @@ class PortfolioHealthTest(unittest.TestCase):
         with patch.object(checker, "fetch", side_effect=fake_fetch):
             return checker.run(BASE, WWW, APP, CONSOLE, timeout=1, attempts=1)
 
-    def test_healthy_portfolio_passes_all_sixteen_checks(self):
+    def test_healthy_portfolio_passes_all_seventeen_checks(self):
         report = self.run_report(healthy_responses())
         self.assertEqual(report["status"], "ready")
-        self.assertEqual(report["checks"], 16)
+        self.assertEqual(report["checks"], 17)
         self.assertEqual(report["failures"], [])
+
+    def test_missing_agent_context_fails_first_proof_route(self):
+        responses = healthy_responses()
+        responses[AGENT_INTAKE] = result(
+            AGENT_INTAKE,
+            responses[AGENT_INTAKE].body.decode().replace("Request first proof", ""),
+        )
+        report = self.run_report(responses)
+        self.assertEqual(report["status"], "error")
+        failure = next(item for item in report["failures"] if item["kind"] == "agent_intake_page")
+        self.assertEqual(failure["url"], AGENT_INTAKE)
+        self.assertIn("Request first proof", failure["missing"])
+
+    def test_technical_intake_field_fails_first_proof_route(self):
+        responses = healthy_responses()
+        responses[AGENT_INTAKE] = result(
+            AGENT_INTAKE,
+            responses[AGENT_INTAKE].body.decode() + 'name="workflow"',
+        )
+        report = self.run_report(responses)
+        self.assertEqual(report["status"], "error")
+        failure = next(item for item in report["failures"] if item["kind"] == "agent_intake_page")
+        self.assertIn('name="workflow"', failure["unexpected"])
 
     def test_missing_plant_link_fails_public_page(self):
         responses = healthy_responses()


### PR DESCRIPTION
## What changed

- Adds the exact `contact/?from=ai-agent-solution` route to the read-only portfolio monitor.
- Requires the client-side agent-intent switch, first-proof copy, four visible-field source contract, and contact action.
- Fails if retired technical intake fields, phantom starter-kit paths, or retired customer branding reappear.
- Reports this conversion path separately as `agent_intake_page`.

## Why

The public first-proof funnel is live, but the scheduled estate monitor checked only generic Contact. The primary agent conversion path could therefore regress while the portfolio remained green.

## Verification

- `uv run --no-sync python -m unittest -v tools/test_public_live_health.py`: 11/11 passed
- `uv run --no-sync python tools/check_public_live_health.py`: 17/17 live checks passed
- New regressions prove missing first-proof context and leaked technical intake fields fail the gate
- Read-only: no form submission, lead, customer record, work order, provider action, payment, pricing, or deployment mutation