### PR TITLE
Expose the live File Analyst offer

### DIFF
--- a/tools/create_public_vercel_output.mjs
+++ b/tools/create_public_vercel_output.mjs
@@ -266,7 +266,7 @@ const headerHtml = `${themeBootstrap}
     <nav class="nav" aria-label="Primary">
       <a class="nav-link optional-nav" href="https://app.supermega.dev/?demo=shop">Shop</a>
       <a class="nav-link optional-nav" href="https://app.supermega.dev/?demo=plant">Plant</a>
-      <a class="nav-link optional-nav" href="/contact/">Contact</a>
+      <a class="nav-link optional-nav" href="https://supermega-machine.vercel.app/workcell">File Analyst</a>
       <button class="icon-button" type="button" data-theme-toggle aria-label="Use dark mode" title="Use dark mode"><svg class="theme-sun" viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="4"></circle><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"></path></svg><svg class="theme-moon" viewBox="0 0 24 24" aria-hidden="true"><path d="M20.5 15.2A8.5 8.5 0 0 1 8.8 3.5 8.5 8.5 0 1 0 20.5 15.2Z"></path></svg></button>
       <a class="btn primary header-cta" href="/contact/">Talk to us</a>
     </nav>
@@ -276,7 +276,7 @@ ${themeToggleScript}`
 
 const footerHtml = `<div class="footer-frame"><footer>
   <span class="footer-brand"><img class="footer-mark" src="/favicon.svg" alt="" width="64" height="64" /> supermega.dev</span>
-  <span class="footer-links"><a href="https://app.supermega.dev/?demo=shop">Shop</a><a href="https://app.supermega.dev/?demo=plant">Plant</a><a href="/contact/">Contact</a><a href="/privacy/">Privacy</a></span>
+  <span class="footer-links"><a href="https://app.supermega.dev/?demo=shop">Shop</a><a href="https://app.supermega.dev/?demo=plant">Plant</a><a href="https://supermega-machine.vercel.app/workcell">File Analyst</a><a href="/contact/">Contact</a><a href="/privacy/">Privacy</a></span>
 </footer></div>`
 
 function socialMeta(title, description, url) {
@@ -317,7 +317,7 @@ const homeProductPreviewScript = `<script>(function(){var root=document.querySel
 
 const homeHtml = documentHtml({
   title: 'supermega.dev | Operational software built to fit',
-  description: 'Try Shop or Plant without an account. When the standard workflow does not fit, SuperMega builds and verifies a private workspace around the operation.',
+  description: 'Try Shop, Plant, or the browser-local File Analyst without an account. When the standard workflow does not fit, SuperMega builds and verifies a private workspace around the operation.',
   canonical: 'https://supermega.dev/',
   style: `
     .home-main { width: 100%; overflow: clip; }
@@ -521,17 +521,18 @@ const homeHtml = documentHtml({
 
   <section class="entry-section page-frame" id="workspaces" aria-labelledby="workspaces-heading">
     <div class="section-intro">
-      <div><div class="eyebrow">Two working systems</div><h2 id="workspaces-heading">Start close to the real work.</h2></div>
+      <div><div class="eyebrow">Three working paths</div><h2 id="workspaces-heading">Start close to the real work.</h2></div>
       <p>See the workflow before you commit. Keep the private workspace when it proves useful to the people doing the work.</p>
     </div>
     <div class="proof-strip" aria-label="How SuperMega starts">
-      <div class="proof-item"><span>01 / WORKING</span><strong>Use working screens</strong><p>Shop and Plant demos open without an account. Explore one current workflow before you choose a path.</p></div>
+      <div class="proof-item"><span>01 / WORKING</span><strong>Use working screens</strong><p>Shop, Plant, and File Analyst open without an account. Explore a workflow or run one file before you choose a path.</p></div>
       <div class="proof-item"><span>02 / PRIVATE</span><strong>Set up with you</strong><p>Your private workspace is configured and verified before handover. We map the people, sources, and approval points that matter.</p></div>
       <div class="proof-item"><span>03 / APPROVED</span><strong>Bring data deliberately</strong><p>Start fresh or add approved business records when ready. See a useful screen before private setup is complete.</p></div>
     </div>
     <div class="destination-list">
       <a class="destination" href="https://app.supermega.dev/?demo=shop" aria-label="Try Shop live"><span class="destination-index">01 / SHOP</span><span class="destination-copy"><strong>Shop</strong><span>Sell, track stock, manage customers, follow receivables, and keep the books together. Ring sales, keep stock honest, and close the day with less chasing.</span></span><span class="destination-arrow" aria-hidden="true">&#8594;</span></a>
       <a class="destination" href="https://app.supermega.dev/?demo=plant" aria-label="Try Plant live"><span class="destination-index">02 / PLANT</span><span class="destination-copy"><strong>Plant</strong><span>See floor state, machine history, shift events, and imports in one workspace. See what is running, capture floor history, and hand the next shift a cleaner brief.</span></span><span class="destination-arrow" aria-hidden="true">&#8594;</span></a>
+      <a class="destination" href="https://supermega-machine.vercel.app/workcell" aria-label="Run File Analyst"><span class="destination-index">03 / AI AGENT SOLUTIONS</span><span class="destination-copy"><strong>AI Agent Solutions</strong><span>Run File Analyst now: drop one CSV or JSON export, get a cleaned draft, ranked exceptions, a decision brief, and approval evidence. Source stays in this browser and is never uploaded.</span></span><span class="destination-arrow" aria-hidden="true">&#8594;</span></a>
     </div>
   </section>
 

--- a/tools/verify_public_enterprise_visual_contract.mjs
+++ b/tools/verify_public_enterprise_visual_contract.mjs
@@ -38,6 +38,7 @@ for (const [relativePath, html] of pages) {
 for (const required of [
   'https://app.supermega.dev/?demo=shop',
   'https://app.supermega.dev/?demo=plant',
+  'https://supermega-machine.vercel.app/workcell',
   '<h1 id="portfolio-heading">Operational software, built to fit.</h1>',
   'data-product-preview',
   'data-preview-open',
@@ -47,6 +48,9 @@ for (const required of [
   'Use working screens',
   'Your private workspace is configured and verified before handover.',
   'Start fresh or add approved business records when ready.',
+  '<strong>AI Agent Solutions</strong>',
+  'Run File Analyst now:',
+  'Source stays in this browser and is never uploaded.',
   '<h2 id="brief-heading">Tell us where the workflow breaks.</h2>',
   '>Describe your workflow</a>',
   '<img src="/favicon.svg" alt="" width="64" height="64" />',
@@ -55,7 +59,7 @@ for (const required of [
   if (!home.includes(required)) fail('homepage_front_door_contract_missing', { required })
 }
 
-for (const forbidden of ['<figure class="site-hero-screen"', '<img src="/site/shots/live-product-', 'Explore products', 'Custom Solutions &amp; AI Agents', 'supermega-portal-card.png', 'https://demo.supermega.dev/', 'AI Agent Solutions', 'Need a repeated task handled?', 'rotate(', 'id="products"', 'Run the operation. See what matters.', 'Open a workspace.', 'Try first. Add data later.', 'Need something different?', '[data-reveal] { opacity: 0', 'Use one account across desktop, tablet, and mobile.', 'Create a workspace only when you want to keep your work and use it across devices.', 'Create with email and password. Return with your password or an email code.']) {
+for (const forbidden of ['<figure class="site-hero-screen"', '<img src="/site/shots/live-product-', 'Explore products', 'Custom Solutions &amp; AI Agents', 'supermega-portal-card.png', 'https://demo.supermega.dev/', 'Need a repeated task handled?', 'rotate(', 'id="products"', 'Run the operation. See what matters.', 'Open a workspace.', 'Try first. Add data later.', 'Need something different?', '[data-reveal] { opacity: 0', 'Use one account across desktop, tablet, and mobile.', 'Create a workspace only when you want to keep your work and use it across devices.', 'Create with email and password. Return with your password or an email code.']) {
   if (home.includes(forbidden)) fail('homepage_stale_catalog_visual_or_copy', { forbidden })
 }
 

--- a/tools/verify_public_release_live.mjs
+++ b/tools/verify_public_release_live.mjs
@@ -5,6 +5,7 @@ const retryDelayMs = 5_000
 const endpoints = {
   home: 'https://supermega.dev/',
   www: 'https://www.supermega.dev/',
+  fileAnalyst: 'https://supermega-machine.vercel.app/workcell',
   agentIntake: 'https://supermega.dev/contact/?from=ai-agent-solution',
   health: 'https://supermega.dev/api/health',
   contactStatus: 'https://supermega.dev/api/contact-submissions/status',
@@ -45,6 +46,10 @@ function verifyHome(html, label) {
     'data-preview-open',
     'src="/live-shop-workspace.png"',
     "src:'/live-plant-workspace.png'",
+    'https://supermega-machine.vercel.app/workcell',
+    '<strong>AI Agent Solutions</strong>',
+    'Run File Analyst now:',
+    'Source stays in this browser and is never uploaded.',
     'Use working screens',
     'Your private workspace is configured and verified before handover.',
     'Start fresh or add approved business records when ready.',
@@ -54,8 +59,22 @@ function verifyHome(html, label) {
   ]) {
     assert(html.includes(required), `${label}_missing_${required.slice(0, 32)}`)
   }
-  for (const forbidden of ['MegaOS', 'DeskPOS', 'General enquiry', 'target="_blank"', 'target=_blank', 'window.open(', 'rotate(', 'Build an agent solution', '>Agent solution<', 'AI Agent Solutions', 'Need a repeated task handled?', '>SM<', 'Run the operation. See what matters.', 'Open a workspace.', 'Try first. Add data later.', 'Need something different?', '[data-reveal] { opacity: 0', 'Use one account across desktop, tablet, and mobile.', 'Create a workspace only when you want to keep your work and use it across devices.', 'Create with email and password. Return with your password or an email code.']) {
+  for (const forbidden of ['MegaOS', 'DeskPOS', 'General enquiry', 'target="_blank"', 'target=_blank', 'window.open(', 'rotate(', 'Build an agent solution', '>Agent solution<', 'Need a repeated task handled?', '>SM<', 'Run the operation. See what matters.', 'Open a workspace.', 'Try first. Add data later.', 'Need something different?', '[data-reveal] { opacity: 0', 'Use one account across desktop, tablet, and mobile.', 'Create a workspace only when you want to keep your work and use it across devices.', 'Create with email and password. Return with your password or an email code.']) {
     assert(!html.includes(forbidden), `${label}_retired_${forbidden}`)
+  }
+}
+
+function verifyFileAnalyst(html) {
+  for (const required of [
+    '<title>File Analyst | SuperMega AI Agent Solutions</title>',
+    'zero source upload',
+    'id="approveButton"',
+    'id="downloadCleanButton"',
+  ]) {
+    assert(html.includes(required), `file_analyst_missing_${required.slice(0, 32)}`)
+  }
+  for (const forbidden of ['MegaOS', 'DeskPOS']) {
+    assert(!html.includes(forbidden), `file_analyst_retired_${forbidden}`)
   }
 }
 
@@ -110,9 +129,10 @@ function verifyProtectedDiagnostics(response, body) {
 }
 
 async function verifyOnce() {
-  const [homeResponse, wwwResponse, intakeResponse, healthResponse, statusResponse, diagnosticsResponse] = await Promise.all([
+  const [homeResponse, wwwResponse, fileAnalystResponse, intakeResponse, healthResponse, statusResponse, diagnosticsResponse] = await Promise.all([
     get(endpoints.home, 'text/html'),
     get(endpoints.www, 'text/html'),
+    get(endpoints.fileAnalyst, 'text/html'),
     get(endpoints.agentIntake, 'text/html'),
     get(endpoints.health, 'application/json'),
     get(endpoints.contactStatus, 'application/json'),
@@ -130,9 +150,10 @@ async function verifyOnce() {
     }),
   ])
 
-  const [home, www, intake, health, contactStatus, protectedDiagnostics] = await Promise.all([
+  const [home, www, fileAnalyst, intake, health, contactStatus, protectedDiagnostics] = await Promise.all([
     homeResponse.text(),
     wwwResponse.text(),
+    fileAnalystResponse.text(),
     intakeResponse.text(),
     healthResponse.json(),
     statusResponse.json(),
@@ -141,6 +162,7 @@ async function verifyOnce() {
 
   verifyHome(home, 'home')
   verifyHome(www, 'www')
+  verifyFileAnalyst(fileAnalyst)
   verifyAgentIntake(intake)
   verifyHealth(health)
   verifyContactStatus(contactStatus)

--- a/tools/verify_public_vercel_output.mjs
+++ b/tools/verify_public_vercel_output.mjs
@@ -89,6 +89,7 @@ for (const required of [
   '<h1 id="portfolio-heading">Operational software, built to fit.</h1>',
   'https://app.supermega.dev/?demo=shop',
   'https://app.supermega.dev/?demo=plant',
+  'https://supermega-machine.vercel.app/workcell',
   'operational software / live',
   'class="hero-lead">Less chasing. More running.</strong>',
   '<h2 id="workspaces-heading">Start close to the real work.</h2>',
@@ -97,6 +98,7 @@ for (const required of [
   'Bring data deliberately',
   '<strong>Shop</strong>',
   '<strong>Plant</strong>',
+  '<strong>AI Agent Solutions</strong>',
   '<h2 id="brief-heading">Tell us where the workflow breaks.</h2>',
   '>Describe your workflow</a>',
   'data-product-preview',
@@ -105,7 +107,9 @@ for (const required of [
   'data-product-preview-button="plant"',
   'src="/live-shop-workspace.png"',
   "src:'/live-plant-workspace.png'",
-  'Shop and Plant demos open without an account.',
+  'Shop, Plant, and File Analyst open without an account.',
+  'Run File Analyst now:',
+  'Source stays in this browser and is never uploaded.',
   'Your private workspace is configured and verified before handover.',
   'Start fresh or add approved business records when ready.',
   'data-public-status',
@@ -117,7 +121,7 @@ for (const required of [
   if (!home.includes(required)) fail('homepage_front_door_contract_missing', { required })
 }
 
-for (const forbidden of ['https://demo.supermega.dev/', 'The intelligent workspace for daily operations.', 'Explore live demos', 'Open workspace', 'target="_blank"', 'target=_blank', 'window.open(', 'rotate(', 'data-hero-media', 'Current build', 'Build an agent solution', '>Agent solution<', 'AI Agent Solutions', 'Need a repeated task handled?', 'id="products"', 'Run the operation. See what matters.', 'Open a workspace.', 'Try first. Add data later.', 'Need something different?', '[data-reveal] { opacity: 0', 'Use one account across desktop, tablet, and mobile.', 'Create a workspace only when you want to keep your work and use it across devices.', 'Create with email and password. Return with your password or an email code.']) {
+for (const forbidden of ['https://demo.supermega.dev/', 'The intelligent workspace for daily operations.', 'Explore live demos', 'Open workspace', 'target="_blank"', 'target=_blank', 'window.open(', 'rotate(', 'data-hero-media', 'Current build', 'Build an agent solution', '>Agent solution<', 'Need a repeated task handled?', 'id="products"', 'Run the operation. See what matters.', 'Open a workspace.', 'Try first. Add data later.', 'Need something different?', '[data-reveal] { opacity: 0', 'Use one account across desktop, tablet, and mobile.', 'Create a workspace only when you want to keep your work and use it across devices.', 'Create with email and password. Return with your password or an email code.']) {
   if (home.includes(forbidden)) fail('homepage_keeps_superseded_portfolio_copy', { forbidden })
 }
 


### PR DESCRIPTION
## What changed
- expose AI Agent Solutions as a third working path on the public homepage
- link directly to the live browser-local File Analyst from navigation, offering row, and footer
- verify the public release against the live File Analyst title, privacy boundary, approval control, and download control

## Proof
- `npm run public:prebuilt`
- Microsoft Edge QA at 1440x900, 768x1024, and 390x844 in light/dark mode
- no horizontal overflow or browser errors
- same-tab handoff to `https://supermega-machine.vercel.app/workcell`
- no form submission, file upload, API request, price, DNS, or product-runtime write