### PR TITLE
Retry AI Agent Solutions intake safely

### DIFF
--- a/api/contact-submissions.js
+++ b/api/contact-submissions.js
@@ -2166,6 +2166,34 @@ function opsIntakeStatus() {
   }
 }
 
+const OPS_INTAKE_MAX_ATTEMPTS = 2
+const OPS_INTAKE_ATTEMPT_TIMEOUT_MS = 3800
+const OPS_INTAKE_RETRY_DELAY_MS = 100
+
+function isRetryableOpsIntakeStatus(status) {
+  return status === 408 || status === 425 || status === 429 || status >= 500
+}
+
+function isValidOpsIntakeResponse(body) {
+  return Boolean(
+    body
+    && body.ok === true
+    && body.accepted === true
+    && typeof body.duplicate === 'boolean'
+    && typeof body.lead_id === 'string'
+    && text(body.lead_id)
+    && text(body.lead_id).length <= 120
+    && typeof body.fit_score === 'number'
+    && Number.isFinite(body.fit_score)
+    && body.fit_score >= 0
+    && body.fit_score <= 100
+  )
+}
+
+function opsIntakeRetryDelay() {
+  return new Promise((resolve) => setTimeout(resolve, OPS_INTAKE_RETRY_DELAY_MS))
+}
+
 function publicContactStatus() {
   const ready = (
     leadLedgerStatus() === 'configured' &&
@@ -2227,43 +2255,60 @@ async function forwardOpsIntake({ record }) {
     record.data || '',
   ].filter(Boolean).join('\n'), 2400)
 
-  try {
-    const response = await fetch(target, {
-      method: 'POST',
-      headers: {
-        'content-type': 'application/json',
-        Authorization: `Bearer ${intakeSecret}`,
-      },
-      signal: AbortSignal.timeout(8000),
-      body: JSON.stringify({
-        secret: intakeSecret,
-        source: 'website',
-        external_id: record.lead_id,
-        name: record.name,
-        email: record.email,
-        phone: record.phone,
-        company: record.company,
-        business_type: record.template_source_category || record.product_area || record.requested_package || 'inbound',
-        template_id: record.template_id,
-        starter_kit_url: record.starter_kit_url,
-        price_hint: record.price_hint,
-        workflow,
-      }),
-    })
-    const body = await response.json().catch(() => ({}))
-    if (!response.ok || body.ok === false) {
-      return { status: 'error', reason: `ops_intake_${response.status}`, target }
+  const requestBody = JSON.stringify({
+    secret: intakeSecret,
+    source: 'website',
+    external_id: record.lead_id,
+    name: record.name,
+    email: record.email,
+    phone: record.phone,
+    company: record.company,
+    business_type: record.template_source_category || record.product_area || record.requested_package || 'inbound',
+    template_id: record.template_id,
+    starter_kit_url: record.starter_kit_url,
+    price_hint: record.price_hint,
+    workflow,
+  })
+  let lastError = null
+  for (let attempt = 1; attempt <= OPS_INTAKE_MAX_ATTEMPTS; attempt += 1) {
+    try {
+      const response = await fetch(target, {
+        method: 'POST',
+        redirect: 'error',
+        headers: {
+          'content-type': 'application/json',
+          Authorization: `Bearer ${intakeSecret}`,
+        },
+        signal: AbortSignal.timeout(OPS_INTAKE_ATTEMPT_TIMEOUT_MS),
+        body: requestBody,
+      })
+      const body = await response.json().catch(() => ({}))
+      if (response.ok && isValidOpsIntakeResponse(body)) {
+        return {
+          status: 'ready',
+          target,
+          lead_id: text(body.lead_id),
+          duplicate: body.duplicate,
+          fit_score: body.fit_score,
+        }
+      }
+      if (response.ok && (body.accepted === false || body.ok === false)) {
+        return { status: 'error', reason: 'ops_intake_rejected', target }
+      }
+      lastError = response.ok ? 'ops_intake_invalid_response' : `ops_intake_${response.status}`
+      const retryable = response.ok || isRetryableOpsIntakeStatus(response.status)
+      if (!retryable || attempt === OPS_INTAKE_MAX_ATTEMPTS) {
+        return { status: 'error', reason: lastError, target }
+      }
+    } catch (error) {
+      lastError = error?.name === 'TimeoutError' ? 'ops_intake_timeout' : 'ops_intake_failed'
+      if (attempt === OPS_INTAKE_MAX_ATTEMPTS) {
+        return { status: 'error', reason: lastError, target }
+      }
     }
-    return {
-      status: 'ready',
-      target,
-      lead_id: text(body.lead_id) || null,
-      duplicate: body.duplicate === true,
-      fit_score: Number.isFinite(Number(body.fit_score)) ? Number(body.fit_score) : null,
-    }
-  } catch (error) {
-    return { status: 'error', reason: text(error?.message) || 'ops_intake_failed', target }
+    await opsIntakeRetryDelay()
   }
+  return { status: 'error', reason: lastError || 'ops_intake_failed', target }
 }
 
 // Build the concise CEO lead-alert text, then push it via the shared Telegram helper.

--- a/tools/verify_contact_ops_intake_handoff.mjs
+++ b/tools/verify_contact_ops_intake_handoff.mjs
@@ -50,6 +50,13 @@ const shopSuccessBody = {
   leadCount: 1,
   lead: { id: 'SHOP-LEAD-1' },
 }
+const opsSuccessBody = {
+  ok: true,
+  accepted: true,
+  duplicate: false,
+  lead_id: 'OPS-LEAD-1',
+  fit_score: 84,
+}
 const contactSource = readFileSync(new URL('../api/contact-submissions.js', import.meta.url), 'utf8')
 const handlerSource = contactSource.slice(
   contactSource.indexOf('async function handler'),
@@ -118,7 +125,7 @@ try {
     return {
       ok: true,
       status: 200,
-      json: async () => ({ ok: true, lead_id: 'OPS-LEAD-1', fit_score: 84 }),
+      json: async () => opsSuccessBody,
     }
   }
   globalThis.fetch = contractFetch
@@ -393,6 +400,7 @@ try {
   const opsCall = calls[1]
   assert.equal(opsCall.url, 'https://supermega-machine.vercel.app/api/intake')
   assert.equal(opsCall.options.method, 'POST')
+  assert.equal(opsCall.options.redirect, 'error')
   assert.equal(opsCall.options.headers.Authorization, `Bearer ${secret}`)
   const payload = JSON.parse(opsCall.options.body)
   assert.equal(payload.secret, secret)
@@ -407,6 +415,94 @@ try {
     fit_score: 84,
   })
   assert.equal(JSON.stringify(result).includes(secret), false)
+
+  const opsRetryCalls = []
+  globalThis.fetch = async (url, options) => {
+    opsRetryCalls.push({ url, options })
+    if (opsRetryCalls.length === 1) {
+      return { ok: false, status: 503, json: async () => ({ ok: false }) }
+    }
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({ ...opsSuccessBody, duplicate: true }),
+    }
+  }
+  assert.deepEqual(await forwardOpsIntake({ record: {
+    lead_id: 'LEAD-PUBLIC-1',
+    name: 'Test Buyer',
+    email: 'buyer@example.com',
+    goal: 'Replace a manual daily reconciliation task.',
+  } }), {
+    status: 'ready',
+    target: 'https://supermega-machine.vercel.app/api/intake',
+    lead_id: 'OPS-LEAD-1',
+    duplicate: true,
+    fit_score: 84,
+  })
+  assert.equal(opsRetryCalls.length, 2)
+  assert.equal(opsRetryCalls[0].options.body, opsRetryCalls[1].options.body)
+  for (const call of opsRetryCalls) {
+    assert.equal(call.url, 'https://supermega-machine.vercel.app/api/intake')
+    assert.equal(call.options.redirect, 'error')
+    assert.equal(call.options.headers.Authorization, `Bearer ${secret}`)
+    assert.equal(JSON.parse(call.options.body).external_id, 'LEAD-PUBLIC-1')
+  }
+
+  const opsNetworkCalls = []
+  globalThis.fetch = async (url, options) => {
+    opsNetworkCalls.push({ url, options })
+    if (opsNetworkCalls.length === 1) throw new TypeError('temporary network failure')
+    return { ok: true, status: 200, json: async () => opsSuccessBody }
+  }
+  assert.equal((await forwardOpsIntake({ record: { lead_id: 'LEAD-NETWORK-1', name: 'Network Retry' } })).status, 'ready')
+  assert.equal(opsNetworkCalls.length, 2)
+
+  const opsTimeoutCalls = []
+  globalThis.fetch = async (url, options) => {
+    opsTimeoutCalls.push({ url, options })
+    if (opsTimeoutCalls.length === 1) throw Object.assign(new Error('request expired'), { name: 'TimeoutError' })
+    return { ok: true, status: 200, json: async () => opsSuccessBody }
+  }
+  assert.equal((await forwardOpsIntake({ record: { lead_id: 'LEAD-TIMEOUT-1', name: 'Timeout Retry' } })).status, 'ready')
+  assert.equal(opsTimeoutCalls.length, 2)
+
+  const opsMalformedCalls = []
+  globalThis.fetch = async (url, options) => {
+    opsMalformedCalls.push({ url, options })
+    return { ok: true, status: 200, json: async () => ({ ok: true, accepted: true }) }
+  }
+  assert.deepEqual(await forwardOpsIntake({ record: { lead_id: 'LEAD-MALFORMED-1', name: 'Malformed Response' } }), {
+    status: 'error',
+    reason: 'ops_intake_invalid_response',
+    target: 'https://supermega-machine.vercel.app/api/intake',
+  })
+  assert.equal(opsMalformedCalls.length, 2)
+
+  const opsRejectedCalls = []
+  globalThis.fetch = async (url, options) => {
+    opsRejectedCalls.push({ url, options })
+    return { ok: true, status: 200, json: async () => ({ ok: true, accepted: false }) }
+  }
+  assert.deepEqual(await forwardOpsIntake({ record: { lead_id: 'LEAD-REJECTED-1', name: 'Rejected Response' } }), {
+    status: 'error',
+    reason: 'ops_intake_rejected',
+    target: 'https://supermega-machine.vercel.app/api/intake',
+  })
+  assert.equal(opsRejectedCalls.length, 1)
+
+  const opsUnauthorizedCalls = []
+  globalThis.fetch = async (url, options) => {
+    opsUnauthorizedCalls.push({ url, options })
+    return { ok: false, status: 401, json: async () => ({ ok: false }) }
+  }
+  assert.deepEqual(await forwardOpsIntake({ record: { lead_id: 'LEAD-UNAUTHORIZED-1', name: 'Unauthorized Response' } }), {
+    status: 'error',
+    reason: 'ops_intake_401',
+    target: 'https://supermega-machine.vercel.app/api/intake',
+  })
+  assert.equal(opsUnauthorizedCalls.length, 1)
+  globalThis.fetch = contractFetch
 
   process.env.SUPERMEGA_OPS_INTAKE_URL = 'https://supermega-machine.vercel.app.evil.example/api/intake'
   const unsafe = await forwardOpsIntake({ record: {} })


### PR DESCRIPTION
## What changed
- make at most two AI Agent Solutions intake attempts within the prior eight-second budget
- reuse the exact body and external ID on every attempt
- disable redirects so the intake credential cannot leave the allowlisted endpoint
- accept only the live Machine ok/accepted/duplicate/lead/fit contract
- retry transient or ambiguous outcomes; stop on explicit rejection and non-retryable 4xx

## Verification
- complete public prebuilt suite: 30 files / 0.37 MB / 3 functions
- public front-door, visual, agent-intake, and Ops handoff contracts
- 66 connectors / 923 adversarial calls / 0 violations
- deterministic success, 503, network, timeout, malformed, rejection, and 401 cases
- syntax and git diff checks

## Safety
No live intake POST or form submission was sent. No lead, account, customer record, model/provider call, payment, price, domain, or alias changed.