### PR TITLE
CI: monitor the simplified public entry

### DIFF
--- a/tools/check_public_live_health.py
+++ b/tools/check_public_live_health.py
@@ -145,24 +145,26 @@ def run(
         (
             base_url,
             [
-                "<title>supermega.dev | Shop, Plant and AI Agent Solutions</title>",
-                '<h1 id="portfolio-heading">Shop. Plant. AI Agent Solutions.</h1>',
+                "<title>supermega.dev | Shop and Plant</title>",
+                '<h1 id="portfolio-heading">Run the operation. See what matters.</h1>',
                 "https://app.supermega.dev/?demo=shop",
                 "https://app.supermega.dev/?demo=plant",
                 "/contact/?from=ai-agent-solution",
-                "external actions approval-gated",
+                "Try first. Add data later.",
+                "Need a repeated task handled?",
                 "data-public-status",
             ],
         ),
         (
             www_url,
             [
-                "<title>supermega.dev | Shop, Plant and AI Agent Solutions</title>",
-                '<h1 id="portfolio-heading">Shop. Plant. AI Agent Solutions.</h1>',
+                "<title>supermega.dev | Shop and Plant</title>",
+                '<h1 id="portfolio-heading">Run the operation. See what matters.</h1>',
                 "https://app.supermega.dev/?demo=shop",
                 "https://app.supermega.dev/?demo=plant",
                 "/contact/?from=ai-agent-solution",
-                "external actions approval-gated",
+                "Try first. Add data later.",
+                "Need a repeated task handled?",
                 "data-public-status",
             ],
         ),
@@ -183,12 +185,11 @@ def run(
             agent_intake_url,
             [
                 "search.get('from')==='ai-agent-solution'",
-                "document.title='AI Agent Solution | supermega.dev'",
-                "What should your agent handle every week?",
-                "Request an agent proof",
-                "What does your team repeat?",
-                "Request first proof",
-                "one redacted sample and one reviewed output",
+                "What do you want to improve?",
+                "Start here",
+                "What should work better?",
+                "idleSubmitLabel='Contact us'",
+                "one reviewed example",
                 'action="/api/contact-submissions"',
                 'name="name"',
                 'name="email"',
@@ -204,7 +205,17 @@ def run(
         body = response.body.decode("utf-8", errors="replace")
         missing = [token for token in tokens if token not in body]
         if url in (base_url, www_url):
-            forbidden = ["MegaOS", "DeskPOS", ">Studio<", "Try demo", "https://demo.supermega.dev/"]
+            forbidden = [
+                "MegaOS",
+                "DeskPOS",
+                ">Studio<",
+                "Try demo",
+                "https://demo.supermega.dev/",
+                'target="_blank"',
+                "rotate(",
+                "Build an agent solution",
+                ">Agent solution<",
+            ]
         elif url == agent_intake_url:
             forbidden = [
                 "MegaOS",
@@ -487,7 +498,7 @@ def run(
         body = response.body.decode("utf-8", errors="replace")
         if route == "home":
             app_home_body = body
-        missing = [token for token in ['<title>Shop - SuperMega</title>', '<div id="root"></div>', 'type="module"'] if token not in body]
+        missing = [token for token in ['<title>Shop | supermega.dev</title>', '<div id="root"></div>', 'type="module"'] if token not in body]
         result = {
             "kind": "app_route",
             "route": route,

--- a/tools/test_public_live_health.py
+++ b/tools/test_public_live_health.py
@@ -34,12 +34,13 @@ def page(*tokens: str) -> str:
 
 def healthy_responses() -> dict[str, checker.HttpResult]:
     home = page(
-        "<title>supermega.dev | Shop, Plant and AI Agent Solutions</title>",
-        '<h1 id="portfolio-heading">Shop. Plant. AI Agent Solutions.</h1>',
+        "<title>supermega.dev | Shop and Plant</title>",
+        '<h1 id="portfolio-heading">Run the operation. See what matters.</h1>',
         "https://app.supermega.dev/?demo=shop",
         "https://app.supermega.dev/?demo=plant",
         "/contact/?from=ai-agent-solution",
-        "external actions approval-gated",
+        "Try first. Add data later.",
+        "Need a repeated task handled?",
         "data-public-status",
     )
     contact = page(
@@ -54,12 +55,11 @@ def healthy_responses() -> dict[str, checker.HttpResult]:
     )
     agent_contact = page(
         "search.get('from')==='ai-agent-solution'",
-        "document.title='AI Agent Solution | supermega.dev'",
-        "What should your agent handle every week?",
-        "Request an agent proof",
-        "What does your team repeat?",
-        "Request first proof",
-        "one redacted sample and one reviewed output",
+        "What do you want to improve?",
+        "Start here",
+        "What should work better?",
+        "idleSubmitLabel='Contact us'",
+        "one reviewed example",
         'action="/api/contact-submissions"',
         'name="name"',
         'name="email"',
@@ -71,7 +71,7 @@ def healthy_responses() -> dict[str, checker.HttpResult]:
         "Only the details needed to reply.",
     )
     app_shell = page(
-        "<title>Shop - SuperMega</title>",
+        "<title>Shop | supermega.dev</title>",
         '<div id="root"></div>',
         '<script type="module" crossorigin src="/assets/index-current.js"></script>',
     )
@@ -326,13 +326,13 @@ class PortfolioHealthTest(unittest.TestCase):
         responses = healthy_responses()
         responses[AGENT_INTAKE] = result(
             AGENT_INTAKE,
-            responses[AGENT_INTAKE].body.decode().replace("Request first proof", ""),
+            responses[AGENT_INTAKE].body.decode().replace("idleSubmitLabel='Contact us'", ""),
         )
         report = self.run_report(responses)
         self.assertEqual(report["status"], "error")
         failure = next(item for item in report["failures"] if item["kind"] == "agent_intake_page")
         self.assertEqual(failure["url"], AGENT_INTAKE)
-        self.assertIn("Request first proof", failure["missing"])
+        self.assertIn("idleSubmitLabel='Contact us'", failure["missing"])
 
     def test_technical_intake_field_fails_first_proof_route(self):
         responses = healthy_responses()


### PR DESCRIPTION
﻿## What changed
- aligns the scheduled public estate monitor with the simplified Shop and Plant homepage
- aligns app-route checks with the new Shop | supermega.dev shell title
- aligns contextual Contact checks with the plain-language intake
- fails closed if target=_blank, rotated hero code, or retired Agent solution copy returns

## Why
The production monitor still required the retired giant portfolio headline and first-proof wording, so it would flag the new verified release as unhealthy.

## Validation
- Python compile
- 20 deterministic monitor tests
- git diff --check

This PR should merge immediately after the matching app and public releases are live.
