### PR TITLE
site: simplify public contact receipts

### DIFF
--- a/api/contact-submissions.js
+++ b/api/contact-submissions.js
@@ -48,10 +48,6 @@ function receiptHtml(res, record) {
   res.statusCode = 200
   res.setHeader('Content-Type', 'text/html; charset=utf-8')
   res.setHeader('Cache-Control', 'no-store')
-  const onboarding = onboardingPlan(record)
-  const subject = encodeURIComponent(`SuperMega source files for ${record.lead_id}`)
-  const body = encodeURIComponent(`Lead: ${record.lead_id}\nTask: ${record.task_id}\nCompany: ${record.company}\n\nSource links / notes:\n`)
-  const sourcePackUrl = sourcePackIntakeUrl(record)
   res.end(`<!doctype html>
 <html lang="en">
 <meta charset="utf-8">
@@ -63,7 +59,7 @@ function receiptHtml(res, record) {
   * { box-sizing: border-box; }
   body { margin: 0; min-height: 100vh; display: grid; place-items: center; background: radial-gradient(circle at 78% 8%, rgba(114,243,255,.18), transparent 28rem), linear-gradient(135deg, #07111f, #02050b); color: var(--text); }
   main { width: min(760px, calc(100% - 32px)); border: 1px solid var(--line); border-radius: 18px; background: rgba(255,255,255,.07); padding: clamp(24px, 5vw, 42px); box-shadow: 0 34px 90px rgba(0,0,0,.34); }
-  h1 { margin: 0 0 14px; font-size: clamp(42px, 8vw, 82px); line-height: .86; letter-spacing: -.075em; }
+  h1 { margin: 0 0 14px; font-size: clamp(38px, 7vw, 56px); line-height: 1; letter-spacing: 0; }
   p { margin: 0; color: var(--muted); font-size: 18px; line-height: 1.55; }
   .meta { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 10px; margin: 24px 0; }
   .box { border: 1px solid rgba(255,255,255,.14); border-radius: 10px; padding: 13px; background: rgba(3,8,16,.36); }
@@ -78,29 +74,43 @@ function receiptHtml(res, record) {
 </style>
 <main>
   <h1>Request received.</h1>
-  <p>SuperMega captured the request. We review the source, reply with the first useful output path, then create app access only after scope approval.</p>
+  <p>We will review what you sent and reply to the submitted email. Nothing is connected, changed, or sent on your behalf until you approve it.</p>
   <div class="meta">
-    <div class="box"><span>Lead</span><strong>${escapeHtml(record.lead_id)}</strong></div>
-    <div class="box"><span>Task</span><strong>${escapeHtml(record.task_id)}</strong></div>
-    <div class="box"><span>Package</span><strong>${escapeHtml(record.public_package || record.requested_package)}</strong></div>
-    <div class="box"><span>First output</span><strong>${escapeHtml(onboarding.first_output)}</strong></div>
-    <div class="box"><span>Reply target</span><strong>${escapeHtml(record.email)}</strong></div>
-    <div class="box"><span>Owner</span><strong>${escapeHtml(onboarding.owner)}</strong></div>
-    <div class="box"><span>App access</span><strong>${escapeHtml(onboarding.workspace_status)}</strong></div>
+    <div class="box"><span>Reference</span><strong>${escapeHtml(record.lead_id)}</strong></div>
+    <div class="box"><span>Status</span><strong>Received</strong></div>
+    <div class="box"><span>Company</span><strong>${escapeHtml(record.company)}</strong></div>
+    <div class="box"><span>Reply to</span><strong>${escapeHtml(record.email)}</strong></div>
   </div>
   <ol>
-    <li>${escapeHtml(onboarding.steps[0])}</li>
-    <li>${escapeHtml(onboarding.steps[1])}</li>
-    <li>${escapeHtml(onboarding.steps[2])}</li>
+    <li>We review the request and identify the smallest useful first proof.</li>
+    <li>We reply with the proof path, scope, price, and approval boundary.</li>
+    <li>Work starts only after you approve the next step.</li>
   </ol>
   <div class="actions">
-    <a class="primary" href="${escapeHtml(sourcePackUrl)}">Open source pack room</a>
-    <a class="primary" href="mailto:${escapeHtml(notifyEmail)}?subject=${subject}&body=${body}">Send source links</a>
+    <a class="primary" href="/">Back to SuperMega</a>
     <a href="/contact/">Send another request</a>
-    <a href="https://app.supermega.dev/?demo=shop">Open Shop</a>
   </div>
 </main>
 </html>`)
+}
+
+function publicSubmissionReceipt(record = {}) {
+  const receipt = {
+    status: 'ready',
+    message: 'Request received.',
+    next_step: 'We will review the request and reply to the submitted email.',
+  }
+  const reference = text(record.lead_id)
+  if (reference) receipt.reference = reference
+  return receipt
+}
+
+function publicSubmissionFailure() {
+  return {
+    status: 'error',
+    reason: 'submission_unavailable',
+    message: 'Request could not be received. Please try again later.',
+  }
 }
 
 function text(value) {
@@ -2297,7 +2307,7 @@ async function handler(req, res) {
 
   const rate = checkRateLimit(req)
   if (!rate.allowed) {
-    json(res, 429, { status: 'error', reason: 'rate_limited', rate })
+    json(res, 429, { status: 'error', reason: 'rate_limited' })
     return
   }
 
@@ -2309,7 +2319,7 @@ async function handler(req, res) {
       html(res, 400, 'Could not send.', `The form could not be read. Email ${notifyEmail} directly.`)
       return
     }
-    json(res, 400, { status: 'error', reason: error.message || 'invalid_request' })
+    json(res, 400, { status: 'error', reason: 'invalid_request' })
     return
   }
 
@@ -2318,7 +2328,7 @@ async function handler(req, res) {
       html(res, 200, 'Received.', 'Your message was routed.')
       return
     }
-    json(res, 200, { status: 'ready', message: 'Submission routed.' })
+    json(res, 200, publicSubmissionReceipt())
     return
   }
 
