### PR TITLE
ci: monitor the live Shop POS demo

### DIFF
--- a/tools/check_public_live_health.py
+++ b/tools/check_public_live_health.py
@@ -15,7 +15,8 @@ from typing import Any
 from urllib.parse import urljoin, urlparse
 
 
-USER_AGENT = "supermega-portfolio-live-health/4.2"
+USER_AGENT = "supermega-portfolio-live-health/4.3"
+DEMO_MAX_BYTES = 256 * 1024
 
 
 class NoRedirect(urllib.request.HTTPRedirectHandler):
@@ -60,7 +61,14 @@ def app_module_url(body: str, app_url: str) -> str | None:
     return None
 
 
-def fetch(url: str, *, timeout: float, attempts: int, follow_redirects: bool = True) -> HttpResult:
+def fetch(
+    url: str,
+    *,
+    timeout: float,
+    attempts: int,
+    follow_redirects: bool = True,
+    max_bytes: int | None = None,
+) -> HttpResult:
     opener = urllib.request.build_opener() if follow_redirects else urllib.request.build_opener(NoRedirect())
     request = urllib.request.Request(
         url,
@@ -77,14 +85,14 @@ def fetch(url: str, *, timeout: float, attempts: int, follow_redirects: bool = T
                     url=response.geturl(),
                     status=response.getcode(),
                     headers=dict(response.headers.items()),
-                    body=response.read(),
+                    body=response.read(max_bytes + 1) if max_bytes is not None else response.read(),
                 )
         except urllib.error.HTTPError as error:
             result = HttpResult(
                 url=url,
                 status=error.code,
                 headers=dict(error.headers.items()),
-                body=error.read(),
+                body=error.read(max_bytes + 1) if max_bytes is not None else error.read(),
             )
             if 500 <= error.code < 600 and attempt < attempts:
                 time.sleep(attempt)
@@ -106,10 +114,16 @@ def nested_value(payload: dict[str, Any], path: str) -> Any:
     return value
 
 
+def header_value(headers: dict[str, str], name: str) -> str:
+    expected = name.lower()
+    return next((value for key, value in headers.items() if key.lower() == expected), "")
+
+
 def run(
     base_url: str,
     www_url: str,
     app_url: str,
+    demo_url: str,
     console_url: str,
     *,
     timeout: float,
@@ -118,6 +132,7 @@ def run(
     base_url = base_url.rstrip("/") + "/"
     www_url = www_url.rstrip("/") + "/"
     app_url = app_url.rstrip("/") + "/"
+    demo_url = demo_url.rstrip("/") + "/"
     console_url = console_url.rstrip("/") + "/"
     failures: list[dict[str, Any]] = []
     results: list[dict[str, Any]] = []
@@ -213,6 +228,76 @@ def run(
         results.append(result)
         if response.status != 200 or len(response.body) < 1000 or missing or unexpected:
             failures.append(result)
+
+    demo_response = fetch(
+        demo_url,
+        timeout=timeout,
+        attempts=attempts,
+        follow_redirects=False,
+        max_bytes=DEMO_MAX_BYTES,
+    )
+    try:
+        demo_body = demo_response.body.decode("utf-8")
+        demo_encoding_error = False
+    except UnicodeDecodeError:
+        demo_body = ""
+        demo_encoding_error = True
+    demo_tokens = [
+        "<title>SuperMega - open the app</title>",
+        "Open a working Shop workspace or Shop POS demo.",
+        "https://app.supermega.dev/",
+        "https://pos.supermega.dev/?demo=",
+        'data-en="Open Shop POS"',
+        'data-my="Shop POS ဖွင့်ရန်"',
+        "assets/noto-sans-myanmar.woff2",
+    ]
+    demo_forbidden = [
+        "DeskPOS",
+        "MegaOS",
+        "Retail OS",
+        "Factory OS",
+        "spa-desk-pilot.vercel.app",
+        "<iframe",
+    ]
+    demo_missing = [token for token in demo_tokens if token not in demo_body]
+    demo_unexpected = [token for token in demo_forbidden if token in demo_body]
+    demo_header_contract = {
+        "content-type": "text/html",
+        "x-content-type-options": "nosniff",
+        "x-frame-options": "sameorigin",
+        "referrer-policy": "strict-origin-when-cross-origin",
+    }
+    demo_header_mismatches = {}
+    for name, expected in demo_header_contract.items():
+        actual = header_value(demo_response.headers, name)
+        valid = actual.lower().startswith(expected) if name == "content-type" else actual.lower() == expected
+        if not valid:
+            demo_header_mismatches[name] = {"expected": expected, "actual": actual}
+    demo_result = {
+        "kind": "demo_shop_pos",
+        "url": demo_url,
+        "status": demo_response.status,
+        "bytes": len(demo_response.body),
+        "response_url_changed": demo_response.url != demo_url,
+        "encoding_error": demo_encoding_error,
+        "shop_pos_markers": demo_body.count("Shop POS"),
+        "missing": demo_missing,
+        "unexpected": demo_unexpected,
+        "header_mismatches": demo_header_mismatches,
+    }
+    results.append(demo_result)
+    if (
+        demo_response.status != 200
+        or demo_response.url != demo_url
+        or len(demo_response.body) < 1000
+        or len(demo_response.body) > DEMO_MAX_BYTES
+        or demo_encoding_error
+        or demo_result["shop_pos_markers"] < 5
+        or demo_missing
+        or demo_unexpected
+        or demo_header_mismatches
+    ):
+        failures.append(demo_result)
 
     for path in ("products/", "pricing/", "ai-agents/", "offers/"):
         url = urljoin(base_url, path)
@@ -448,6 +533,7 @@ def main() -> int:
     parser.add_argument("--base-url", default="https://supermega.dev")
     parser.add_argument("--www-url", default="https://www.supermega.dev")
     parser.add_argument("--app-url", default="https://app.supermega.dev")
+    parser.add_argument("--demo-url", default="https://demo.supermega.dev")
     parser.add_argument("--console-url", default="https://console.supermega.dev")
     parser.add_argument("--timeout", type=float, default=30.0)
     parser.add_argument("--attempts", type=int, default=3)
@@ -460,6 +546,7 @@ def main() -> int:
             args.base_url,
             args.www_url,
             args.app_url,
+            args.demo_url,
             args.console_url,
             timeout=args.timeout,
             attempts=args.attempts,

--- a/tools/test_public_live_health.py
+++ b/tools/test_public_live_health.py
@@ -17,6 +17,7 @@ import check_public_live_health as checker
 BASE = "https://public.example/"
 WWW = "https://www.example/"
 APP = "https://app.example/"
+DEMO = "https://demo.example/"
 CONSOLE = "https://console.example/"
 AGENT_INTAKE = f"{BASE}contact/?from=ai-agent-solution"
 
@@ -72,6 +73,16 @@ def healthy_responses() -> dict[str, checker.HttpResult]:
         "<title>Shop - SuperMega</title>",
         '<div id="root"></div>',
         '<script type="module" crossorigin src="/assets/index-current.js"></script>',
+    )
+    demo = page(
+        "<title>SuperMega - open the app</title>",
+        "Open a working Shop workspace or Shop POS demo.",
+        "https://app.supermega.dev/",
+        "https://pos.supermega.dev/?demo=",
+        'data-en="Open Shop POS"',
+        'data-my="Shop POS ဖွင့်ရန်"',
+        "assets/noto-sans-myanmar.woff2",
+        "Shop POS Shop POS Shop POS Shop POS",
     )
     console = page(
         "<title>SuperMega Console</title>",
@@ -157,6 +168,16 @@ def healthy_responses() -> dict[str, checker.HttpResult]:
             f"{APP}assets/index-current.js", "Shop" + ("x" * 1400)
         ),
         f"{APP}api/health": result(f"{APP}api/health", app_health),
+        DEMO: result(
+            DEMO,
+            demo,
+            headers={
+                "Content-Type": "text/html; charset=utf-8",
+                "X-Content-Type-Options": "nosniff",
+                "X-Frame-Options": "SAMEORIGIN",
+                "Referrer-Policy": "strict-origin-when-cross-origin",
+            },
+        ),
         CONSOLE: result(CONSOLE, console),
         f"{CONSOLE}api/status": result(f"{CONSOLE}api/status", kernel_status),
         f"{CONSOLE}api/agent-company": result(
@@ -177,13 +198,55 @@ class PortfolioHealthTest(unittest.TestCase):
             return responses[url]
 
         with patch.object(checker, "fetch", side_effect=fake_fetch):
-            return checker.run(BASE, WWW, APP, CONSOLE, timeout=1, attempts=1)
+            return checker.run(BASE, WWW, APP, DEMO, CONSOLE, timeout=1, attempts=1)
 
-    def test_healthy_portfolio_passes_all_seventeen_checks(self):
+    def test_healthy_portfolio_passes_all_eighteen_checks(self):
         report = self.run_report(healthy_responses())
         self.assertEqual(report["status"], "ready")
-        self.assertEqual(report["checks"], 17)
+        self.assertEqual(report["checks"], 18)
         self.assertEqual(report["failures"], [])
+
+    def test_retired_product_name_fails_demo_page(self):
+        responses = healthy_responses()
+        responses[DEMO] = result(
+            DEMO,
+            responses[DEMO].body.decode() + "DeskPOS",
+            headers=responses[DEMO].headers,
+        )
+        report = self.run_report(responses)
+        self.assertEqual(report["status"], "error")
+        failure = next(item for item in report["failures"] if item["kind"] == "demo_shop_pos")
+        self.assertIn("DeskPOS", failure["unexpected"])
+
+    def test_missing_burmese_action_fails_demo_page(self):
+        responses = healthy_responses()
+        responses[DEMO] = result(
+            DEMO,
+            responses[DEMO].body.decode().replace('data-my="Shop POS ဖွင့်ရန်"', ""),
+            headers=responses[DEMO].headers,
+        )
+        report = self.run_report(responses)
+        failure = next(item for item in report["failures"] if item["kind"] == "demo_shop_pos")
+        self.assertIn('data-my="Shop POS ဖွင့်ရန်"', failure["missing"])
+
+    def test_invalid_demo_security_header_fails_closed(self):
+        responses = healthy_responses()
+        responses[DEMO].headers["X-Frame-Options"] = "ALLOWALL"
+        report = self.run_report(responses)
+        failure = next(item for item in report["failures"] if item["kind"] == "demo_shop_pos")
+        self.assertIn("x-frame-options", failure["header_mismatches"])
+
+    def test_redirected_or_oversized_demo_fails_closed(self):
+        for response in (
+            result(DEMO, "", status=308, headers={"Location": "https://other.example/"}),
+            result(DEMO, "x" * (checker.DEMO_MAX_BYTES + 1)),
+        ):
+            with self.subTest(status=response.status, bytes=len(response.body)):
+                responses = healthy_responses()
+                responses[DEMO] = response
+                report = self.run_report(responses)
+                self.assertEqual(report["status"], "error")
+                self.assertTrue(any(item["kind"] == "demo_shop_pos" for item in report["failures"]))
 
     def test_missing_agent_context_fails_first_proof_route(self):
         responses = healthy_responses()


### PR DESCRIPTION
## Why
The daily portfolio monitor covered public, Shop/Plant, and Agent Company but omitted `demo.supermega.dev`, so alias drift outside the demo repository could bypass its post-deploy guard.

## What changed
- add `demo.supermega.dev` as an eighteenth independent GET-only portfolio check
- cap that response at 256 KB and disable redirects
- require Shop POS title/description, English and Burmese actions, canonical Shop/POS links, bundled Burmese font, and four content/security headers
- fail on retired labels, the legacy direct host, iframe embeds, redirects, invalid UTF-8, unexpected URL changes, bad headers, too few Shop POS markers, and oversized content
- keep all existing public, app, and Agent Company checks unchanged

## Verification
- 15/15 deterministic tests
- Python compile check
- `git diff --check`
- full live estate: ready, 18/18 checks, 0 failures
- live demo result: 200, 25,168 bytes, unchanged URL, 17 Shop POS markers, 0 missing/unexpected/header mismatches

The monitor performs bounded reads only. It sends no form, passcode, model request, customer data, approval, provider action, or payment.