### PR TITLE
ci: stop persisting public checkout credentials

### DIFF
--- a/.github/workflows/supermega-public-release.yml
+++ b/.github/workflows/supermega-public-release.yml
@@ -30,6 +30,7 @@ jobs:
         with:
           ref: ${{ github.event_name == 'push' && github.sha || 'codex/public-enterprise-site' }}
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Setup Node
         uses: actions/setup-node@v6

--- a/tools/verify_public_vercel_config.mjs
+++ b/tools/verify_public_vercel_config.mjs
@@ -99,6 +99,7 @@ for (const required of [
   'codex/public-enterprise-site',
   'actions/checkout@v6',
   'actions/setup-node@v6',
+  'persist-credentials: false',
   'node-version: 24',
   'package-manager-cache: false',
   'VERCEL_ORG_ID: team_wI4l7ZgSxcEztQPSlCCYVeJ5',
@@ -118,6 +119,10 @@ if (releaseWorkflow.includes('npm ci')) {
 
 if (/actions\/(?:checkout|setup-node)@v[1-5]\b/.test(releaseWorkflow)) {
   fail('public_release_deprecated_action_runtime_forbidden')
+}
+
+if (/persist-credentials:\s*true/.test(releaseWorkflow)) {
+  fail('public_release_checkout_credentials_must_not_persist')
 }
 
 if (/vercel(?:@\S+)? deploy --prod/.test(releaseWorkflow)) {


### PR DESCRIPTION
## Fix
The v6 action upgrade removed the Node 20 warning. The remaining annotation is from checkout's post-job credential cleanup invoking `git submodule foreach` against a legacy unmatched gitlink. This workflow does not perform authenticated Git operations after checkout, so it now opts out of credential persistence and makes that secure setting fail-closed.

## Proof
- canonical workflow matches the `main` registration from #75
- Vercel guard and full prebuilt gate passed
- 30 files / 0.41 MB / 3 functions
- 66 connectors / 923 adversarial calls / 0 violations
- live alias/intake/health/routing probe passed with zero writes

No form, lead, customer, work order, provider/model, payment, revenue, schema, product, or pricing mutation.