### PR TITLE
fix(public): keep contact intake ready when email is locked

### DIFF
--- a/api/contact-submissions.js
+++ b/api/contact-submissions.js
@@ -2251,10 +2251,12 @@ function opsIntakeRetryDelay() {
 }
 
 function publicContactStatus() {
+  // Intake remains available when its durable/operator handoffs are ready.
+  // Outbound email is an optional, owner-controlled notification effect and
+  // must never make the public capture route look unavailable.
   const ready = (
     leadLedgerStatus() === 'configured' &&
     pipelineActionStatus() === 'configured' &&
-    fallbackQueueStatus().email_delivery === 'configured' &&
     shopPipelineStatus().status === 'ready' &&
     opsIntakeStatus().status === 'ready'
   )

--- a/api/lib/outbound-email-policy.test.mjs
+++ b/api/lib/outbound-email-policy.test.mjs
@@ -42,3 +42,15 @@ test('every direct Resend sender checks the shared owner gate first', () => {
     assert.match(source, /getOutboundEmailPolicy\(\)/)
   }
 })
+
+test('public contact readiness does not depend on outbound email delivery', () => {
+  const source = readFileSync(new URL('../contact-submissions.js', import.meta.url), 'utf8')
+  const start = source.indexOf('function publicContactStatus()')
+  const end = source.indexOf('function contactDiagnostics()', start)
+  assert.ok(start >= 0 && end > start, 'public contact status function was not found')
+
+  const functionBody = source.slice(start, end)
+  assert.doesNotMatch(functionBody, /fallbackQueueStatus\(\)\.email_delivery/)
+  assert.match(functionBody, /leadLedgerStatus\(\) === 'configured'/)
+  assert.match(functionBody, /opsIntakeStatus\(\)\.status === 'ready'/)
+})


### PR DESCRIPTION
## Why\nOutbound email is intentionally disabled. The public release probe incorrectly treated that owner-controlled notification effect as a contact intake outage.\n\n## Change\n- Defines public contact readiness from durable lead capture and configured Shop/Ops handoffs.\n- Keeps email delivery as an optional disabled effect, not a public availability dependency.\n- Adds a regression test guarding the separation.\n\n## Verification\n- 
ode --test api/lib/outbound-email-policy.test.mjs (5/5)\n- 
ode --check api/contact-submissions.js\n- git diff --check\n\nNo email is enabled by this change.