### PR TITLE
ci: avoid persisting public release credentials

### DIFF
--- a/.github/workflows/supermega-public-release.yml
+++ b/.github/workflows/supermega-public-release.yml
@@ -30,6 +30,7 @@ jobs:
         with:
           ref: ${{ github.event_name == 'push' && github.sha || 'codex/public-enterprise-site' }}
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Setup Node
         uses: actions/setup-node@v6


### PR DESCRIPTION
The verified public release only reads repository content and never runs an authenticated Git command after checkout. Setting `persist-credentials: false` tightens that boundary and avoids checkout's unnecessary post-job credential cleanup, which currently trips over a legacy unmatched gitlink in this repository.

Registration only: no deploy, form submission, customer/provider write, product, pricing, or data change.