### PR TITLE
ci: release public source from exact archive

### DIFF
--- a/.github/workflows/supermega-public-release.yml
+++ b/.github/workflows/supermega-public-release.yml
@@ -25,12 +25,32 @@ jobs:
       VERCEL_PROJECT_ID: prj_Yaf0cZYbiFXcLkMcKaAm4alPWMhR
 
     steps:
-      - name: Checkout canonical public source
-        uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event_name == 'push' && github.sha || 'codex/public-enterprise-site' }}
-          fetch-depth: 1
-          persist-credentials: false
+      - name: Fetch exact canonical public source
+        id: source
+        env:
+          PUSH_SHA: ${{ github.event_name == 'push' && github.sha || '' }}
+        run: |
+          if [ -n "$PUSH_SHA" ]; then
+            SOURCE_SHA="$PUSH_SHA"
+          else
+            SOURCE_SHA="$(git ls-remote --exit-code "https://github.com/${GITHUB_REPOSITORY}.git" "refs/heads/codex/public-enterprise-site" | awk 'NR == 1 { print $1 }')"
+          fi
+
+          if ! [[ "$SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::Canonical public source did not resolve to one commit."
+            exit 1
+          fi
+
+          curl --fail --silent --show-error --location \
+            --proto '=https' --proto-redir '=https' \
+            --retry 3 --retry-all-errors \
+            "https://codeload.github.com/${GITHUB_REPOSITORY}/tar.gz/${SOURCE_SHA}" \
+            --output "$RUNNER_TEMP/supermega-public-source.tgz"
+          tar --extract --gzip \
+            --file "$RUNNER_TEMP/supermega-public-source.tgz" \
+            --directory "$GITHUB_WORKSPACE" \
+            --strip-components=1
+          printf 'sha=%s\n' "$SOURCE_SHA" >> "$GITHUB_OUTPUT"
 
       - name: Setup Node
         uses: actions/setup-node@v6
@@ -61,7 +81,7 @@ jobs:
       - name: Deploy verified artifact to production
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-        run: npx --yes vercel@56.1.0 deploy --prebuilt --prod --yes --token="$VERCEL_TOKEN"
+        run: npx --yes vercel@56.1.0 deploy --prebuilt --prod --yes --token="$VERCEL_TOKEN" --meta "githubCommitSha=${{ steps.source.outputs.sha }}" --meta "githubCommitRef=codex/public-enterprise-site"
 
       - name: Verify live aliases and first-proof route
         run: npm run public:verify:live

--- a/tools/verify_public_vercel_config.mjs
+++ b/tools/verify_public_vercel_config.mjs
@@ -97,9 +97,11 @@ for (const scriptName of ['vercel:deploy', 'vercel:deploy:prod', 'deploy:public:
 for (const required of [
   'SuperMega Public - Verified Prebuilt Release',
   'codex/public-enterprise-site',
-  'actions/checkout@v6',
+  'Fetch exact canonical public source',
+  'git ls-remote --exit-code',
+  'https://codeload.github.com/${GITHUB_REPOSITORY}/tar.gz/${SOURCE_SHA}',
+  '--strip-components=1',
   'actions/setup-node@v6',
-  'persist-credentials: false',
   'node-version: 24',
   'package-manager-cache: false',
   'VERCEL_ORG_ID: team_wI4l7ZgSxcEztQPSlCCYVeJ5',
@@ -108,6 +110,8 @@ for (const required of [
   'npm run vercel:guard',
   'npm run public:prebuilt',
   'vercel@56.1.0 deploy --prebuilt --prod',
+  'githubCommitSha=${{ steps.source.outputs.sha }}',
+  'githubCommitRef=codex/public-enterprise-site',
   'npm run public:verify:live',
 ]) {
   if (!releaseWorkflow.includes(required)) fail(`public_release_workflow_missing_${required}`)
@@ -117,12 +121,12 @@ if (releaseWorkflow.includes('npm ci')) {
   fail('public_release_must_not_require_missing_root_lockfile')
 }
 
-if (/actions\/(?:checkout|setup-node)@v[1-5]\b/.test(releaseWorkflow)) {
-  fail('public_release_deprecated_action_runtime_forbidden')
+if (releaseWorkflow.includes('actions/checkout@')) {
+  fail('public_release_checkout_action_forbidden')
 }
 
-if (/persist-credentials:\s*true/.test(releaseWorkflow)) {
-  fail('public_release_checkout_credentials_must_not_persist')
+if (/actions\/setup-node@v[1-5]\b/.test(releaseWorkflow)) {
+  fail('public_release_deprecated_action_runtime_forbidden')
 }
 
 if (/vercel(?:@\S+)? deploy --prod/.test(releaseWorkflow)) {
@@ -130,6 +134,7 @@ if (/vercel(?:@\S+)? deploy --prod/.test(releaseWorkflow)) {
 }
 
 const workflowOrder = [
+  'Fetch exact canonical public source',
   'vercel@56.1.0 pull --yes --environment=production',
   'npm run vercel:guard',
   'npm run public:prebuilt',


### PR DESCRIPTION
## Fix
`actions/checkout` cannot safely clean this repository because a legacy gitlink has no matching `.gitmodules` entry. The canonical release now resolves one exact branch SHA, downloads that public codeload archive with HTTPS-only redirects and retries, extracts it into the clean runner workspace, and passes the same SHA and branch explicitly to Vercel metadata. No GitHub credential is persisted.

The release contract rejects any future checkout action, source deploy, unpinned source SHA path, or missing Vercel provenance metadata.

## Proof
- workflow exactly matches the default-branch registration from #77
- Vercel guard and 30-file / 0.41 MB / 3-function prebuilt gate passed
- agent intake and contact/Ops handoff contracts passed
- 66 connectors / 923 adversarial calls / 0 violations
- read-only live probe passed all five groups in one attempt

Run #3 failed before deploy, so the prior verified production release remained active. No form, lead, customer, work order, provider/model, payment, revenue, schema, product, or pricing mutation occurred.