### PR TITLE
Add the browser-local Payment Reconciler

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "vercel:deploy": "npm run public:prebuilt && npx vercel deploy --prebuilt -y",
     "vercel:deploy:prod": "npm run public:prebuilt && npx vercel deploy --prebuilt --prod -y",
     "public:build": "node tools/create_public_vercel_output.mjs",
-    "public:verify": "node tools/verify_public_vercel_artifact_budget.mjs && node tools/verify_public_vercel_output.mjs && node tools/verify_public_enterprise_visual_contract.mjs && node tools/verify_public_agent_intake_contract.mjs && node tools/verify_contact_ops_intake_handoff.mjs && node tools/test_connector_resilience.mjs",
+    "public:verify": "node tools/verify_public_vercel_artifact_budget.mjs && node tools/verify_payment_reconciler.mjs && node tools/verify_public_vercel_output.mjs && node tools/verify_public_enterprise_visual_contract.mjs && node tools/verify_public_agent_intake_contract.mjs && node tools/verify_contact_ops_intake_handoff.mjs && node tools/test_connector_resilience.mjs",
     "public:prebuilt": "npm run public:build && npm run public:verify",
     "public:verify:live": "node tools/verify_public_release_live.mjs",
     "_public:verify:RETIRED": "source-to-screen/workcell/intake/contact-order + operator-retainer contracts retired 2026-07-09 — they enforced the discontinued 'source-to-screen / AI Workcell' model the founder removed. Kept only artifact-budget + vercel-output structural checks.",

--- a/tools/create_public_vercel_output.mjs
+++ b/tools/create_public_vercel_output.mjs
@@ -276,7 +276,7 @@ ${themeToggleScript}`
 
 const footerHtml = `<div class="footer-frame"><footer>
   <span class="footer-brand"><img class="footer-mark" src="/favicon.svg" alt="" width="64" height="64" /> supermega.dev</span>
