### PR TITLE
Route managed Shop and Plant workspace requests

### DIFF
--- a/api/contact-submissions.js
+++ b/api/contact-submissions.js
@@ -150,7 +150,8 @@ function contactEntryIntent(payload = {}) {
       const url = new URL(raw, 'https://supermega.dev')
       if (!['supermega.dev', 'www.supermega.dev'].includes(url.hostname)) continue
       if (url.pathname.replace(/\/+$/, '') !== '/contact') continue
-      if (url.searchParams.get('from') === 'ai-agent-solution') return 'ai-agent-solution'
+      const intent = url.searchParams.get('from')
+      if (['ai-agent-solution', 'shop-workspace', 'plant-workspace'].includes(intent)) return intent
     } catch {
       // Ignore malformed attribution and continue with the neutral intake route.
     }
@@ -336,7 +337,7 @@ function leadScore(payload) {
   if (goal.length > 80) score += 20
   if (goal.match(/\b(approval|operations|workflow|files|spreadsheet|crm|erp|portal|manager|team|data|ai|meter|sensor|machine|energy|digital twin)\b/i)) score += 15
   if (text(payload.source_file_names) || Number(payload.source_file_count || 0) > 0) score += 10
-  if (text(payload.requested_package) || text(payload.public_package) || text(payload.workflow)) score += 10
+  if (text(payload.requested_package) || text(payload.public_package) || text(payload.workflow) || contactEntryIntent(payload)) score += 10
   if (text(payload.template_id)) score += 5
   if (text(payload.first_proof_target) || text(payload.acceptance_tests)) score += 5
   if (text(payload.utm_campaign)) score += 5
@@ -1760,18 +1761,32 @@ function buildLeadRecord({ leadId, taskId, payload, req }) {
   const score = leadScore(payload)
   const entryIntent = contactEntryIntent(payload)
   const agentIntent = entryIntent === 'ai-agent-solution'
+  const workspaceProduct = entryIntent === 'shop-workspace'
+    ? 'Shop'
+    : entryIntent === 'plant-workspace'
+      ? 'Plant'
+      : ''
+  const workspacePackage = workspaceProduct ? `${workspaceProduct} private workspace` : ''
+  const workspaceTemplateId = entryIntent === 'shop-workspace'
+    ? 'deskpos-quickstart'
+    : entryIntent === 'plant-workspace'
+      ? 'factory-ops-ledger'
+      : ''
+  const workspaceFirstProofTarget = workspaceProduct
+    ? `One private ${workspaceProduct} workspace configured from buyer-approved starting data and verified before handover.`
+    : ''
   const sourceLinks = truncate(payload.source_links, 700)
   const firstStep = truncate(payload.first_step, 160)
-  const publicPackage = truncate(payload.public_package, 160) || (agentIntent ? 'AI Agent Solutions' : '')
+  const publicPackage = truncate(payload.public_package, 160) || (agentIntent ? 'AI Agent Solutions' : workspacePackage)
   const firstProofTarget = truncate(payload.first_proof_target, 300) || (agentIntent
     ? 'One source-traced draft output from one redacted approved sample, reviewed against the buyer\'s stated useful result.'
-    : '')
+    : workspaceFirstProofTarget)
   const acceptanceTests = truncate(payload.acceptance_tests, 900)
   const launchBlockers = truncate(payload.launch_blockers, 500)
   const automationBoundary = truncate(payload.automation_boundary, 700)
-  const firstOutput = truncate(payload.requested_package, 120) || truncate(payload.first_output, 120) || truncate(payload.workflow, 120) || (agentIntent ? 'AI Agent Solutions' : 'First useful output')
-  const productArea = truncate(payload.product_area, 160) || (agentIntent ? 'Custom Solutions & AI Agents' : '')
-  const templateId = truncate(payload.template_id, 100)
+  const firstOutput = truncate(payload.requested_package, 120) || truncate(payload.first_output, 120) || truncate(payload.workflow, 120) || (agentIntent ? 'AI Agent Solutions' : workspacePackage || 'First useful output')
+  const productArea = truncate(payload.product_area, 160) || (agentIntent ? 'Custom Solutions & AI Agents' : workspaceProduct)
+  const templateId = truncate(payload.template_id, 100) || workspaceTemplateId
   const templateStatus = truncate(payload.template_status, 80)
   const templateSourceCategory = truncate(payload.template_source_category, 120)
   const templateSourceArea = truncate(payload.template_source_area, 160)
@@ -1784,7 +1799,7 @@ function buildLeadRecord({ leadId, taskId, payload, req }) {
   const entitlementGate = truncate(payload.entitlement_gate, 700)
   const sourceFileNames = truncate(payload.source_file_names, 1200)
   const sourceFileCount = truncate(payload.source_file_count, 20)
-  const onboardingStage = truncate(payload.onboarding_stage, 80) || 'source_review'
+  const onboardingStage = truncate(payload.onboarding_stage, 80) || (workspaceProduct ? 'workspace_request' : 'source_review')
   const accessPolicy = truncate(payload.access_policy, 120) || 'approval_required'
   const workspaceStatus = truncate(payload.workspace_status, 120) || 'not_created_until_approved'
   const urgency = truncate(payload.urgency, 120)
@@ -1825,7 +1840,7 @@ function buildLeadRecord({ leadId, taskId, payload, req }) {
     email: truncate(payload.email, 180).toLowerCase(),
     phone: truncate(payload.phone, 80),
     company: truncate(payload.company, 180),
-    workflow: truncate(payload.workflow, 120) || (agentIntent ? 'AI Agent Solutions discovery' : 'Workflow system'),
+    workflow: truncate(payload.workflow, 120) || (agentIntent ? 'AI Agent Solutions discovery' : workspacePackage ? `${workspacePackage} request` : 'Workflow system'),
     requested_package: firstOutput,
     public_package: publicPackage,
     first_output: firstOutput,

--- a/tools/create_public_vercel_output.mjs
+++ b/tools/create_public_vercel_output.mjs
@@ -630,7 +630,9 @@ const contactHtml = documentHtml({
   var form=document.querySelector('[data-sm-contact-form]');
   if(!form)return;
   var search=new URLSearchParams(window.location.search);
-  var agentIntent=search.get('from')==='ai-agent-solution';
+  var entryIntent=search.get('from')||'';
+  var agentIntent=entryIntent==='ai-agent-solution';
+  var workspaceProduct=entryIntent==='shop-workspace'?'Shop':entryIntent==='plant-workspace'?'Plant':'';
   var submit=form.querySelector('[data-contact-submit]');
   var idleSubmitLabel='Send request';
   function text(selector,value){var element=document.querySelector(selector);if(element)element.textContent=value;}
@@ -650,6 +652,16 @@ const contactHtml = documentHtml({
     text('[data-contact-goal-label]','What should work better?');
     text('[data-contact-policy]','We start with one reviewed example. No account, data connection, or external action is made before you approve it.');
     idleSubmitLabel='Contact us';
+    if(submit)submit.textContent=idleSubmitLabel;
+  }else if(workspaceProduct){
+    form.dataset.intake=entryIntent;
+    text('[data-contact-command]','>_ contact / workspace');
+    text('[data-contact-heading]','Request a private '+workspaceProduct+' workspace.');
+    text('[data-contact-intro]','Tell us who will use it and what should be ready first. SuperMega will set it up and verify it before handover.');
+    text('[data-contact-form-heading]','Request '+workspaceProduct);
+    text('[data-contact-goal-label]','What should be ready first?');
+    text('[data-contact-policy]','Sending this request does not create an account or connect data. Setup begins only after scope approval.');
+    idleSubmitLabel='Request workspace';
     if(submit)submit.textContent=idleSubmitLabel;
   }
   hydrateTracking();

--- a/tools/verify_public_agent_intake_contract.mjs
+++ b/tools/verify_public_agent_intake_contract.mjs
@@ -20,12 +20,16 @@ const contact = await readFile(resolve('.vercel/output/static/contact/index.html
 for (const required of [
   'data-contact-heading',
   'data-contact-goal-label',
-  "search.get('from')==='ai-agent-solution'",
+  "entryIntent==='ai-agent-solution'",
   'What do you want to improve?',
   'Start here',
   'What should work better?',
   "idleSubmitLabel='Contact us'",
   'one reviewed example',
+  "entryIntent==='shop-workspace'?'Shop':entryIntent==='plant-workspace'?'Plant':''",
+  "text('[data-contact-heading]','Request a private '+workspaceProduct+' workspace.')",
+  "text('[data-contact-goal-label]','What should be ready first?')",
+  "idleSubmitLabel='Request workspace'",
 ]) {
   assert.ok(contact.includes(required), `missing agent intake copy: ${required}`)
 }
@@ -53,8 +57,11 @@ for (const source of [...contact.matchAll(/<script>([\s\S]*?)<\/script>/g)].map(
 
 assert.equal(contactEntryIntent({ page_path: '/contact/?from=ai-agent-solution' }), 'ai-agent-solution')
 assert.equal(contactEntryIntent({ source_url: 'https://www.supermega.dev/contact/?from=ai-agent-solution' }), 'ai-agent-solution')
+assert.equal(contactEntryIntent({ page_path: '/contact/?from=shop-workspace' }), 'shop-workspace')
+assert.equal(contactEntryIntent({ source_url: 'https://www.supermega.dev/contact/?from=plant-workspace' }), 'plant-workspace')
 assert.equal(contactEntryIntent({ page_path: '/contact/?from=shop' }), '')
 assert.equal(contactEntryIntent({ source_url: 'https://example.com/contact/?from=ai-agent-solution' }), '')
+assert.equal(contactEntryIntent({ source_url: 'https://example.com/contact/?from=shop-workspace' }), '')
 
 function lead(payload = {}) {
   return buildLeadRecord({
@@ -83,6 +90,35 @@ assert.equal(vagueAgentRoute.delivery_lane, 'agent_solution_discovery')
 assert.equal(vagueAgentRoute.status, 'needs_operator_review')
 assert.equal(vagueAgentRoute.starter_kit_url, '')
 assert.deepEqual(vagueAgentRoute.matched_keywords, [])
+
+const shopWorkspaceLead = lead({ page_path: '/contact/?from=shop-workspace' })
+assert.equal(shopWorkspaceLead.workflow, 'Shop private workspace request')
+assert.equal(shopWorkspaceLead.requested_package, 'Shop private workspace')
+assert.equal(shopWorkspaceLead.public_package, 'Shop private workspace')
+assert.equal(shopWorkspaceLead.product_area, 'Shop')
+assert.equal(shopWorkspaceLead.template_id, 'deskpos-quickstart')
+assert.equal(shopWorkspaceLead.onboarding_stage, 'workspace_request')
+assert.equal(shopWorkspaceLead.access_policy, 'approval_required')
+assert.equal(shopWorkspaceLead.workspace_status, 'not_created_until_approved')
+assert.equal(shopWorkspaceLead.lead_stage, 'qualified')
+assert.match(shopWorkspaceLead.first_proof_target, /buyer-approved starting data/i)
+const shopWorkspaceRoute = buildSolutionRoute(shopWorkspaceLead)
+assert.equal(shopWorkspaceRoute.template_id, 'deskpos-quickstart')
+assert.equal(shopWorkspaceRoute.delivery_lane, 'pos_launch_workcell')
+assert.equal(shopWorkspaceRoute.status, 'route_ready')
+
+const plantWorkspaceLead = lead({ source_url: 'https://supermega.dev/contact/?from=plant-workspace' })
+assert.equal(plantWorkspaceLead.workflow, 'Plant private workspace request')
+assert.equal(plantWorkspaceLead.requested_package, 'Plant private workspace')
+assert.equal(plantWorkspaceLead.public_package, 'Plant private workspace')
+assert.equal(plantWorkspaceLead.product_area, 'Plant')
+assert.equal(plantWorkspaceLead.template_id, 'factory-ops-ledger')
+assert.equal(plantWorkspaceLead.onboarding_stage, 'workspace_request')
+assert.equal(plantWorkspaceLead.lead_stage, 'qualified')
+const plantWorkspaceRoute = buildSolutionRoute(plantWorkspaceLead)
+assert.equal(plantWorkspaceRoute.template_id, 'factory-ops-ledger')
+assert.equal(plantWorkspaceRoute.delivery_lane, 'factory_ops_workcell')
+assert.equal(plantWorkspaceRoute.status, 'route_ready')
 
 const reportingLead = lead({
   page_path: '/contact/?from=ai-agent-solution',
@@ -118,5 +154,6 @@ console.log(JSON.stringify({
   visible_fields: 4,
   fallback_route: vagueAgentRoute.template_id,
   specific_route: reportingRoute.template_id,
+  workspace_routes: [shopWorkspaceRoute.template_id, plantWorkspaceRoute.template_id],
   phantom_starter_kit_paths: 0,
 }))


### PR DESCRIPTION
## What changed
- preserve allowlisted Shop and Plant workspace intent through the public Contact form
- show product-specific request copy without creating an account or connecting data
- route accepted requests into the existing Shop and Plant delivery templates
- reject attribution from non-SuperMega domains

## Verification
- `npm run public:prebuilt`
- public artifact, visual, contact, agent-intake, and connector contracts
- desktop/tablet/mobile no-submit Contact QA for generic, AI Agent Solutions, Shop, and Plant contexts

No form was submitted and no account, workspace, customer data, price, payment, or provider action changed.