### PR TITLE
Retry Shop lead delivery safely

### DIFF
--- a/api/contact-submissions.js
+++ b/api/contact-submissions.js
@@ -1020,6 +1020,30 @@ function deskposPipelinePayload(record) {
   }
 }
 
+const SHOP_PIPELINE_MAX_ATTEMPTS = 2
+const SHOP_PIPELINE_ATTEMPT_TIMEOUT_MS = 2400
+const SHOP_PIPELINE_RETRY_DELAY_MS = 100
+
+function isRetryableShopPipelineStatus(status) {
+  return status === 408 || status === 425 || status === 429 || status >= 500
+}
+
+function isValidShopPipelineResponse(body) {
+  return Boolean(
+    body
+    && body.ok === true
+    && body.accepted === true
+    && typeof body.duplicate === 'boolean'
+    && Number.isInteger(body.leadCount)
+    && body.leadCount >= 0
+    && text(body.lead?.id)
+  )
+}
+
+function shopPipelineRetryDelay() {
+  return new Promise((resolve) => setTimeout(resolve, SHOP_PIPELINE_RETRY_DELAY_MS))
+}
+
 async function forwardDeskposPipeline({ record }) {
   if (!isDeskposLead(record)) {
     return { status: 'skipped', reason: 'not_shop_lead' }
@@ -1032,30 +1056,47 @@ async function forwardDeskposPipeline({ record }) {
   if (!ingestToken) {
     return { status: 'skipped', reason: 'shop_pipeline_not_configured' }
   }
-  try {
-    const response = await fetch(target, {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${ingestToken}`,
-        'content-type': 'application/json',
-      },
-      signal: AbortSignal.timeout(5000),
-      body: JSON.stringify(deskposPipelinePayload(record)),
-    })
-    const body = await response.json().catch(() => ({}))
-    if (!response.ok || body.accepted === false) {
-      return { status: 'error', reason: `shop_${response.status}`, target }
+  const requestBody = JSON.stringify(deskposPipelinePayload(record))
+  let lastError = null
+  for (let attempt = 1; attempt <= SHOP_PIPELINE_MAX_ATTEMPTS; attempt += 1) {
+    try {
+      const response = await fetch(target, {
+        method: 'POST',
+        redirect: 'error',
+        headers: {
+          Authorization: `Bearer ${ingestToken}`,
+          'content-type': 'application/json',
+        },
+        signal: AbortSignal.timeout(SHOP_PIPELINE_ATTEMPT_TIMEOUT_MS),
+        body: requestBody,
+      })
+      const body = await response.json().catch(() => ({}))
+      if (response.ok && isValidShopPipelineResponse(body)) {
+        return {
+          status: 'ready',
+          target,
+          duplicate: body.duplicate,
+          lead_count: body.leadCount,
+          shop_lead_id: text(body.lead.id),
+        }
+      }
+      if (response.ok && (body.accepted === false || body.ok === false)) {
+        return { status: 'error', reason: 'shop_rejected', target }
+      }
+      lastError = response.ok ? 'shop_invalid_response' : `shop_${response.status}`
+      const retryable = response.ok || isRetryableShopPipelineStatus(response.status)
+      if (!retryable || attempt === SHOP_PIPELINE_MAX_ATTEMPTS) {
+        return { status: 'error', reason: lastError, target }
+      }
+    } catch (error) {
+      lastError = error?.name === 'TimeoutError' ? 'shop_timeout' : 'shop_forward_failed'
+      if (attempt === SHOP_PIPELINE_MAX_ATTEMPTS) {
+        return { status: 'error', reason: lastError, target }
+      }
     }
-    return {
-      status: 'ready',
-      target,
-      duplicate: Boolean(body.duplicate),
-      lead_count: body.leadCount ?? null,
-      shop_lead_id: body.lead?.id || null,
-    }
-  } catch (error) {
-    return { status: 'error', reason: text(error?.message) || 'shop_forward_failed', target }
+    await shopPipelineRetryDelay()
   }
+  return { status: 'error', reason: lastError || 'shop_forward_failed', target }
 }
 
 function fallbackQueueStatus() {

--- a/tools/verify_contact_ops_intake_handoff.mjs
+++ b/tools/verify_contact_ops_intake_handoff.mjs
@@ -43,6 +43,13 @@ const calls = []
 const secret = 'contract-test-secret'
 const opsKey = 'contract-test-ops-key'
 const shopIngestToken = 'contract-test-shop-ingest-token'
+const shopSuccessBody = {
+  ok: true,
+  accepted: true,
+  duplicate: false,
+  leadCount: 1,
+  lead: { id: 'SHOP-LEAD-1' },
+}
 const contactSource = readFileSync(new URL('../api/contact-submissions.js', import.meta.url), 'utf8')
 const handlerSource = contactSource.slice(
   contactSource.indexOf('async function handler'),
@@ -99,13 +106,13 @@ try {
   process.env.RESEND_API_KEY = 'contract-test-resend-key'
   delete process.env.SUPERMEGA_OPS_INTAKE_URL
   delete process.env.DESKPOS_PIPELINE_URL
-  globalThis.fetch = async (url, options) => {
+  const contractFetch = async (url, options) => {
     calls.push({ url, options })
     if (url === 'https://pos.supermega.dev/api/pipeline-leads') {
       return {
         ok: true,
         status: 200,
-        json: async () => ({ accepted: true, duplicate: false, leadCount: 1, lead: { id: 'SHOP-LEAD-1' } }),
+        json: async () => shopSuccessBody,
       }
     }
     return {
@@ -114,6 +121,7 @@ try {
       json: async () => ({ ok: true, lead_id: 'OPS-LEAD-1', fit_score: 84 }),
     }
   }
+  globalThis.fetch = contractFetch
 
   assert.deepEqual(opsIntakeStatus(), {
     status: 'ready',
@@ -278,6 +286,7 @@ try {
   assert.equal(calls.length, 1)
   assert.equal(calls[0].url, 'https://pos.supermega.dev/api/pipeline-leads')
   assert.equal(calls[0].options.method, 'POST')
+  assert.equal(calls[0].options.redirect, 'error')
   assert.equal(calls[0].options.headers.Authorization, `Bearer ${shopIngestToken}`)
   assert.deepEqual(JSON.parse(calls[0].options.body), shopPayload)
   assert.deepEqual(shopForward, {
@@ -293,6 +302,79 @@ try {
     reason: 'not_shop_lead',
   })
   assert.equal(calls.length, 1)
+
+  const retryCalls = []
+  globalThis.fetch = async (url, options) => {
+    retryCalls.push({ url, options })
+    if (retryCalls.length === 1) {
+      return { ok: false, status: 503, json: async () => ({ ok: false }) }
+    }
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({ ...shopSuccessBody, duplicate: true }),
+    }
+  }
+  assert.deepEqual(await forwardDeskposPipeline({ record: shopRecord }), {
+    status: 'ready',
+    target: 'https://pos.supermega.dev/api/pipeline-leads',
+    duplicate: true,
+    lead_count: 1,
+    shop_lead_id: 'SHOP-LEAD-1',
+  })
+  assert.equal(retryCalls.length, 2)
+  for (const call of retryCalls) {
+    assert.equal(call.url, 'https://pos.supermega.dev/api/pipeline-leads')
+    assert.equal(call.options.redirect, 'error')
+    assert.equal(call.options.headers.Authorization, `Bearer ${shopIngestToken}`)
+    assert.deepEqual(JSON.parse(call.options.body), shopPayload)
+  }
+
+  const networkCalls = []
+  globalThis.fetch = async (url, options) => {
+    networkCalls.push({ url, options })
+    if (networkCalls.length === 1) throw new TypeError('temporary network failure')
+    return { ok: true, status: 200, json: async () => shopSuccessBody }
+  }
+  assert.equal((await forwardDeskposPipeline({ record: shopRecord })).status, 'ready')
+  assert.equal(networkCalls.length, 2)
+
+  const malformedCalls = []
+  globalThis.fetch = async (url, options) => {
+    malformedCalls.push({ url, options })
+    return { ok: true, status: 200, json: async () => ({ accepted: true }) }
+  }
+  assert.deepEqual(await forwardDeskposPipeline({ record: shopRecord }), {
+    status: 'error',
+    reason: 'shop_invalid_response',
+    target: 'https://pos.supermega.dev/api/pipeline-leads',
+  })
+  assert.equal(malformedCalls.length, 2)
+
+  const rejectedCalls = []
+  globalThis.fetch = async (url, options) => {
+    rejectedCalls.push({ url, options })
+    return { ok: true, status: 200, json: async () => ({ ok: true, accepted: false }) }
+  }
+  assert.deepEqual(await forwardDeskposPipeline({ record: shopRecord }), {
+    status: 'error',
+    reason: 'shop_rejected',
+    target: 'https://pos.supermega.dev/api/pipeline-leads',
+  })
+  assert.equal(rejectedCalls.length, 1)
+
+  const unauthorizedCalls = []
+  globalThis.fetch = async (url, options) => {
+    unauthorizedCalls.push({ url, options })
+    return { ok: false, status: 401, json: async () => ({ error: 'Unauthorized.' }) }
+  }
+  assert.deepEqual(await forwardDeskposPipeline({ record: shopRecord }), {
+    status: 'error',
+    reason: 'shop_401',
+    target: 'https://pos.supermega.dev/api/pipeline-leads',
+  })
+  assert.equal(unauthorizedCalls.length, 1)
+  globalThis.fetch = contractFetch
 
   const result = await forwardOpsIntake({
     record: {


### PR DESCRIPTION
## What changed
- retry the authenticated Shop queue handoff once on timeout, network failure, malformed 2xx, 408/425/429, or 5xx
- keep the total retry envelope near the existing five-second timeout
- never retry explicit receiver rejection, 4xx authentication/configuration errors, or unrelated requests
- require the receiver's exact success body before reporting delivery ready
- disable redirect following so the bearer stays on the allowlisted endpoint

## Verification
- `npm run public:prebuilt`
- 30 files / 0.37 MB / 3 functions
- public front-door, visual, intake, and integrated handoff contracts
- 66 connectors / 923 adversarial calls / 0 violations
- deterministic success, 503 recovery, network recovery, malformed body, explicit rejection, and 401 cases

No form or live endpoint POST was sent and no production lead was created.