### PR TITLE
Monitor the protected Shop lead intake

### DIFF
--- a/tools/check_public_live_health.py
+++ b/tools/check_public_live_health.py
@@ -15,9 +15,10 @@ from typing import Any
 from urllib.parse import urljoin, urlparse
 
 
-USER_AGENT = "supermega-portfolio-live-health/4.5"
+USER_AGENT = "supermega-portfolio-live-health/4.6"
 DEMO_MAX_BYTES = 256 * 1024
 POS_MAX_BYTES = 256 * 1024
+PIPELINE_MAX_BYTES = 8 * 1024
 
 
 class NoRedirect(urllib.request.HTTPRedirectHandler):
@@ -452,6 +453,112 @@ def run(
     results.append(pos_diagnostics_result)
     if pos_diagnostics_response.status != 401 or pos_diagnostics_mismatches:
         failures.append(pos_diagnostics_result)
+
+    pipeline_url = urljoin(pos_url, "api/pipeline-leads")
+    pipeline_response = fetch(
+        pipeline_url,
+        timeout=timeout,
+        attempts=attempts,
+        follow_redirects=False,
+        max_bytes=PIPELINE_MAX_BYTES,
+    )
+    try:
+        pipeline_body = pipeline_response.body.decode("utf-8")
+        pipeline_payload = json.loads(pipeline_body)
+        if not isinstance(pipeline_payload, dict):
+            pipeline_payload = {}
+        pipeline_encoding_error = False
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        pipeline_body = ""
+        pipeline_payload = {}
+        pipeline_encoding_error = True
+
+    expected_pipeline = {
+        "configured": True,
+        "dataBoundary": "Stores Shop prospect metadata only; do not submit customer sales, payment payloads, or private shop data.",
+        "detail": "Shop lead intake is ready.",
+        "mode": "shop-lead-intake",
+        "ok": True,
+        "protectedRead": True,
+        "store.provider": "vercel-blob-private",
+        "writeProtected": True,
+        "authorized": False,
+        "leads": [],
+    }
+    pipeline_mismatches = {
+        path: {"expected": expected, "actual": nested_value(pipeline_payload, path)}
+        for path, expected in expected_pipeline.items()
+        if nested_value(pipeline_payload, path) != expected
+    }
+    expected_pipeline_keys = {
+        "authorized",
+        "checkedAt",
+        "configured",
+        "dataBoundary",
+        "detail",
+        "leadCount",
+        "leads",
+        "mode",
+        "ok",
+        "protectedRead",
+        "store",
+        "updatedAt",
+        "writeProtected",
+    }
+    if set(pipeline_payload) != expected_pipeline_keys:
+        pipeline_mismatches["payload_keys"] = {
+            "expected": sorted(expected_pipeline_keys),
+            "actual": sorted(pipeline_payload),
+        }
+    pipeline_store = pipeline_payload.get("store")
+    if not isinstance(pipeline_store, dict) or set(pipeline_store) != {"provider"}:
+        pipeline_mismatches["store_keys"] = {
+            "expected": ["provider"],
+            "actual": sorted(pipeline_store)
+            if isinstance(pipeline_store, dict)
+            else type(pipeline_store).__name__,
+        }
+    lead_count = pipeline_payload.get("leadCount")
+    if isinstance(lead_count, bool) or not isinstance(lead_count, int) or lead_count < 0:
+        pipeline_mismatches["leadCount"] = {
+            "expected": "non-negative integer",
+            "actual": lead_count,
+        }
+    for field in ("checkedAt", "updatedAt"):
+        value = pipeline_payload.get(field)
+        if not isinstance(value, str) or not value:
+            pipeline_mismatches[field] = {"expected": "non-empty timestamp", "actual": value}
+    pipeline_unexpected = [
+        token
+        for token in ("DeskPOS", "MegaOS", "deskpos-pipeline", "pathname")
+        if token in pipeline_body
+    ]
+    pipeline_cache_control = header_value(pipeline_response.headers, "cache-control")
+    if pipeline_cache_control.lower() != "no-store":
+        pipeline_mismatches["cache-control"] = {
+            "expected": "no-store",
+            "actual": pipeline_cache_control,
+        }
+    pipeline_result = {
+        "kind": "shop_pipeline_guard",
+        "url": pipeline_url,
+        "status": pipeline_response.status,
+        "bytes": len(pipeline_response.body),
+        "response_url_changed": pipeline_response.url != pipeline_url,
+        "encoding_error": pipeline_encoding_error,
+        "mismatches": pipeline_mismatches,
+        "unexpected": pipeline_unexpected,
+    }
+    results.append(pipeline_result)
+    if (
+        pipeline_response.status != 200
+        or pipeline_response.url != pipeline_url
+        or len(pipeline_response.body) > PIPELINE_MAX_BYTES
+        or pipeline_encoding_error
+        or pipeline_mismatches
+        or pipeline_unexpected
+    ):
+        failures.append(pipeline_result)
 
     for path in ("products/", "pricing/", "ai-agents/", "offers/"):
         url = urljoin(base_url, path)

--- a/tools/test_public_live_health.py
+++ b/tools/test_public_live_health.py
@@ -192,6 +192,25 @@ def healthy_responses() -> dict[str, checker.HttpResult]:
             {"error": "operator_auth_required"},
             status=401,
         ),