@@ -2339,8 +2349,6 @@ async function handler(req, res) {
   const leadId = `LEAD-${crypto.randomBytes(6).toString('hex').toUpperCase()}`
   const taskId = `TASK-${crypto.randomBytes(6).toString('hex').toUpperCase()}`
   const record = buildLeadRecord({ leadId, taskId, payload: { ...payload, name, email, company, goal }, req })
-  const solutionRoute = buildSolutionRoute(record)
-  const firstProofTask = buildFirstProofTaskPayload(record)
   const ledger = await saveLeadLedger({ record })
   const pipelineAction = await savePipelineAction({ record })
   const [webhook, deskposPipeline, opsIntake] = await Promise.all([
@@ -2362,7 +2370,7 @@ async function handler(req, res) {
       html(res, 502, 'Could not send.', `Email ${notifyEmail} directly and include your company, workflow, and contact details.`)
       return
     }
-    json(res, 502, { status: 'error', reason: 'email_delivery_failed', delivery, fallback_email: notifyEmail })
+    json(res, 502, publicSubmissionFailure())
     return
   }
 
@@ -2371,7 +2379,7 @@ async function handler(req, res) {
       html(res, 502, 'Could not route.', `Email ${notifyEmail} directly and include your company, workflow, and contact details.`)
       return
     }
-    json(res, 502, { status: 'error', reason: 'lead_webhook_failed', webhook, delivery })
+    json(res, 502, publicSubmissionFailure())
     return
   }
 
@@ -2380,7 +2388,7 @@ async function handler(req, res) {
       html(res, 502, 'Could not save.', `Email ${notifyEmail} directly and include your company, workflow, and contact details.`)
       return
     }
-    json(res, 502, { status: 'error', reason: 'lead_ledger_failed', ledger, delivery, webhook })
+    json(res, 502, publicSubmissionFailure())
     return
   }
 
@@ -2389,7 +2397,7 @@ async function handler(req, res) {
       html(res, 502, 'Could not create task.', `Email ${notifyEmail} directly and include your company, workflow, and contact details.`)
       return
     }
