### PR TITLE
ci: run public release actions on Node 24

### DIFF
--- a/.github/workflows/supermega-public-release.yml
+++ b/.github/workflows/supermega-public-release.yml
@@ -26,15 +26,16 @@ jobs:
 
     steps:
       - name: Checkout canonical public source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event_name == 'push' && github.sha || 'codex/public-enterprise-site' }}
           fetch-depth: 1
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24
+          package-manager-cache: false
 
       - name: Require production deploy credential
         env:

--- a/tools/verify_public_vercel_config.mjs
+++ b/tools/verify_public_vercel_config.mjs
@@ -97,7 +97,10 @@ for (const scriptName of ['vercel:deploy', 'vercel:deploy:prod', 'deploy:public:
 for (const required of [
   'SuperMega Public - Verified Prebuilt Release',
   'codex/public-enterprise-site',
+  'actions/checkout@v6',
+  'actions/setup-node@v6',
   'node-version: 24',
+  'package-manager-cache: false',
   'VERCEL_ORG_ID: team_wI4l7ZgSxcEztQPSlCCYVeJ5',
   'VERCEL_PROJECT_ID: prj_Yaf0cZYbiFXcLkMcKaAm4alPWMhR',
   'vercel@56.1.0 pull --yes --environment=production',
@@ -111,6 +114,10 @@ for (const required of [
 
 if (releaseWorkflow.includes('npm ci')) {
   fail('public_release_must_not_require_missing_root_lockfile')
+}
+
+if (/actions\/(?:checkout|setup-node)@v[1-5]\b/.test(releaseWorkflow)) {
+  fail('public_release_deprecated_action_runtime_forbidden')
 }
 
 if (/vercel(?:@\S+)? deploy --prod/.test(releaseWorkflow)) {


### PR DESCRIPTION
## Fix
The first automated public release completed successfully, but GitHub annotated the run because checkout/setup-node v4 still target the deprecated Node 20 action runtime. This moves the canonical workflow to the official v6 actions, explicitly disables unused package-manager caching, and makes any future v1-v5 regression fail the release configuration contract.

## Proof
- canonical workflow matches the v6 copy registered on `main` by #73
- `npm run vercel:guard` passed
- `npm run public:prebuilt` passed: 30 files / 0.41 MB / 3 functions
- 66 connectors / 923 adversarial calls / 0 violations
- five-group live probe passed in one attempt with zero writes

No form was submitted and no lead, customer, work order, provider/model call, payment, revenue, schema, product, or pricing change was made.