### PR TITLE
Apply Console security headers through routes

### DIFF
--- a/kernel/agent-company-ui-contract.test.mjs
+++ b/kernel/agent-company-ui-contract.test.mjs
@@ -222,8 +222,10 @@ test('Agent Company API route is a dedicated function before the catch-all', asy
   const config = JSON.parse(await readFile(new URL('./vercel.json', import.meta.url), 'utf8'))
   assert.equal(config.functions['api/agent-company-auth.mjs'].maxDuration, 15)
   assert.equal(config.functions['api/agent-company.mjs'].maxDuration, 60)
-  const securityHeaderRule = config.headers.find((rule) => rule.source === '/(.*)')
-  assert.deepEqual(Object.fromEntries(securityHeaderRule.headers.map((header) => [header.key, header.value])), {
+  assert.equal(Object.hasOwn(config, 'headers'), false)
+  const securityHeaderRule = config.routes.find((route) => route.src === '/(.*)' && route.continue === true)
+  assert.ok(securityHeaderRule)
+  assert.deepEqual(securityHeaderRule.headers, {
     'Content-Security-Policy': "base-uri 'self'; frame-ancestors 'none'; object-src 'none'",
     'Permissions-Policy': 'camera=(), geolocation=(), microphone=(), payment=(), usb=()',
     'Referrer-Policy': 'no-referrer',

--- a/kernel/vercel.json
+++ b/kernel/vercel.json
@@ -19,19 +19,18 @@
   "crons": [
     { "path": "/api/brief", "schedule": "30 1 * * *" }
   ],
-  "headers": [
-    {
-      "source": "/(.*)",
-      "headers": [
-        { "key": "Content-Security-Policy", "value": "base-uri 'self'; frame-ancestors 'none'; object-src 'none'" },
-        { "key": "Permissions-Policy", "value": "camera=(), geolocation=(), microphone=(), payment=(), usb=()" },
-        { "key": "Referrer-Policy", "value": "no-referrer" },
-        { "key": "X-Content-Type-Options", "value": "nosniff" },
-        { "key": "X-Frame-Options", "value": "DENY" }
-      ]
-    }
-  ],
   "routes": [
+    {
+      "src": "/(.*)",
+      "headers": {
+        "Content-Security-Policy": "base-uri 'self'; frame-ancestors 'none'; object-src 'none'",
+        "Permissions-Policy": "camera=(), geolocation=(), microphone=(), payment=(), usb=()",
+        "Referrer-Policy": "no-referrer",
+        "X-Content-Type-Options": "nosniff",
+        "X-Frame-Options": "DENY"
+      },
+      "continue": true
+    },
     { "src": "/api/stripe-webhook", "dest": "/api/stripe-webhook" },
     { "src": "/api/kbzpay-notify", "dest": "/api/kbzpay-notify" },
     { "src": "/api/wavepay-notify", "dest": "/api/wavepay-notify" },


### PR DESCRIPTION
## Fix for #139
The #139 Vercel deployment passed, but the stable alias did not emit the declared headers. Vercel's current routing model does not mix top-level `headers` with legacy `routes`, so the declaration was ignored.

This moves the exact policy to a leading legacy route with `continue: true`, preserving every existing API/static destination while applying the headers first. The contract now rejects a future top-level `headers` block.

## Validation
- `npm --prefix kernel run verify` (254 tests, brand, connector, and crew gates)
- targeted config contract and JSON parse
- #139's local Console HTTP check already proved local-server parity

No routes, CORS, auth behavior, account activation, source data, connector, or customer operational write changes.