-    json(res, 502, { status: 'error', reason: 'pipeline_action_failed', ledger, pipeline_action: pipelineAction, delivery, webhook })
+    json(res, 502, publicSubmissionFailure())
     return
   }
 
@@ -2398,50 +2406,7 @@ async function handler(req, res) {
     return
   }
 
-  // Do not echo the submitter's own IP/User-Agent back in the response body.
-  const { ip_hint, user_agent, ...publicSubmission } = record
-  json(res, 200, {
-    status: 'ready',
-    message: 'Submission routed.',
-    submission: publicSubmission,
-    onboarding: onboardingPlan(record),
-    solution_route: solutionRoute,
-    source_pack_request: firstProofTask.source_pack_request,
-    owner_onboarding_alert: firstProofTask.owner_onboarding_alert,
-    delivery,
-    ledger,
-    pipeline_action: pipelineAction,
-    shop_pipeline: deskposPipeline,
-    ops_intake: opsIntake,
-    webhook,
-    confirmation,
-    telegram,
-    sheets,
-    pipeline: {
-      saved_count: ledger.status === 'ready' ? 1 : 0,
-      saved_task_count: pipelineAction.status === 'ready' ? 1 : 0,
-      email_routed_count: delivery.status === 'ready' ? 1 : 0,
-      management_mode: ledger.status === 'ready' && pipelineAction.status === 'ready'
-        ? 'database_queue'
-        : pipelineAction.status === 'ready' && pipelineAction.adapter === 'vercel_blob'
-          ? 'blob_action_queue'
-          : 'email_fallback',
-      datastore: pipelineAction.adapter || ledger.adapter || 'email_fallback',
-      shop: deskposPipeline,
-      ops_intake: opsIntake,
-      workspace_id: 'public-site',
-      lead_id: leadId,
-      task_id: taskId,
-      lead_score: record.lead_score,
-      lead_stage: record.lead_stage,
-      summary: {
-        status: 'routed',
-        next_step: record.next_step,
-      },
-      onboarding: onboardingPlan(record),
-      solution_route: solutionRoute,
-    },
-  })
+  json(res, 200, publicSubmissionReceipt(record))
 }
 
 handler.__test = {
@@ -2464,6 +2429,9 @@ handler.__test = {
   publicContactStatus,
   contactDiagnostics,
   hasStatusDiagnosticsAccess,
+  publicSubmissionReceipt,
+  publicSubmissionFailure,
+  receiptHtml,
 }
 
 module.exports = handler

--- a/tools/serve_public_output.mjs
+++ b/tools/serve_public_output.mjs
@@ -29,18 +29,6 @@ function redirect(location) {
   return { redirect: location }
 }
 
-function extractMultipartValue(body, field) {
-  const pattern = new RegExp(`name="${field}"\\r?\\n\\r?\\n([\\s\\S]*?)\\r?\\n(?:--|Content-Disposition:)`, 'i')
-  const match = body.match(pattern)
-  return match?.[1]?.trim() || ''
-}
-
-function extractMultipartFilename(body, field) {
-  const pattern = new RegExp(`name="${field}"; filename="([^"]+)"`, 'i')
-  const match = body.match(pattern)
-  return match?.[1]?.trim() || ''
-}
-
 const nodeFunctionHandlers = new Map()
 
 function nodeFunctionHandler(name) {
@@ -137,75 +125,16 @@ const server = createServer((request, response) => {
   if (target.api === 'health') return send(response, 200, JSON.stringify({ status: 'ready' }), 'application/json; charset=utf-8')
   if (target.api === 'contact-submissions') {
     if (request.method !== 'POST') return send(response, 401, 'login required')
-    let body = ''
-    request.setEncoding('utf8')
-    request.on('data', (chunk) => {
-      body += chunk
-    })
+    request.resume()
     request.on('end', () => {
-      let payload = {}
-      try {
-        payload = body ? JSON.parse(body) : {}
-      } catch {
-        payload = {}
-      }
-      if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
-        payload = {}
-      }
-      if (!payload.utm_source && body.includes('Content-Disposition: form-data;')) {
-        payload = {
-          ...payload,
-          utm_source: extractMultipartValue(body, 'utm_source'),
-          utm_medium: extractMultipartValue(body, 'utm_medium'),
-          utm_campaign: extractMultipartValue(body, 'utm_campaign'),
-          public_package: extractMultipartValue(body, 'public_package'),
-          first_proof_target: extractMultipartValue(body, 'first_proof_target'),
-          acceptance_tests: extractMultipartValue(body, 'acceptance_tests'),
-          launch_blockers: extractMultipartValue(body, 'launch_blockers'),
-          automation_boundary: extractMultipartValue(body, 'automation_boundary'),
-          source_file_count: extractMultipartValue(body, 'source_file_count') || '1',
-          source_file_names: extractMultipartValue(body, 'source_file_names') || extractMultipartFilename(body, 'source_files'),
-        }
-      }
       return send(
         response,
         200,
         JSON.stringify({
           status: 'ready',
-          message: 'Local contact submission accepted.',
-          received_bytes: body.length,
-          submission: {
-            id: 'LOCAL-CONTACT-SUBMISSION',
-            lead_id: 'LEAD-LOCAL-BLUEPRINT',
-            task_id: 'TASK-LOCAL-BLUEPRINT',
-            utm_source: payload.utm_source || '',
-            utm_medium: payload.utm_medium || '',
-            utm_campaign: payload.utm_campaign || '',
-            public_package: payload.public_package || '',
-            first_proof_target: payload.first_proof_target || '',
-            acceptance_tests: payload.acceptance_tests || '',
-            launch_blockers: payload.launch_blockers || '',
-            automation_boundary: payload.automation_boundary || '',
-            source_file_count: payload.source_file_count || '0',
-            source_file_names: payload.source_file_names || '',
-          },
-          pipeline: {
-            lead_id: 'LEAD-LOCAL-BLUEPRINT',
-            task_id: 'TASK-LOCAL-BLUEPRINT',
-            lead_score: 82,
-            lead_stage: 'local_smoke',
-            saved_count: 1,
-            saved_task_count: 1,
-            email_routed_count: 1,
-            management_mode: 'local_stub',
-          },
-          onboarding: {
-            status: 'source_review',
-            owner: 'swanhtet@supermega.dev',
-            first_output: 'First useful build',
-            access_policy: 'approval_required',
-            workspace_status: 'not_created_until_approved',
-          },
+          message: 'Request received.',
+          next_step: 'We will review the request and reply to the submitted email.',
+          reference: 'LEAD-LOCAL-RECEIPT',
         }),
         'application/json; charset=utf-8',
       )

--- a/tools/verify_contact_ops_intake_handoff.mjs
+++ b/tools/verify_contact_ops_intake_handoff.mjs
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
 import { createRequire } from 'node:module'
 
 const require = createRequire(import.meta.url)
@@ -11,6 +12,9 @@ const {
   publicContactStatus,
   contactDiagnostics,
   hasStatusDiagnosticsAccess,
+  publicSubmissionReceipt,
+  publicSubmissionFailure,
+  receiptHtml,
 } = handler.__test
 
 assert.equal(typeof forwardOpsIntake, 'function')
@@ -28,6 +32,11 @@ const originalResendApiKey = process.env.RESEND_API_KEY
 const calls = []
 const secret = 'contract-test-secret'
 const opsKey = 'contract-test-ops-key'
+const contactSource = readFileSync(new URL('../api/contact-submissions.js', import.meta.url), 'utf8')
+const handlerSource = contactSource.slice(
+  contactSource.indexOf('async function handler'),
+  contactSource.indexOf('handler.__test'),
+)
 
 async function invokeStatus(url, headers = {}) {
   let rawBody = ''
@@ -118,6 +127,78 @@ try {
   assert.deepEqual(authorizedStatus.body, contactDiagnostics())
   assert.equal(authorizedStatus.body.shop_pipeline.mode, 'public_contact_to_shop_queue')
   assert.equal(Object.hasOwn(authorizedStatus.body, 'deskpos_pipeline'), false)
+
+  const receipt = publicSubmissionReceipt({ lead_id: 'LEAD-RECEIPT-1' })
+  assert.deepEqual(receipt, {
+    status: 'ready',
+    message: 'Request received.',
+    next_step: 'We will review the request and reply to the submitted email.',
+    reference: 'LEAD-RECEIPT-1',
+  })
+  assert.deepEqual(Object.keys(receipt).sort(), ['message', 'next_step', 'reference', 'status'])
+  assert.deepEqual(publicSubmissionReceipt(), {
+    status: 'ready',
+    message: 'Request received.',
+    next_step: 'We will review the request and reply to the submitted email.',
+  })
+  assert.deepEqual(publicSubmissionFailure(), {
+    status: 'error',
+    reason: 'submission_unavailable',
+    message: 'Request could not be received. Please try again later.',
+  })
+
+  let receiptHtmlBody = ''
+  const receiptHeaders = {}
+  const receiptResponse = {
+    statusCode: 0,
+    setHeader(name, value) {
+      receiptHeaders[name.toLowerCase()] = value
+    },
+    end(body = '') {
+      receiptHtmlBody = body
+    },
+  }
+  receiptHtml(receiptResponse, {
+    lead_id: 'LEAD-RECEIPT-1',
+    task_id: 'TASK-INTERNAL-1',
+    company: 'Example Co',
+    email: 'buyer@example.com',
+    requested_package: 'Internal route',
+  })
+  assert.equal(receiptResponse.statusCode, 200)
+  assert.equal(receiptHeaders['cache-control'], 'no-store')
+  for (const required of [
+    'Request received.',
+    'LEAD-RECEIPT-1',
+    'Example Co',
+    'buyer@example.com',
+    'Nothing is connected, changed, or sent on your behalf until you approve it.',
+  ]) {
+    assert.equal(receiptHtmlBody.includes(required), true, `receipt_missing_${required}`)
+  }
+  for (const forbidden of [
+    'TASK-INTERNAL-1',
+    'Internal route',
+    'Source pack room',
+    'App access',
+    'swanhtet@supermega.dev',
+  ]) {
+    assert.equal(receiptHtmlBody.includes(forbidden), false, `receipt_exposes_${forbidden}`)
+  }
+
+  for (const retiredResponseFragment of [
+    'submission: publicSubmission',
+    'owner_onboarding_alert: firstProofTask.owner_onboarding_alert',
+    'pipeline_action: pipelineAction',
+    'shop_pipeline: deskposPipeline',
+    'ops_intake: opsIntake',
+    'fallback_email: notifyEmail',
+    "reason: 'rate_limited', rate",
+  ]) {
+    assert.equal(handlerSource.includes(retiredResponseFragment), false, `public_response_exposes_${retiredResponseFragment}`)
+  }
+  assert.equal(handlerSource.includes('json(res, 200, publicSubmissionReceipt(record))'), true)
+  assert.equal(handlerSource.match(/json\(res, 502, publicSubmissionFailure\(\)\)/g)?.length, 4)
 
   const healthGet = await invokeHealth('GET')
   assert.equal(healthGet.statusCode, 200)


### PR DESCRIPTION
## What changed

- replace the public JSON success payload with a bounded customer receipt: status, message, next step, and one reference
- replace provider-specific 502 payloads with a generic customer-safe failure
- remove rate-window internals and parser error details from public JSON
- simplify the normal HTML receipt to reference, status, company, reply destination, approval boundary, and three next steps
- remove task IDs, package routing, owner assignment, source-pack room, internal queue/adapters, provider results, and downstream targets from customer responses
- align the local public-output stub and add fail-closed regression contracts

All existing datastore writes, Shop forwarding, Machine intake, email/Telegram/Sheets notifications, and required integration gates remain unchanged.

## Validation

- `npm run public:prebuilt`
- `npm run vercel:guard`
- 30 files / 0.41 MB / 3 functions
- 66 connectors / 923 adversarial calls / 0 violations
- focused receipt, diagnostics, health, and Machine handoff contracts
- Edge visual QA at 1280x900 and 390x844: zero horizontal overflow or clipped text, 49px controls, zero retired internal receipt markers

No form was submitted and no credential, lead, customer record, email, model call, provider action, payment, product price, or revenue was created or changed.