### PR TITLE
fix(public): hard stop outbound email delivery

### DIFF
--- a/api/action-runner.js
+++ b/api/action-runner.js
@@ -19,6 +19,7 @@
 const crypto = require('crypto')
 const datastore = require('./lib/supermega-datastore')
 const blobQueue = require('./lib/supermega-blob-queue')
+const { getOutboundEmailPolicy } = require('./lib/outbound-email-policy')
 
 const BATCH_LIMIT = 10
 const SUPABASE_TIMEOUT_MS = 8000
@@ -611,6 +612,8 @@ async function dispatchSendReply(store, row) {
   // is skipped, never sent. This closes the "Telegram message → autonomous email" vector.
   const approved = row.approval_state === 'approved' || row.approved === true || Boolean(row.approved_at)
   if (!approved) return { status: 'skipped', reason: 'awaiting_approval' }
+  const policy = getOutboundEmailPolicy()
+  if (!policy.allowed) return { status: 'skipped', reason: policy.reason }
 
   const apiKey = text(process.env.RESEND_API_KEY)
   if (!apiKey) return { status: 'skipped', reason: 'resend_not_configured' }

--- a/api/contact-submissions.js
+++ b/api/contact-submissions.js
@@ -2,6 +2,7 @@ const crypto = require('crypto')
 const datastore = require('./lib/supermega-datastore')
 const blobQueue = require('./lib/supermega-blob-queue')
 const { notifyTelegram: sendTelegram } = require('./lib/notify-telegram')
+const { getOutboundEmailPolicy } = require('./lib/outbound-email-policy')
 
 const notifyEmail = process.env.SUPERMEGA_CONTACT_NOTIFY_EMAIL || 'swanhtet@supermega.dev'
 const fallbackFrom = 'SUPERMEGA <onboarding@resend.dev>'
@@ -2057,6 +2058,8 @@ function emailRows(record) {
 }
 
 async function sendEmail({ record }) {
+  const policy = getOutboundEmailPolicy()
+  if (!policy.allowed) return { status: 'skipped', reason: policy.reason }
   const apiKey = text(process.env.RESEND_API_KEY)
   if (!apiKey) {
     return { status: 'error', reason: 'resend_not_configured' }
@@ -2111,6 +2114,8 @@ async function sendEmail({ record }) {
 }
 
 async function sendConfirmationEmail({ record }) {
+  const policy = getOutboundEmailPolicy()
+  if (!policy.allowed) return { status: 'skipped', reason: policy.reason }
   if (text(process.env.SUPERMEGA_SEND_CONTACT_CONFIRMATION) !== '1') {
     return { status: 'skipped', reason: 'confirmation_disabled' }
   }

--- a/api/lead.js
+++ b/api/lead.js
@@ -4,6 +4,7 @@
 // CJS module — matches .vercel/output/functions/api/lead.js.func/package.json "type":"commonjs"
 const crypto = require('crypto')
 const { notifyTelegram } = require('./lib/notify-telegram')
+const { getOutboundEmailPolicy } = require('./lib/outbound-email-policy')
 
 const ALLOWED_ORIGINS = [
   'https://supermega.dev',
@@ -84,6 +85,7 @@ async function aiScope(workflow, name, company) {
 }
 
 async function notifySwann(lead) {
+  if (!getOutboundEmailPolicy().allowed) return
   const key = process.env.RESEND_API_KEY
   const to = process.env.SUPERMEGA_CONTACT_NOTIFY_EMAIL || 'swanhtet@supermega.dev'
   const from = process.env.SUPERMEGA_RESEND_FROM || 'leads@supermega.dev'

--- a/api/lib/outbound-email-policy.js
+++ b/api/lib/outbound-email-policy.js
@@ -1,0 +1,21 @@
+// One deployment-wide owner gate for every SuperMega email sender.
+//
+// Email is an external side effect. It stays off unless the owner deliberately
+// enables it with two independent environment values. Existing feature-level
+// flags are intentionally insufficient on their own.
+
+const UNLOCK_PHRASE = 'UNLOCK_SUPERMEGA_OUTBOUND_EMAIL_001'
+
+function text(value) {
+  return String(value == null ? '' : value).trim()
+}
+
+function getOutboundEmailPolicy(env = process.env) {
+  const requested = text(env.SUPERMEGA_OUTBOUND_EMAILS_ENABLED || env.SUPERMEGA_EMAIL_SENDS_ENABLED) === '1'
+  const approved = text(env.SUPERMEGA_OUTBOUND_EMAIL_APPROVAL) === UNLOCK_PHRASE
+  if (!requested) return { allowed: false, reason: 'outbound_email_disabled' }
+  if (!approved) return { allowed: false, reason: 'outbound_email_locked' }
+  return { allowed: true, reason: 'outbound_email_enabled' }
+}
+
+module.exports = { getOutboundEmailPolicy }

--- a/api/lib/outbound-email-policy.test.mjs
+++ b/api/lib/outbound-email-policy.test.mjs
@@ -1,0 +1,44 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import test from 'node:test'
+
+const require = createRequire(import.meta.url)
+const { getOutboundEmailPolicy } = require('./outbound-email-policy.js')
+
+test('outbound email is disabled by default', () => {
+  assert.deepEqual(getOutboundEmailPolicy({}), { allowed: false, reason: 'outbound_email_disabled' })
+})
+
+test('a single stale email flag cannot enable delivery', () => {
+  assert.deepEqual(
+    getOutboundEmailPolicy({ SUPERMEGA_EMAIL_SENDS_ENABLED: '1' }),
+    { allowed: false, reason: 'outbound_email_locked' },
+  )
+})
+
+test('delivery requires both explicit owner gates', () => {
+  assert.deepEqual(
+    getOutboundEmailPolicy({
+      SUPERMEGA_OUTBOUND_EMAILS_ENABLED: '1',
+      SUPERMEGA_OUTBOUND_EMAIL_APPROVAL: 'UNLOCK_SUPERMEGA_OUTBOUND_EMAIL_001',
+    }),
+    { allowed: true, reason: 'outbound_email_enabled' },
+  )
+})
+
+test('every direct Resend sender checks the shared owner gate first', () => {
+  const files = [
+    '../contact-submissions.js',
+    '../action-runner.js',
+    '../lead.js',
+    '../pipeline-control.js',
+    '../sales-daily.js',
+  ]
+
+  for (const file of files) {
+    const source = readFileSync(new URL(file, import.meta.url), 'utf8')
+    assert.match(source, /outbound-email-policy/)
+    assert.match(source, /getOutboundEmailPolicy\(\)/)
+  }
+})

--- a/api/pipeline-control.js
+++ b/api/pipeline-control.js
@@ -2,6 +2,8 @@
 const datastore = require('./lib/supermega-datastore')
 const blobQueue = require('./lib/supermega-blob-queue')
 
+const { getOutboundEmailPolicy } = require('./lib/outbound-email-policy')
+
 function safeEqual(a, b) {
   const aHash = crypto.createHash('sha256').update(String(a)).digest()
   const bHash = crypto.createHash('sha256').update(String(b)).digest()
@@ -2855,6 +2857,8 @@ async function readAutopilotApprovalLedger(limit = 5, opts = {}) {
 }
 
 async function sendAutopilotDraftApprovalEmail({ approval, draft, blocker }) {
+  const policy = getOutboundEmailPolicy()
+  if (!policy.allowed) return { status: 'skipped', reason: policy.reason }
   const apiKey = envText('RESEND_API_KEY')
   if (!apiKey) return { status: 'error', reason: 'resend_not_configured' }
   const notifyEmail = envText('SUPERMEGA_CONTACT_NOTIFY_EMAIL') || 'swanhtet@supermega.dev'

--- a/api/sales-daily.js
+++ b/api/sales-daily.js
@@ -1,6 +1,7 @@
 const crypto = require('crypto')
 const datastore = require('./lib/supermega-datastore')
 const blobQueue = require('./lib/supermega-blob-queue')
+const { getOutboundEmailPolicy } = require('./lib/outbound-email-policy')
 
 const defaultNotifyEmail = 'swanhtet@supermega.dev'
 const defaultFrom = 'SuperMega Owner Brief <onboarding@supermega.dev>'
@@ -633,6 +634,8 @@ function emailHtml(run) {
 }
 
 async function sendBrief(run) {
+  const policy = getOutboundEmailPolicy()
+  if (!policy.allowed) return { status: 'skipped', reason: policy.reason }
   if (!envFlag('SUPERMEGA_SALES_DAILY_EMAIL_ENABLED', false)) {
     return { status: 'skipped', reason: 'sales_daily_email_disabled_by_default' }
   }


### PR DESCRIPTION
## Why\nUser-requested immediate stop to SuperMega outbound email. Production Resend credentials have already been removed and the public alias redeployed.\n\n## Change\n- Adds a shared fail-closed outbound email policy.\n- Requires both an explicit enablement flag and exact owner approval before any direct Resend sender can deliver.\n- Guards contact confirmation, owner alerts, approved replies, lead alerts, pipeline fallback, and daily sales briefs.\n\n## Verification\n- 
ode --test api/lib/outbound-email-policy.test.mjs (4/4)\n- 
ode --check on every changed handler\n- git diff --check\n\nNo email is enabled by this change.