### PR TITLE
ci: move public release actions to Node 24

### DIFF
--- a/.github/workflows/supermega-public-release.yml
+++ b/.github/workflows/supermega-public-release.yml
@@ -26,15 +26,16 @@ jobs:
 
     steps:
       - name: Checkout canonical public source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event_name == 'push' && github.sha || 'codex/public-enterprise-site' }}
           fetch-depth: 1
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24
+          package-manager-cache: false
 
       - name: Require production deploy credential
         env:


### PR DESCRIPTION
The first verified public release succeeded, but GitHub warned that `actions/checkout@v4` and `actions/setup-node@v4` still use the deprecated Node 20 action runtime. This updates the registered recovery workflow to the official v6 actions, keeps Node 24, and explicitly disables setup-node package-manager caching because this production workflow installs no project dependencies.

No deploy, form submission, product, pricing, customer, provider, or data mutation is performed by this registration-only PR.