### PR TITLE
ci: monitor canonical Shop POS health

### DIFF
--- a/tools/check_public_live_health.py
+++ b/tools/check_public_live_health.py
@@ -15,8 +15,9 @@ from typing import Any
 from urllib.parse import urljoin, urlparse
 
 
-USER_AGENT = "supermega-portfolio-live-health/4.4"
+USER_AGENT = "supermega-portfolio-live-health/4.5"
 DEMO_MAX_BYTES = 256 * 1024
+POS_MAX_BYTES = 256 * 1024
 
 
 class NoRedirect(urllib.request.HTTPRedirectHandler):
@@ -124,6 +125,7 @@ def run(
     www_url: str,
     app_url: str,
     demo_url: str,
+    pos_url: str,
     console_url: str,
     *,
     timeout: float,
@@ -133,6 +135,7 @@ def run(
     www_url = www_url.rstrip("/") + "/"
     app_url = app_url.rstrip("/") + "/"
     demo_url = demo_url.rstrip("/") + "/"
+    pos_url = pos_url.rstrip("/") + "/"
     console_url = console_url.rstrip("/") + "/"
     failures: list[dict[str, Any]] = []
     results: list[dict[str, Any]] = []
@@ -298,6 +301,114 @@ def run(
         or demo_header_mismatches
     ):
         failures.append(demo_result)
+
+    pos_response = fetch(
+        pos_url,
+        timeout=timeout,
+        attempts=attempts,
+        follow_redirects=False,
+        max_bytes=POS_MAX_BYTES,
+    )
+    try:
+        pos_body = pos_response.body.decode("utf-8")
+        pos_encoding_error = False
+    except UnicodeDecodeError:
+        pos_body = ""
+        pos_encoding_error = True
+    pos_tokens = [
+        "<title>Shop ",
+        "the simple POS for Myanmar businesses</title>",
+        '<link rel="canonical" href="https://pos.supermega.dev/" />',
+        '<meta property="og:site_name" content="Shop" />',
+        '"name": "Shop"',
+        '<div id="root"></div>',
+    ]
+    pos_forbidden = [
+        "MegaOS",
+        "Mega OS",
+        "<title>DeskPOS",
+        'content="DeskPOS',
+        "spa-desk-pilot.vercel.app",
+    ]
+    pos_result = {
+        "kind": "shop_pos_page",
+        "url": pos_url,
+        "status": pos_response.status,
+        "bytes": len(pos_response.body),
+        "response_url_changed": pos_response.url != pos_url,
+        "encoding_error": pos_encoding_error,
+        "missing": [token for token in pos_tokens if token not in pos_body],
+        "unexpected": [token for token in pos_forbidden if token in pos_body],
+    }
+    results.append(pos_result)
+    if (
+        pos_response.status != 200
+        or pos_response.url != pos_url
+        or len(pos_response.body) < 1000
+        or len(pos_response.body) > POS_MAX_BYTES
+        or pos_encoding_error
+        or pos_result["missing"]
+        or pos_result["unexpected"]
+    ):
+        failures.append(pos_result)
+
+    pos_health_url = urljoin(pos_url, "api/health")
+    pos_health_response = fetch(pos_health_url, timeout=timeout, attempts=attempts)
+    try:
+        pos_health_payload = json.loads(pos_health_response.body.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        pos_health_payload = {}
+    expected_pos_health = {
+        "ok": True,
+        "service": "supermega-shop-pos",
+        "status": "ready",
+    }
+    pos_health_mismatches = {
+        path: {"expected": expected, "actual": nested_value(pos_health_payload, path)}
+        for path, expected in expected_pos_health.items()
+        if nested_value(pos_health_payload, path) != expected
+    }
+    if set(pos_health_payload) != set(expected_pos_health):
+        pos_health_mismatches["payload_keys"] = {
+            "expected": sorted(expected_pos_health),
+            "actual": sorted(pos_health_payload),
+        }
+    pos_health_result = {
+        "kind": "shop_pos_health",
+        "url": pos_health_url,
+        "status": pos_health_response.status,
+        "mismatches": pos_health_mismatches,
+    }
+    results.append(pos_health_result)
+    if pos_health_response.status != 200 or pos_health_mismatches:
+        failures.append(pos_health_result)
+
+    pos_diagnostics_url = f"{pos_health_url}?detail=1"
+    pos_diagnostics_response = fetch(pos_diagnostics_url, timeout=timeout, attempts=attempts)
+    try:
+        pos_diagnostics_payload = json.loads(pos_diagnostics_response.body.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        pos_diagnostics_payload = {}
+    expected_pos_diagnostics = {"error": "operator_auth_required"}
+    pos_diagnostics_mismatches = {
+        path: {"expected": expected, "actual": nested_value(pos_diagnostics_payload, path)}
+        for path, expected in expected_pos_diagnostics.items()
+        if nested_value(pos_diagnostics_payload, path) != expected
+    }
+    if set(pos_diagnostics_payload) != set(expected_pos_diagnostics):
+        pos_diagnostics_mismatches["payload_keys"] = {
+            "expected": sorted(expected_pos_diagnostics),
+            "actual": sorted(pos_diagnostics_payload),
+        }
+    pos_diagnostics_result = {
+        "kind": "shop_pos_diagnostics_guard",
+        "url": pos_diagnostics_url,
+        "status": pos_diagnostics_response.status,
+        "mismatches": pos_diagnostics_mismatches,
+    }
+    results.append(pos_diagnostics_result)
+    if pos_diagnostics_response.status != 401 or pos_diagnostics_mismatches:
+        failures.append(pos_diagnostics_result)
 
     for path in ("products/", "pricing/", "ai-agents/", "offers/"):
         url = urljoin(base_url, path)
@@ -562,6 +673,7 @@ def main() -> int:
     parser.add_argument("--www-url", default="https://www.supermega.dev")
     parser.add_argument("--app-url", default="https://app.supermega.dev")
     parser.add_argument("--demo-url", default="https://demo.supermega.dev")
+    parser.add_argument("--pos-url", default="https://pos.supermega.dev")
     parser.add_argument("--console-url", default="https://console.supermega.dev")
     parser.add_argument("--timeout", type=float, default=30.0)
     parser.add_argument("--attempts", type=int, default=3)
@@ -575,6 +687,7 @@ def main() -> int:
             args.www_url,
             args.app_url,
             args.demo_url,
+            args.pos_url,
             args.console_url,
             timeout=args.timeout,
             attempts=args.attempts,

--- a/tools/test_public_live_health.py
+++ b/tools/test_public_live_health.py
@@ -18,6 +18,7 @@ BASE = "https://public.example/"
 WWW = "https://www.example/"
 APP = "https://app.example/"
 DEMO = "https://demo.example/"
+POS = "https://pos.example/"
 CONSOLE = "https://console.example/"
 AGENT_INTAKE = f"{BASE}contact/?from=ai-agent-solution"
 
@@ -83,6 +84,13 @@ def healthy_responses() -> dict[str, checker.HttpResult]:
         'data-my="Shop POS ဖွင့်ရန်"',
         "assets/noto-sans-myanmar.woff2",
         "Shop POS Shop POS Shop POS Shop POS",
+    )
+    pos = page(
+        "<title>Shop - the simple POS for Myanmar businesses</title>",
+        '<link rel="canonical" href="https://pos.supermega.dev/" />',
+        '<meta property="og:site_name" content="Shop" />',
+        '"name": "Shop"',
+        '<div id="root"></div>',
     )
     console = page(
         "<title>SuperMega Console</title>",
@@ -162,6 +170,16 @@ def healthy_responses() -> dict[str, checker.HttpResult]:
             f"{APP}assets/index-current.js", "Shop" + ("x" * 1400)
         ),
         f"{APP}api/health": result(f"{APP}api/health", app_health),
+        POS: result(POS, pos),
+        f"{POS}api/health": result(
+            f"{POS}api/health",
+            {"ok": True, "service": "supermega-shop-pos", "status": "ready"},
+        ),
+        f"{POS}api/health?detail=1": result(
+            f"{POS}api/health?detail=1",
+            {"error": "operator_auth_required"},
+            status=401,
+        ),
         DEMO: result(
             DEMO,
             demo,
@@ -192,13 +210,49 @@ class PortfolioHealthTest(unittest.TestCase):
             return responses[url]
 
         with patch.object(checker, "fetch", side_effect=fake_fetch):
-            return checker.run(BASE, WWW, APP, DEMO, CONSOLE, timeout=1, attempts=1)
+            return checker.run(BASE, WWW, APP, DEMO, POS, CONSOLE, timeout=1, attempts=1)
 
-    def test_healthy_portfolio_passes_all_nineteen_checks(self):
+    def test_healthy_portfolio_passes_all_twenty_two_checks(self):
         report = self.run_report(healthy_responses())
         self.assertEqual(report["status"], "ready")
-        self.assertEqual(report["checks"], 19)
+        self.assertEqual(report["checks"], 22)
         self.assertEqual(report["failures"], [])
+
+    def test_shop_pos_health_rejects_internal_fields(self):
+        responses = healthy_responses()
+        health_url = f"{POS}api/health"
+        payload = json.loads(responses[health_url].body)
+        payload["project"] = "internal-project"
+        responses[health_url] = result(health_url, payload)
+        report = self.run_report(responses)
+        self.assertEqual(report["status"], "error")
+        failure = next(item for item in report["failures"] if item["kind"] == "shop_pos_health")
+        self.assertIn("payload_keys", failure["mismatches"])
+
+    def test_unprotected_shop_pos_diagnostics_fails_guard(self):
+        responses = healthy_responses()
+        diagnostics_url = f"{POS}api/health?detail=1"
+        responses[diagnostics_url] = result(
+            diagnostics_url,
+            {"ok": True, "project": "internal-project"},
+        )
+        report = self.run_report(responses)
+        self.assertEqual(report["status"], "error")
+        failure = next(
+            item for item in report["failures"] if item["kind"] == "shop_pos_diagnostics_guard"
+        )
+        self.assertEqual(failure["status"], 200)
+        self.assertIn("payload_keys", failure["mismatches"])
+
+    def test_retired_identity_or_legacy_host_fails_shop_pos_page(self):
+        for token in ("MegaOS", "<title>DeskPOS", "spa-desk-pilot.vercel.app"):
+            with self.subTest(token=token):
+                responses = healthy_responses()
+                responses[POS] = result(POS, responses[POS].body.decode() + token)
+                report = self.run_report(responses)
+                self.assertEqual(report["status"], "error")
+                failure = next(item for item in report["failures"] if item["kind"] == "shop_pos_page")
+                self.assertIn(token, failure["unexpected"])
 
     def test_public_contact_status_rejects_internal_fields(self):
         responses = healthy_responses()


### PR DESCRIPTION
## What changed
- add `pos.supermega.dev` as a first-class daily estate target
- verify canonical Shop identity and reject customer-facing MegaOS/DeskPOS or legacy deployment-host regressions
- enforce the exact public POS health payload `{ok, service, status}`
- enforce unauthenticated `?detail=1` as exact 401 `operator_auth_required`
- expand the deterministic fixture from 19 to 22 live checks

## Proof
- monitor fixture: 20/20 tests passed
- Python compile: passed
- current live estate: 22 checks / 0 failures

Read-only only: no lead, customer, payment, model, provider, Blob, or database write.