### PR TITLE
ci: monitor minimal public diagnostics

### DIFF
--- a/tools/check_public_live_health.py
+++ b/tools/check_public_live_health.py
@@ -15,7 +15,7 @@ from typing import Any
 from urllib.parse import urljoin, urlparse
 
 
-USER_AGENT = "supermega-portfolio-live-health/4.3"
+USER_AGENT = "supermega-portfolio-live-health/4.4"
 DEMO_MAX_BYTES = 256 * 1024
 
 
@@ -317,20 +317,18 @@ def run(
 
     expected_status = {
         "status": "ready",
-        "lead_ledger": "configured",
-        "pipeline_actions": "configured",
-        "primary_datastore.status": "configured",
-        "fallback_queue.status": "ready",
-        "fallback_queue.email_delivery": "configured",
-        "ops_intake.status": "ready",
-        "ops_intake.target": "https://supermega-machine.vercel.app/api/intake",
-        "ops_intake.contract": "body_secret",
+        "service": "supermega-contact",
     }
     mismatches = {
         path: {"expected": expected, "actual": nested_value(status_payload, path)}
         for path, expected in expected_status.items()
         if nested_value(status_payload, path) != expected
     }
+    if set(status_payload) != set(expected_status):
+        mismatches["payload_keys"] = {
+            "expected": sorted(expected_status),
+            "actual": sorted(status_payload),
+        }
     api_result = {
         "kind": "conversion_api",
         "url": status_url,
@@ -340,6 +338,36 @@ def run(
     results.append(api_result)
     if status_response.status != 200 or mismatches:
         failures.append(api_result)
+
+    diagnostics_url = f"{status_url}?detail=1"
+    diagnostics_response = fetch(diagnostics_url, timeout=timeout, attempts=attempts)
+    try:
+        diagnostics_payload = json.loads(diagnostics_response.body.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        diagnostics_payload = {}
+    expected_diagnostics = {
+        "status": "error",
+        "reason": "operator_auth_required",
+    }
+    diagnostics_mismatches = {
+        path: {"expected": expected, "actual": nested_value(diagnostics_payload, path)}
+        for path, expected in expected_diagnostics.items()
+        if nested_value(diagnostics_payload, path) != expected
+    }
+    if set(diagnostics_payload) != set(expected_diagnostics):
+        diagnostics_mismatches["payload_keys"] = {
+            "expected": sorted(expected_diagnostics),
+            "actual": sorted(diagnostics_payload),
+        }
+    diagnostics_result = {
+        "kind": "conversion_diagnostics_guard",
+        "url": diagnostics_url,
+        "status": diagnostics_response.status,
+        "mismatches": diagnostics_mismatches,
+    }
+    results.append(diagnostics_result)
+    if diagnostics_response.status != 401 or diagnostics_mismatches:
+        failures.append(diagnostics_result)
 
     app_home_body = ""
     for route in ("home", "factory"):

--- a/tools/test_public_live_health.py
+++ b/tools/test_public_live_health.py
@@ -101,18 +101,7 @@ def healthy_responses() -> dict[str, checker.HttpResult]:
         "CANCEL AND SCRUB ${order.workOrderId} ${order.planHash}",
         "cancelled excluded from delivery metrics",
     )
-    contact_status = {
-        "status": "ready",
-        "lead_ledger": "configured",
-        "pipeline_actions": "configured",
-        "primary_datastore": {"status": "configured"},
-        "fallback_queue": {"status": "ready", "email_delivery": "configured"},
-        "ops_intake": {
-            "status": "ready",
-            "target": "https://supermega-machine.vercel.app/api/intake",
-            "contract": "body_secret",
-        },
-    }
+    contact_status = {"status": "ready", "service": "supermega-contact"}
     app_health = {
         "ok": True,
         "status": "ready",
@@ -162,6 +151,11 @@ def healthy_responses() -> dict[str, checker.HttpResult]:
         f"{BASE}api/contact-submissions/status": result(
             f"{BASE}api/contact-submissions/status", contact_status
         ),
+        f"{BASE}api/contact-submissions/status?detail=1": result(
+            f"{BASE}api/contact-submissions/status?detail=1",
+            {"status": "error", "reason": "operator_auth_required"},
+            status=401,
+        ),
         f"{APP}home": result(f"{APP}home", app_shell),
         f"{APP}factory": result(f"{APP}factory", app_shell),
         f"{APP}assets/index-current.js": result(
@@ -200,11 +194,37 @@ class PortfolioHealthTest(unittest.TestCase):
         with patch.object(checker, "fetch", side_effect=fake_fetch):
             return checker.run(BASE, WWW, APP, DEMO, CONSOLE, timeout=1, attempts=1)
 
-    def test_healthy_portfolio_passes_all_eighteen_checks(self):
+    def test_healthy_portfolio_passes_all_nineteen_checks(self):
         report = self.run_report(healthy_responses())
         self.assertEqual(report["status"], "ready")
-        self.assertEqual(report["checks"], 18)
+        self.assertEqual(report["checks"], 19)
         self.assertEqual(report["failures"], [])
+
+    def test_public_contact_status_rejects_internal_fields(self):
+        responses = healthy_responses()
+        status_url = f"{BASE}api/contact-submissions/status"
+        payload = json.loads(responses[status_url].body)
+        payload["lead_ledger"] = "configured"
+        responses[status_url] = result(status_url, payload)
+        report = self.run_report(responses)
+        self.assertEqual(report["status"], "error")
+        failure = next(item for item in report["failures"] if item["kind"] == "conversion_api")
+        self.assertIn("payload_keys", failure["mismatches"])
+
+    def test_unprotected_contact_diagnostics_fails_guard(self):
+        responses = healthy_responses()
+        diagnostics_url = f"{BASE}api/contact-submissions/status?detail=1"
+        responses[diagnostics_url] = result(
+            diagnostics_url,
+            {"status": "ready", "lead_ledger": "configured"},
+        )
+        report = self.run_report(responses)
+        self.assertEqual(report["status"], "error")
+        failure = next(
+            item for item in report["failures"] if item["kind"] == "conversion_diagnostics_guard"
+        )
+        self.assertEqual(failure["status"], 200)
+        self.assertIn("payload_keys", failure["mismatches"])
 
     def test_retired_product_name_fails_demo_page(self):
         responses = healthy_responses()


### PR DESCRIPTION
## What changed

- align the daily portfolio monitor with the minimal public Contact status contract
- fail if unauthenticated status responses expose any additional topology fields
- add a nineteenth read-only check requiring `?detail=1` to return the exact 401 operator boundary
- add deterministic regression tests for both disclosure and unprotected diagnostics

## Why

Public PR #80 intentionally removed internal datastore, table, email, and downstream details from unauthenticated status. The existing monitor still expected those fields and therefore reported a false outage after a successful secure release.

## Validation

- 17 deterministic unit tests passed
- Python compile passed
- live read-only portfolio run: 19 checks, 0 failures
- `git diff --check`

No form, credential, lead, customer data, provider action, payment, product deployment, or price changed.