### PR TITLE
ops: guard Vercel public hosting

### DIFF
--- a/.github/workflows/public-hosting-guard.yml
+++ b/.github/workflows/public-hosting-guard.yml
@@ -1,0 +1,110 @@
+name: Public Hosting Guard
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/public-hosting-guard.yml'
+      - '.github/workflows/showroom-pages.yml'
+      - 'CNAME'
+      - 'tools/bootstrap_supermega_ops.ps1'
+      - 'tools/deploy_website_actions.ps1'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/public-hosting-guard.yml'
+      - '.github/workflows/showroom-pages.yml'
+      - 'CNAME'
+      - 'tools/bootstrap_supermega_ops.ps1'
+      - 'tools/deploy_website_actions.ps1'
+  workflow_dispatch:
+  schedule:
+    - cron: '5 2 * * *'
+
+permissions:
+  contents: read
+  pages: read
+
+concurrency:
+  group: public-hosting-guard-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  hosting-contract:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout without submodules
+        uses: actions/checkout@v6
+        with:
+          submodules: false
+
+      - name: Verify Vercel-only public hosting
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          $ErrorActionPreference = "Stop"
+          $failures = @()
+
+          if (Test-Path -LiteralPath "CNAME") {
+            $failures += "Root CNAME must not assign supermega.dev to GitHub Pages."
+          }
+          if (Test-Path -LiteralPath ".github/workflows/showroom-pages.yml") {
+            $failures += "Legacy showroom Pages workflow must remain retired."
+          }
+
+          $selfGitlink = (git ls-files --stage -- swanhtet01.github.io | Out-String).Trim()
+          if (-not [string]::IsNullOrWhiteSpace($selfGitlink)) {
+            $failures += "Malformed swanhtet01.github.io self-gitlink must remain removed."
+          }
+
+          foreach ($script in @(
+            "tools/bootstrap_supermega_ops.ps1",
+            "tools/deploy_website_actions.ps1"
+          )) {
+            $tokens = $null
+            $parseErrors = $null
+            [System.Management.Automation.Language.Parser]::ParseFile(
+              (Resolve-Path -LiteralPath $script),
+              [ref]$tokens,
+              [ref]$parseErrors
+            ) | Out-Null
+            if ($parseErrors) {
+              $failures += "$script has PowerShell parse errors."
+            }
+          }
+
+          $rawPlan = & ./tools/deploy_website_actions.ps1 -DryRun
+          if ($LASTEXITCODE -ne 0) {
+            $failures += "Verified Vercel release wrapper dry-run failed."
+          }
+          else {
+            $plan = $rawPlan | ConvertFrom-Json
+            if ($plan.hosting -ne "vercel") {
+              $failures += "Public hosting must be Vercel."
+            }
+            if ($plan.domain -ne "supermega.dev") {
+              $failures += "Public release domain drifted from supermega.dev."
+            }
+            if ($plan.workflow -ne "supermega-public-release.yml") {
+              $failures += "Public release workflow is not the verified prebuilt release."
+            }
+            if ($plan.source_ref -ne "codex/public-enterprise-site") {
+              $failures += "Canonical public source branch drifted."
+            }
+            if ($plan.legacy_pages_enabled) {
+              $failures += "GitHub Pages must stay workflow-managed with no CNAME or legacy deploy workflow."
+            }
+            if ($plan.mutates_customer_data) {
+              $failures += "Public release wrapper must not mutate customer data."
+            }
+          }
+
+          if ($failures.Count -gt 0) {
+            throw ($failures -join "`n")
+          }
+
+          $plan | ConvertTo-Json -Depth 4

--- a/DEPLOY_APP.md
+++ b/DEPLOY_APP.md
@@ -1,5 +1,9 @@
 # SuperMega App Deploy
 
+> Historical combined-app runbook. Production `supermega.dev` is released from
+> `codex/public-enterprise-site` through the verified Vercel workflow. Shop,
+> Plant, Shop POS, and Agent Company have separate production lanes.
+
 This is the cleanest way to run SuperMega as one connected system:
 
 - public website
@@ -109,7 +113,7 @@ That means:
 - the default local runtime still works on SQLite
 - a customer deployment can move that store to Postgres by setting `SUPERMEGA_DATABASE_URL`
 
