### PR TITLE
Monitor managed workspace intake and current Console

### DIFF
--- a/tools/check_public_live_health.py
+++ b/tools/check_public_live_health.py
@@ -140,6 +140,10 @@ def run(
     failures: list[dict[str, Any]] = []
     results: list[dict[str, Any]] = []
     agent_intake_url = urljoin(base_url, "contact/?from=ai-agent-solution")
+    workspace_intake_kinds = {
+        urljoin(base_url, "contact/?from=shop-workspace"): "shop_workspace_intake_page",
+        urljoin(base_url, "contact/?from=plant-workspace"): "plant_workspace_intake_page",
+    }
 
     page_checks = [
         (
@@ -190,7 +194,7 @@ def run(
         (
             agent_intake_url,
             [
-                "search.get('from')==='ai-agent-solution'",
+                "entryIntent==='ai-agent-solution'",
                 "What do you want to improve?",
                 "Start here",
                 "What should work better?",
@@ -203,6 +207,22 @@ def run(
                 'name="goal"',
             ],
         ),
+        *[
+            (
+                url,
+                [
+                    "entryIntent==='shop-workspace'?'Shop':entryIntent==='plant-workspace'?'Plant':''",
+                    "text('[data-contact-heading]','Request a private '+workspaceProduct+' workspace.')",
+                    "idleSubmitLabel='Request workspace'",
+                    'action="/api/contact-submissions"',
+                    'name="name"',
+                    'name="email"',
+                    'name="company"',
+                    'name="goal"',
+                ],
+            )
+            for url in workspace_intake_kinds
+        ],
         (urljoin(base_url, "privacy/"), ["<title>Privacy | supermega.dev</title>", "Only the details needed to reply."]),
     ]
 
@@ -227,7 +247,7 @@ def run(
                 "Create a workspace only when you want to keep your work and use it across devices.",
                 "Create with email and password. Return with your password or an email code.",
             ]
-        elif url == agent_intake_url:
+        elif url == agent_intake_url or url in workspace_intake_kinds:
             forbidden = [
                 "MegaOS",
                 "DeskPOS",
@@ -242,8 +262,9 @@ def run(
         else:
             forbidden = []
         unexpected = [token for token in forbidden if token in body]
+        kind = "agent_intake_page" if url == agent_intake_url else workspace_intake_kinds.get(url, "page")
         result = {
-            "kind": "agent_intake_page" if url == agent_intake_url else "page",
+            "kind": kind,
             "url": url,
             "status": response.status,
             "bytes": len(response.body),
@@ -583,10 +604,12 @@ def run(
     console_page_response = fetch(console_url, timeout=timeout, attempts=attempts)
     console_page_body = console_page_response.body.decode("utf-8", errors="replace")
     console_page_tokens = [
-        "<title>SuperMega Console</title>",
+        "<title>SuperMega Operations</title>",
+        "Operations control room",
+        "<h1>Command center</h1>",
+        "Move client work from request to delegated agents, reviewed action, and proven delivery.",
         'data-view="company"',
         'id="view-company"',
-        "Plan, queue, dispatch, evaluate, and deliver one bounded specialist wave",
         "I reviewed this exact client, evidence, assignments, and budget",
         "api('POST','/api/agent-company',{action:'plan',...input})",
         "api('POST','/api/agent-company',{action:'work-order-create',...companyDraft.input})",

--- a/tools/test_public_live_health.py
+++ b/tools/test_public_live_health.py
@@ -21,6 +21,8 @@ DEMO = "https://demo.example/"
 POS = "https://pos.example/"
 CONSOLE = "https://console.example/"
 AGENT_INTAKE = f"{BASE}contact/?from=ai-agent-solution"
+SHOP_WORKSPACE_INTAKE = f"{BASE}contact/?from=shop-workspace"
+PLANT_WORKSPACE_INTAKE = f"{BASE}contact/?from=plant-workspace"
 
 
 def result(url: str, body: str | dict, *, status: int = 200, headers: dict[str, str] | None = None):
@@ -57,11 +59,14 @@ def healthy_responses() -> dict[str, checker.HttpResult]:
         "No account or data connection is made before you approve it.",
     )
     agent_contact = page(
-        "search.get('from')==='ai-agent-solution'",
+        "entryIntent==='ai-agent-solution'",
+        "entryIntent==='shop-workspace'?'Shop':entryIntent==='plant-workspace'?'Plant':''",
         "What do you want to improve?",
         "Start here",
         "What should work better?",
         "idleSubmitLabel='Contact us'",
+        "text('[data-contact-heading]','Request a private '+workspaceProduct+' workspace.')",
+        "idleSubmitLabel='Request workspace'",
         "one reviewed example",
         'action="/api/contact-submissions"',
         'name="name"',
@@ -96,10 +101,12 @@ def healthy_responses() -> dict[str, checker.HttpResult]:
         '<div id="root"></div>',
     )
     console = page(
-        "<title>SuperMega Console</title>",
+        "<title>SuperMega Operations</title>",
+        "Operations control room",
+        "<h1>Command center</h1>",
+        "Move client work from request to delegated agents, reviewed action, and proven delivery.",
         'data-view="company"',
         'id="view-company"',
-        "Plan, queue, dispatch, evaluate, and deliver one bounded specialist wave",
         "I reviewed this exact client, evidence, assignments, and budget",
         "api('POST','/api/agent-company',{action:'plan',...input})",
         "api('POST','/api/agent-company',{action:'work-order-create',...companyDraft.input})",
@@ -158,6 +165,8 @@ def healthy_responses() -> dict[str, checker.HttpResult]:
         WWW: result(WWW, home),
         f"{BASE}contact/": result(f"{BASE}contact/", contact),
         AGENT_INTAKE: result(AGENT_INTAKE, agent_contact),
+        SHOP_WORKSPACE_INTAKE: result(SHOP_WORKSPACE_INTAKE, agent_contact),
+        PLANT_WORKSPACE_INTAKE: result(PLANT_WORKSPACE_INTAKE, agent_contact),
         f"{BASE}privacy/": result(f"{BASE}privacy/", privacy),
         f"{BASE}api/contact-submissions/status": result(
             f"{BASE}api/contact-submissions/status", contact_status
@@ -215,10 +224,10 @@ class PortfolioHealthTest(unittest.TestCase):
         with patch.object(checker, "fetch", side_effect=fake_fetch):
             return checker.run(BASE, WWW, APP, DEMO, POS, CONSOLE, timeout=1, attempts=1)
 
-    def test_healthy_portfolio_passes_all_twenty_two_checks(self):
+    def test_healthy_portfolio_passes_all_twenty_four_checks(self):
         report = self.run_report(healthy_responses())
         self.assertEqual(report["status"], "ready")
-        self.assertEqual(report["checks"], 22)
+        self.assertEqual(report["checks"], 24)
         self.assertEqual(report["failures"], [])
 
     def test_shop_pos_health_rejects_internal_fields(self):
@@ -347,6 +356,17 @@ class PortfolioHealthTest(unittest.TestCase):
         self.assertEqual(report["status"], "error")
         failure = next(item for item in report["failures"] if item["kind"] == "agent_intake_page")
         self.assertIn('name="workflow"', failure["unexpected"])
+
+    def test_missing_workspace_context_fails_product_intake(self):
+        responses = healthy_responses()
+        responses[SHOP_WORKSPACE_INTAKE] = result(
+            SHOP_WORKSPACE_INTAKE,
+            responses[SHOP_WORKSPACE_INTAKE].body.decode().replace("idleSubmitLabel='Request workspace'", ""),
+        )
+        report = self.run_report(responses)
+        self.assertEqual(report["status"], "error")
+        failure = next(item for item in report["failures"] if item["kind"] == "shop_workspace_intake_page")
+        self.assertIn("idleSubmitLabel='Request workspace'", failure["missing"])
 
     def test_missing_plant_link_fails_public_page(self):
         responses = healthy_responses()


### PR DESCRIPTION
## What changed
- update the AI intake assertion to the current implementation
- add read-only live checks for Shop and Plant workspace-intake routes
- align the Console page contract with the current Operations command center identity
- expand deterministic coverage from 22 to 24 production checks

## Verification
- Python compile
- 22/22 deterministic monitor tests
- fresh live run: 24 checks, 0 failures

This change is monitor-only. It performs bounded GET requests and protected unauthenticated probes; it does not submit forms or write customer data.