### PR TITLE
Fix the File Analyst live release contract

### DIFF
--- a/tools/verify_public_release_live.mjs
+++ b/tools/verify_public_release_live.mjs
@@ -69,7 +69,7 @@ function verifyFileAnalyst(html) {
     '<title>File Analyst | SuperMega AI Agent Solutions</title>',
     'zero source upload',
     'id="approveButton"',
-    'id="downloadCleanButton"',
+    'id="downloadClean"',
   ]) {
     assert(html.includes(required), `file_analyst_missing_${required.slice(0, 32)}`)
   }


### PR DESCRIPTION
## Fix
Align the live-release contract with the verified File Analyst cleaned-CSV control id (`downloadClean`).

## Proof
- `node tools/verify_public_release_live.mjs`
- 7 GET-only endpoints passed on the first attempt
- `writes_performed: false`