### PR TITLE
site: fit current product preview into first viewport

### DIFF
--- a/tools/create_public_vercel_output.mjs
+++ b/tools/create_public_vercel_output.mjs
@@ -497,7 +497,7 @@ const homeHtml = documentHtml({
           <h1 id="portfolio-heading">Operational software, built to fit.</h1>
         </div>
         <div class="hero-side">
-          <p><strong class="hero-lead">Less chasing. More running.</strong> Start with working Shop or Plant software. If your work still lives in spreadsheets, messages, and handoffs, SuperMega shapes one useful path around the real operation and verifies it before handover.</p>
+          <p><strong class="hero-lead">Less chasing. More running.</strong> Open a working Shop or Plant workspace in one click. Run one real workflow, then keep the private workspace when your team is ready. If the standard path still does not fit, SuperMega shapes one useful route around the real operation and verifies it before handover.</p>
           <div class="hero-actions">
             <a class="btn primary" data-preview-open href="https://app.supermega.dev/?demo=shop">Try Shop live</a>
             <a class="btn secondary" href="/contact/">Talk to us</a>
@@ -521,7 +521,7 @@ const homeHtml = documentHtml({
   <section class="entry-section page-frame" id="workspaces" aria-labelledby="workspaces-heading">
     <div class="section-intro">
       <div><div class="eyebrow">Two working systems</div><h2 id="workspaces-heading">Start close to the real work.</h2></div>
-      <p>Open a live path first. Keep the private workspace when it proves useful to the people doing the work.</p>
+      <p>See the workflow before you commit. Keep the private workspace when it proves useful to the people doing the work.</p>
     </div>
     <div class="proof-strip" aria-label="How SuperMega starts">
       <div class="proof-item"><span>01 / WORKING</span><strong>Use working screens</strong><p>Shop and Plant demos open without an account. Explore one current workflow before you choose a path.</p></div>
@@ -538,7 +538,7 @@ const homeHtml = documentHtml({
     <div class="brief-inner page-frame">
       <div class="brief-intro">
         <div><div class="eyebrow">Beyond the standard</div><h2 id="brief-heading">Tell us where the workflow breaks.</h2></div>
-        <p>If one repeatable task depends on scattered files, repeated decisions, or awkward handoffs, send the real example. We will reply with the smallest useful system to prove first.</p>
+        <p>If one repeatable task depends on scattered files, repeated decisions, or awkward handoffs, send the real example. We will show the smallest useful system to prove first.</p>
       </div>
       <div class="brief-steps">
         <div class="brief-step"><span>01 / INPUT</span><strong>Show one real workflow</strong><p>Share the example, the people involved, and the current handoffs.</p></div>

--- a/tools/create_public_vercel_output.mjs
+++ b/tools/create_public_vercel_output.mjs
@@ -325,7 +325,7 @@ const homeHtml = documentHtml({
       position: relative;
       overflow: clip;
       border-bottom: 1px solid var(--line);
-      padding: 126px 0 42px;
+      padding: 100px 0 28px;
       background: var(--surface);
       isolation: isolate;
     }
@@ -365,7 +365,7 @@ const homeHtml = documentHtml({
     .hero-preview {
       position: relative;
       width: 100%;
-      margin: 32px auto 0;
+      margin: 24px auto 0;
       border: 1px solid var(--line-strong);
       border-radius: 8px;
       overflow: hidden;
@@ -379,7 +379,7 @@ const homeHtml = documentHtml({
     .preview-switch button { min-height: 44px; border: 0; border-radius: 5px; padding: 0 14px; background: transparent; color: var(--muted); font: inherit; font-size: 13px; font-weight: 780; cursor: pointer; transition: background 160ms ease, color 160ms ease, box-shadow 160ms ease; }
     .preview-switch button[aria-pressed="true"] { background: var(--surface-strong); color: var(--ink); box-shadow: 0 4px 14px rgba(3, 8, 18, 0.1); }
     .preview-media { overflow: hidden; background: #071524; }
-    .preview-media img { display: block; width: 100%; height: auto; aspect-ratio: 10 / 3; object-fit: contain; opacity: 1; transition: opacity 180ms ease; }
+    .preview-media img { display: block; width: 100%; height: auto; aspect-ratio: 10 / 2.55; object-fit: cover; object-position: top; opacity: 1; transition: opacity 180ms ease; }
     .preview-media img.is-switching { opacity: .28; }
     .live-dot { width: 8px; height: 8px; flex: none; border-radius: 50%; background: var(--quiet); box-shadow: 0 0 0 4px color-mix(in srgb, var(--quiet) 16%, transparent); }
     .hero-status.is-ready .live-dot { background: var(--signal); box-shadow: 0 0 0 4px color-mix(in srgb, var(--signal) 16%, transparent); }
@@ -462,6 +462,7 @@ const homeHtml = documentHtml({
       .preview-toolbar { min-height: 56px; padding-left: 12px; }
       .preview-switch { grid-template-columns: repeat(2, minmax(68px, 1fr)); }
       .preview-switch button { min-height: 44px; padding-inline: 10px; }
+      .preview-media img { aspect-ratio: 10 / 3; object-fit: contain; }
       .entry-section { padding: 30px 0 74px; }
       .section-intro { margin-bottom: 34px; }
       .section-intro h2 { font-size: 36px; }


### PR DESCRIPTION
## What changed\n- reduce hero spacing and preview height so the current Shop/Plant screenshot resolves cleanly in a normal desktop viewport\n- preserve the full-width glass toolbar and the full uncropped product image on mobile\n- keep the >_ terminal mark, same-tab links, and the no-catalog front door\n\n## Verification\n- npm run public:prebuilt\n- local 1440x900 visual check: preview bottom and next-section boundary visible\n