-## Cloud Run deploy
+## Legacy Cloud Run app deploy
 
 Workflow:
 
@@ -117,6 +121,8 @@ Workflow:
 - direct script:
   - `powershell -ExecutionPolicy Bypass -File .\tools\deploy_supermega_gcp.ps1`
 - repo/bootstrap sync:
+  - `-DeployApp` dispatches the legacy Cloud Run app workflow
+  - `-DeployWebsite` dispatches the verified Vercel public release
   - `powershell -ExecutionPolicy Bypass -File .\tools\bootstrap_supermega_ops.ps1 -UseLiveRunUrl -DeployApp -DeployWebsite`
 
 Required secret:

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -45,7 +45,7 @@ Open on this machine:
 Open from other devices on same network:
 - `http://<this-computer-ip>:8787`
 
-## 4) Build the public showroom (supermega.dev source)
+## 4) Build the legacy showroom prototype locally
 
 ```powershell
 cd .\showroom
@@ -54,9 +54,19 @@ npm run build
 npm run lint
 ```
 
-Deployment target:
-- GitHub Pages workflow: `.github/workflows/showroom-pages.yml`
+Production target:
+- Canonical source: `codex/public-enterprise-site`
+- Verified release: `.github/workflows/supermega-public-release.yml`
+- Hosting: Vercel only
 - Domain: `https://supermega.dev`
+
+```powershell
+# Read-only release plan
+powershell -ExecutionPolicy Bypass -File .\tools\deploy_website_actions.ps1 -DryRun
+
+# Verified production release
+powershell -ExecutionPolicy Bypass -File .\tools\deploy_website_actions.ps1
+```
 
 ## 4b) Run the full app in one container
 
@@ -81,7 +91,7 @@ Includes:
 - Gmail token presence check
 - next command suggestions
 
