### PR TITLE
Kernel: lock Agent Company first-run preflight

### DIFF
--- a/kernel/README.md
+++ b/kernel/README.md
@@ -127,18 +127,32 @@ runner, scheduler, or model supervisor. Start from the redacted example and keep
 outside version control:
 
 ```powershell
-$env:SUPERMEGA_OPS_KEY = '<owner-provided in this terminal only>'
-npm run agent-company:operate -- --manifest C:\secure-local\work-order.json
-Remove-Item Env:SUPERMEGA_OPS_KEY
+npm run agent-company:operate -- --manifest C:\secure-local\work-order.json --preflight
+$secureOpsKey = Read-Host 'Ops key' -AsSecureString
+$opsKeyBuffer = [Runtime.InteropServices.Marshal]::SecureStringToBSTR($secureOpsKey)
+try {
+  $env:SUPERMEGA_OPS_KEY = [Runtime.InteropServices.Marshal]::PtrToStringBSTR($opsKeyBuffer)
+  npm run agent-company:operate -- --manifest C:\secure-local\work-order.json
+} finally {
+  Remove-Item Env:SUPERMEGA_OPS_KEY -ErrorAction SilentlyContinue
+  [Runtime.InteropServices.Marshal]::ZeroFreeBSTR($opsKeyBuffer)
+}
 ```
 
-The default is plan-only. Queueing requires exact `QUEUE <runId>` confirmation, dispatch requires a
-separate exact `RUN <workOrderId>` confirmation, and optional internal evaluation requires the four
-fixed checks plus `EVALUATE <workOrderId>`. The command then retrieves the deterministic delivery
-proof. It rejects credential-shaped manifest fields before network access, fixes the API host to
-`console.supermega.dev`, accepts the Ops key only from the process environment, and has no customer
-review or connector-write command. Customer decisions still belong in the console after the operator
-has exact evidence from an allowed source.
+`--preflight` is offline and keyless. It validates the redacted manifest against the same local roster,
+crew definitions, role budget, and no-write controls used by the server, prints evidence byte counts
+without evidence content, and computes the exact expected run ID, work-order ID, and `expectedPlanHash`
+that the durable queue must return. It creates no claim and makes no network or model call. Normal
+operation refuses planning or queue creation if any identity differs. It also fingerprints the exact
+server plan the owner reviews and refuses dispatch if the durable queue or terminal result contains a
+different plan. The default remains plan-only.
+Queueing requires exact `QUEUE <runId>` confirmation, dispatch requires a separate exact
+`RUN <workOrderId>` confirmation, and optional internal evaluation requires the four fixed checks plus
+`EVALUATE <workOrderId>`. The command then retrieves the deterministic delivery proof. It rejects
+credential-shaped manifest fields before network access, fixes the API host to `console.supermega.dev`,
+accepts the Ops key only from the process environment, and has no customer review or connector-write
+command. Customer decisions still belong in the console after the operator has exact evidence from an
+allowed source.
 
 ## Core Environment
 

--- a/kernel/agent-company-operator.mjs
+++ b/kernel/agent-company-operator.mjs
@@ -1,3 +1,5 @@
+import { createHash } from 'node:crypto'
+
 const ID_RE = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,79}$/
 const HASH_RE = /^[a-f0-9]{64}$/
 const MANIFEST_FIELDS = new Set(['clientId', 'cycleId', 'agents', 'evidence', 'roleBudget'])
@@ -48,6 +50,26 @@ function evidenceText(value) {
   }
 }
 
