### PR TITLE
Keep the terminal logo tappable on small phones

### DIFF
--- a/tools/create_public_vercel_output.mjs
+++ b/tools/create_public_vercel_output.mjs
@@ -149,7 +149,7 @@ const sharedStyle = `
   }
   .brand {
     display: inline-flex;
-    min-width: 0;
+    min-width: 44px;
     min-height: 44px;
     align-items: center;
     gap: 10px;

--- a/tools/verify_public_enterprise_visual_contract.mjs
+++ b/tools/verify_public_enterprise_visual_contract.mjs
@@ -21,7 +21,7 @@ const work = pages.get('work/index.html')
 const contact = pages.get('contact/index.html')
 
 for (const [relativePath, html] of pages) {
-  for (const required of ['data-theme="light"', 'data-theme="dark"', 'prefers-color-scheme', 'prefers-reduced-motion', 'data-theme-toggle']) {
+  for (const required of ['data-theme="light"', 'data-theme="dark"', 'prefers-color-scheme', 'prefers-reduced-motion', 'data-theme-toggle', 'min-width: 44px;\n    min-height: 44px;']) {
     if (!html.includes(required)) fail('public_page_missing_theme_contract', { relativePath, required })
   }
   for (const forbidden of ['>Products<', '>Pricing<', '>AI workers<', 'target="_blank"', 'target=_blank', 'window.open(', '>SM<', 'File Analyst', 'Payment Reconciler', 'data-clean-report-agent', 'supermega-machine.vercel.app/workcell', 'href="/reconcile/"']) {


### PR DESCRIPTION
Locks the compact terminal home link to a 44x44 target when the wordmark hides at 360px and below. Local Edge proof at 360x732 reports zero overflow and zero undersized controls; the public artifact and all connector contracts pass.