### PR TITLE
fix(public): clarify private setup handoff

### DIFF
--- a/tools/create_public_vercel_output.mjs
+++ b/tools/create_public_vercel_output.mjs
@@ -777,6 +777,7 @@ const contactHtml = documentHtml({
   var entryIntent=search.get('from')||'';
   var agentIntent=entryIntent==='ai-agent-solution';
   var workspaceProduct=entryIntent==='shop-workspace'?'Shop':entryIntent==='plant-workspace'?'Plant':'';
+  var privateSetupIntent=entryIntent==='homepage-private-setup';
   var submit=form.querySelector('[data-contact-submit]');
   var idleSubmitLabel='Send request';
   function text(selector,value){var element=document.querySelector(selector);if(element)element.textContent=value;}
@@ -797,12 +798,18 @@ const contactHtml = documentHtml({
     text('[data-contact-policy]','We start with one reviewed example. No account, data connection, or external action is made before you approve it.');
     idleSubmitLabel='Contact us';
     if(submit)submit.textContent=idleSubmitLabel;
-  }else if(workspaceProduct){
-    form.dataset.intake=entryIntent;
+  }else if(workspaceProduct||privateSetupIntent){
+    form.dataset.intake=workspaceProduct?entryIntent:'private-workspace';
     text('[data-contact-command]','>_ contact / workspace');
-    text('[data-contact-heading]','Request a private '+workspaceProduct+' workspace.');
-    text('[data-contact-intro]','Tell us who will use it and what should be ready first. SuperMega will set it up and verify it before handover.');
-    text('[data-contact-form-heading]','Request '+workspaceProduct);
+    if(workspaceProduct){
+      text('[data-contact-heading]','Request a private '+workspaceProduct+' workspace.');
+      text('[data-contact-intro]','Tell us who will use it and what should be ready first. SuperMega will set it up and verify it before handover.');
+      text('[data-contact-form-heading]','Request '+workspaceProduct);
+    }else{
+      text('[data-contact-heading]','Set up a private workspace.');
+      text('[data-contact-intro]','Tell us whether Shop or Plant should be ready first and who will use it. SuperMega will define the setup path and verify it before handover.');
+      text('[data-contact-form-heading]','Private setup');
+    }
     text('[data-contact-goal-label]','What should be ready first?');
     text('[data-contact-policy]','Sending this request does not create an account or connect data. Setup begins only after scope approval.');
     idleSubmitLabel='Request workspace';

--- a/tools/verify_public_enterprise_visual_contract.mjs
+++ b/tools/verify_public_enterprise_visual_contract.mjs
@@ -101,6 +101,15 @@ for (const forbidden of ['<figure class="site-hero-screen"', '<img src="/site/sh
 
 if (!contact.includes('.header-cta { display: none; }')) fail('contact_page_keeps_redundant_start_control')
 if (!contact.includes('<h1 data-contact-heading>What should run better?</h1>')) fail('contact_page_missing_direct_sales_prompt')
+for (const required of [
+  "var privateSetupIntent=entryIntent==='homepage-private-setup';",
+  "form.dataset.intake=workspaceProduct?entryIntent:'private-workspace';",
+  "text('[data-contact-heading]','Set up a private workspace.');",
+  "text('[data-contact-form-heading]','Private setup');",
+  "text('[data-contact-goal-label]','What should be ready first?');",
+]) {
+  if (!contact.includes(required)) fail('contact_page_missing_private_setup_handoff', { required })
+}
 for (const required of ['class="contact-next"', '<h2 id="contact-next-heading">What happens next</h2>', 'We read the handoff', 'We name the smallest next step', 'You approve before setup', 'No account, data connection, or external action starts without approval.']) {
   if (!contact.includes(required)) fail('contact_page_missing_first_step_guidance', { required })
 }


### PR DESCRIPTION
## What changed\n- Make the homepage Private setup CTA render a clear private-workspace request flow rather than a generic contact form.\n- Preserve the existing Shop and Plant-specific workspace request flows.\n- Keep the approval-first boundary explicit: no account or data connection is created by the request.\n\n## Verification\n- 
pm run public:prebuilt\n- Local 390x844 Playwright check of /contact/?from=homepage-private-setup: correct heading, form labels, intent marker, no errors, no horizontal overflow.\n- Local regression check of /contact/?from=shop-workspace.\n\nNo contact request, lead, account, tenant, data connection, external action, price, payment, or domain setting was created or changed.