### PR TITLE
Public: lock verified AI proof release

### DIFF
--- a/tools/public_deployment_lock.json
+++ b/tools/public_deployment_lock.json
@@ -1,11 +1,11 @@
 {
-    "public_host":  "supermega-public-plb0swkmt-swanhtet01s-projects.vercel.app",
-    "deployment_id":  "dpl_ADHTd8LfzK3SfzqUNwscX7EuYPQ1",
-    "locked_at":  "2026-07-15T09:10:21.7542761Z",
+    "public_host":  "supermega-public-pyy4ng7hn-swanhtet01s-projects.vercel.app",
+    "deployment_id":  "dpl_HiWeNkiNvWYEaK5RLU4fY35XTKxJ",
+    "locked_at":  "2026-07-15T09:57:58.563Z",
     "domains":  [
                     "supermega.dev",
                     "www.supermega.dev"
                 ],
     "project":  "supermega-public",
-    "reason":  "Separated public project deployment verified and attached to public domains."
+    "reason":  "Merged AI Agent Solutions proof tools verified and attached to both public domains."
 }


### PR DESCRIPTION
Records the immutable Vercel deployment that currently owns `supermega.dev`, `www.supermega.dev`, and the stable public aliases after live browser proof.

- deployment: `dpl_HiWeNkiNvWYEaK5RLU4fY35XTKxJ`
- host: `supermega-public-pyy4ng7hn-swanhtet01s-projects.vercel.app`
- source: merged PR #115 (`bd27909b`)
- alias check: both domains on the expected host; contact API ready; lead ledger configured

This metadata-only change does not rebuild or redeploy the product.