### PR TITLE
site: protect public service diagnostics

### DIFF
--- a/api/contact-submissions.js
+++ b/api/contact-submissions.js
@@ -115,6 +115,18 @@ function envText(...names) {
   return ''
 }
 
+function secretMatches(value, expected) {
+  const configured = text(expected)
+  if (!configured) return false
+  const providedDigest = crypto.createHash('sha256').update(text(value)).digest()
+  const configuredDigest = crypto.createHash('sha256').update(configured).digest()
+  return crypto.timingSafeEqual(providedDigest, configuredDigest)
+}
+
+function hasStatusDiagnosticsAccess(req) {
+  return secretMatches(req?.headers?.['x-ops-key'], envText('SUPERMEGA_OPS_KEY'))
+}
+
 function truncate(value, maxLength) {
   const normalized = text(value)
   return normalized.length > maxLength ? `${normalized.slice(0, maxLength - 3)}...` : normalized
@@ -193,7 +205,7 @@ function cors(req, res) {
     res.setHeader('Access-Control-Allow-Origin', 'https://supermega.dev')
   }
   res.setHeader('Access-Control-Allow-Methods', 'GET,POST,OPTIONS')
-  res.setHeader('Access-Control-Allow-Headers', 'Content-Type')
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type, X-Ops-Key')
 }
 
 function readBody(req) {
@@ -906,7 +918,7 @@ function deskposPipelineTarget() {
 function deskposPipelineStatus() {
   return {
     status: 'ready',
-    mode: 'public_contact_to_deskpos_queue',
+    mode: 'public_contact_to_shop_queue',
     target: deskposPipelineTarget(),
   }
 }
@@ -983,11 +995,11 @@ function deskposPipelinePayload(record) {
 
 async function forwardDeskposPipeline({ record }) {
   if (!isDeskposLead(record)) {
-    return { status: 'skipped', reason: 'not_deskpos_lead' }
+    return { status: 'skipped', reason: 'not_shop_lead' }
   }
   const target = deskposPipelineTarget()
   if (!isSafeDeskposPipelineUrl(target)) {
-    return { status: 'skipped', reason: 'unsafe_deskpos_pipeline_url' }
+    return { status: 'skipped', reason: 'unsafe_shop_pipeline_url' }
   }
   try {
     const response = await fetch(target, {
@@ -998,16 +1010,16 @@ async function forwardDeskposPipeline({ record }) {
     })
     const body = await response.json().catch(() => ({}))
     if (!response.ok || body.accepted === false) {
-      return { status: 'error', reason: `deskpos_${response.status}`, target }
+      return { status: 'error', reason: `shop_${response.status}`, target }
     }
     return {
       status: 'ready',
       target,
       lead_count: body.leadCount ?? null,
-      deskpos_lead_id: body.lead?.id || null,
+      shop_lead_id: body.lead?.id || null,
     }
   } catch (error) {
-    return { status: 'error', reason: text(error?.message) || 'deskpos_forward_failed', target }
+    return { status: 'error', reason: text(error?.message) || 'shop_forward_failed', target }
   }
 }
 
@@ -2064,6 +2076,43 @@ function opsIntakeStatus() {
   }
 }
 
+function publicContactStatus() {
+  const ready = (
+    leadLedgerStatus() === 'configured' &&
+    pipelineActionStatus() === 'configured' &&
+    fallbackQueueStatus().email_delivery === 'configured' &&
+    opsIntakeStatus().status === 'ready'
+  )
+  return {
+    status: ready ? 'ready' : 'degraded',
+    service: 'supermega-contact',
+  }
+}
+
+function contactDiagnostics() {
+  return {
+    status: publicContactStatus().status,
+    endpoint: 'contact-submissions',
+    lead_scoring: 'ready',
+    utm_tracking: 'ready',
+    lead_ledger: leadLedgerStatus(),
+    ledger_table: 'supermega_leads',
+    pipeline_actions: pipelineActionStatus(),
+    pipeline_actions_table: 'supermega_pipeline_actions',
+    shop_pipeline: deskposPipelineStatus(),
+    ops_intake: opsIntakeStatus(),
+    primary_datastore: datastore.datastoreStatus(),
+    fallback_queue: fallbackQueueStatus(),
+    management_mode: databaseConfigured() ? 'database_queue' : 'email_fallback',
+    setup_checklist: {
+      resend_api_key: Boolean(envText('RESEND_API_KEY')) ? 'configured' : 'missing - contact form email will not send',
+      supabase: (envText('SUPABASE_URL') && envText('SUPABASE_SERVICE_ROLE_KEY')) ? 'configured' : 'missing - leads will not be saved to DB',
+      telegram: envText('TELEGRAM_BOT_TOKEN') ? 'configured' : 'missing - no Telegram alerts on new leads',
+      ops_key: Boolean(envText('SUPERMEGA_OPS_KEY')) ? 'configured' : 'missing - commercial-control and action-runner are blocked',
+    },
+  }
+}
+
 async function forwardOpsIntake({ record }) {
   const intakeSecret = envText('SUPERMEGA_INTAKE_SECRET')
   if (!intakeSecret) return { status: 'skipped', reason: 'ops_intake_not_configured' }
@@ -2206,7 +2255,8 @@ async function appendToGoogleSheet({ record }) {
 
 async function handler(req, res) {
   cors(req, res)
-  const pathname = new URL(req.url || '/api/contact-submissions', 'https://supermega.dev').pathname
+  const requestUrl = new URL(req.url || '/api/contact-submissions', 'https://supermega.dev')
+  const pathname = requestUrl.pathname
 
   if (req.method === 'OPTIONS') {
     if (!isAllowedOrigin(req.headers.origin)) {
@@ -2220,27 +2270,15 @@ async function handler(req, res) {
 
   if (req.method === 'GET') {
     if (pathname === '/api/contact-submissions/status') {
-      json(res, 200, {
-        status: 'ready',
-        endpoint: 'contact-submissions',
-        lead_scoring: 'ready',
-        utm_tracking: 'ready',
-        lead_ledger: leadLedgerStatus(),
-        ledger_table: 'supermega_leads',
-        pipeline_actions: pipelineActionStatus(),
-        pipeline_actions_table: 'supermega_pipeline_actions',
-        deskpos_pipeline: deskposPipelineStatus(),
-        ops_intake: opsIntakeStatus(),
-        primary_datastore: datastore.datastoreStatus(),
-        fallback_queue: fallbackQueueStatus(),
-        management_mode: databaseConfigured() ? 'database_queue' : 'email_fallback',
-        setup_checklist: {
-          resend_api_key: Boolean(envText('RESEND_API_KEY')) ? 'configured' : 'missing — contact form email will not send',
-          supabase: (envText('SUPABASE_URL') && envText('SUPABASE_SERVICE_ROLE_KEY')) ? 'configured' : 'missing — leads will not be saved to DB',
-          telegram: envText('TELEGRAM_BOT_TOKEN') ? 'configured' : 'missing — no Telegram alerts on new leads',
-          ops_key: Boolean(envText('SUPERMEGA_OPS_KEY')) ? 'configured' : 'missing — commercial-control and action-runner are blocked',
-        },
-      })
+      if (requestUrl.searchParams.get('detail') === '1') {
+        if (!hasStatusDiagnosticsAccess(req)) {
+          json(res, 401, { status: 'error', reason: 'operator_auth_required' })
+          return
+        }
+        json(res, 200, contactDiagnostics())
+        return
+      }
+      json(res, 200, publicContactStatus())
       return
     }
     json(res, 401, { status: 'error', reason: 'login_required', detail: 'Contact submission list requires app login.' })
@@ -2373,7 +2411,7 @@ async function handler(req, res) {
     delivery,
     ledger,
     pipeline_action: pipelineAction,
-    deskpos_pipeline: deskposPipeline,
+    shop_pipeline: deskposPipeline,
     ops_intake: opsIntake,
     webhook,
     confirmation,
@@ -2389,7 +2427,7 @@ async function handler(req, res) {
           ? 'blob_action_queue'
           : 'email_fallback',
       datastore: pipelineAction.adapter || ledger.adapter || 'email_fallback',
-      deskpos: deskposPipeline,
+      shop: deskposPipeline,
       ops_intake: opsIntake,
       workspace_id: 'public-site',
       lead_id: leadId,
@@ -2423,6 +2461,9 @@ handler.__test = {
   forwardOpsIntake,
   isSafeOpsIntakeUrl,
   opsIntakeStatus,
+  publicContactStatus,
+  contactDiagnostics,
+  hasStatusDiagnosticsAccess,
 }
 
 module.exports = handler

--- a/api/health.js
+++ b/api/health.js
@@ -1,34 +1,19 @@
-// Public health probe for the supermega.dev backend (the api/* serverless functions). Reports real
-// data-store reachability + which integrations are configured (booleans only — no secret values).
-// 200 when healthy, 503 when the configured DB is unreachable. CJS — matches the bundled function shape.
-const { ping } = require('./lib/supermega-datastore')
-
-const env = (n) => Boolean(String(process.env[n] || '').trim())
-const withTimeout = (p, ms, fallback) => Promise.race([p, new Promise((r) => setTimeout(() => r(fallback), ms))])
-
-module.exports = async function handler(_req, res) {
-  let db
-  try { db = await withTimeout(ping(), 2500, { ok: false, detail: 'ping_timeout' }) }
-  catch (e) { db = { ok: false, detail: String((e && e.message) || 'ping_error').slice(0, 120) } }
-
-  const integrations = {
-    ai: env('ANTHROPIC_API_KEY') || env('CLAUDE_API_KEY'),
-    email: env('RESEND_API_KEY'),
-    telegram: env('TELEGRAM_BOT_TOKEN'),
-    stripe: env('STRIPE_SECRET_KEY'),
-    db_configured: db.configured !== false,
+module.exports = function handler(req, res) {
+  if (!['GET', 'HEAD'].includes(req.method)) {
+    res.statusCode = 405
+    res.setHeader('Allow', 'GET, HEAD')
+    res.setHeader('Content-Type', 'application/json; charset=utf-8')
+    res.setHeader('Cache-Control', 'no-store')
+    res.end(JSON.stringify({ ok: false, status: 'method_not_allowed', service: 'supermega-public-site' }))
+    return
   }
-  const ok = db.ok !== false
 
-  res.statusCode = ok ? 200 : 503
+  res.statusCode = 200
   res.setHeader('Content-Type', 'application/json; charset=utf-8')
   res.setHeader('Cache-Control', 'no-store')
-  res.end(JSON.stringify({
-    ok,
-    status: ok ? 'ready' : 'degraded',
-    service: 'supermega-public-site',
-    db,
-    integrations,
-    checked_at: new Date().toISOString(),
-  }))
+  if (req.method === 'HEAD') {
+    res.end()
+    return
+  }
+  res.end(JSON.stringify({ ok: true, status: 'ready', service: 'supermega-public-site' }))
 }

--- a/tools/verify_contact_ops_intake_handoff.mjs
+++ b/tools/verify_contact_ops_intake_handoff.mjs
@@ -3,7 +3,15 @@ import { createRequire } from 'node:module'
 
 const require = createRequire(import.meta.url)
 const handler = require('../api/contact-submissions.js')
-const { forwardOpsIntake, isSafeOpsIntakeUrl, opsIntakeStatus } = handler.__test
+const healthHandler = require('../api/health.js')
+const {
+  forwardOpsIntake,
+  isSafeOpsIntakeUrl,
+  opsIntakeStatus,
+  publicContactStatus,
+  contactDiagnostics,
+  hasStatusDiagnosticsAccess,
+} = handler.__test
 
 assert.equal(typeof forwardOpsIntake, 'function')
 assert.equal(isSafeOpsIntakeUrl('https://supermega-machine.vercel.app/api/intake'), true)
@@ -13,11 +21,61 @@ assert.equal(isSafeOpsIntakeUrl('https://supermega-machine.vercel.app/api/intake
 const originalFetch = globalThis.fetch
 const originalSecret = process.env.SUPERMEGA_INTAKE_SECRET
 const originalUrl = process.env.SUPERMEGA_OPS_INTAKE_URL
+const originalOpsKey = process.env.SUPERMEGA_OPS_KEY
+const originalSupabaseUrl = process.env.SUPABASE_URL
+const originalSupabaseServiceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+const originalResendApiKey = process.env.RESEND_API_KEY
 const calls = []
 const secret = 'contract-test-secret'
+const opsKey = 'contract-test-ops-key'
+
+async function invokeStatus(url, headers = {}) {
+  let rawBody = ''
+  const responseHeaders = {}
+  const res = {
+    statusCode: 0,
+    setHeader(name, value) {
+      responseHeaders[name.toLowerCase()] = value
+    },
+    end(body = '') {
+      rawBody = body
+    },
+  }
+  await handler({ method: 'GET', url, headers }, res)
+  return {
+    statusCode: res.statusCode,
+    headers: responseHeaders,
+    body: JSON.parse(rawBody),
+  }
+}
+
+async function invokeHealth(method) {
+  let rawBody = ''
+  const responseHeaders = {}
+  const res = {
+    statusCode: 0,
+    setHeader(name, value) {
+      responseHeaders[name.toLowerCase()] = value
+    },
+    end(body = '') {
+      rawBody = body
+    },
+  }
+  await healthHandler({ method }, res)
+  return {
+    statusCode: res.statusCode,
+    headers: responseHeaders,
+    rawBody,
+    body: rawBody ? JSON.parse(rawBody) : null,
+  }
+}
 
 try {
   process.env.SUPERMEGA_INTAKE_SECRET = secret
+  process.env.SUPERMEGA_OPS_KEY = opsKey
+  process.env.SUPABASE_URL = 'https://contract-test.supabase.co'
+  process.env.SUPABASE_SERVICE_ROLE_KEY = 'contract-test-service-role-key'
+  process.env.RESEND_API_KEY = 'contract-test-resend-key'
   delete process.env.SUPERMEGA_OPS_INTAKE_URL
   globalThis.fetch = async (url, options) => {
     calls.push({ url, options })
@@ -33,6 +91,47 @@ try {
     target: 'https://supermega-machine.vercel.app/api/intake',
     contract: 'body_secret',
   })
+
+  assert.deepEqual(publicContactStatus(), {
+    status: 'ready',
+    service: 'supermega-contact',
+  })
+  assert.equal(hasStatusDiagnosticsAccess({ headers: { 'x-ops-key': opsKey } }), true)
+  assert.equal(hasStatusDiagnosticsAccess({ headers: { 'x-ops-key': `${opsKey}-wrong` } }), false)
+
+  const publicStatus = await invokeStatus('/api/contact-submissions/status')
+  assert.equal(publicStatus.statusCode, 200)
+  assert.deepEqual(publicStatus.body, { status: 'ready', service: 'supermega-contact' })
+  const publicBody = JSON.stringify(publicStatus.body).toLowerCase()
+  for (const forbidden of ['table', 'env', 'email', 'target', 'deskpos', 'supabase', 'resend']) {
+    assert.equal(publicBody.includes(forbidden), false, `public_status_exposes_${forbidden}`)
+  }
+
+  for (const suppliedKey of ['', `${opsKey}-wrong`]) {
+    const protectedStatus = await invokeStatus('/api/contact-submissions/status?detail=1', suppliedKey ? { 'x-ops-key': suppliedKey } : {})
+    assert.equal(protectedStatus.statusCode, 401)
+    assert.deepEqual(protectedStatus.body, { status: 'error', reason: 'operator_auth_required' })
+  }
+
+  const authorizedStatus = await invokeStatus('/api/contact-submissions/status?detail=1', { 'x-ops-key': opsKey })
+  assert.equal(authorizedStatus.statusCode, 200)
+  assert.deepEqual(authorizedStatus.body, contactDiagnostics())
+  assert.equal(authorizedStatus.body.shop_pipeline.mode, 'public_contact_to_shop_queue')
+  assert.equal(Object.hasOwn(authorizedStatus.body, 'deskpos_pipeline'), false)
+
+  const healthGet = await invokeHealth('GET')
+  assert.equal(healthGet.statusCode, 200)
+  assert.deepEqual(healthGet.body, { ok: true, status: 'ready', service: 'supermega-public-site' })
+  assert.equal(healthGet.headers['cache-control'], 'no-store')
+
+  const healthHead = await invokeHealth('HEAD')
+  assert.equal(healthHead.statusCode, 200)
+  assert.equal(healthHead.rawBody, '')
+
+  const healthPost = await invokeHealth('POST')
+  assert.equal(healthPost.statusCode, 405)
+  assert.equal(healthPost.headers.allow, 'GET, HEAD')
+  assert.deepEqual(healthPost.body, { ok: false, status: 'method_not_allowed', service: 'supermega-public-site' })
 
   const result = await forwardOpsIntake({
     record: {
@@ -80,6 +179,14 @@ try {
   else process.env.SUPERMEGA_INTAKE_SECRET = originalSecret
   if (originalUrl === undefined) delete process.env.SUPERMEGA_OPS_INTAKE_URL
   else process.env.SUPERMEGA_OPS_INTAKE_URL = originalUrl
+  if (originalOpsKey === undefined) delete process.env.SUPERMEGA_OPS_KEY
+  else process.env.SUPERMEGA_OPS_KEY = originalOpsKey
+  if (originalSupabaseUrl === undefined) delete process.env.SUPABASE_URL
+  else process.env.SUPABASE_URL = originalSupabaseUrl
+  if (originalSupabaseServiceRoleKey === undefined) delete process.env.SUPABASE_SERVICE_ROLE_KEY
+  else process.env.SUPABASE_SERVICE_ROLE_KEY = originalSupabaseServiceRoleKey
+  if (originalResendApiKey === undefined) delete process.env.RESEND_API_KEY
+  else process.env.RESEND_API_KEY = originalResendApiKey
 }
 
 console.log('contact_ops_intake_handoff=ready')

--- a/tools/verify_public_release_live.mjs
+++ b/tools/verify_public_release_live.mjs
@@ -8,6 +8,7 @@ const endpoints = {
   agentIntake: 'https://supermega.dev/contact/?from=ai-agent-solution',
   health: 'https://supermega.dev/api/health',
   contactStatus: 'https://supermega.dev/api/contact-submissions/status',
+  contactDiagnostics: 'https://supermega.dev/api/contact-submissions/status?detail=1',
 }
 
 function assert(condition, code) {
@@ -77,38 +78,53 @@ function verifyAgentIntake(html) {
 }
 
 function verifyHealth(body) {
+  assert(Object.keys(body || {}).sort().join(',') === 'ok,service,status', 'health_exposes_internal_fields')
   assert(body?.ok === true, 'health_not_ok')
   assert(body?.status === 'ready', 'health_not_ready')
   assert(body?.service === 'supermega-public-site', 'health_wrong_service')
-  assert(body?.integrations?.email === true, 'health_owner_email_missing')
 }
 
 function verifyContactStatus(body) {
+  assert(Object.keys(body || {}).sort().join(',') === 'service,status', 'contact_status_exposes_internal_fields')
   assert(body?.status === 'ready', 'contact_status_not_ready')
-  assert(body?.endpoint === 'contact-submissions', 'contact_status_wrong_endpoint')
-  assert(['configured', 'ready'].includes(body?.lead_ledger), 'contact_lead_ledger_missing')
-  assert(['configured', 'ready'].includes(body?.pipeline_actions), 'contact_action_queue_missing')
-  assert(body?.fallback_queue?.email_delivery === 'configured', 'contact_email_fallback_missing')
-  assert(body?.ops_intake?.status === 'ready', 'contact_ops_handoff_missing')
-  assert(body?.setup_checklist?.supabase === 'configured', 'contact_supabase_missing')
-  assert(body?.setup_checklist?.resend_api_key === 'configured', 'contact_resend_missing')
+  assert(body?.service === 'supermega-contact', 'contact_status_wrong_service')
+}
+
+function verifyProtectedDiagnostics(response, body) {
+  assert(response.status === 401, 'contact_diagnostics_not_protected')
+  assert(Object.keys(body || {}).sort().join(',') === 'reason,status', 'contact_diagnostics_auth_exposes_fields')
+  assert(body?.status === 'error', 'contact_diagnostics_auth_wrong_status')
+  assert(body?.reason === 'operator_auth_required', 'contact_diagnostics_auth_wrong_reason')
 }
 
 async function verifyOnce() {
-  const [homeResponse, wwwResponse, intakeResponse, healthResponse, statusResponse] = await Promise.all([
+  const [homeResponse, wwwResponse, intakeResponse, healthResponse, statusResponse, diagnosticsResponse] = await Promise.all([
     get(endpoints.home, 'text/html'),
     get(endpoints.www, 'text/html'),
     get(endpoints.agentIntake, 'text/html'),
     get(endpoints.health, 'application/json'),
     get(endpoints.contactStatus, 'application/json'),
+    fetch(endpoints.contactDiagnostics, {
+      method: 'GET',
+      redirect: 'follow',
+      cache: 'no-store',
+      headers: {
+        accept: 'application/json',
+        'cache-control': 'no-cache',
+        pragma: 'no-cache',
+        'user-agent': 'SuperMegaVerifiedRelease/1.0',
+      },
+      signal: AbortSignal.timeout(requestTimeoutMs),
+    }),
   ])
 
-  const [home, www, intake, health, contactStatus] = await Promise.all([
+  const [home, www, intake, health, contactStatus, protectedDiagnostics] = await Promise.all([
     homeResponse.text(),
     wwwResponse.text(),
     intakeResponse.text(),
     healthResponse.json(),
     statusResponse.json(),
+    diagnosticsResponse.json(),
   ])
 
   verifyHome(home, 'home')
@@ -116,6 +132,7 @@ async function verifyOnce() {
   verifyAgentIntake(intake)
   verifyHealth(health)
   verifyContactStatus(contactStatus)
+  verifyProtectedDiagnostics(diagnosticsResponse, protectedDiagnostics)
 }
 
 let lastError


### PR DESCRIPTION
## What changed

- reduce unauthenticated health and Contact status responses to minimal readiness contracts
- protect full Contact diagnostics behind the existing `SUPERMEGA_OPS_KEY`
- rename customer-visible DeskPOS pipeline fields and reasons to Shop while preserving internal compatibility wiring
- add mandatory local and live contracts for GET, HEAD, 405, minimal payload shape, and unauthorized diagnostics

## Why

The live public probes exposed internal table names, provider configuration, owner routing, and downstream URLs. They also surfaced retired DeskPOS naming even though the customer-facing product is Shop.

## Validation

- `npm run public:prebuilt`
- `npm run vercel:guard`
- 30 release files, 0.41 MB, 3 functions
- 66 connectors, 923 adversarial calls, 0 violations
- no contact form, provider write, customer record, payment, or lead was created