-## 6) Cloud Run fallback preflight (if your network blocks supermega.dev on Pages)
+## 6) Legacy Cloud Run prototype preflight (not the public domain owner)
 
 ```powershell
 powershell -ExecutionPolicy Bypass -File .\tools\supermega_machine.ps1 -Action cloudrun-preflight -ProjectId supermega-468612 -Region asia-southeast1 -Service supermega-showroom

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ Core docs:
 
 - `personal-pilot-architecture.md` - v1 architecture and stack decision for the personal pilot
 - `mark1_pilot/README.md` - runnable pilot scaffold for Yangon Tyre plus Gmail
-- `showroom/` - React + TypeScript + Tailwind public showroom for `supermega.dev`
-- `showroom/DEPLOY_CLOUD_RUN.md` - fallback hosting path when GitHub Pages connectivity is blocked
+- `showroom/` - legacy React showroom prototype; it is not the production `supermega.dev` source
+- `.github/workflows/supermega-public-release.yml` - verified Vercel release for the canonical public branch
 - `command-center/ARCHITECTURE_v2.3.md` - broader Mark 1 machine vision and long-term architecture
 - `DOCUMENTATION-INDEX.md` - map of active vs legacy docs
 - `QUICKSTART.md` - fastest path to run pilot, fix Gmail, and test on phone/laptop
@@ -101,8 +101,11 @@ powershell -ExecutionPolicy Bypass -File .\tools\run_solution.ps1 -Config .\conf
 # Run the full app as one container with persistent saved data
 docker compose -f .\docker-compose.app.yml up --build
 
-# Deploy website via GitHub Actions (sync secret + dispatch Pages/Cloud Run)
-powershell -ExecutionPolicy Bypass -File .\tools\deploy_website_actions.ps1 -ProjectId supermega-468612 -Region asia-southeast1 -Service supermega-showroom
+# Inspect the Vercel-only production release plan without deploying
+powershell -ExecutionPolicy Bypass -File .\tools\deploy_website_actions.ps1 -DryRun
+
+# Dispatch the verified Vercel production release and wait for live checks
+powershell -ExecutionPolicy Bypass -File .\tools\deploy_website_actions.ps1
 
 # Showroom
 cd showroom

--- a/tools/deploy_website_actions.ps1
+++ b/tools/deploy_website_actions.ps1
@@ -19,6 +19,7 @@ param(
 $ErrorActionPreference = "Stop"
 $workflowFile = "supermega-public-release.yml"
 $workflowName = "SuperMega Public - Verified Prebuilt Release"
+$repoRoot = Split-Path -Parent $PSScriptRoot
 
 function Require-Command {
     param([string]$Name)
@@ -77,9 +78,34 @@ if (-not [string]::IsNullOrWhiteSpace($Token)) {
 
 try {
     $pagesText = (& gh api "repos/$Repo/pages" 2>&1 | Out-String).Trim()
-    $pagesEnabled = $LASTEXITCODE -eq 0
-    if (-not $pagesEnabled -and $pagesText -notmatch 'HTTP 404|Not Found') {
-        throw "Could not verify the retired GitHub Pages state. $pagesText"
+    $pagesServicePresent = $LASTEXITCODE -eq 0
+    $pagesBuildType = "absent"
+    $pagesCname = $null
+    if ($pagesServicePresent) {
+        try {
+            $pages = $pagesText | ConvertFrom-Json
+            $pagesBuildType = [string]$pages.build_type
+            $pagesCname = [string]$pages.cname
+        }
+        catch {
+            throw "Could not parse the GitHub Pages state. $pagesText"
+        }
+    }
+    elseif ($pagesText -notmatch 'HTTP 404|Not Found') {
+        throw "Could not read the GitHub Pages state. $pagesText"
+    }
+
+    $legacyWorkflowPath = Join-Path $repoRoot ".github\workflows\showroom-pages.yml"
+    $verifiedWorkflowPath = Join-Path $repoRoot ".github\workflows\$workflowFile"
+    $legacyWorkflowPresent = Test-Path -LiteralPath $legacyWorkflowPath
+    $legacyPagesEnabled = $legacyWorkflowPresent -or (
+        $pagesServicePresent -and (
+            $pagesBuildType -ne "workflow" -or
+            -not [string]::IsNullOrWhiteSpace($pagesCname)
+        )
+    )
+    if (-not (Test-Path -LiteralPath $verifiedWorkflowPath)) {
+        throw "Verified public release workflow is missing: $verifiedWorkflowPath"
     }
 
     $plan = [ordered]@{
@@ -90,7 +116,11 @@ try {
         workflow = $workflowFile
         dispatch_ref = "main"
         source_ref = "codex/public-enterprise-site"
-        legacy_pages_enabled = $pagesEnabled
+        pages_service = if ($pagesServicePresent) { "present" } else { "absent" }
+        pages_build_type = $pagesBuildType
+        pages_cname = $pagesCname
+        legacy_pages_workflow_present = $legacyWorkflowPresent
+        legacy_pages_enabled = $legacyPagesEnabled
         mutates_customer_data = $false
     }
 
@@ -98,8 +128,8 @@ try {
         $plan | ConvertTo-Json -Depth 4
         return
     }
-    if ($pagesEnabled) {
-        throw "Legacy GitHub Pages is still enabled for $Repo. Disable it before releasing through Vercel."
+    if ($legacyPagesEnabled) {
+        throw "Legacy GitHub Pages still owns a branch, custom domain, or deploy workflow for $Repo. Keep Pages in workflow mode with no CNAME and release supermega.dev only through Vercel."
     }
 
     $startedAt = (Get-Date).ToUniversalTime()


### PR DESCRIPTION
## What changed
- add a read-only hosting contract guard for pull requests, main pushes, manual checks, and daily drift detection
- treat GitHub Pages workflow mode without a CNAME as a dormant user-site shell, while blocking legacy Pages ownership
- lock the public release wrapper to the verified Vercel workflow and canonical public branch
- update operator docs so GitHub Pages and the old Cloud Run showroom are no longer described as production paths

## Verification
- PowerShell AST parse passed for both deployment scripts
- live dry-run reports Vercel, workflow-mode Pages, no CNAME, no legacy workflow, and no customer-data mutation
- invalid branch and domain inputs fail closed
- retired CNAME, legacy Pages workflow, and malformed self-gitlink are absent

## Boundaries
- no deployment dispatched
- no customer, tenant, payment, lead, provider, or database mutation
- no pricing changes