### PR TITLE
site: make private workspace entry truthful

### DIFF
--- a/tools/create_public_vercel_output.mjs
+++ b/tools/create_public_vercel_output.mjs
@@ -520,7 +520,7 @@ const homeHtml = documentHtml({
   <section class="entry-section page-frame" id="workspaces" aria-labelledby="workspaces-heading">
     <div class="section-intro">
       <div><div class="eyebrow">Shop + Plant</div><h2 id="workspaces-heading">Open a workspace.</h2></div>
-      <p>Use one account across desktop, tablet, and mobile. Demos open immediately in this browser.</p>
+      <p>Demos open immediately on this device. Private workspaces are verified before handover.</p>
     </div>
     <div class="destination-list">
       <a class="destination" href="https://app.supermega.dev/?demo=shop"><span class="destination-index">01 / SHOP</span><span class="destination-copy"><strong>Shop</strong><span>Point of sale, customers, stock, receivables, and books.</span></span><span class="destination-arrow" aria-hidden="true">&#8594;</span></a>
@@ -532,12 +532,12 @@ const homeHtml = documentHtml({
     <div class="start-inner page-frame" data-reveal>
       <div class="start-intro">
         <div><div class="eyebrow">New here?</div><h2 id="start-heading">Try first. Add data later.</h2></div>
-        <p>The demo needs no account. Create a workspace only when you want to keep your work and use it across devices.</p>
+        <p>The demo needs no account. Request a private workspace when you are ready to keep business data.</p>
       </div>
       <div class="start-steps">
         <div class="start-step"><span>01 / TRY</span><strong>Open a demo</strong><p>Choose Shop or Plant and use the working screens immediately.</p></div>
-        <div class="start-step"><span>02 / ACCOUNT</span><strong>Create your workspace</strong><p>Create with email and password. Return with your password or an email code.</p></div>
-        <div class="start-step"><span>03 / DATA</span><strong>Bring your data</strong><p>Import your own rows when you are ready, or start fresh.</p></div>
+        <div class="start-step"><span>02 / PRIVATE</span><strong>Request your workspace</strong><p>SuperMega sets it up and verifies it before handover.</p></div>
+        <div class="start-step"><span>03 / DATA</span><strong>Bring your data</strong><p>Bring approved rows when your private workspace is ready, or start fresh.</p></div>
       </div>
       <div class="start-actions">
         <a class="btn primary" href="https://app.supermega.dev/?demo=shop">Try Shop</a>

--- a/tools/verify_public_enterprise_visual_contract.mjs
+++ b/tools/verify_public_enterprise_visual_contract.mjs
@@ -44,6 +44,9 @@ for (const required of [
   "src:'/live-plant-workspace.png'",
   '<h2 id="workspaces-heading">Open a workspace.</h2>',
   'Try first. Add data later.',
+  'Private workspaces are verified before handover.',
+  'Request your workspace',
+  'SuperMega sets it up and verifies it before handover.',
   'Need something different?',
   '>Contact us</a>',
   'href="/favicon.svg"',
@@ -51,7 +54,7 @@ for (const required of [
   if (!home.includes(required)) fail('homepage_front_door_contract_missing', { required })
 }
 
-for (const forbidden of ['<figure class="site-hero-screen"', '<img src="/site/shots/live-product-', 'Explore products', 'Custom Solutions &amp; AI Agents', 'supermega-portal-card.png', 'https://demo.supermega.dev/', 'AI Agent Solutions', 'Need a repeated task handled?', 'rotate(', 'id="products"']) {
+for (const forbidden of ['<figure class="site-hero-screen"', '<img src="/site/shots/live-product-', 'Explore products', 'Custom Solutions &amp; AI Agents', 'supermega-portal-card.png', 'https://demo.supermega.dev/', 'AI Agent Solutions', 'Need a repeated task handled?', 'rotate(', 'id="products"', 'Use one account across desktop, tablet, and mobile.', 'Create a workspace only when you want to keep your work and use it across devices.', 'Create with email and password. Return with your password or an email code.']) {
   if (home.includes(forbidden)) fail('homepage_stale_catalog_visual_or_copy', { forbidden })
 }
 

--- a/tools/verify_public_release_live.mjs
+++ b/tools/verify_public_release_live.mjs
@@ -45,12 +45,15 @@ function verifyHome(html, label) {
     'src="/live-shop-workspace.png"',
     "src:'/live-plant-workspace.png'",
     'Try first. Add data later.',
+    'Private workspaces are verified before handover.',
+    'Request your workspace',
+    'SuperMega sets it up and verifies it before handover.',
     'Need something different?',
     '>Contact us</a>',
   ]) {
     assert(html.includes(required), `${label}_missing_${required.slice(0, 32)}`)
   }
-  for (const forbidden of ['MegaOS', 'DeskPOS', 'General enquiry', 'target="_blank"', 'target=_blank', 'window.open(', 'rotate(', 'Build an agent solution', '>Agent solution<', 'AI Agent Solutions', 'Need a repeated task handled?', '>SM<']) {
+  for (const forbidden of ['MegaOS', 'DeskPOS', 'General enquiry', 'target="_blank"', 'target=_blank', 'window.open(', 'rotate(', 'Build an agent solution', '>Agent solution<', 'AI Agent Solutions', 'Need a repeated task handled?', '>SM<', 'Use one account across desktop, tablet, and mobile.', 'Create a workspace only when you want to keep your work and use it across devices.', 'Create with email and password. Return with your password or an email code.']) {
     assert(!html.includes(forbidden), `${label}_retired_${forbidden}`)
   }
 }

--- a/tools/verify_public_vercel_output.mjs
+++ b/tools/verify_public_vercel_output.mjs
@@ -101,7 +101,10 @@ for (const required of [
   'data-product-preview-button="plant"',
   'src="/live-shop-workspace.png"',
   "src:'/live-plant-workspace.png'",
-  'Return with your password or an email code.',
+  'Demos open immediately on this device. Private workspaces are verified before handover.',
+  'Request your workspace',
+  'SuperMega sets it up and verifies it before handover.',
+  'Bring approved rows when your private workspace is ready, or start fresh.',
   'data-public-status',
   "fetch('/api/health'",
   'Point of sale, customers, stock, receivables, and books.',
@@ -111,7 +114,7 @@ for (const required of [
   if (!home.includes(required)) fail('homepage_front_door_contract_missing', { required })
 }
 
-for (const forbidden of ['https://demo.supermega.dev/', 'The intelligent workspace for daily operations.', 'Explore live demos', 'Open workspace', 'target="_blank"', 'target=_blank', 'window.open(', 'rotate(', 'data-hero-media', 'Current build', 'Build an agent solution', '>Agent solution<', 'AI Agent Solutions', 'Need a repeated task handled?', 'id="products"']) {
+for (const forbidden of ['https://demo.supermega.dev/', 'The intelligent workspace for daily operations.', 'Explore live demos', 'Open workspace', 'target="_blank"', 'target=_blank', 'window.open(', 'rotate(', 'data-hero-media', 'Current build', 'Build an agent solution', '>Agent solution<', 'AI Agent Solutions', 'Need a repeated task handled?', 'id="products"', 'Use one account across desktop, tablet, and mobile.', 'Create a workspace only when you want to keep your work and use it across devices.', 'Create with email and password. Return with your password or an email code.']) {
   if (home.includes(forbidden)) fail('homepage_keeps_superseded_portfolio_copy', { forbidden })
 }
 


### PR DESCRIPTION
## What changed

- replaces self-service account and cross-device claims with the current managed private-workspace handoff
- keeps Shop and Plant demos immediate and account-free
- extends structural, visual, and live-release contracts to reject the retired account claims

## Why

The Shop deployment now correctly disables account entry until durable tenant provisioning is available. The public homepage still promised self-service signup and cross-device persistence, which overstated current production capability.

## Verification

- `npm run public:prebuilt`
- generated artifact: 30 files, 0.36 MB, 3 functions
- 66 connectors / 923 adversarial calls / 0 violations
- Playwright at 1440x1000, 768x1024, and 390x844: no overflow, undersized command controls, popup targets, retired labels, or browser errors
- Shop/Plant preview switch verified in all three viewports

No form, account, customer data, provider action, price, payment, domain, or alias was changed.