+function stableStringify(value) {
+  if (value === null || typeof value !== 'object') return JSON.stringify(value)
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(',')}]`
+  return `{${Object.keys(value).sort().map((key) => `${JSON.stringify(key)}:${stableStringify(value[key])}`).join(',')}}`
+}
+
+function storedManifestInput(manifest) {
+  return {
+    clientId: manifest.clientId,
+    cycleId: manifest.cycleId,
+    agents: [...manifest.agents],
+    evidence: Object.fromEntries(manifest.agents.map((agentId) => [agentId, evidenceText(manifest.evidence[agentId])])),
+    roleBudget: manifest.roleBudget,
+  }
+}
+
+function stableHash(value) {
+  return createHash('sha256').update(stableStringify(value)).digest('hex')
+}
+
 export function validateAgentCompanyManifest(value) {
   if (!isRecord(value)) fail('agent_company_operator_invalid_manifest')
   const unknown = Object.keys(value).filter((field) => !MANIFEST_FIELDS.has(field)).sort()
@@ -87,6 +109,35 @@ export function validateAgentCompanyManifest(value) {
   return { clientId, cycleId, agents, evidence, roleBudget }
 }
 
+export function buildAgentCompanyManifestPreflight(value) {
+  const manifest = validateAgentCompanyManifest(value)
+  const storedInput = storedManifestInput(manifest)
+  const cycleDigest = createHash('sha256').update(`${manifest.clientId}\n${manifest.cycleId}`).digest('hex').slice(0, 40)
+  const evidence = manifest.agents.map((agentId) => ({
+    agentId,
+    bytes: Buffer.byteLength(storedInput.evidence[agentId], 'utf8'),
+  }))
+  return {
+    version: 1,
+    kind: 'agent_company_manifest_preflight',
+    clientId: manifest.clientId,
+    cycleId: manifest.cycleId,
+    expectedRunId: `agent-company:${cycleDigest}`,
+    expectedWorkOrderId: `company-order:${cycleDigest}`,
+    agents: evidence,
+    roleBudget: manifest.roleBudget,
+    totalEvidenceBytes: evidence.reduce((total, entry) => total + entry.bytes, 0),
+    expectedPlanHash: stableHash(storedInput),
+    controls: {
+      planOnlyDefault: true,
+      explicitQueue: true,
+      explicitDispatch: true,
+      externalWrites: false,
+      rawEvidenceIncluded: false,
+    },
+  }
+}
+
 function safeReason(value) {
   const reason = String(value || '')
   return /^company_[a-z0-9_]{1,120}$/.test(reason) ? reason : 'agent_company_request_failed'
@@ -122,13 +173,15 @@ export function createAgentCompanyApi(options = {}) {
   }
 }
 
-function summarizePlan(plan) {
+function summarizePlan(plan, preflight) {
   return {
     runId: plan.runId,
     clientId: plan.clientId,
     cycleId: plan.cycleId,
     actionMode: plan.actionMode,
     approvalRequired: plan.approvalRequired === true,
+    expectedPlanHash: preflight.expectedPlanHash,
+    reviewedPlanHash: stableHash(plan),
     assignments: (plan.assignments || []).map((assignment) => ({
       agentId: assignment.agentId,
       name: assignment.name,
@@ -143,9 +196,10 @@ function summarizePlan(plan) {
   }
 }
 
-function assertPlan(plan, manifest, roster) {
+function assertPlan(plan, manifest, roster, preflight) {
   if (!isRecord(plan) || !ID_RE.test(String(plan.runId || ''))) fail('agent_company_operator_invalid_plan')
-  if (plan.clientId !== manifest.clientId
+  if (plan.runId !== preflight.expectedRunId
+    || plan.clientId !== manifest.clientId
     || plan.cycleId !== manifest.cycleId
     || plan.actionMode !== 'draft_only'
     || plan.approvalRequired !== true) {
@@ -168,22 +222,28 @@ function assertPlan(plan, manifest, roster) {
   }
 }
 
-function assertQueuedWorkOrder(workOrder, manifest) {
+function assertQueuedWorkOrder(workOrder, manifest, preflight, reviewedPlanHash) {
   if (!isRecord(workOrder)
     || !ID_RE.test(String(workOrder.workOrderId || ''))
     || !HASH_RE.test(String(workOrder.planHash || ''))
+    || !isRecord(workOrder.plan)
     || !WORK_ORDER_STATUSES.has(workOrder.status)) {
     fail('agent_company_operator_invalid_work_order')
   }
-  if (workOrder.clientId !== manifest.clientId || workOrder.cycleId !== manifest.cycleId) {
+  if (workOrder.workOrderId !== preflight.expectedWorkOrderId
+    || workOrder.clientId !== manifest.clientId
+    || workOrder.cycleId !== manifest.cycleId) {
     fail('agent_company_operator_work_order_mismatch')
   }
+  if (workOrder.planHash !== preflight.expectedPlanHash) fail('agent_company_operator_plan_hash_mismatch')
+  if (stableHash(workOrder.plan) !== reviewedPlanHash) fail('agent_company_operator_queued_plan_mismatch')
 }
 
-function assertCompletedWorkOrder(completed, queued, manifest) {
+function assertCompletedWorkOrder(completed, queued, manifest, reviewedPlanHash) {
   if (!isRecord(completed)
     || !TERMINAL_STATUSES.has(completed.status)
     || !isRecord(completed.result)
+    || !isRecord(completed.plan)
     || !HASH_RE.test(String(completed.resultHash || ''))
     || completed.evidenceState !== 'scrubbed') {
     fail('agent_company_operator_invalid_result')
@@ -192,6 +252,7 @@ function assertCompletedWorkOrder(completed, queued, manifest) {
     || completed.clientId !== manifest.clientId
     || completed.cycleId !== manifest.cycleId
     || completed.planHash !== queued.planHash
+    || stableHash(completed.plan) !== reviewedPlanHash
     || completed.result.actionMode !== 'draft_only') {
     fail('agent_company_operator_result_mismatch')
   }
@@ -246,6 +307,7 @@ function validateEvaluation(value, workOrderId) {
 
 export async function runGuidedAgentCompany(manifestValue, options = {}) {
   const manifest = validateAgentCompanyManifest(manifestValue)
+  const preflight = buildAgentCompanyManifestPreflight(manifest)
   const manifestPayload = () => structuredClone(manifest)
   const request = options.request
   if (typeof request !== 'function') fail('agent_company_request_required')
@@ -254,8 +316,8 @@ export async function runGuidedAgentCompany(manifestValue, options = {}) {
   const rosterResult = await request('GET')
   const planResult = await request('POST', { action: 'plan', ...manifestPayload() })
   const plan = planResult?.plan
-  assertPlan(plan, manifest, rosterResult?.agents)
-  const planSummary = summarizePlan(plan)
+  assertPlan(plan, manifest, rosterResult?.agents, preflight)
+  const planSummary = summarizePlan(plan, preflight)
   await options.onPlan?.(planSummary)
 
   const queueConfirmation = `QUEUE ${plan.runId}`
@@ -265,7 +327,7 @@ export async function runGuidedAgentCompany(manifestValue, options = {}) {
 
   const queued = await request('POST', { action: 'work-order-create', ...manifestPayload() })
   const workOrder = queued?.workOrder
-  assertQueuedWorkOrder(workOrder, manifest)
+  assertQueuedWorkOrder(workOrder, manifest, preflight, planSummary.reviewedPlanHash)
   await options.onQueued?.(workOrder)
 
   const runConfirmation = `RUN ${workOrder.workOrderId}`
@@ -281,7 +343,7 @@ export async function runGuidedAgentCompany(manifestValue, options = {}) {
     confirmation: runConfirmation,
   })
   const completed = dispatched?.workOrder
-  assertCompletedWorkOrder(completed, workOrder, manifest)
+  assertCompletedWorkOrder(completed, workOrder, manifest, planSummary.reviewedPlanHash)
   await options.onResult?.(completed)
 
   let evaluation = null
@@ -318,4 +380,10 @@ export async function runGuidedAgentCompany(manifestValue, options = {}) {
   }
 }
 
-export default { AGENT_COMPANY_ENDPOINT, createAgentCompanyApi, runGuidedAgentCompany, validateAgentCompanyManifest }
+export default {
+  AGENT_COMPANY_ENDPOINT,
+  buildAgentCompanyManifestPreflight,
+  createAgentCompanyApi,
+  runGuidedAgentCompany,
+  validateAgentCompanyManifest,
+}

--- a/kernel/agent-company-operator.test.mjs
+++ b/kernel/agent-company-operator.test.mjs
@@ -1,15 +1,18 @@
+import { spawnSync } from 'node:child_process'
 import { readFile } from 'node:fs/promises'
 import { test } from 'node:test'
+import { fileURLToPath } from 'node:url'
 import assert from 'node:assert/strict'
 
 import {
   AGENT_COMPANY_ENDPOINT,
+  buildAgentCompanyManifestPreflight,
   createAgentCompanyApi,
   runGuidedAgentCompany,
   validateAgentCompanyManifest,
 } from './agent-company-operator.mjs'
+import { createCompanyWorkOrder } from './agent-company-work-orders.mjs'
 
-const HASH = 'a'.repeat(64)
 const MANIFEST = {
   clientId: 'supermega-internal',
   cycleId: 'internal-proof-a',
@@ -20,9 +23,11 @@ const MANIFEST = {
     'project-controller': { outcome: 'Produce one bounded delivery plan.', blockers: ['Owner evidence required.'] },
   },
 }
+const PREFLIGHT = buildAgentCompanyManifestPreflight(MANIFEST)
+const HASH = PREFLIGHT.expectedPlanHash
 
 const PLAN = {
-  runId: 'agent-company:internal-proof-a',
+  runId: PREFLIGHT.expectedRunId,
   clientId: MANIFEST.clientId,
   cycleId: MANIFEST.cycleId,
   actionMode: 'draft_only',
@@ -58,12 +63,13 @@ const PLAN = {
 }
 
 const PLANNED_ORDER = {
-  workOrderId: 'company-order:internal-proof-a',
+  workOrderId: PREFLIGHT.expectedWorkOrderId,
   clientId: MANIFEST.clientId,
   cycleId: MANIFEST.cycleId,
   status: 'planned',
   planHash: HASH,
   evidenceState: 'retained',
+  plan: PLAN,
 }
 
 const COMPLETED_ORDER = {
@@ -154,6 +160,37 @@ test('operator validates a bounded redacted manifest and rejects secret-shaped e
   assert.equal(requests, 0)
 })
 
+test('offline preflight hides evidence and matches the durable queue plan hash exactly', async () => {
+  const preflight = buildAgentCompanyManifestPreflight(MANIFEST)
+  const printed = JSON.stringify(preflight)
+  assert.equal(preflight.kind, 'agent_company_manifest_preflight')
+  assert.equal(preflight.expectedPlanHash, HASH)
+  assert.equal(preflight.expectedRunId, PLAN.runId)
+  assert.equal(preflight.expectedWorkOrderId, PLANNED_ORDER.workOrderId)
+  assert.match(preflight.expectedPlanHash, /^[a-f0-9]{64}$/)
+  assert.deepEqual(preflight.agents.map((entry) => entry.agentId), MANIFEST.agents)
+  assert.equal(preflight.totalEvidenceBytes, preflight.agents.reduce((total, entry) => total + entry.bytes, 0))
+  assert.equal(printed.includes('No customer claim'), false)
+  assert.equal(printed.includes('Owner evidence required'), false)
+  assert.notEqual(buildAgentCompanyManifestPreflight({
+    ...MANIFEST,
+    evidence: {
+      ...MANIFEST.evidence,
+      'operations-analyst': { objective: 'A reviewed change produces a new hash.' },
+    },
+  }).expectedPlanHash, HASH)
+
+  let stored
+  const created = await createCompanyWorkOrder(MANIFEST, {
+    claimActivity: async () => ({ fresh: true, durable: true }),
+    putWorkOrder: async (_key, record) => { stored = record; return true },
+  })
+  assert.equal(created.ok, true)
+  assert.equal(created.workOrder.planHash, preflight.expectedPlanHash)
+  assert.equal(created.workOrder.workOrderId, preflight.expectedWorkOrderId)
+  assert.equal(stored.planHash, preflight.expectedPlanHash)
+})
+
 test('operator is plan-only by default and returns no raw evidence in its plan summary', async () => {
   const state = harness()
   let printed
@@ -167,6 +204,7 @@ test('operator is plan-only by default and returns no raw evidence in its plan s
   assert.equal(printed.includes('No customer claim'), false)
   assert.equal(printed.includes('Owner evidence required'), false)
   assert.equal(result.plan.controls.externalWrites, false)
+  assert.match(result.plan.reviewedPlanHash, /^[a-f0-9]{64}$/)
 })
 
 test('queue and dispatch require separate exact confirmations', async () => {
@@ -182,7 +220,7 @@ test('queue and dispatch require separate exact confirmations', async () => {
   await assert.rejects(runGuidedAgentCompany(MANIFEST, {
     request: wrongState.request,
     readConfirmation: async (_confirmation, stage) => stage === 'queue' ? 'QUEUE wrong-run' : '',
-  }), /confirmation_required:QUEUE agent-company:internal-proof-a/)
+  }), new RegExp(`confirmation_required:QUEUE ${PREFLIGHT.expectedRunId}`))
   assert.deepEqual(wrongState.calls.map((call) => call.body?.action || call.method), ['GET', 'plan'])
 })
 
@@ -233,7 +271,11 @@ test('full operator flow dispatches once, records checklist evaluation, and retr
 test('operator rejects identity, hash, and boundary drift across server responses', async () => {
   for (const testCase of [
     { action: 'plan', mutate: (body) => { body.plan.clientId = 'another-client' } },
+    { action: 'plan', mutate: (body) => { body.plan.runId = 'agent-company:another-run' } },
     { action: 'work-order-create', mutate: (body) => { body.workOrder.cycleId = 'another-cycle' } },
+    { action: 'work-order-create', mutate: (body) => { body.workOrder.workOrderId = 'company-order:another-order' } },
+    { action: 'work-order-create', mutate: (body) => { body.workOrder.planHash = 'f'.repeat(64) } },
+    { action: 'work-order-create', mutate: (body) => { body.workOrder.plan.assignments[0].crew = 'drifted-crew' } },
     { action: 'work-order-run', mutate: (body) => { body.workOrder.planHash = 'f'.repeat(64) } },
     { action: 'work-order-proof', mutate: (body) => { body.proofPacket.controls.externalWrites = true } },
   ]) {
@@ -246,7 +288,7 @@ test('operator rejects identity, hash, and boundary drift across server response
     await assert.rejects(runGuidedAgentCompany(MANIFEST, {
       request,
       readConfirmation: async (confirmation) => confirmation,
-    }), /agent_company_operator_(plan_mismatch|work_order_mismatch|result_mismatch|invalid_proof)/)
+    }), /agent_company_operator_(plan_mismatch|work_order_mismatch|plan_hash_mismatch|queued_plan_mismatch|result_mismatch|invalid_proof)/)
   }
 })
 
@@ -278,4 +320,30 @@ test('CLI takes the Ops key only from the environment and has no customer-review
   assert.match(source, /press Enter to stop/)
   assert.match(source, /customerReviewRecorded: false/)
   assert.doesNotMatch(source, /--ops-key|--secret|work-order-review|writeFile|appendFile/)
+
+  const script = fileURLToPath(new URL('./scripts/operate-agent-company.mjs', import.meta.url))
+  const manifest = fileURLToPath(new URL('./examples/agent-company-work-order.example.json', import.meta.url))
+  const result = spawnSync(process.execPath, [script, '--manifest', manifest, '--preflight'], {
+    encoding: 'utf8',
+    env: { ...process.env, SUPERMEGA_OPS_KEY: '' },
+  })
+  assert.equal(result.status, 0, result.stderr)
+  const output = JSON.parse(result.stdout)
+  assert.equal(output.mode, 'agent_company_manifest_preflight')
+  assert.match(output.preflight.expectedPlanHash, /^[a-f0-9]{64}$/)
+  assert.match(output.preflight.expectedRunId, /^agent-company:[a-f0-9]{40}$/)
+  assert.match(output.preflight.expectedWorkOrderId, /^company-order:[a-f0-9]{40}$/)
+  assert.equal(output.preflight.planner.assignments.length, 2)
+  assert.equal(output.preflight.planner.budget.plannedRoles, 6)
+  assert.equal(output.preflight.planner.controls.externalWrites, false)
+  assert.equal(result.stdout.includes('owner-approved business evidence'), false)
+  assert.equal(result.stdout.includes('approved baseline and current state'), false)
+
+  const blocked = spawnSync(process.execPath, [script, '--manifest', manifest], {
+    encoding: 'utf8',
+    env: { ...process.env, SUPERMEGA_OPS_KEY: '' },
+  })
+  assert.equal(blocked.status, 1)
+  assert.match(blocked.stderr, /agent_company_ops_key_required/)
+  assert.equal(blocked.stdout, '')
 })

--- a/kernel/scripts/operate-agent-company.mjs
+++ b/kernel/scripts/operate-agent-company.mjs
@@ -5,9 +5,11 @@ import { stdin, stdout } from 'node:process'
 import { resolve } from 'node:path'
 
 import {
+  buildAgentCompanyManifestPreflight,
   createAgentCompanyApi,
   runGuidedAgentCompany,
 } from '../agent-company-operator.mjs'
+import { planCompanyCycle } from '../agent-company.mjs'
 import { TerminalPrompt } from '../terminal-prompt.mjs'
 
 function parseArgs(argv) {
@@ -15,6 +17,7 @@ function parseArgs(argv) {
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index]
     if (arg === '--help' || arg === '-h') out.help = true
+    else if (arg === '--preflight') out.preflight = true
     else if (arg === '--manifest') {
       const value = argv[index + 1]
       if (!value || value.startsWith('--')) throw new Error('argument_value_required:--manifest')
@@ -29,11 +32,13 @@ function help() {
   return [
     'SuperMega Agent Company operator',
     '',
-    '  SUPERMEGA_OPS_KEY=<owner-provided> npm run agent-company:operate -- --manifest <work-order.json>',
+    '  npm run agent-company:operate -- --manifest <work-order.json> --preflight',
+    '  npm run agent-company:operate -- --manifest <work-order.json>',
     '',
-    'The command validates a redacted manifest, prints a plan, and stops by default. Queueing,',
+    'Preflight validates locally, prints no raw evidence, and requires no Ops key or network call.',
+    'Normal operation prints the expected durable plan hash and stops at plan by default. Queueing,',
     'dispatch, and internal evaluation each require a separate exact terminal confirmation.',
-    'The Ops key is accepted only from the process environment and is never printed or stored.',
+    'Set SUPERMEGA_OPS_KEY in the current process first; the key is never printed or stored.',
     'This command cannot record a customer review or perform connector writes.',
   ].join('\n')
 }
@@ -59,18 +64,61 @@ function resultSummary(workOrder) {
   }
 }
 
+async function buildOfflinePreflight(manifest) {
+  const preflight = buildAgentCompanyManifestPreflight(manifest)
+  const plan = await planCompanyCycle(manifest)
+  if (!plan?.ok) {
+    const reason = /^company_[a-z0-9_]{1,120}$/.test(String(plan?.reason || ''))
+      ? plan.reason
+      : 'agent_company_local_plan_failed'
+    throw new Error(reason)
+  }
+  if (plan.runId !== preflight.expectedRunId
+    || plan.budget?.roleLimit !== preflight.roleBudget
+    || plan.assignments?.some((assignment, index) => assignment.agentId !== preflight.agents[index]?.agentId)
+    || plan.controls?.execution !== 'sequential'
+    || plan.controls?.dynamicDelegation !== false
+    || plan.controls?.crossAgentContext !== false
+    || plan.controls?.externalWrites !== false
+    || plan.controls?.durableClaimRequired !== true) {
+    throw new Error('agent_company_local_plan_mismatch')
+  }
+  return {
+    ...preflight,
+    planner: {
+      assignments: plan.assignments.map((assignment) => ({
+        agentId: assignment.agentId,
+        name: assignment.name,
+        department: assignment.department,
+        crew: assignment.crew,
+        roleCount: assignment.roleCount,
+        evidenceBytes: assignment.evidenceBytes,
+        returns: assignment.returns,
+      })),
+      budget: plan.budget,
+      controls: plan.controls,
+    },
+  }
+}
+
 async function main() {
   const args = parseArgs(process.argv.slice(2))
   if (args.help) { stdout.write(`${help()}\n`); return }
   if (!args.manifest) throw new Error('manifest_path_required')
+  const manifest = JSON.parse(await readFile(resolve(args.manifest), 'utf8'))
+  const preflight = await buildOfflinePreflight(manifest)
+  if (args.preflight) {
+    stdout.write(`${JSON.stringify({ ok: true, mode: 'agent_company_manifest_preflight', preflight }, null, 2)}\n`)
+    return
+  }
+
   const opsKey = String(process.env.SUPERMEGA_OPS_KEY || '').trim()
   if (!opsKey) throw new Error('agent_company_ops_key_required')
-
-  const manifest = JSON.parse(await readFile(resolve(args.manifest), 'utf8'))
   const prompt = new TerminalPrompt(stdin, stdout)
   prompt.assertInteractive()
   const request = createAgentCompanyApi({ opsKey })
 
+  stdout.write(`${JSON.stringify({ ok: true, mode: 'agent_company_manifest_preflight', preflight }, null, 2)}\n`)
   stdout.write('Ops key stays in process memory. No connector writes or customer review are available.\n')
   const result = await runGuidedAgentCompany(manifest, {
     request,


### PR DESCRIPTION
## What changed
- Add a keyless offline preflight to the existing Agent Company operator.
- Validate the manifest against the local fixed roster, crew definitions, role budget, evidence limits, and no-write controls without a network, model, or durable-store call.
- Predict the exact run ID, work-order ID, and durable input hash before the Ops key is supplied.
- Fingerprint the exact server plan reviewed by the owner and reject queue or terminal-result drift before dispatch.
- Keep the Ops key environment-only and document a masked PowerShell 5.1 handoff that clears the process value and unmanaged buffer.

## Verification
- 205 tests
- brand contract
- 69 connectors / 993 adversarial calls / 0 violations
- 12 crews / 172 checks / 0 violations
- 15 Vercel runtime functions / 0 test, source-map, or operator artifacts
- keyless preflight exercised against a redacted two-specialist, six-role first-order draft

## Boundary
This adds no second orchestrator, scheduler, recursive delegation, customer-review command, or connector-write command. The prepared internal manifest and generated preflight packet stay outside version control. No Ops key was accessed, no work order was queued or dispatched, no model/provider call occurred, and no customer decision, external write, payment, lead, revenue, schema, or pricing change was created.