+        f"{POS}api/pipeline-leads": result(
+            f"{POS}api/pipeline-leads",
+            {
+                "checkedAt": "2026-07-14T16:27:03.781Z",
+                "configured": True,
+                "dataBoundary": "Stores Shop prospect metadata only; do not submit customer sales, payment payloads, or private shop data.",
+                "detail": "Shop lead intake is ready.",
+                "leadCount": 1,
+                "mode": "shop-lead-intake",
+                "ok": True,
+                "protectedRead": True,
+                "store": {"provider": "vercel-blob-private"},
+                "updatedAt": "2026-06-29T07:50:10.273Z",
+                "writeProtected": True,
+                "authorized": False,
+                "leads": [],
+            },
+            headers={"Cache-Control": "no-store"},
+        ),
         DEMO: result(
             DEMO,
             demo,
@@ -224,10 +243,10 @@ class PortfolioHealthTest(unittest.TestCase):
         with patch.object(checker, "fetch", side_effect=fake_fetch):
             return checker.run(BASE, WWW, APP, DEMO, POS, CONSOLE, timeout=1, attempts=1)
 
-    def test_healthy_portfolio_passes_all_twenty_four_checks(self):
+    def test_healthy_portfolio_passes_all_twenty_five_checks(self):
         report = self.run_report(healthy_responses())
         self.assertEqual(report["status"], "ready")
-        self.assertEqual(report["checks"], 24)
+        self.assertEqual(report["checks"], 25)
         self.assertEqual(report["failures"], [])
 
     def test_shop_pos_health_rejects_internal_fields(self):
@@ -255,6 +274,64 @@ class PortfolioHealthTest(unittest.TestCase):
         )
         self.assertEqual(failure["status"], 200)
         self.assertIn("payload_keys", failure["mismatches"])
+
+    def test_shop_pipeline_guard_requires_protected_empty_public_posture(self):
+        pipeline_url = f"{POS}api/pipeline-leads"
+        for field, value in (
+            ("writeProtected", False),
+            ("protectedRead", False),
+            ("authorized", True),
+            ("leads", [{"id": "must-not-be-public"}]),
+        ):
+            with self.subTest(field=field):
+                responses = healthy_responses()
+                payload = json.loads(responses[pipeline_url].body)
+                payload[field] = value
+                responses[pipeline_url] = result(
+                    pipeline_url,
+                    payload,
+                    headers={"Cache-Control": "no-store"},
+                )
+                report = self.run_report(responses)
+                self.assertEqual(report["status"], "error")
+                failure = next(
+                    item for item in report["failures"] if item["kind"] == "shop_pipeline_guard"
+                )
+                self.assertIn(field, failure["mismatches"])
+
+    def test_shop_pipeline_guard_rejects_internal_path_and_retired_identity(self):
+        responses = healthy_responses()
+        pipeline_url = f"{POS}api/pipeline-leads"
+        payload = json.loads(responses[pipeline_url].body)
+        payload["store"]["pathname"] = "deskpos-pipeline/leads/latest.json"
+        payload["dataBoundary"] = "Stores DeskPOS prospect metadata."
+        responses[pipeline_url] = result(
+            pipeline_url,
+            payload,
+            headers={"Cache-Control": "no-store"},
+        )
+        report = self.run_report(responses)
+        self.assertEqual(report["status"], "error")
+        failure = next(item for item in report["failures"] if item["kind"] == "shop_pipeline_guard")
+        self.assertIn("store_keys", failure["mismatches"])
+        self.assertIn("DeskPOS", failure["unexpected"])
+        self.assertIn("deskpos-pipeline", failure["unexpected"])
+        self.assertIn("pathname", failure["unexpected"])
+
+    def test_shop_pipeline_guard_rejects_cacheable_or_oversized_responses(self):
+        pipeline_url = f"{POS}api/pipeline-leads"
+        for response in (
+            result(pipeline_url, json.loads(healthy_responses()[pipeline_url].body)),
+            result(pipeline_url, "x" * (checker.PIPELINE_MAX_BYTES + 1)),
+        ):
+            with self.subTest(bytes=len(response.body)):
+                responses = healthy_responses()
+                responses[pipeline_url] = response
+                report = self.run_report(responses)
+                self.assertEqual(report["status"], "error")
+                self.assertTrue(
+                    any(item["kind"] == "shop_pipeline_guard" for item in report["failures"])
+                )
 
     def test_retired_identity_or_legacy_host_fails_shop_pos_page(self):
         for token in ("MegaOS", "<title>DeskPOS", "spa-desk-pilot.vercel.app"):


### PR DESCRIPTION
## What changed
- add a GET-only production check for the Shop lead intake endpoint
- require configured private storage plus protected reads and writes
- require zero public leads, no internal pathname, no retired customer naming, and `Cache-Control: no-store`
- bound the response to 8 KB and reject redirects or malformed JSON

## Verification
- `python -m py_compile tools/check_public_live_health.py tools/test_public_live_health.py`
- `python -m unittest -v tools/test_public_live_health.py` (25/25)
- live read-only sweep (25 checks / 0 failures)
- `git diff --check`

No form or endpoint POST was sent and no production data was changed.