-  <span class="footer-links"><a href="https://app.supermega.dev/?demo=shop">Shop</a><a href="https://app.supermega.dev/?demo=plant">Plant</a><a href="https://supermega-machine.vercel.app/workcell">File Analyst</a><a href="/contact/">Contact</a><a href="/privacy/">Privacy</a></span>
+  <span class="footer-links"><a href="https://app.supermega.dev/?demo=shop">Shop</a><a href="https://app.supermega.dev/?demo=plant">Plant</a><a href="https://supermega-machine.vercel.app/workcell">File Analyst</a><a href="/reconcile/">Reconcile</a><a href="/contact/">Contact</a><a href="/privacy/">Privacy</a></span>
 </footer></div>`
 
 function socialMeta(title, description, url) {
@@ -317,7 +317,7 @@ const homeProductPreviewScript = `<script>(function(){var root=document.querySel
 
 const homeHtml = documentHtml({
   title: 'supermega.dev | Operational software built to fit',
-  description: 'Try Shop, Plant, or the browser-local File Analyst without an account. When the standard workflow does not fit, SuperMega builds and verifies a private workspace around the operation.',
+  description: 'Try Shop, Plant, File Analyst, or the browser-local Payment Reconciler without an account. When the standard workflow does not fit, SuperMega builds and verifies a private workspace around the operation.',
   canonical: 'https://supermega.dev/',
   style: `
     .home-main { width: 100%; overflow: clip; }
@@ -525,14 +525,14 @@ const homeHtml = documentHtml({
       <p>See the workflow before you commit. Keep the private workspace when it proves useful to the people doing the work.</p>
     </div>
     <div class="proof-strip" aria-label="How SuperMega starts">
-      <div class="proof-item"><span>01 / WORKING</span><strong>Use working screens</strong><p>Shop, Plant, and File Analyst open without an account. Explore a workflow or run one file before you choose a path.</p></div>
+      <div class="proof-item"><span>01 / WORKING</span><strong>Use working screens</strong><p>Shop, Plant, File Analyst, and Payment Reconciler open without an account. Explore a workflow or run a bounded file task before you choose a path.</p></div>
       <div class="proof-item"><span>02 / PRIVATE</span><strong>Set up with you</strong><p>Your private workspace is configured and verified before handover. We map the people, sources, and approval points that matter.</p></div>
       <div class="proof-item"><span>03 / APPROVED</span><strong>Bring data deliberately</strong><p>Start fresh or add approved business records when ready. See a useful screen before private setup is complete.</p></div>
     </div>
     <div class="destination-list">
       <a class="destination" href="https://app.supermega.dev/?demo=shop" aria-label="Try Shop live"><span class="destination-index">01 / SHOP</span><span class="destination-copy"><strong>Shop</strong><span>Sell, track stock, manage customers, follow receivables, and keep the books together. Ring sales, keep stock honest, and close the day with less chasing.</span></span><span class="destination-arrow" aria-hidden="true">&#8594;</span></a>
       <a class="destination" href="https://app.supermega.dev/?demo=plant" aria-label="Try Plant live"><span class="destination-index">02 / PLANT</span><span class="destination-copy"><strong>Plant</strong><span>See floor state, machine history, shift events, and imports in one workspace. See what is running, capture floor history, and hand the next shift a cleaner brief.</span></span><span class="destination-arrow" aria-hidden="true">&#8594;</span></a>
-      <a class="destination" href="https://supermega-machine.vercel.app/workcell" aria-label="Run File Analyst"><span class="destination-index">03 / AI AGENT SOLUTIONS</span><span class="destination-copy"><strong>AI Agent Solutions</strong><span>Run File Analyst now: drop one CSV or JSON export, get a cleaned draft, ranked exceptions, a decision brief, and approval evidence. Source stays in this browser and is never uploaded.</span></span><span class="destination-arrow" aria-hidden="true">&#8594;</span></a>
+      <a class="destination" href="/reconcile/" aria-label="Run Payment Reconciler"><span class="destination-index">03 / AI AGENT SOLUTIONS</span><span class="destination-copy"><strong>AI Agent Solutions</strong><span>Use File Analyst to clean one export, or run Payment Reconciler now to match sales and money files, isolate uncertain pairs, and produce approval evidence. Sources stay in this browser and are never uploaded.</span></span><span class="destination-arrow" aria-hidden="true">&#8594;</span></a>
     </div>
   </section>
 
@@ -799,8 +799,11 @@ await writeStatic('index.html', homeHtml)
 await writeStatic('404.html', notFoundHtml)
 await writeStatic('contact/index.html', contactHtml)
 await writeStatic('privacy/index.html', privacyHtml)
+await mkdir(resolve(staticDir, 'reconcile'), { recursive: true })
+await cp(resolve(root, 'tools', 'public-workcells', 'payment-reconciler.html'), resolve(staticDir, 'reconcile', 'index.html'), { force: true })
+await cp(resolve(root, 'tools', 'public-workcells', 'payment-reconciler.mjs'), resolve(staticDir, 'reconcile', 'payment-reconciler.mjs'), { force: true })
 await writeStatic('robots.txt', 'User-agent: *\nAllow: /\nDisallow: /api/\nSitemap: https://supermega.dev/sitemap.xml\n')
-await writeStatic('sitemap.xml', '<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n  <url><loc>https://supermega.dev/</loc><changefreq>weekly</changefreq><priority>1.0</priority></url>\n  <url><loc>https://supermega.dev/contact/</loc><changefreq>monthly</changefreq><priority>0.9</priority></url>\n  <url><loc>https://supermega.dev/privacy/</loc><changefreq>yearly</changefreq><priority>0.3</priority></url>\n</urlset>\n')
+await writeStatic('sitemap.xml', '<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n  <url><loc>https://supermega.dev/</loc><changefreq>weekly</changefreq><priority>1.0</priority></url>\n  <url><loc>https://supermega.dev/reconcile/</loc><changefreq>monthly</changefreq><priority>0.8</priority></url>\n  <url><loc>https://supermega.dev/contact/</loc><changefreq>monthly</changefreq><priority>0.9</priority></url>\n  <url><loc>https://supermega.dev/privacy/</loc><changefreq>yearly</changefreq><priority>0.3</priority></url>\n</urlset>\n')
 await writeStatic('sw.js', "const CACHE_VERSION = 'supermega-front-door-20260713-terminal'\nself.addEventListener('install', function(){ self.skipWaiting() })\nself.addEventListener('activate', function(event){ event.waitUntil(caches.keys().then(function(keys){ return Promise.all(keys.map(function(key){ return caches.delete(key) })) }).then(function(){ return self.clients.claim() })) })\n")
 await writeStatic('site.webmanifest', `${JSON.stringify({
   name: 'supermega.dev',

--- a/tools/public-workcells/payment-reconciler.html
+++ b/tools/public-workcells/payment-reconciler.html
@@ -1,0 +1,440 @@
+<!doctype html>
+<html lang="en" data-theme="light">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover" />
+    <title>Payment Reconciler | SuperMega AI Agent Solutions</title>
+    <meta name="description" content="Match invoice and payment CSV or JSON exports in this browser, review exceptions, and export approval evidence." />
+    <link rel="icon" href="/favicon.svg" />
+    <link rel="canonical" href="https://supermega.dev/reconcile/" />
+    <script>
+      (function () {
+        var stored = ''
+        try { stored = localStorage.getItem('supermega-theme') || '' } catch (_) {}
+        var theme = stored === 'dark' || stored === 'light' ? stored : (matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light')
+        document.documentElement.dataset.theme = theme
+      })()
+    </script>
+    <style>
+      :root {
+        color-scheme: light;
+        --page: #f4f6f5;
+        --surface: #ffffff;
+        --surface-2: #eef2f0;
+        --ink: #101412;
+        --muted: #5d6963;
+        --quiet: #7a8680;
+        --line: #ccd4d0;
+        --line-strong: #aeb9b3;
+        --accent: #0d7f55;
+        --accent-ink: #ffffff;
+        --blue: #245bea;
+        --warn: #9a5600;
+        --danger: #a52a2a;
+        --shadow: 0 16px 42px rgba(16, 20, 18, 0.08);
+      }
+      :root[data-theme="dark"] {
+        color-scheme: dark;
+        --page: #0b0f0d;
+        --surface: #111714;
+        --surface-2: #171f1b;
+        --ink: #edf3ef;
+        --muted: #a9b7af;
+        --quiet: #829087;
+        --line: #2c3932;
+        --line-strong: #435249;
+        --accent: #45c58e;
+        --accent-ink: #07110c;
+        --blue: #7ca0ff;
+        --warn: #e5a34f;
+        --danger: #f18484;
+        --shadow: 0 18px 48px rgba(0, 0, 0, 0.28);
+      }
+      * { box-sizing: border-box; }
+      html { background: var(--page); scroll-behavior: smooth; }
+      body {
+        margin: 0;
+        min-width: 320px;
+        background: var(--page);
+        color: var(--ink);
+        font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        letter-spacing: 0;
+      }
+      button, input, select, textarea { font: inherit; letter-spacing: 0; }
+      button, a, label[for] { -webkit-tap-highlight-color: transparent; }
+      button:focus-visible, a:focus-visible, input:focus-visible, select:focus-visible, textarea:focus-visible {
+        outline: 3px solid color-mix(in srgb, var(--blue) 46%, transparent);
+        outline-offset: 2px;
+      }
+      [hidden] { display: none !important; }
+      .topbar {
+        position: sticky;
+        top: 0;
+        z-index: 20;
+        min-height: 70px;
+        border-bottom: 1px solid var(--line);
+        background: color-mix(in srgb, var(--surface) 88%, transparent);
+        backdrop-filter: blur(24px);
+      }
+      .topbar-inner {
+        width: min(1180px, calc(100% - 40px));
+        min-height: 70px;
+        margin: 0 auto;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 20px;
+      }
+      .brand {
+        min-width: 0;
+        display: flex;
+        align-items: center;
+        gap: 11px;
+        color: var(--ink);
+        text-decoration: none;
+      }
+      .brand img { width: 34px; height: 34px; }
+      .brand-copy { min-width: 0; display: grid; gap: 1px; }
+      .brand-copy strong { font-size: 14px; line-height: 1.2; }
+      .brand-copy span { color: var(--muted); font-size: 12px; line-height: 1.2; }
+      .terminal-mark { display: none; }
+      .domain { color: var(--muted); }
+      .top-actions { display: flex; align-items: center; gap: 8px; }
+      .icon-button, .button {
+        min-height: 44px;
+        border: 1px solid var(--line-strong);
+        border-radius: 5px;
+        background: var(--surface);
+        color: var(--ink);
+        font-weight: 750;
+        cursor: pointer;
+        transition: transform 150ms ease, border-color 150ms ease, background 150ms ease;
+      }
+      .icon-button:hover, .button:hover:not(:disabled) { transform: translateY(-1px); border-color: var(--accent); }
+      .icon-button { width: 44px; padding: 0; font-size: 18px; }
+      .button { min-width: 44px; padding: 0 16px; }
+      .button.primary { border-color: var(--accent); background: var(--accent); color: var(--accent-ink); }
+      .button.strong { border-color: var(--ink); background: var(--ink); color: var(--surface); }
+      .button:disabled { cursor: not-allowed; opacity: 0.42; transform: none; }
+      .back-link { min-height: 44px; display: inline-flex; align-items: center; padding: 0 4px; color: var(--muted); font-size: 13px; font-weight: 750; text-decoration: none; }
+      .back-link:hover { color: var(--ink); }
+      main { width: min(1180px, calc(100% - 40px)); margin: 0 auto; padding: 54px 0 80px; }
+      .intro {
+        display: grid;
+        grid-template-columns: minmax(0, 1.2fr) minmax(300px, 0.8fr);
+        gap: 64px;
+        align-items: end;
+        padding-bottom: 34px;
+        border-bottom: 1px solid var(--line-strong);
+      }
+      .eyebrow {
+        margin-bottom: 12px;
+        color: var(--accent);
+        font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+        font-size: 12px;
+        font-weight: 800;
+        text-transform: uppercase;
+      }
+      h1, h2, h3, p { margin-top: 0; }
+      h1 { max-width: 720px; margin-bottom: 14px; font-family: Georgia, "Times New Roman", serif; font-size: clamp(42px, 6vw, 78px); line-height: 0.98; font-weight: 700; }
+      .intro-copy { max-width: 650px; margin-bottom: 0; color: var(--muted); font-size: 18px; line-height: 1.55; }
+      .scope-list { margin: 0; display: grid; gap: 0; }
+      .scope-list div { min-height: 48px; display: grid; grid-template-columns: 110px 1fr; align-items: center; gap: 16px; border-top: 1px solid var(--line); }
+      .scope-list div:last-child { border-bottom: 1px solid var(--line); }
+      .scope-list dt { color: var(--quiet); font-size: 12px; }
+      .scope-list dd { margin: 0; font-size: 13px; font-weight: 800; }
+      .workspace { padding-top: 42px; }
+      .section-head { display: flex; align-items: end; justify-content: space-between; gap: 24px; margin-bottom: 18px; }
+      .section-head h2 { margin-bottom: 4px; font-size: 26px; line-height: 1.1; }
+      .section-head p { margin-bottom: 0; color: var(--muted); font-size: 14px; line-height: 1.5; }
+      .source-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 16px; }
+      .source-picker {
+        min-height: 180px;
+        display: grid;
+        align-content: center;
+        justify-items: center;
+        gap: 8px;
+        padding: 24px;
+        border: 1px dashed var(--line-strong);
+        border-radius: 6px;
+        background: var(--surface);
+        box-shadow: var(--shadow);
+        cursor: pointer;
+        text-align: center;
+        transition: border-color 150ms ease, background 150ms ease, transform 150ms ease;
+      }
+      .source-picker:hover, .source-picker.is-dragging { border-color: var(--accent); background: color-mix(in srgb, var(--surface) 92%, var(--accent)); transform: translateY(-1px); }
+      .source-picker input { position: absolute; width: 1px; height: 1px; opacity: 0; pointer-events: none; }
+      .source-number { color: var(--accent); font-family: "SFMono-Regular", Consolas, monospace; font-size: 12px; font-weight: 800; }
+      .source-picker strong { font-size: 18px; }
+      .source-name { max-width: 100%; color: var(--blue); font-size: 14px; font-weight: 800; overflow-wrap: anywhere; }
+      .source-meta { color: var(--muted); font-size: 12px; line-height: 1.4; }
+      .mapping-section { margin-top: 42px; scroll-margin-top: 90px; }
+      .mapping-columns { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 28px; }
+      .mapping-group { border-top: 2px solid var(--ink); padding-top: 14px; }
+      .mapping-group h3 { margin-bottom: 14px; font-size: 17px; }
+      .field-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 14px; }
+      .field { min-width: 0; display: grid; gap: 6px; }
+      .field label { color: var(--muted); font-size: 12px; font-weight: 800; }
+      select, input[type="number"], input[type="text"], textarea {
+        width: 100%;
+        min-height: 44px;
+        border: 1px solid var(--line-strong);
+        border-radius: 4px;
+        background: var(--surface);
+        color: var(--ink);
+        padding: 9px 11px;
+      }
+      textarea { min-height: 88px; resize: vertical; line-height: 1.45; }
+      .settings-row { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)) auto; align-items: end; gap: 14px; margin-top: 24px; padding-top: 24px; border-top: 1px solid var(--line); }
+      .run-strip { margin-top: 14px; min-height: 46px; display: flex; align-items: center; justify-content: space-between; gap: 16px; border-top: 1px solid var(--line); border-bottom: 1px solid var(--line); color: var(--muted); font-size: 13px; }
+      #runStatus[data-tone="ready"] { color: var(--accent); }
+      #runStatus[data-tone="review"] { color: var(--warn); }
+      #runStatus[data-tone="error"] { color: var(--danger); }
+      .results { margin-top: 64px; scroll-margin-top: 88px; }
+      .result-title { display: flex; align-items: end; justify-content: space-between; gap: 20px; margin-bottom: 18px; }
+      .result-title h2 { margin-bottom: 4px; font-size: 30px; }
+      .result-title p { margin-bottom: 0; color: var(--muted); }
+      .result-chip { min-height: 32px; display: inline-flex; align-items: center; border: 1px solid var(--line-strong); border-radius: 999px; padding: 0 11px; color: var(--muted); font-size: 12px; font-weight: 800; }
+      .metric-grid { display: grid; grid-template-columns: repeat(6, minmax(0, 1fr)); border-top: 1px solid var(--line-strong); border-bottom: 1px solid var(--line-strong); }
+      .metric { min-width: 0; min-height: 90px; display: grid; align-content: center; gap: 7px; padding: 14px; border-left: 1px solid var(--line); }
+      .metric:first-child { border-left: 0; }
+      .metric span { color: var(--quiet); font-size: 11px; font-weight: 800; text-transform: uppercase; }
+      .metric strong { font-size: 20px; overflow-wrap: anywhere; }
+      .result-layout { display: grid; grid-template-columns: minmax(240px, 0.32fr) minmax(0, 0.68fr); gap: 32px; margin-top: 38px; }
+      .table-panel { min-width: 0; }
+      .action-panel h3, .table-panel h3, .approval h3 { margin-bottom: 14px; font-size: 17px; }
+      .action-list { margin: 0; padding: 0; list-style: none; border-top: 1px solid var(--line); }
+      .action-list li { display: grid; grid-template-columns: 92px 1fr; gap: 12px; padding: 15px 0; border-bottom: 1px solid var(--line); }
+      .action-list strong { font-size: 14px; }
+      .action-list p { margin: 4px 0 0; color: var(--muted); font-size: 12px; line-height: 1.45; }
+      .priority { align-self: start; font-family: "SFMono-Regular", Consolas, monospace; font-size: 10px; font-weight: 800; text-transform: uppercase; }
+      .priority.high { color: var(--danger); }
+      .priority.medium { color: var(--warn); }
+      .priority.low { color: var(--accent); }
+      .table-wrap { width: 100%; overflow: auto; border-top: 1px solid var(--line-strong); border-bottom: 1px solid var(--line-strong); background: var(--surface); }
+      table { width: 100%; min-width: 820px; border-collapse: collapse; font-size: 12px; }
+      th, td { padding: 11px 10px; border-bottom: 1px solid var(--line); text-align: left; vertical-align: top; }
+      th { position: sticky; top: 0; z-index: 1; background: var(--surface-2); color: var(--quiet); font-size: 10px; text-transform: uppercase; }
+      tbody tr:hover { background: color-mix(in srgb, var(--surface) 92%, var(--blue)); }
+      td.number { text-align: right; font-variant-numeric: tabular-nums; }
+      .status { font-weight: 800; text-transform: uppercase; font-size: 10px; }
+      .status.matched { color: var(--accent); }
+      .status.suggested { color: var(--blue); }
+      .status.amount_mismatch, .status.invalid_invoice, .status.invalid_payment { color: var(--danger); }
+      .status.unmatched_invoice, .status.unmatched_payment { color: var(--warn); }
+      .row-limit { margin: 8px 0 0; color: var(--muted); font-size: 11px; }
+      .approval { margin-top: 42px; padding-top: 30px; border-top: 2px solid var(--ink); }
+      .approval-grid { display: grid; grid-template-columns: minmax(0, 0.9fr) minmax(0, 1.1fr); gap: 30px; }
+      .review-fields { display: grid; gap: 13px; }
+      .check-row { min-height: 44px; display: grid; grid-template-columns: 22px 1fr; gap: 10px; align-items: start; color: var(--muted); font-size: 12px; line-height: 1.4; cursor: pointer; }
+      .check-row input { width: 18px; height: 18px; margin: 1px 0 0; accent-color: var(--accent); }
+      .approval-actions { display: flex; flex-wrap: wrap; gap: 8px; align-items: center; }
+      .approval-state { margin-left: 4px; color: var(--muted); font-size: 12px; font-weight: 750; }
+      .brief-shell { min-width: 0; }
+      .brief-shell pre { min-height: 264px; max-height: 420px; margin: 0; overflow: auto; border: 1px solid var(--line); border-radius: 4px; background: var(--surface-2); padding: 16px; color: var(--ink); font: 12px/1.55 "SFMono-Regular", Consolas, monospace; white-space: pre-wrap; overflow-wrap: anywhere; }
+      .downloads { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 12px; }
+      footer { margin-top: 70px; padding-top: 22px; border-top: 1px solid var(--line); display: flex; justify-content: space-between; gap: 20px; color: var(--muted); font-size: 12px; }
+      footer a { color: inherit; font-weight: 750; }
+      @media (max-width: 900px) {
+        .intro { grid-template-columns: 1fr; gap: 28px; }
+        .scope-list { max-width: 560px; }
+        .metric-grid { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+        .metric:nth-child(4) { border-left: 0; }
+        .metric:nth-child(-n+3) { border-bottom: 1px solid var(--line); }
+        .result-layout { grid-template-columns: 1fr; }
+      }
+      @media (max-width: 680px) {
+        .topbar-inner, main { width: min(100% - 24px, 1180px); }
+        .topbar-inner { min-height: 62px; }
+        .topbar { min-height: 62px; }
+        .brand-copy span, .back-link { display: none; }
+        main { padding-top: 30px; }
+        h1 { font-size: 44px; }
+        .intro-copy { font-size: 16px; }
+        .source-grid, .mapping-columns, .field-grid, .approval-grid { grid-template-columns: 1fr; }
+        .section-head { align-items: flex-start; flex-direction: column; }
+        .section-head > .button { width: 100%; }
+        .source-picker { min-height: 154px; }
+        .settings-row { grid-template-columns: 1fr 1fr; }
+        .settings-row .field:nth-child(3) { grid-column: 1 / -1; }
+        .settings-row .button { grid-column: 1 / -1; width: 100%; }
+        .run-strip { align-items: flex-start; flex-direction: column; padding: 10px 0; }
+        .result-title { align-items: flex-start; flex-direction: column; }
+        .metric-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+        .metric:nth-child(odd) { border-left: 0; }
+        .metric:nth-child(even) { border-left: 1px solid var(--line); }
+        .metric:nth-child(-n+4) { border-bottom: 1px solid var(--line); }
+        .action-list li { grid-template-columns: 82px 1fr; }
+        .approval-actions .button { flex: 1 1 150px; }
+        .downloads .button { flex: 1 1 150px; }
+        footer { align-items: flex-start; flex-direction: column; }
+      }
+      @media (prefers-reduced-motion: reduce) {
+        *, *::before, *::after { scroll-behavior: auto !important; transition-duration: 0.01ms !important; }
+      }
+    </style>
+  </head>
+  <body>
+    <header class="topbar">
+      <div class="topbar-inner">
+        <a class="brand" href="/" aria-label="SuperMega home">
+          <img src="/favicon.svg" alt="" width="64" height="64" />
+          <span class="brand-copy"><strong>SuperMega Payment Reconciler</strong><span>AI Agent Solutions</span></span>
+          <span class="terminal-mark">&gt;_ supermega<span class="domain">.dev</span></span>
+        </a>
+        <div class="top-actions">
+          <a class="back-link" href="/">Back to SuperMega</a>
+          <button class="icon-button" type="button" data-theme-toggle aria-label="Use dark mode" title="Use dark mode">◐</button>
+        </div>
+      </div>
+    </header>
+
+    <main>
+      <section class="intro" aria-labelledby="reconcile-heading">
+        <div>
+          <div class="eyebrow">AI Agent Solutions / payment reconciliation</div>
+          <h1 id="reconcile-heading">Match sales to money.</h1>
+          <p class="intro-copy">Compare one sales export with one bank, wallet, or settlement export. Keep exact matches, isolate uncertain pairs, and close with a named review record.</p>
+        </div>
+        <dl class="scope-list">
+          <div><dt>Sources</dt><dd>Two CSV / JSON files</dd></div>
+          <div><dt>Limit</dt><dd>10 MB / 50,000 rows each</dd></div>
+          <div><dt>Processing</dt><dd>This browser</dd></div>
+          <div><dt>Boundary</dt><dd>Zero source upload or money movement</dd></div>
+        </dl>
+      </section>
+
+      <section class="workspace" aria-labelledby="source-heading">
+        <div class="section-head">
+          <div><div class="eyebrow">01 / source exports</div><h2 id="source-heading">Load both sides.</h2><p>Choose matching-period exports. The original files remain unchanged.</p></div>
+          <button class="button" type="button" id="loadSample">Load safe sample</button>
+        </div>
+        <div class="source-grid">
+          <label class="source-picker" for="invoiceFile" data-drop-side="invoice">
+            <input id="invoiceFile" type="file" accept=".csv,.json,text/csv,application/json" />
+            <span class="source-number">A / SALES</span>
+            <strong>Drop or choose the sales export</strong>
+            <span class="source-name" id="invoiceFileName">No file selected</span>
+            <span class="source-meta" id="invoiceFileMeta">Sales or invoice export</span>
+          </label>
+          <label class="source-picker" for="paymentFile" data-drop-side="payment">
+            <input id="paymentFile" type="file" accept=".csv,.json,text/csv,application/json" />
+            <span class="source-number">B / MONEY</span>
+            <strong>Drop or choose the payment export</strong>
+            <span class="source-name" id="paymentFileName">No file selected</span>
+            <span class="source-meta" id="paymentFileMeta">Bank, wallet, or settlement export</span>
+          </label>
+        </div>
+      </section>
+
+      <section class="mapping-section" id="mappingSection" aria-labelledby="mapping-heading" hidden>
+        <div class="section-head">
+          <div><div class="eyebrow">02 / mapping</div><h2 id="mapping-heading">Confirm the columns.</h2><p>Amount is required. Reference, party, and date strengthen the match.</p></div>
+        </div>
+        <div class="mapping-columns">
+          <div class="mapping-group">
+            <h3>Sales or invoice columns</h3>
+            <div class="field-grid">
+              <div class="field"><label for="invoiceReference">Reference</label><select id="invoiceReference"></select></div>
+              <div class="field"><label for="invoiceAmount">Amount *</label><select id="invoiceAmount"></select></div>
+              <div class="field"><label for="invoiceDate">Date</label><select id="invoiceDate"></select></div>
+              <div class="field"><label for="invoiceParty">Customer</label><select id="invoiceParty"></select></div>
+            </div>
+          </div>
+          <div class="mapping-group">
+            <h3>Payment or settlement columns</h3>
+            <div class="field-grid">
+              <div class="field"><label for="paymentReference">Reference</label><select id="paymentReference"></select></div>
+              <div class="field"><label for="paymentAmount">Amount *</label><select id="paymentAmount"></select></div>
+              <div class="field"><label for="paymentDate">Date</label><select id="paymentDate"></select></div>
+              <div class="field"><label for="paymentParty">Payer</label><select id="paymentParty"></select></div>
+            </div>
+          </div>
+        </div>
+        <div class="settings-row">
+          <div class="field"><label for="amountTolerance">Amount tolerance</label><input id="amountTolerance" type="number" min="0" step="0.01" value="0" /></div>
+          <div class="field"><label for="dateWindow">Suggestion window (days)</label><input id="dateWindow" type="number" min="0" max="30" step="1" value="3" /></div>
+          <div class="field"><label for="dateOrder">Short date order</label><select id="dateOrder"><option value="day-first">Day first</option><option value="month-first">Month first</option></select></div>
+          <button class="button primary" type="button" id="analyzeButton" disabled>Reconcile exports</button>
+        </div>
+      </section>
+
+      <div class="run-strip" aria-live="polite"><span id="runStatus">Load two exports or use the safe sample.</span><span>Exact reference first / mutual-unique suggestions only</span></div>
+
+      <section class="results" id="results" aria-labelledby="resultHeadline" hidden>
+        <div class="result-title">
+          <div><div class="eyebrow">03 / review</div><h2 id="resultHeadline">Review before close</h2><p id="resultState"></p></div>
+          <span class="result-chip">No automatic finalization</span>
+        </div>
+        <div class="metric-grid" id="metricGrid"></div>
+        <div class="result-layout">
+          <aside class="action-panel" aria-labelledby="action-heading">
+            <h3 id="action-heading">Ranked review</h3>
+            <ol class="action-list" id="actionList"></ol>
+          </aside>
+          <div class="table-panel">
+            <h3>Reconciliation rows</h3>
+            <div class="table-wrap">
+              <table>
+                <thead><tr><th>Status</th><th>Invoice ref</th><th>Invoice</th><th>Payment ref</th><th>Payment</th><th>Difference</th><th>Method</th></tr></thead>
+                <tbody id="reconciliationBody"></tbody>
+              </table>
+            </div>
+            <p class="row-limit" id="rowLimitNote"></p>
+          </div>
+        </div>
+
+        <div class="approval">
+          <div class="eyebrow">04 / approval evidence</div>
+          <div class="approval-grid">
+            <div class="review-fields">
+              <h3>Record the review.</h3>
+              <div class="field"><label for="reviewName">Reviewer name</label><input id="reviewName" type="text" autocomplete="name" maxlength="100" /></div>
+              <div class="field"><label for="reviewNote">Exception note</label><textarea id="reviewNote" maxlength="1000"></textarea></div>
+              <label class="check-row"><input id="reviewCheck" type="checkbox" /><span>I reviewed the matched and exception rows. This approval does not send money, update invoices, or post to the books.</span></label>
+              <div class="approval-actions">
+                <button class="button strong" type="button" id="approveButton" disabled>Record approval</button>
+                <button class="button" type="button" id="copyBrief">Copy brief</button>
+                <span class="approval-state" id="approvalState">Not approved</span>
+              </div>
+            </div>
+            <div class="brief-shell">
+              <h3>Decision brief</h3>
+              <pre id="briefPreview"></pre>
+              <div class="downloads">
+                <button class="button" type="button" id="downloadReconciliation" disabled>Reconciliation CSV</button>
+                <button class="button" type="button" id="downloadExceptions" disabled>Exceptions CSV</button>
+                <button class="button" type="button" id="downloadBrief" disabled>Decision brief</button>
+                <button class="button" type="button" id="downloadEvidence" disabled>Evidence JSON</button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <footer><span>SuperMega AI Agent Solutions / source-preserving / approval-gated</span><a href="/privacy/">Privacy boundary</a></footer>
+    </main>
+
+    <script>
+      (function () {
+        var button = document.querySelector('[data-theme-toggle]')
+        if (!button) return
+        function sync() {
+          var dark = document.documentElement.dataset.theme === 'dark'
+          button.setAttribute('aria-label', dark ? 'Use light mode' : 'Use dark mode')
+          button.setAttribute('title', dark ? 'Use light mode' : 'Use dark mode')
+          button.setAttribute('aria-pressed', String(dark))
+        }
+        button.addEventListener('click', function () {
+          var next = document.documentElement.dataset.theme === 'dark' ? 'light' : 'dark'
+          document.documentElement.dataset.theme = next
+          try { localStorage.setItem('supermega-theme', next) } catch (_) {}
+          sync()
+        })
+        sync()
+      })()
+    </script>
+    <script type="module" src="/reconcile/payment-reconciler.mjs"></script>
+  </body>
+</html>

--- a/tools/public-workcells/payment-reconciler.mjs
+++ b/tools/public-workcells/payment-reconciler.mjs
@@ -1,0 +1,856 @@
+const MAX_FILE_BYTES = 10 * 1024 * 1024
+const MAX_ROWS = 50000
+const MAX_RENDERED_ROWS = 200
+
+export const RECONCILIATION_LIMITS = Object.freeze({
+  maxFileBytes: MAX_FILE_BYTES,
+  maxRowsPerFile: MAX_ROWS,
+  maxRenderedRows: MAX_RENDERED_ROWS,
+})
+
+function stringValue(value) {
+  if (value == null) return ''
+  if (typeof value === 'object') return JSON.stringify(value)
+  return String(value)
+}
+
+function cleanText(value) {
+  return stringValue(value).replace(/\r\n?/g, '\n').trim()
+}
+
+function normalizeHeader(value, index, used) {
+  let base = cleanText(value)
+    .normalize('NFKC')
+    .toLocaleLowerCase('en-US')
+    .replace(/%/g, ' percent ')
+    .replace(/#/g, ' number ')
+    .replace(/[^\p{L}\p{N}]+/gu, '_')
+    .replace(/^_+|_+$/g, '')
+
+  if (!base) base = `column_${index + 1}`
+  if (/^\d/.test(base)) base = `field_${base}`
+
+  let candidate = base
+  let suffix = 2
+  while (used.has(candidate)) {
+    candidate = `${base}_${suffix}`
+    suffix += 1
+  }
+  used.add(candidate)
+  return candidate
+}
+
+export function parseCsv(source) {
+  const text = stringValue(source).replace(/^\uFEFF/, '').replace(/\r\n?/g, '\n')
+  const rows = []
+  let row = []
+  let field = ''
+  let inQuotes = false
+  let justClosedQuote = false
+
+  for (let index = 0; index < text.length; index += 1) {
+    const char = text[index]
+    if (inQuotes) {
+      if (char === '"' && text[index + 1] === '"') {
+        field += '"'
+        index += 1
+      } else if (char === '"') {
+        inQuotes = false
+        justClosedQuote = true
+      } else {
+        field += char
+      }
+      continue
+    }
+
+    if (char === '"') {
+      if (field.length || justClosedQuote) throw new Error(`Unexpected quote at character ${index + 1}`)
+      inQuotes = true
+      continue
+    }
+    if (char === ',') {
+      row.push(field)
+      field = ''
+      justClosedQuote = false
+      continue
+    }
+    if (char === '\n' || char === '\r') {
+      if (char === '\r' && text[index + 1] === '\n') index += 1
+      row.push(field)
+      rows.push(row)
+      row = []
+      field = ''
+      justClosedQuote = false
+      continue
+    }
+    if (justClosedQuote && !/\s/.test(char)) throw new Error(`Unexpected character after closing quote at ${index + 1}`)
+    if (!justClosedQuote || !/\s/.test(char)) field += char
+  }
+
+  if (inQuotes) throw new Error('CSV contains an unclosed quoted field')
+  if (field.length || row.length || (text.length && !/[\r\n]$/.test(text))) {
+    row.push(field)
+    rows.push(row)
+  }
+  return rows
+}
+
+function parseJsonRows(source) {
+  let parsed
+  try {
+    parsed = JSON.parse(source)
+  } catch (error) {
+    throw new Error(`JSON could not be parsed: ${error.message}`)
+  }
+
+  if (!Array.isArray(parsed) && parsed && typeof parsed === 'object') {
+    const nested = ['rows', 'data', 'items', 'results', 'transactions', 'payments', 'invoices'].find((key) => Array.isArray(parsed[key]))
+    if (nested) parsed = parsed[nested]
+  }
+  if (!Array.isArray(parsed)) throw new Error('JSON must be an array of records or contain a supported record array')
+  if (parsed.some((record) => !record || typeof record !== 'object' || Array.isArray(record))) {
+    throw new Error('Every JSON record must be an object')
+  }
+
+  const headers = []
+  const seen = new Set()
+  for (const record of parsed) {
+    for (const key of Object.keys(record)) {
+      if (!seen.has(key)) {
+        seen.add(key)
+        headers.push(key)
+      }
+    }
+  }
+  return {
+    kind: 'json',
+    headers,
+    rows: parsed.map((record) => headers.map((header) => stringValue(record[header]))),
+    firstSourceRow: 1,
+  }
+}
+
+export function parseDataset(source, fileName = 'source.csv') {
+  const text = stringValue(source)
+  if (!text.trim()) throw new Error('The source file is empty')
+  if (new TextEncoder().encode(text).byteLength > MAX_FILE_BYTES) throw new Error('The source is larger than 10 MB')
+
+  const jsonLike = /\.json$/i.test(fileName) || /^[\s\uFEFF]*[\[{]/.test(text)
+  let table
+  if (jsonLike) {
+    table = parseJsonRows(text)
+  } else {
+    const matrix = parseCsv(text)
+    if (!matrix.length) throw new Error('The CSV has no rows')
+    const width = Math.max(...matrix.map((row) => row.length))
+    table = {
+      kind: 'csv',
+      headers: Array.from({ length: width }, (_, index) => matrix[0][index] || ''),
+      rows: matrix.slice(1).map((row) => Array.from({ length: width }, (_, index) => row[index] || '')),
+      firstSourceRow: 2,
+    }
+  }
+
+  if (!table.headers.length) throw new Error('The source has no columns')
+  if (table.rows.length > MAX_ROWS) throw new Error(`The source has more than ${MAX_ROWS.toLocaleString('en-US')} rows`)
+
+  const used = new Set()
+  const headers = table.headers.map((sourceName, index) => ({
+    source: cleanText(sourceName) || `Column ${index + 1}`,
+    name: normalizeHeader(sourceName, index, used),
+  }))
+  const rows = table.rows.map((values, index) => ({
+    sourceRow: table.firstSourceRow + index,
+    values: Object.fromEntries(headers.map((header, column) => [header.name, cleanText(values[column])])),
+  }))
+  return { kind: table.kind, headers, rows }
+}
+
+export function parseMoney(value) {
+  let normalized = cleanText(value)
+  let negative = false
+  if (/^\(.*\)$/.test(normalized)) {
+    negative = true
+    normalized = normalized.slice(1, -1).trim()
+  }
+  normalized = normalized
+    .replace(/^(?:MMK|USD|Ks)\s*/i, '')
+    .replace(/\s*(?:MMK|USD|Ks)$/i, '')
+    .replace(/^[$\u00A3\u00A5\u20AC\u20B9]\s*/, '')
+    .replace(/,/g, '')
+    .trim()
+  if (!/^[+-]?\d+(?:\.\d+)?$/.test(normalized)) return { valid: false, raw: cleanText(value) }
+  const number = Number(normalized)
+  if (!Number.isFinite(number)) return { valid: false, raw: cleanText(value) }
+  return { valid: true, number: negative ? -Math.abs(number) : number }
+}
+
+function validDateParts(year, month, day) {
+  const date = new Date(Date.UTC(year, month - 1, day))
+  return date.getUTCFullYear() === year && date.getUTCMonth() === month - 1 && date.getUTCDate() === day
+}
+
+function isoDate(year, month, day) {
+  return `${String(year).padStart(4, '0')}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}`
+}
+
+export function parseDate(value, order = 'day-first') {
+  const normalized = cleanText(value)
+  if (!normalized) return { valid: false, raw: '' }
+
+  let match = normalized.match(/^(\d{4})[-/.](\d{1,2})[-/.](\d{1,2})(?:[T\s].*)?$/)
+  if (match) {
+    const year = Number(match[1])
+    const month = Number(match[2])
+    const day = Number(match[3])
+    if (!validDateParts(year, month, day)) return { valid: false, raw: normalized }
+    const iso = isoDate(year, month, day)
+    return { valid: true, iso, epochDay: Math.floor(Date.parse(`${iso}T00:00:00Z`) / 86400000) }
+  }
+
+  match = normalized.match(/^(\d{1,2})[-/.](\d{1,2})[-/.](\d{4})$/)
+  if (!match) return { valid: false, raw: normalized }
+  const first = Number(match[1])
+  const second = Number(match[2])
+  const year = Number(match[3])
+  const day = order === 'month-first' ? second : first
+  const month = order === 'month-first' ? first : second
+  if (!validDateParts(year, month, day)) return { valid: false, raw: normalized }
+  const iso = isoDate(year, month, day)
+  return { valid: true, iso, epochDay: Math.floor(Date.parse(`${iso}T00:00:00Z`) / 86400000) }
+}
+
+const MAPPING_ALIASES = Object.freeze({
+  invoice: {
+    reference: ['invoice_reference', 'invoice_ref', 'invoice_number', 'invoice_no', 'order_reference', 'order_id', 'order_number', 'receipt_number', 'reference', 'ref'],
+    amount: ['invoice_amount', 'invoice_total', 'grand_total', 'sale_amount', 'net_amount', 'total', 'amount', 'balance'],
+    date: ['invoice_date', 'sale_date', 'order_date', 'created_date', 'created_at', 'date'],
+    party: ['customer_name', 'customer', 'client_name', 'client', 'buyer', 'account_name'],
+  },
+  payment: {
+    reference: ['invoice_reference', 'invoice_ref', 'order_reference', 'order_id', 'transaction_reference', 'transaction_id', 'payment_reference', 'reference', 'ref'],
+    amount: ['paid_amount', 'payment_amount', 'settlement_amount', 'credit_amount', 'net_amount', 'credit', 'amount', 'total'],
+    date: ['payment_date', 'settlement_date', 'transaction_date', 'paid_at', 'created_at', 'date'],
+    party: ['payer_name', 'payer', 'sender_name', 'sender', 'customer_name', 'customer', 'account_name'],
+  },
+})
+
+export function suggestMappings(dataset, side) {
+  const aliases = MAPPING_ALIASES[side]
+  if (!aliases) throw new Error(`Unsupported mapping side: ${side}`)
+  const names = new Set(dataset.headers.map((header) => header.name))
+  return Object.fromEntries(Object.entries(aliases).map(([field, candidates]) => [field, candidates.find((candidate) => names.has(candidate)) || '']))
+}
+
+function normalizeReference(value) {
+  return cleanText(value).normalize('NFKC').toLocaleLowerCase('en-US').replace(/[^\p{L}\p{N}]+/gu, '')
+}
+
+function normalizeParty(value) {
+  return cleanText(value).normalize('NFKC').toLocaleLowerCase('en-US').replace(/[^\p{L}\p{N}]+/gu, '')
+}
+
+function valueFor(row, column) {
+  return column ? row.values[column] || '' : ''
+}
+
+function makeRecord(row, side, mapping, dateOrder) {
+  const amount = parseMoney(valueFor(row, mapping.amount))
+  const date = mapping.date ? parseDate(valueFor(row, mapping.date), dateOrder) : { valid: false, raw: '' }
+  const rawReference = valueFor(row, mapping.reference)
+  const rawParty = valueFor(row, mapping.party)
+  return {
+    id: `${side}:${row.sourceRow}`,
+    side,
+    sourceRow: row.sourceRow,
+    reference: cleanText(rawReference),
+    referenceKey: normalizeReference(rawReference),
+    party: cleanText(rawParty),
+    partyKey: normalizeParty(rawParty),
+    amount: amount.valid ? amount.number : null,
+    validAmount: amount.valid,
+    rawAmount: valueFor(row, mapping.amount),
+    date: date.valid ? date.iso : '',
+    epochDay: date.valid ? date.epochDay : null,
+  }
+}
+
+function groupByReference(records) {
+  const groups = new Map()
+  for (const record of records) {
+    if (!record.referenceKey) continue
+    if (!groups.has(record.referenceKey)) groups.set(record.referenceKey, [])
+    groups.get(record.referenceKey).push(record)
+  }
+  return groups
+}
+
+function sum(records) {
+  return records.reduce((total, record) => total + (record.validAmount ? record.amount : 0), 0)
+}
+
+function amountDifference(invoice, payment) {
+  return Number((payment.amount - invoice.amount).toFixed(6))
+}
+
+function createPair(invoice, payment, status, method, confidence, reason) {
+  return {
+    status,
+    method,
+    confidence,
+    invoice,
+    payment,
+    difference: invoice?.validAmount && payment?.validAmount ? amountDifference(invoice, payment) : null,
+    reviewReason: reason,
+  }
+}
+
+function applyMutualUniqueSuggestions({ invoices, payments, usedInvoices, usedPayments, pairs, method, confidence, predicate }) {
+  const availableInvoices = invoices.filter((record) => record.validAmount && !usedInvoices.has(record.id))
+  const availablePayments = payments.filter((record) => record.validAmount && !usedPayments.has(record.id))
+  const candidates = new Map()
+  const reverse = new Map()
+
+  for (const invoice of availableInvoices) {
+    const matches = availablePayments.filter((payment) => predicate(invoice, payment))
+    candidates.set(invoice.id, matches)
+    for (const payment of matches) {
+      if (!reverse.has(payment.id)) reverse.set(payment.id, [])
+      reverse.get(payment.id).push(invoice)
+    }
+  }
+
+  for (const invoice of availableInvoices) {
+    const matches = candidates.get(invoice.id) || []
+    if (matches.length !== 1) continue
+    const payment = matches[0]
+    if ((reverse.get(payment.id) || []).length !== 1) continue
+    usedInvoices.add(invoice.id)
+    usedPayments.add(payment.id)
+    pairs.push(createPair(invoice, payment, 'suggested', method, confidence, 'Mutual-unique suggestion; reviewer confirmation required.'))
+  }
+}
+
+function buildActions(summary) {
+  const actions = []
+  if (summary.invalidAmounts) actions.push({ priority: 'high', title: 'Fix invalid amounts', detail: `${summary.invalidAmounts} row${summary.invalidAmounts === 1 ? '' : 's'} cannot enter the matching pool.` })
+  if (summary.amountMismatches) actions.push({ priority: 'high', title: 'Resolve amount mismatches', detail: `${summary.amountMismatches} exact reference${summary.amountMismatches === 1 ? '' : 's'} carries a different amount.` })
+  if (summary.duplicateReferences) actions.push({ priority: 'high', title: 'Resolve duplicate references', detail: `${summary.duplicateReferences} repeated reference group${summary.duplicateReferences === 1 ? '' : 's'} needs a source check.` })
+  if (summary.suggestedMatches) actions.push({ priority: 'medium', title: 'Confirm suggested pairs', detail: `${summary.suggestedMatches} mutual-unique match${summary.suggestedMatches === 1 ? '' : 'es'} did not share an exact reference.` })
+  if (summary.unmatchedPayments) actions.push({ priority: 'medium', title: 'Trace unmatched payments', detail: `${summary.unmatchedPayments} payment row${summary.unmatchedPayments === 1 ? '' : 's'} has no safe invoice pair.` })
+  if (summary.unmatchedInvoices) actions.push({ priority: 'medium', title: 'Follow up unmatched invoices', detail: `${summary.unmatchedInvoices} invoice row${summary.unmatchedInvoices === 1 ? '' : 's'} remains outside an exact or suggested pair.` })
+  if (!actions.length) actions.push({ priority: 'low', title: 'Approve the reconciliation', detail: 'Every valid invoice and payment row has an exact reference and amount match.' })
+  return actions.slice(0, 5)
+}
+
+export function reconcileDatasets(invoiceDataset, paymentDataset, settings) {
+  const tolerance = Math.max(0, Number(settings?.tolerance || 0))
+  const dateWindowDays = Math.min(30, Math.max(0, Number(settings?.dateWindowDays ?? 3)))
+  const dateOrder = settings?.dateOrder === 'month-first' ? 'month-first' : 'day-first'
+  const invoiceMapping = settings?.invoiceMapping || {}
+  const paymentMapping = settings?.paymentMapping || {}
+  if (!invoiceMapping.amount || !paymentMapping.amount) throw new Error('Map the amount column for both files')
+
+  const invoices = invoiceDataset.rows.map((row) => makeRecord(row, 'invoice', invoiceMapping, dateOrder))
+  const payments = paymentDataset.rows.map((row) => makeRecord(row, 'payment', paymentMapping, dateOrder))
+  const invoiceGroups = groupByReference(invoices)
+  const paymentGroups = groupByReference(payments)
+  const exceptions = []
+  const pairs = []
+  const usedInvoices = new Set()
+  const usedPayments = new Set()
+
+  for (const record of [...invoices, ...payments]) {
+    if (!record.validAmount) exceptions.push({
+      severity: 'high',
+      type: 'invalid_amount',
+      side: record.side,
+      sourceRow: record.sourceRow,
+      reference: record.reference,
+      amount: record.rawAmount,
+      detail: 'Amount is blank or not a supported number.',
+    })
+  }
+
+  for (const [reference, records] of invoiceGroups) {
+    if (records.length > 1) exceptions.push({ severity: 'high', type: 'duplicate_reference', side: 'invoice', sourceRow: '', reference: records[0].reference || reference, amount: '', detail: `${records.length} invoice rows share this reference.` })
+  }
+  for (const [reference, records] of paymentGroups) {
+    if (records.length > 1) exceptions.push({ severity: 'high', type: 'duplicate_reference', side: 'payment', sourceRow: '', reference: records[0].reference || reference, amount: '', detail: `${records.length} payment rows share this reference.` })
+  }
+
+  for (const invoice of invoices) {
+    if (!invoice.validAmount || !invoice.referenceKey || usedInvoices.has(invoice.id)) continue
+    const invoiceReferenceRows = invoiceGroups.get(invoice.referenceKey) || []
+    const paymentReferenceRows = paymentGroups.get(invoice.referenceKey) || []
+    if (invoiceReferenceRows.length !== 1 || paymentReferenceRows.length !== 1) continue
+    const payment = paymentReferenceRows[0]
+    if (!payment.validAmount || usedPayments.has(payment.id)) continue
+    usedInvoices.add(invoice.id)
+    usedPayments.add(payment.id)
+    const difference = Math.abs(amountDifference(invoice, payment))
+    if (difference <= tolerance) {
+      pairs.push(createPair(invoice, payment, 'matched', 'exact_reference', 100, 'Exact normalized reference and amount.'))
+    } else {
+      pairs.push(createPair(invoice, payment, 'amount_mismatch', 'exact_reference', 100, 'Exact reference but different amount.'))
+      exceptions.push({
+        severity: 'high',
+        type: 'amount_mismatch',
+        side: 'pair',
+        sourceRow: `${invoice.sourceRow} / ${payment.sourceRow}`,
+        reference: invoice.reference || payment.reference,
+        amount: `${invoice.amount} / ${payment.amount}`,
+        detail: `Payment minus invoice = ${amountDifference(invoice, payment)}.`,
+      })
+    }
+  }
+
+  const amountClose = (invoice, payment) => Math.abs(amountDifference(invoice, payment)) <= tolerance
+  const dateClose = (invoice, payment, window) => invoice.epochDay != null && payment.epochDay != null && Math.abs(invoice.epochDay - payment.epochDay) <= window
+
+  applyMutualUniqueSuggestions({
+    invoices,
+    payments,
+    usedInvoices,
+    usedPayments,
+    pairs,
+    method: 'amount_party_date',
+    confidence: 90,
+    predicate: (invoice, payment) => amountClose(invoice, payment) && invoice.partyKey && invoice.partyKey === payment.partyKey && dateClose(invoice, payment, dateWindowDays),
+  })
+  applyMutualUniqueSuggestions({
+    invoices,
+    payments,
+    usedInvoices,
+    usedPayments,
+    pairs,
+    method: 'amount_date',
+    confidence: 75,
+    predicate: (invoice, payment) => amountClose(invoice, payment) && dateClose(invoice, payment, 1),
+  })
+  applyMutualUniqueSuggestions({
+    invoices,
+    payments,
+    usedInvoices,
+    usedPayments,
+    pairs,
+    method: 'amount_party',
+    confidence: 70,
+    predicate: (invoice, payment) => amountClose(invoice, payment) && invoice.partyKey && invoice.partyKey === payment.partyKey,
+  })
+
+  const unmatchedInvoices = invoices.filter((record) => !usedInvoices.has(record.id))
+  const unmatchedPayments = payments.filter((record) => !usedPayments.has(record.id))
+
+  for (const invoice of unmatchedInvoices.filter((record) => record.validAmount)) {
+    exceptions.push({ severity: 'medium', type: 'unmatched_invoice', side: 'invoice', sourceRow: invoice.sourceRow, reference: invoice.reference, amount: invoice.amount, detail: 'No safe payment pair was found.' })
+  }
+  for (const payment of unmatchedPayments.filter((record) => record.validAmount)) {
+    exceptions.push({ severity: 'medium', type: 'unmatched_payment', side: 'payment', sourceRow: payment.sourceRow, reference: payment.reference, amount: payment.amount, detail: 'No safe invoice pair was found.' })
+  }
+
+  const reconciliationRows = [
+    ...pairs,
+    ...unmatchedInvoices.map((invoice) => createPair(invoice, null, invoice.validAmount ? 'unmatched_invoice' : 'invalid_invoice', 'none', 0, invoice.validAmount ? 'No safe payment pair.' : 'Invalid invoice amount.')),
+    ...unmatchedPayments.map((payment) => createPair(null, payment, payment.validAmount ? 'unmatched_payment' : 'invalid_payment', 'none', 0, payment.validAmount ? 'No safe invoice pair.' : 'Invalid payment amount.')),
+  ].sort((left, right) => (left.invoice?.sourceRow || Number.MAX_SAFE_INTEGER) - (right.invoice?.sourceRow || Number.MAX_SAFE_INTEGER) || (left.payment?.sourceRow || Number.MAX_SAFE_INTEGER) - (right.payment?.sourceRow || Number.MAX_SAFE_INTEGER))
+
+  const exactPairs = pairs.filter((pair) => pair.status === 'matched')
+  const suggestedPairs = pairs.filter((pair) => pair.status === 'suggested')
+  const mismatchPairs = pairs.filter((pair) => pair.status === 'amount_mismatch')
+  const duplicateReferences = exceptions.filter((exception) => exception.type === 'duplicate_reference').length
+  const invalidAmounts = exceptions.filter((exception) => exception.type === 'invalid_amount').length
+  const validInvoices = invoices.filter((record) => record.validAmount)
+  const validPayments = payments.filter((record) => record.validAmount)
+  const reviewedInvoiceIds = new Set(exactPairs.map((pair) => pair.invoice.id))
+  const reviewInvoiceTotal = validInvoices.filter((record) => !reviewedInvoiceIds.has(record.id)).reduce((total, record) => total + record.amount, 0)
+
+  const summary = {
+    invoiceRows: invoices.length,
+    paymentRows: payments.length,
+    validInvoices: validInvoices.length,
+    validPayments: validPayments.length,
+    exactMatches: exactPairs.length,
+    suggestedMatches: suggestedPairs.length,
+    amountMismatches: mismatchPairs.length,
+    unmatchedInvoices: unmatchedInvoices.filter((record) => record.validAmount).length,
+    unmatchedPayments: unmatchedPayments.filter((record) => record.validAmount).length,
+    duplicateReferences,
+    invalidAmounts,
+    exceptionCount: exceptions.length,
+    highExceptions: exceptions.filter((exception) => exception.severity === 'high').length,
+    invoiceTotal: sum(validInvoices),
+    paymentTotal: sum(validPayments),
+    exactMatchedTotal: exactPairs.reduce((total, pair) => total + pair.invoice.amount, 0),
+    suggestedTotal: suggestedPairs.reduce((total, pair) => total + pair.invoice.amount, 0),
+    reviewInvoiceTotal,
+    unmatchedPaymentTotal: unmatchedPayments.filter((record) => record.validAmount).reduce((total, record) => total + record.amount, 0),
+  }
+
+  return {
+    settings: { tolerance, dateWindowDays, dateOrder, invoiceMapping, paymentMapping },
+    invoices,
+    payments,
+    reconciliationRows,
+    exceptions,
+    summary,
+    actions: buildActions(summary),
+  }
+}
+
+function spreadsheetSafe(value) {
+  const text = stringValue(value)
+  return /^[=+@]/.test(text) || (/^-/.test(text) && !/^-\d+(?:\.\d+)?$/.test(text)) ? `'${text}` : text
+}
+
+function csvCell(value) {
+  const text = spreadsheetSafe(value)
+  return /[",\r\n]/.test(text) ? `"${text.replace(/"/g, '""')}"` : text
+}
+
+function rowsToCsv(headers, rows) {
+  return [headers.join(','), ...rows.map((row) => headers.map((header) => csvCell(row[header] ?? '')).join(','))].join('\r\n') + '\r\n'
+}
+
+export function buildReconciliationCsv(result) {
+  const headers = ['status', 'method', 'confidence', 'invoice_source_row', 'invoice_reference', 'invoice_party', 'invoice_date', 'invoice_amount', 'payment_source_row', 'payment_reference', 'payment_party', 'payment_date', 'payment_amount', 'difference', 'review_reason']
+  return rowsToCsv(headers, result.reconciliationRows.map((pair) => ({
+    status: pair.status,
+    method: pair.method,
+    confidence: pair.confidence,
+    invoice_source_row: pair.invoice?.sourceRow || '',
+    invoice_reference: pair.invoice?.reference || '',
+    invoice_party: pair.invoice?.party || '',
+    invoice_date: pair.invoice?.date || '',
+    invoice_amount: pair.invoice?.validAmount ? pair.invoice.amount : pair.invoice?.rawAmount || '',
+    payment_source_row: pair.payment?.sourceRow || '',
+    payment_reference: pair.payment?.reference || '',
+    payment_party: pair.payment?.party || '',
+    payment_date: pair.payment?.date || '',
+    payment_amount: pair.payment?.validAmount ? pair.payment.amount : pair.payment?.rawAmount || '',
+    difference: pair.invoice?.validAmount && pair.payment?.validAmount ? pair.difference : '',
+    review_reason: pair.reviewReason,
+  })))
+}
+
+export function buildExceptionsCsv(result) {
+  const headers = ['severity', 'type', 'side', 'source_row', 'reference', 'amount', 'detail']
+  return rowsToCsv(headers, result.exceptions.map((exception) => ({
+    severity: exception.severity,
+    type: exception.type,
+    side: exception.side,
+    source_row: exception.sourceRow,
+    reference: exception.reference,
+    amount: exception.amount,
+    detail: exception.detail,
+  })))
+}
+
+function formatPlainNumber(value) {
+  return Number(value || 0).toLocaleString('en-US', { maximumFractionDigits: 6 })
+}
+
+export function buildDecisionBrief(result, context = {}, approval = null) {
+  const summary = result.summary
+  return [
+    'SUPERMEGA PAYMENT RECONCILIATION BRIEF',
+    `Run: ${context.runId || 'pending'}`,
+    `Prepared: ${context.generatedAt || new Date().toISOString()}`,
+    `Invoices: ${summary.invoiceRows} rows / ${formatPlainNumber(summary.invoiceTotal)}`,
+    `Payments: ${summary.paymentRows} rows / ${formatPlainNumber(summary.paymentTotal)}`,
+    `Exact matches: ${summary.exactMatches} / ${formatPlainNumber(summary.exactMatchedTotal)}`,
+    `Suggested pairs: ${summary.suggestedMatches} / ${formatPlainNumber(summary.suggestedTotal)}`,
+    `Amount mismatches: ${summary.amountMismatches}`,
+    `Unmatched invoices: ${summary.unmatchedInvoices}`,
+    `Unmatched payments: ${summary.unmatchedPayments} / ${formatPlainNumber(summary.unmatchedPaymentTotal)}`,
+    `Exceptions: ${summary.exceptionCount} (${summary.highExceptions} high)`,
+    '',
+    'NEXT REVIEW',
+    ...result.actions.map((action, index) => `${index + 1}. [${action.priority.toUpperCase()}] ${action.title}: ${action.detail}`),
+    '',
+    approval ? `Reviewed by: ${approval.name} at ${approval.approvedAt}` : 'Reviewed by: pending',
+    approval?.note ? `Review note: ${approval.note}` : 'Review note: pending when exceptions remain',
+    'Boundary: review output only; no payment, invoice, message, or books entry was changed.',
+  ].join('\n')
+}
+
+export function buildEvidence(result, context = {}, approval = null) {
+  return {
+    contract: 'supermega_payment_reconciliation_evidence_v1',
+    run_id: context.runId || 'pending',
+    generated_at: context.generatedAt || new Date().toISOString(),
+    source_files: context.sourceFiles || [],
+    settings: result.settings,
+    summary: result.summary,
+    approval,
+    boundaries: {
+      processing: 'browser_local',
+      source_upload: false,
+      source_rows_in_evidence: false,
+      payment_or_books_write: false,
+      automatic_finalization: false,
+    },
+  }
+}
+
+async function sha256(value) {
+  const bytes = new TextEncoder().encode(value)
+  if (globalThis.crypto?.subtle) {
+    const digest = await globalThis.crypto.subtle.digest('SHA-256', bytes)
+    return Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, '0')).join('')
+  }
+  const { createHash } = await import('node:crypto')
+  return createHash('sha256').update(bytes).digest('hex')
+}
+
+function escapeHtml(value) {
+  return stringValue(value).replace(/[&<>"']/g, (char) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' })[char])
+}
+
+function displayNumber(value) {
+  return Number(value || 0).toLocaleString('en-US', { maximumFractionDigits: 2 })
+}
+
+function saveText(name, text, type) {
+  const link = document.createElement('a')
+  link.href = URL.createObjectURL(new Blob([text], { type }))
+  link.download = name
+  document.body.append(link)
+  link.click()
+  link.remove()
+  window.setTimeout(() => URL.revokeObjectURL(link.href), 0)
+}
+
+function initWorkcell() {
+  const state = { invoice: null, payment: null, result: null, context: null, approval: null }
+  const byId = (id) => document.getElementById(id)
+  const requiredIds = ['invoiceFile', 'paymentFile', 'loadSample', 'mappingSection', 'analyzeButton', 'results', 'reviewName', 'reviewNote', 'reviewCheck', 'approveButton', 'downloadReconciliation', 'downloadExceptions', 'downloadBrief', 'downloadEvidence', 'copyBrief']
+  if (requiredIds.some((id) => !byId(id))) return
+
+  const mappingIds = {
+    invoice: { reference: 'invoiceReference', amount: 'invoiceAmount', date: 'invoiceDate', party: 'invoiceParty' },
+    payment: { reference: 'paymentReference', amount: 'paymentAmount', date: 'paymentDate', party: 'paymentParty' },
+  }
+
+  function setStatus(message, tone = '') {
+    const node = byId('runStatus')
+    node.textContent = message
+    node.dataset.tone = tone
+  }
+
+  function resetApproval() {
+    state.approval = null
+    byId('approvalState').textContent = 'Not approved'
+    for (const id of ['downloadReconciliation', 'downloadExceptions', 'downloadBrief', 'downloadEvidence']) byId(id).disabled = true
+    updateApprovalButton()
+  }
+
+  function updateApprovalButton() {
+    const hasExceptions = Boolean(state.result?.summary.exceptionCount)
+    const ready = Boolean(state.result && cleanText(byId('reviewName').value) && byId('reviewCheck').checked && (!hasExceptions || cleanText(byId('reviewNote').value)))
+    byId('approveButton').disabled = !ready
+  }
+
+  function renderFile(side) {
+    const item = state[side]
+    const name = byId(`${side}FileName`)
+    const meta = byId(`${side}FileMeta`)
+    if (!item) {
+      name.textContent = 'No file selected'
+      meta.textContent = side === 'invoice' ? 'Sales or invoice export' : 'Bank, wallet, or settlement export'
+      return
+    }
+    name.textContent = item.name
+    meta.textContent = `${item.dataset.rows.length.toLocaleString('en-US')} rows / ${item.dataset.headers.length} columns / ${item.dataset.kind.toUpperCase()}`
+  }
+
+  function fillMappingSelect(side, field, suggested) {
+    const select = byId(mappingIds[side][field])
+    const dataset = state[side].dataset
+    const optional = field !== 'amount'
+    select.innerHTML = `${optional ? '<option value="">Not available</option>' : '<option value="">Choose amount column</option>'}${dataset.headers.map((header) => `<option value="${escapeHtml(header.name)}">${escapeHtml(header.source)}</option>`).join('')}`
+    select.value = suggested[field] || ''
+  }
+
+  function renderMappings() {
+    const ready = Boolean(state.invoice && state.payment)
+    byId('mappingSection').hidden = !ready
+    byId('analyzeButton').disabled = !ready
+    if (!ready) return
+    for (const side of ['invoice', 'payment']) {
+      const suggested = suggestMappings(state[side].dataset, side)
+      for (const field of ['reference', 'amount', 'date', 'party']) fillMappingSelect(side, field, suggested)
+    }
+    setStatus('Map the columns, then run the reconciliation.', 'ready')
+  }
+
+  async function setSource(side, name, raw) {
+    const dataset = parseDataset(raw, name)
+    state[side] = { name, raw, hash: await sha256(raw), dataset }
+    state.result = null
+    state.context = null
+    byId('results').hidden = true
+    renderFile(side)
+    renderMappings()
+    resetApproval()
+  }
+
+  async function loadFile(side, file) {
+    if (!file) return
+    if (file.size > MAX_FILE_BYTES) throw new Error(`${side === 'invoice' ? 'Sales' : 'Payment'} file is larger than 10 MB`)
+    await setSource(side, file.name, await file.text())
+  }
+
+  function currentMapping(side) {
+    return Object.fromEntries(Object.entries(mappingIds[side]).map(([field, id]) => [field, byId(id).value]))
+  }
+
+  function renderResults() {
+    const { result } = state
+    const summary = result.summary
+    byId('results').hidden = false
+    byId('resultHeadline').textContent = summary.highExceptions ? 'Review before close' : summary.exceptionCount ? 'Review remaining exceptions' : 'Exact reconciliation ready'
+    byId('resultState').textContent = `${summary.exactMatches} exact / ${summary.suggestedMatches} suggested / ${summary.exceptionCount} exceptions`
+    byId('metricGrid').innerHTML = [
+      ['Invoice total', displayNumber(summary.invoiceTotal)],
+      ['Payment total', displayNumber(summary.paymentTotal)],
+      ['Exact matched', displayNumber(summary.exactMatchedTotal)],
+      ['Needs review', displayNumber(summary.reviewInvoiceTotal)],
+      ['Unmatched money', displayNumber(summary.unmatchedPaymentTotal)],
+      ['High exceptions', summary.highExceptions.toLocaleString('en-US')],
+    ].map(([label, value]) => `<div class="metric"><span>${escapeHtml(label)}</span><strong>${escapeHtml(value)}</strong></div>`).join('')
+
+    byId('actionList').innerHTML = result.actions.map((action, index) => `<li><span class="priority ${escapeHtml(action.priority)}">${index + 1} / ${escapeHtml(action.priority)}</span><div><strong>${escapeHtml(action.title)}</strong><p>${escapeHtml(action.detail)}</p></div></li>`).join('')
+
+    const visibleRows = result.reconciliationRows.slice(0, MAX_RENDERED_ROWS)
+    byId('reconciliationBody').innerHTML = visibleRows.map((pair) => `<tr><td><span class="status ${escapeHtml(pair.status)}">${escapeHtml(pair.status.replaceAll('_', ' '))}</span></td><td>${escapeHtml(pair.invoice?.reference || '—')}</td><td class="number">${escapeHtml(pair.invoice?.validAmount ? displayNumber(pair.invoice.amount) : pair.invoice?.rawAmount || '—')}</td><td>${escapeHtml(pair.payment?.reference || '—')}</td><td class="number">${escapeHtml(pair.payment?.validAmount ? displayNumber(pair.payment.amount) : pair.payment?.rawAmount || '—')}</td><td class="number">${pair.invoice?.validAmount && pair.payment?.validAmount ? escapeHtml(displayNumber(pair.difference)) : '—'}</td><td>${escapeHtml(pair.method.replaceAll('_', ' '))}</td></tr>`).join('')
+    byId('rowLimitNote').textContent = result.reconciliationRows.length > MAX_RENDERED_ROWS ? `Showing the first ${MAX_RENDERED_ROWS} of ${result.reconciliationRows.length.toLocaleString('en-US')} result rows. Approved downloads include every row.` : `${result.reconciliationRows.length.toLocaleString('en-US')} result rows.`
+    byId('briefPreview').textContent = buildDecisionBrief(result, state.context, state.approval)
+    setStatus('Reconciliation complete. Review exceptions and record approval.', summary.highExceptions ? 'review' : 'ready')
+    resetApproval()
+    byId('results').scrollIntoView({ behavior: 'smooth', block: 'start' })
+  }
+
+  async function analyze() {
+    try {
+      const generatedAt = new Date().toISOString()
+      const settings = {
+        tolerance: byId('amountTolerance').value,
+        dateWindowDays: byId('dateWindow').value,
+        dateOrder: byId('dateOrder').value,
+        invoiceMapping: currentMapping('invoice'),
+        paymentMapping: currentMapping('payment'),
+      }
+      const result = reconcileDatasets(state.invoice.dataset, state.payment.dataset, settings)
+      const runId = `REC-${state.invoice.hash.slice(0, 8)}-${state.payment.hash.slice(0, 8)}`.toUpperCase()
+      state.context = {
+        runId,
+        generatedAt,
+        sourceFiles: [
+          { role: 'invoice', name: state.invoice.name, sha256: state.invoice.hash, rows: state.invoice.dataset.rows.length, columns: state.invoice.dataset.headers.length },
+          { role: 'payment', name: state.payment.name, sha256: state.payment.hash, rows: state.payment.dataset.rows.length, columns: state.payment.dataset.headers.length },
+        ],
+      }
+      state.result = result
+      renderResults()
+    } catch (error) {
+      setStatus(error.message, 'error')
+    }
+  }
+
+  async function loadSample() {
+    try {
+      const invoiceCsv = 'invoice_no,customer_name,invoice_date,amount\r\nINV-1001,Aye Aye,2026-07-10,125000\r\nINV-1002,Ko Min,2026-07-11,88000\r\nINV-1003,May Store,2026-07-12,220000\r\nINV-1004,Lotus Cafe,2026-07-12,54000\r\nINV-1005,Shwe Mart,2026-07-13,150000\r\n'
+      const paymentCsv = 'invoice_ref,payer_name,payment_date,paid_amount\r\nINV-1001,Aye Aye,2026-07-10,125000\r\nINV-1002,Ko Min,2026-07-11,80000\r\n,May Store,2026-07-13,220000\r\nTX-889,Lotus Cafe,2026-07-12,54000\r\nEXTRA-77,Walk in,2026-07-13,45000\r\n'
+      await setSource('invoice', 'sample-invoices.csv', invoiceCsv)
+      await setSource('payment', 'sample-payments.csv', paymentCsv)
+      setStatus('Sample loaded. Review the suggested mappings, then reconcile.', 'ready')
+    } catch (error) {
+      setStatus(error.message, 'error')
+    }
+  }
+
+  async function copyBrief() {
+    const text = buildDecisionBrief(state.result, state.context, state.approval)
+    try {
+      await navigator.clipboard.writeText(text)
+    } catch {
+      const area = document.createElement('textarea')
+      area.value = text
+      area.style.position = 'fixed'
+      area.style.opacity = '0'
+      document.body.append(area)
+      area.select()
+      document.execCommand('copy')
+      area.remove()
+    }
+    byId('copyBrief').textContent = 'Copied'
+    window.setTimeout(() => { byId('copyBrief').textContent = 'Copy brief' }, 1400)
+  }
+
+  for (const side of ['invoice', 'payment']) {
+    byId(`${side}File`).addEventListener('change', async (event) => {
+      try {
+        await loadFile(side, event.target.files?.[0])
+      } catch (error) {
+        setStatus(error.message, 'error')
+      }
+    })
+  }
+  for (const picker of document.querySelectorAll('[data-drop-side]')) {
+    const side = picker.getAttribute('data-drop-side')
+    for (const eventName of ['dragenter', 'dragover']) {
+      picker.addEventListener(eventName, (event) => {
+        event.preventDefault()
+        picker.classList.add('is-dragging')
+      })
+    }
+    for (const eventName of ['dragleave', 'drop']) {
+      picker.addEventListener(eventName, (event) => {
+        event.preventDefault()
+        picker.classList.remove('is-dragging')
+      })
+    }
+    picker.addEventListener('drop', async (event) => {
+      try {
+        await loadFile(side, event.dataTransfer?.files?.[0])
+      } catch (error) {
+        setStatus(error.message, 'error')
+      }
+    })
+  }
+  byId('loadSample').addEventListener('click', loadSample)
+  byId('analyzeButton').addEventListener('click', analyze)
+  for (const id of [...Object.values(mappingIds.invoice), ...Object.values(mappingIds.payment), 'amountTolerance', 'dateWindow', 'dateOrder']) {
+    byId(id).addEventListener('change', () => {
+      state.result = null
+      byId('results').hidden = true
+      resetApproval()
+      setStatus('Mappings changed. Run the reconciliation again.', 'ready')
+    })
+  }
+  for (const id of ['reviewName', 'reviewNote']) byId(id).addEventListener('input', updateApprovalButton)
+  byId('reviewCheck').addEventListener('change', updateApprovalButton)
+  byId('approveButton').addEventListener('click', () => {
+    state.approval = {
+      name: cleanText(byId('reviewName').value),
+      note: cleanText(byId('reviewNote').value),
+      approvedAt: new Date().toISOString(),
+      disposition: state.result.summary.exceptionCount ? 'reviewed_with_exceptions' : 'approved_exact',
+    }
+    byId('approvalState').textContent = `${state.approval.disposition.replaceAll('_', ' ')} / ${state.approval.name}`
+    for (const id of ['downloadReconciliation', 'downloadExceptions', 'downloadBrief', 'downloadEvidence']) byId(id).disabled = false
+    byId('briefPreview').textContent = buildDecisionBrief(state.result, state.context, state.approval)
+    byId('approveButton').disabled = true
+  })
+  byId('copyBrief').addEventListener('click', copyBrief)
+  byId('downloadReconciliation').addEventListener('click', () => saveText(`${state.context.runId.toLowerCase()}-reconciliation.csv`, buildReconciliationCsv(state.result), 'text/csv;charset=utf-8'))
+  byId('downloadExceptions').addEventListener('click', () => saveText(`${state.context.runId.toLowerCase()}-exceptions.csv`, buildExceptionsCsv(state.result), 'text/csv;charset=utf-8'))
+  byId('downloadBrief').addEventListener('click', () => saveText(`${state.context.runId.toLowerCase()}-brief.txt`, buildDecisionBrief(state.result, state.context, state.approval), 'text/plain;charset=utf-8'))
+  byId('downloadEvidence').addEventListener('click', () => saveText(`${state.context.runId.toLowerCase()}-evidence.json`, `${JSON.stringify(buildEvidence(state.result, state.context, state.approval), null, 2)}\n`, 'application/json;charset=utf-8'))
+  renderFile('invoice')
+  renderFile('payment')
+  updateApprovalButton()
+}
+
+if (typeof document !== 'undefined') initWorkcell()

--- a/tools/serve_public_output.mjs
+++ b/tools/serve_public_output.mjs
@@ -14,6 +14,7 @@ const contentTypes = new Map([
   ['.html', 'text/html; charset=utf-8'],
   ['.css', 'text/css; charset=utf-8'],
   ['.js', 'text/javascript; charset=utf-8'],
+  ['.mjs', 'text/javascript; charset=utf-8'],
   ['.json', 'application/json; charset=utf-8'],
   ['.png', 'image/png'],
   ['.svg', 'image/svg+xml'],

--- a/tools/verify_payment_reconciler.mjs
+++ b/tools/verify_payment_reconciler.mjs
@@ -1,0 +1,127 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import {
+  RECONCILIATION_LIMITS,
+  buildDecisionBrief,
+  buildEvidence,
+  buildExceptionsCsv,
+  buildReconciliationCsv,
+  parseCsv,
+  parseDataset,
+  parseDate,
+  parseMoney,
+  reconcileDatasets,
+  suggestMappings,
+} from './public-workcells/payment-reconciler.mjs'
+
+let checks = 0
+function check(condition, message) {
+  assert.ok(condition, message)
+  checks += 1
+}
+
+function sampleRun() {
+  const invoices = parseDataset('invoice_no,customer_name,invoice_date,amount\r\nINV-1001,Aye Aye,2026-07-10,125000\r\nINV-1002,Ko Min,2026-07-11,88000\r\nINV-1003,May Store,2026-07-12,220000\r\nINV-1004,Lotus Cafe,2026-07-12,54000\r\nINV-1005,Shwe Mart,2026-07-13,150000\r\n', 'invoices.csv')
+  const payments = parseDataset('invoice_ref,payer_name,payment_date,paid_amount\r\nINV-1001,Aye Aye,2026-07-10,125000\r\nINV-1002,Ko Min,2026-07-11,80000\r\n,May Store,2026-07-13,220000\r\nTX-889,Lotus Cafe,2026-07-12,54000\r\nEXTRA-77,Walk in,2026-07-13,45000\r\n', 'payments.csv')
+  return reconcileDatasets(invoices, payments, {
+    tolerance: 0,
+    dateWindowDays: 3,
+    dateOrder: 'day-first',
+    invoiceMapping: suggestMappings(invoices, 'invoice'),
+    paymentMapping: suggestMappings(payments, 'payment'),
+  })
+}
+
+check(RECONCILIATION_LIMITS.maxFileBytes === 10 * 1024 * 1024, 'file size limit drifted')
+check(RECONCILIATION_LIMITS.maxRowsPerFile === 50000, 'row limit drifted')
+
+const quoted = parseCsv('reference,note\r\nINV-1,"line one\r\nline two"\r\n')
+check(quoted.length === 2, 'quoted multiline CSV changed row count')
+check(quoted[1][1] === 'line one\r\nline two'.replace(/\r\n?/g, '\n'), 'quoted multiline CSV did not preserve the field')
+
+const duplicateHeaders = parseDataset('Amount,Amount\r\n1,2\r\n', 'duplicate.csv')
+check(duplicateHeaders.headers.map((header) => header.name).join(',') === 'amount,amount_2', 'duplicate headers were not made unique')
+
+const json = parseDataset('{"payments":[{"Reference":"TX-1","Amount":10}]}', 'payments.json')
+check(json.kind === 'json' && json.rows.length === 1, 'JSON envelope was not parsed')
+check(json.headers.some((header) => header.name === 'reference'), 'JSON headers were not normalized')
+
+check(parseMoney('Ks 1,250').number === 1250, 'MMK amount parsing failed')
+check(parseMoney('(500)').number === -500, 'parenthesized negative parsing failed')
+check(parseMoney('1O0').valid === false, 'invalid amount was accepted')
+check(parseDate('07/08/2026', 'day-first').iso === '2026-08-07', 'day-first date parsing failed')
+check(parseDate('07/08/2026', 'month-first').iso === '2026-07-08', 'month-first date parsing failed')
+
+const result = sampleRun()
+check(result.summary.invoiceRows === 5 && result.summary.paymentRows === 5, 'sample source counts changed')
+check(result.summary.exactMatches === 1, 'exact reference matching failed')
+check(result.summary.suggestedMatches === 2, 'mutual-unique suggestions failed')
+check(result.summary.amountMismatches === 1, 'amount mismatch was not isolated')
+check(result.summary.unmatchedInvoices === 1 && result.summary.unmatchedPayments === 1, 'unmatched rows were not retained')
+check(result.summary.invoiceTotal === 637000 && result.summary.paymentTotal === 524000, 'source totals are wrong')
+check(result.summary.exactMatchedTotal === 125000 && result.summary.suggestedTotal === 274000, 'match totals are wrong')
+check(result.reconciliationRows.length === 6, 'a source row disappeared or was duplicated in reconciliation output')
+check(result.actions.length <= 5 && result.actions[0].priority === 'high', 'ranked review is not bounded or prioritized')
+
+const ambiguousInvoices = parseDataset('ref,customer,date,amount\r\nA,One,2026-07-10,100\r\nB,Two,2026-07-10,100\r\n', 'invoices.csv')
+const ambiguousPayments = parseDataset('ref,payer,date,amount\r\n,Unknown,2026-07-10,100\r\n', 'payments.csv')
+const ambiguous = reconcileDatasets(ambiguousInvoices, ambiguousPayments, {
+  invoiceMapping: { reference: 'ref', party: 'customer', date: 'date', amount: 'amount' },
+  paymentMapping: { reference: 'ref', party: 'payer', date: 'date', amount: 'amount' },
+  tolerance: 0,
+  dateWindowDays: 3,
+  dateOrder: 'day-first',
+})
+check(ambiguous.summary.suggestedMatches === 0, 'ambiguous candidate was auto-suggested')
+check(ambiguous.summary.unmatchedInvoices === 2 && ambiguous.summary.unmatchedPayments === 1, 'ambiguous rows were not retained')
+
+const duplicateInvoices = parseDataset('ref,amount\r\nDUP,10\r\nDUP,10\r\n', 'invoices.csv')
+const duplicatePayments = parseDataset('ref,amount\r\nDUP,10\r\n', 'payments.csv')
+const duplicates = reconcileDatasets(duplicateInvoices, duplicatePayments, {
+  invoiceMapping: { reference: 'ref', amount: 'amount' },
+  paymentMapping: { reference: 'ref', amount: 'amount' },
+})
+check(duplicates.summary.exactMatches === 0, 'duplicate invoice reference entered exact matching')
+check(duplicates.summary.duplicateReferences === 1, 'duplicate reference group was not surfaced')
+
+const formulaInvoices = parseDataset('ref,amount\r\n=2+2,10\r\n', 'invoices.csv')
+const formulaPayments = parseDataset('ref,amount\r\n=2+2,10\r\n', 'payments.csv')
+const formulaResult = reconcileDatasets(formulaInvoices, formulaPayments, {
+  invoiceMapping: { reference: 'ref', amount: 'amount' },
+  paymentMapping: { reference: 'ref', amount: 'amount' },
+})
+check(buildReconciliationCsv(formulaResult).includes("'=2+2"), 'spreadsheet formula was not neutralized')
+
+const context = {
+  runId: 'REC-TEST-001',
+  generatedAt: '2026-07-15T00:00:00.000Z',
+  sourceFiles: [
+    { role: 'invoice', name: 'invoices.csv', sha256: 'a'.repeat(64), rows: 5, columns: 4 },
+    { role: 'payment', name: 'payments.csv', sha256: 'b'.repeat(64), rows: 5, columns: 4 },
+  ],
+}
+const approval = { name: 'Owner', note: 'Reviewed exceptions.', approvedAt: '2026-07-15T00:10:00.000Z', disposition: 'reviewed_with_exceptions' }
+const brief = buildDecisionBrief(result, context, approval)
+check(brief.includes('no payment, invoice, message, or books entry was changed'), 'decision brief lost the no-write boundary')
+check(brief.includes('Reviewed by: Owner'), 'decision brief lost named approval')
+check(buildExceptionsCsv(result).split('\r\n').length > 2, 'exceptions export is empty')
+
+const evidence = buildEvidence(result, context, approval)
+check(evidence.boundaries.source_upload === false && evidence.boundaries.payment_or_books_write === false, 'evidence boundary drifted')
+check(!JSON.stringify(evidence).includes('Aye Aye'), 'source rows leaked into metadata-only evidence')
+check(evidence.source_files.every((file) => /^[a-f0-9]{64}$/.test(file.sha256)), 'source hashes are malformed')
+
+const html = readFileSync(resolve(process.cwd(), 'tools', 'public-workcells', 'payment-reconciler.html'), 'utf8')
+for (const required of [
+  '<title>Payment Reconciler | SuperMega AI Agent Solutions</title>',
+  'Zero source upload or money movement',
+  'id="invoiceFile"',
+  'id="paymentFile"',
+  'id="approveButton"',
+  'id="downloadReconciliation"',
+  'src="/reconcile/payment-reconciler.mjs"',
+]) check(html.includes(required), `workcell HTML is missing ${required}`)
+for (const forbidden of ['target="_blank"', 'window.open(', 'MegaOS', 'DeskPOS', 'automatically posts', 'connect your bank']) check(!html.includes(forbidden), `workcell HTML contains forbidden content: ${forbidden}`)
+
+console.log(JSON.stringify({ status: 'ok', contract: 'payment_reconciliation_workcell', checks }))

--- a/tools/verify_public_enterprise_visual_contract.mjs
+++ b/tools/verify_public_enterprise_visual_contract.mjs
@@ -19,12 +19,14 @@ const publicPages = [
   'index.html',
   'contact/index.html',
   'privacy/index.html',
+  'reconcile/index.html',
   '404.html',
 ]
 
 const pages = new Map(publicPages.map((relativePath) => [relativePath, readPage(relativePath)]))
 const home = pages.get('index.html')
 const contact = pages.get('contact/index.html')
+const reconciler = pages.get('reconcile/index.html')
 
 for (const [relativePath, html] of pages) {
   for (const required of ['data-theme="light"', 'data-theme="dark"', 'prefers-color-scheme', 'prefers-reduced-motion', 'data-theme-toggle']) {
@@ -39,6 +41,7 @@ for (const required of [
   'https://app.supermega.dev/?demo=shop',
   'https://app.supermega.dev/?demo=plant',
   'https://supermega-machine.vercel.app/workcell',
+  'href="/reconcile/"',
   '<h1 id="portfolio-heading">Operational software, built to fit.</h1>',
   'data-product-preview',
   'data-preview-open',
@@ -49,8 +52,8 @@ for (const required of [
   'Your private workspace is configured and verified before handover.',
   'Start fresh or add approved business records when ready.',
   '<strong>AI Agent Solutions</strong>',
-  'Run File Analyst now:',
-  'Source stays in this browser and is never uploaded.',
+  'Use File Analyst to clean one export, or run Payment Reconciler now',
+  'Sources stay in this browser and are never uploaded.',
   '<h2 id="brief-heading">Tell us where the workflow breaks.</h2>',
   '>Describe your workflow</a>',
   '<img src="/favicon.svg" alt="" width="64" height="64" />',
@@ -64,6 +67,10 @@ for (const forbidden of ['<figure class="site-hero-screen"', '<img src="/site/sh
 }
 
 if (!contact.includes('.header-cta { display: none; }')) fail('contact_page_keeps_redundant_start_control')
+
+for (const required of ['<h1 id="reconcile-heading">Match sales to money.</h1>', 'class="source-grid"', 'class="mapping-columns"', 'class="result-layout"', 'class="approval-grid"']) {
+  if (!reconciler.includes(required)) fail('payment_reconciler_visual_contract_missing', { required })
+}
 
 for (const forbidden of ['placeholder="Drive folder', 'placeholder="Example:', 'Role-aware onboarding', 'Device-aware onboarding', 'Adaptive setup plan', 'First proof planner']) {
   if (contact.includes(forbidden)) fail('contact_surface_is_not_blank_or_honest', { forbidden })

--- a/tools/verify_public_release_live.mjs
+++ b/tools/verify_public_release_live.mjs
@@ -6,6 +6,7 @@ const endpoints = {
   home: 'https://supermega.dev/',
   www: 'https://www.supermega.dev/',
   fileAnalyst: 'https://supermega-machine.vercel.app/workcell',
+  paymentReconciler: 'https://supermega.dev/reconcile/',
   agentIntake: 'https://supermega.dev/contact/?from=ai-agent-solution',
   health: 'https://supermega.dev/api/health',
   contactStatus: 'https://supermega.dev/api/contact-submissions/status',
@@ -47,9 +48,10 @@ function verifyHome(html, label) {
     'src="/live-shop-workspace.png"',
     "src:'/live-plant-workspace.png'",
     'https://supermega-machine.vercel.app/workcell',
+    'href="/reconcile/"',
     '<strong>AI Agent Solutions</strong>',
-    'Run File Analyst now:',
-    'Source stays in this browser and is never uploaded.',
+    'Use File Analyst to clean one export, or run Payment Reconciler now',
+    'Sources stay in this browser and are never uploaded.',
     'Use working screens',
     'Your private workspace is configured and verified before handover.',
     'Start fresh or add approved business records when ready.',
@@ -75,6 +77,23 @@ function verifyFileAnalyst(html) {
   }
   for (const forbidden of ['MegaOS', 'DeskPOS']) {
     assert(!html.includes(forbidden), `file_analyst_retired_${forbidden}`)
+  }
+}
+
+function verifyPaymentReconciler(html) {
+  for (const required of [
+    '<title>Payment Reconciler | SuperMega AI Agent Solutions</title>',
+    'Zero source upload or money movement',
+    'id="invoiceFile"',
+    'id="paymentFile"',
+    'id="approveButton"',
+    'id="downloadReconciliation"',
+    'src="/reconcile/payment-reconciler.mjs"',
+  ]) {
+    assert(html.includes(required), `payment_reconciler_missing_${required.slice(0, 32)}`)
+  }
+  for (const forbidden of ['MegaOS', 'DeskPOS', 'target="_blank"', 'window.open(', 'connect your bank']) {
+    assert(!html.includes(forbidden), `payment_reconciler_retired_${forbidden}`)
   }
 }
 
@@ -129,10 +148,11 @@ function verifyProtectedDiagnostics(response, body) {
 }
 
 async function verifyOnce() {
-  const [homeResponse, wwwResponse, fileAnalystResponse, intakeResponse, healthResponse, statusResponse, diagnosticsResponse] = await Promise.all([
+  const [homeResponse, wwwResponse, fileAnalystResponse, paymentReconcilerResponse, intakeResponse, healthResponse, statusResponse, diagnosticsResponse] = await Promise.all([
     get(endpoints.home, 'text/html'),
     get(endpoints.www, 'text/html'),
     get(endpoints.fileAnalyst, 'text/html'),
+    get(endpoints.paymentReconciler, 'text/html'),
     get(endpoints.agentIntake, 'text/html'),
     get(endpoints.health, 'application/json'),
     get(endpoints.contactStatus, 'application/json'),
@@ -150,10 +170,11 @@ async function verifyOnce() {
     }),
   ])
 
-  const [home, www, fileAnalyst, intake, health, contactStatus, protectedDiagnostics] = await Promise.all([
+  const [home, www, fileAnalyst, paymentReconciler, intake, health, contactStatus, protectedDiagnostics] = await Promise.all([
     homeResponse.text(),
     wwwResponse.text(),
     fileAnalystResponse.text(),
+    paymentReconcilerResponse.text(),
     intakeResponse.text(),
     healthResponse.json(),
     statusResponse.json(),
@@ -163,6 +184,7 @@ async function verifyOnce() {
   verifyHome(home, 'home')
   verifyHome(www, 'www')
   verifyFileAnalyst(fileAnalyst)
+  verifyPaymentReconciler(paymentReconciler)
   verifyAgentIntake(intake)
   verifyHealth(health)
   verifyContactStatus(contactStatus)

--- a/tools/verify_public_vercel_output.mjs
+++ b/tools/verify_public_vercel_output.mjs
@@ -30,7 +30,7 @@ if (!existsSync(configPath)) fail('missing_public_config')
 const config = JSON.parse(readFileSync(configPath, 'utf8'))
 const routes = Array.isArray(config.routes) ? config.routes : []
 
-const expectedStaticEntries = new Set(['404.html', 'contact', 'favicon.svg', 'index.html', 'live-plant-workspace.png', 'live-shop-workspace.png', 'privacy', 'robots.txt', 'site.webmanifest', 'sitemap.xml', 'sw.js'])
+const expectedStaticEntries = new Set(['404.html', 'contact', 'favicon.svg', 'index.html', 'live-plant-workspace.png', 'live-shop-workspace.png', 'privacy', 'reconcile', 'robots.txt', 'site.webmanifest', 'sitemap.xml', 'sw.js'])
 const actualStaticEntries = readdirSync(staticDir)
 for (const entry of actualStaticEntries) {
   if (!expectedStaticEntries.has(entry)) fail('retired_public_static_entry_present', { entry })
@@ -64,11 +64,14 @@ if (!existsSync(publicDatastoreShim) || !readFileSync(publicDatastoreShim, 'utf8
 const home = readText('index.html')
 const contact = readText('contact/index.html')
 const privacy = readText('privacy/index.html')
+const reconciler = readText('reconcile/index.html')
+const reconcilerModule = readText('reconcile/payment-reconciler.mjs')
 const notFound = readText('404.html')
 const pages = new Map([
   ['index.html', home],
   ['contact/index.html', contact],
   ['privacy/index.html', privacy],
+  ['reconcile/index.html', reconciler],
   ['404.html', notFound],
 ])
 
@@ -90,6 +93,7 @@ for (const required of [
   'https://app.supermega.dev/?demo=shop',
   'https://app.supermega.dev/?demo=plant',
   'https://supermega-machine.vercel.app/workcell',
+  'href="/reconcile/"',
   'operational software / live',
   'class="hero-lead">Less chasing. More running.</strong>',
   '<h2 id="workspaces-heading">Start close to the real work.</h2>',
@@ -107,9 +111,9 @@ for (const required of [
   'data-product-preview-button="plant"',
   'src="/live-shop-workspace.png"',
   "src:'/live-plant-workspace.png'",
-  'Shop, Plant, and File Analyst open without an account.',
-  'Run File Analyst now:',
-  'Source stays in this browser and is never uploaded.',
+  'Shop, Plant, File Analyst, and Payment Reconciler open without an account.',
+  'Use File Analyst to clean one export, or run Payment Reconciler now',
+  'Sources stay in this browser and are never uploaded.',
   'Your private workspace is configured and verified before handover.',
   'Start fresh or add approved business records when ready.',
   'data-public-status',
@@ -123,6 +127,16 @@ for (const required of [
 
 for (const forbidden of ['https://demo.supermega.dev/', 'The intelligent workspace for daily operations.', 'Explore live demos', 'Open workspace', 'target="_blank"', 'target=_blank', 'window.open(', 'rotate(', 'data-hero-media', 'Current build', 'Build an agent solution', '>Agent solution<', 'Need a repeated task handled?', 'id="products"', 'Run the operation. See what matters.', 'Open a workspace.', 'Try first. Add data later.', 'Need something different?', '[data-reveal] { opacity: 0', 'Use one account across desktop, tablet, and mobile.', 'Create a workspace only when you want to keep your work and use it across devices.', 'Create with email and password. Return with your password or an email code.']) {
   if (home.includes(forbidden)) fail('homepage_keeps_superseded_portfolio_copy', { forbidden })
+}
+
+for (const required of ['<title>Payment Reconciler | SuperMega AI Agent Solutions</title>', 'Zero source upload or money movement', 'id="invoiceFile"', 'id="paymentFile"', 'id="approveButton"', 'id="downloadReconciliation"', 'src="/reconcile/payment-reconciler.mjs"']) {
+  if (!reconciler.includes(required)) fail('payment_reconciler_contract_missing', { required })
+}
+for (const forbidden of ['target="_blank"', 'window.open(', 'MegaOS', 'DeskPOS', 'connect your bank']) {
+  if (reconciler.includes(forbidden)) fail('payment_reconciler_contains_forbidden_content', { forbidden })
+}
+for (const forbidden of ['fetch(', 'XMLHttpRequest', 'WebSocket(', 'sendBeacon(', 'localStorage.setItem']) {
+  if (reconcilerModule.includes(forbidden)) fail('payment_reconciler_module_breaks_local_only_boundary', { forbidden })
 }
 
 for (const required of ['action="/api/contact-submissions"', 'name="name"', 'name="email"', 'name="company"', 'name="goal"', 'No account or data connection is made before you approve it.']) {
@@ -158,7 +172,7 @@ if (manifest.name !== 'supermega.dev' || manifest.short_name !== 'supermega' || 
 }
 
 const sitemap = readText('sitemap.xml')
-for (const required of ['https://supermega.dev/', 'https://supermega.dev/contact/', 'https://supermega.dev/privacy/']) {
+for (const required of ['https://supermega.dev/', 'https://supermega.dev/reconcile/', 'https://supermega.dev/contact/', 'https://supermega.dev/privacy/']) {
   if (!sitemap.includes(required)) fail('sitemap_missing_current_page', { required })
 }
 for (const forbidden of ['/products/', '/pricing/', '/ai-agents/', '/agent-templates/', '/offers/']) {


### PR DESCRIPTION
## What changed
- add a browser-local Payment Reconciler for two CSV/JSON exports
- preserve every source row, isolate ambiguous or mismatched records, and require named review before downloads
- generate reconciliation, exception, decision-brief, and metadata-only evidence outputs
- expose the live workcell from the public AI Agent Solutions offer
- add artifact, visual, workcell, and live-release contracts

## Boundary
- no source upload, bank connection, payment movement, invoice write, or books posting
- no pricing, contact-submission, Shop, Plant, DNS, or account-access changes

## Verification
- `npm run public:prebuilt`
- 45 deterministic Payment Reconciler checks
- all public front-door, visual, intake, handoff, and 66-connector resilience checks
- fresh Microsoft Edge QA at 390x844: same-tab entry, expected sample result, zero overflow, zero errors/warnings, static requests only