### PR TITLE
Align live release proof with workspace intake

### DIFF
--- a/tools/verify_public_release_live.mjs
+++ b/tools/verify_public_release_live.mjs
@@ -60,11 +60,14 @@ function verifyHome(html, label) {
 
 function verifyAgentIntake(html) {
   for (const required of [
-    "search.get('from')==='ai-agent-solution'",
+    "entryIntent==='ai-agent-solution'",
+    "entryIntent==='shop-workspace'?'Shop':entryIntent==='plant-workspace'?'Plant':''",
     'What do you want to improve?',
     'What should work better?',
     'one reviewed example',
     "idleSubmitLabel='Contact us'",
+    "text('[data-contact-heading]','Request a private '+workspaceProduct+' workspace.')",
+    "idleSubmitLabel='Request workspace'",
     'action="/api/contact-submissions"',
   ]) {
     assert(html.includes(required), `agent_intake_missing_${required.slice(0, 32)}`)


### PR DESCRIPTION
## What changed
- replace the retired AI-intake implementation literal in the live release verifier
- require the deployed Shop and Plant workspace-intake markers as part of live proof

## Verification
- `node --check tools/verify_public_release_live.mjs`
- `npm run public:prebuilt`
- `npm run public:verify:live` (first attempt, read-only)

The production artifact deployed by #98 is healthy; run 29347067606 failed only after deployment because this verifier still expected the retired literal. No form was submitted and no production data was written.