### PR TITLE
Fix the live Payment Reconciler route

### DIFF
--- a/tools/create_public_vercel_output.mjs
+++ b/tools/create_public_vercel_output.mjs
@@ -5849,6 +5849,15 @@ const config = {
       dest: '/work/index.html',
     },
     {
+      src: '^/reconcile/?$',
+      dest: '/reconcile.html',
+    },
+    {
+      src: '^/reconcile/payment-reconciler\\.mjs$',
+      dest: '/payment-reconciler.mjs',
+      headers: { 'cache-control': 'public, max-age=3600, must-revalidate' },
+    },
+    {
       src: '^/(?:site/.*|favicon\\.svg|favicon-[0-9]+\\.png|apple-touch-icon\\.png|vite\\.svg|site\\.webmanifest)$',
       headers: { 'cache-control': 'public, max-age=31536000, immutable' },
       continue: true,
@@ -6130,6 +6139,8 @@ await writeFile(resolve(staticDir, 'index.html'), normalizePublicProductNames(un
 await mkdir(resolve(staticDir, 'reconcile'), { recursive: true })
 await cp(resolve(root, 'tools', 'public-workcells', 'payment-reconciler.html'), resolve(staticDir, 'reconcile', 'index.html'), { force: true })
 await cp(resolve(root, 'tools', 'public-workcells', 'payment-reconciler.mjs'), resolve(staticDir, 'reconcile', 'payment-reconciler.mjs'), { force: true })
+await cp(resolve(root, 'tools', 'public-workcells', 'payment-reconciler.html'), resolve(staticDir, 'reconcile.html'), { force: true })
+await cp(resolve(root, 'tools', 'public-workcells', 'payment-reconciler.mjs'), resolve(staticDir, 'payment-reconciler.mjs'), { force: true })
 await writeFile(resolve(staticDir, '404.html'), `<!doctype html><html lang="en"><head><meta charset="UTF-8" /><meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="robots" content="noindex,nofollow" /><title>Page not found | SUPERMEGA.dev</title><meta name="theme-color" content="#07111f" /><link rel="icon" type="image/svg+xml" href="/favicon.svg?v=supermega-atelier-20260623" /><style>${unicornShellStyle}</style></head><body><div class="wrap">${unicornHeader}<main><section class="poster" style="min-height:58vh;align-items:center"><div class="copy"><div class="eyebrow">404</div><h1>Page not found.</h1><p>That page doesn’t exist. Head back home, or open a live workspace.</p><div class="cta"><a class="btn primary" href="/">Home</a><a class="btn secondary" href="https://app.supermega.dev/?demo=shop">Open app</a></div></div></section></main></div></body></html>`, 'utf8')
 await mkdir(resolve(staticDir, 'products'), { recursive: true })
 await writeFile(resolve(staticDir, 'products', 'index.html'), publicRedirectHtml('https://app.supermega.dev/?demo=shop', 'Open Shop'), 'utf8')

--- a/tools/verify_public_vercel_output.mjs
+++ b/tools/verify_public_vercel_output.mjs
@@ -48,6 +48,8 @@ for (const [src, dest] of [
   ['^/api/checkout-start/status$', '/api/checkout-start.js'],
   ['^/api/pipeline-control$', '/api/pipeline-control.js'],
   ['^/api/pipeline-control/status$', '/api/pipeline-control.js'],
+  ['^/reconcile/?$', '/reconcile.html'],
+  ['^/reconcile/payment-reconciler\\.mjs$', '/payment-reconciler.mjs'],
 ]) {
   if (routes.get(src) !== dest) fail('route_contract_missing', { src, expected: dest, actual: routes.get(src) })
 }
@@ -97,6 +99,8 @@ for (const entry of [
   'work/index.html',
   'reconcile/index.html',
   'reconcile/payment-reconciler.mjs',
+  'reconcile.html',
+  'payment-reconciler.mjs',
   'app/start/index.html',
   'site/shots/actual-custom-workflow-queue.png',
   'site/shots/actual-custom-workflow-modules.png',


### PR DESCRIPTION
## What changed
- add explicit Vercel routes for `/reconcile/` and its browser module
- publish root-level static artifacts so the homepage Payment Reconciler button cannot fall through to the 404 route
- lock both routes and artifacts in the public release contract

## Verification
- `npm run public:build`
- `npm run public:verify` (211 files, 7.82 MB; Payment Reconciler 45 checks; 66 connectors / 923 calls / 0 violations)
- confirmed the pre-fix live button returned 404, so this PR addresses a measured production failure

No form, customer record, payment, or price changed.