### PR TITLE
Public: add privacy-safe contact routing proof

### DIFF
--- a/api/contact-submissions.js
+++ b/api/contact-submissions.js
@@ -142,6 +142,63 @@ function truncate(value, maxLength) {
   return normalized.length > maxLength ? `${normalized.slice(0, maxLength - 3)}...` : normalized
 }
 
+function routingOutcome(result = {}) {
+  const outcome = {
+    status: truncate(result.status || 'unknown', 80),
+  }
+  for (const key of ['reason', 'adapter']) {
+    const value = truncate(result[key], 120)
+    if (value) outcome[key] = value
+  }
+  for (const key of ['code', 'lead_count']) {
+    if (Number.isFinite(result[key])) outcome[key] = result[key]
+  }
+  if (typeof result.duplicate === 'boolean') outcome.duplicate = result.duplicate
+  return outcome
+}
+
+function buildContactRoutingEvent({
+  record = {},
+  ledger = {},
+  pipelineAction = {},
+  webhook = {},
+  shopPipeline = {},
+  opsIntake = {},
+  delivery = {},
+  confirmation = {},
+  telegram = {},
+  sheets = {},
+} = {}) {
+  return {
+    event: 'supermega.contact.routed',
+    version: 1,
+    reference: truncate(record.lead_id, 120),
+    task_reference: truncate(record.task_id, 120),
+    product_area: truncate(record.product_area || 'Custom workflow', 80),
+    template_id: truncate(record.template_id || 'custom', 120),
+    submitted_at: truncate(record.submitted_at, 40),
+    durable: ledger.status === 'ready' || pipelineAction.status === 'ready',
+    notified: delivery.status === 'ready',
+    sinks: {
+      lead_ledger: routingOutcome(ledger),
+      pipeline_action: routingOutcome(pipelineAction),
+      webhook: routingOutcome(webhook),
+      shop_pipeline: routingOutcome(shopPipeline),
+      ops_intake: routingOutcome(opsIntake),
+      owner_notification: routingOutcome(delivery),
+      requester_confirmation: routingOutcome(confirmation),
+      telegram: routingOutcome(telegram),
+      sheets: routingOutcome(sheets),
+    },
+  }
+}
+
+function emitContactRoutingEvent(input) {
+  const event = buildContactRoutingEvent(input)
+  console.info(JSON.stringify(event))
+  return event
+}
+
 function contactEntryIntent(payload = {}) {
   for (const value of [payload.page_path, payload.source_url]) {
     const raw = text(value)
@@ -2483,6 +2540,19 @@ async function handler(req, res) {
     appendToGoogleSheet({ record }),
   ])
 
+  emitContactRoutingEvent({
+    record,
+    ledger,
+    pipelineAction,
+    webhook,
+    shopPipeline,
+    opsIntake,
+    delivery,
+    confirmation,
+    telegram,
+    sheets,
+  })
+
   // Email is a notification layer — only fail hard if the lead was not saved anywhere
   const leadSaved = ledger.status === 'ready' || pipelineAction.status === 'ready'
   if (delivery.status !== 'ready' && !leadSaved) {
@@ -2553,6 +2623,7 @@ handler.__test = {
   publicContactStatus,
   contactDiagnostics,
   hasStatusDiagnosticsAccess,
+  buildContactRoutingEvent,
   publicSubmissionReceipt,
   publicSubmissionFailure,
   receiptHtml,

--- a/tools/verify_contact_ops_intake_handoff.mjs
+++ b/tools/verify_contact_ops_intake_handoff.mjs
@@ -12,6 +12,7 @@ const {
   publicContactStatus,
   contactDiagnostics,
   hasStatusDiagnosticsAccess,
+  buildContactRoutingEvent,
   publicSubmissionReceipt,
   publicSubmissionFailure,
   receiptHtml,
@@ -28,6 +29,7 @@ assert.equal(typeof isShopLead, 'function')
 assert.equal(typeof isSafeShopPipelineUrl, 'function')
 assert.equal(typeof shopPipelinePayload, 'function')
 assert.equal(typeof forwardShopPipeline, 'function')
+assert.equal(typeof buildContactRoutingEvent, 'function')
 assert.equal(isSafeOpsIntakeUrl('https://supermega-machine.vercel.app/api/intake'), true)
 assert.equal(isSafeOpsIntakeUrl('https://supermega-machine.vercel.app.evil.example/api/intake'), false)
 assert.equal(isSafeOpsIntakeUrl('https://supermega-machine.vercel.app/api/intake?redirect=1'), false)
@@ -244,7 +246,67 @@ try {
     assert.equal(handlerSource.includes(retiredResponseFragment), false, `public_response_exposes_${retiredResponseFragment}`)
   }
   assert.equal(handlerSource.includes('json(res, 200, publicSubmissionReceipt(record))'), true)
+  assert.equal(handlerSource.includes('emitContactRoutingEvent({'), true)
   assert.equal(handlerSource.match(/json\(res, 502, publicSubmissionFailure\(\)\)/g)?.length, 4)
+
+  const routingEvent = buildContactRoutingEvent({
+    record: {
+      lead_id: 'LEAD-ROUTING-1',
+      task_id: 'TASK-ROUTING-1',
+      product_area: 'Shop',
+      template_id: 'shop-private-workspace',
+      submitted_at: '2026-07-15T12:00:00.000Z',
+      name: 'Private Person',
+      email: 'private@example.com',
+      phone: '+959000000000',
+      company: 'Private Company',
+      goal: 'Private workflow detail',
+    },
+    ledger: { status: 'ready', adapter: 'vercel_postgres_neon' },
+    pipelineAction: { status: 'ready', adapter: 'vercel_blob_private' },
+    webhook: { status: 'skipped', reason: 'webhook_not_configured' },
+    shopPipeline: { status: 'ready', duplicate: false, lead_count: 2, shop_lead_id: 'PRIVATE-SHOP-ID' },
+    opsIntake: { status: 'ready', duplicate: false, fit_score: 84, lead_id: 'PRIVATE-OPS-ID' },
+    delivery: { status: 'ready', email_id: 'PRIVATE-EMAIL-ID', to: 'private@example.com' },
+    confirmation: { status: 'skipped', reason: 'confirmation_disabled' },
+    telegram: { status: 'skipped', reason: 'telegram_not_configured' },
+    sheets: { status: 'skipped', reason: 'sheets_not_configured' },
+  })
+  assert.deepEqual(routingEvent, {
+    event: 'supermega.contact.routed',
+    version: 1,
+    reference: 'LEAD-ROUTING-1',
+    task_reference: 'TASK-ROUTING-1',
+    product_area: 'Shop',
+    template_id: 'shop-private-workspace',
+    submitted_at: '2026-07-15T12:00:00.000Z',
+    durable: true,
+    notified: true,
+    sinks: {
+      lead_ledger: { status: 'ready', adapter: 'vercel_postgres_neon' },
+      pipeline_action: { status: 'ready', adapter: 'vercel_blob_private' },
+      webhook: { status: 'skipped', reason: 'webhook_not_configured' },
+      shop_pipeline: { status: 'ready', lead_count: 2, duplicate: false },
+      ops_intake: { status: 'ready', duplicate: false },
+      owner_notification: { status: 'ready' },
+      requester_confirmation: { status: 'skipped', reason: 'confirmation_disabled' },
+      telegram: { status: 'skipped', reason: 'telegram_not_configured' },
+      sheets: { status: 'skipped', reason: 'sheets_not_configured' },
+    },
+  })
+  const serializedRoutingEvent = JSON.stringify(routingEvent)
+  for (const privateValue of [
+    'Private Person',
+    'private@example.com',
+    '+959000000000',
+    'Private Company',
+    'Private workflow detail',
+    'PRIVATE-SHOP-ID',
+    'PRIVATE-OPS-ID',
+    'PRIVATE-EMAIL-ID',
+  ]) {
+    assert.equal(serializedRoutingEvent.includes(privateValue), false, `routing_event_exposes_${privateValue}`)
+  }
 
   const healthGet = await invokeHealth('GET')
   assert.equal(healthGet.statusCode, 200)


### PR DESCRIPTION
## Summary
- emit one structured contact routing event keyed by generated lead/task references
- include durability, notification, and per-sink outcomes without logging buyer PII or upstream provider IDs
- lock the privacy boundary and handler wiring in the contact handoff contract

## Verification
- npm run public:prebuilt
- 31 files / 0.39 MB
- 5 public pages and 3 functions checked
- 66 connectors / 923 adversarial calls / 0 violations

## Scope
No customer request was submitted by this PR. No schema, account, price, DNS, or product data changed.