### PR TITLE
Clarify the public contact entry

### DIFF
--- a/tools/create_public_vercel_output.mjs
+++ b/tools/create_public_vercel_output.mjs
@@ -275,7 +275,7 @@ const headerHtml = `${themeBootstrap}
       <a class="nav-link optional-nav" href="${shopStartHref}">Shop</a>
       <a class="nav-link optional-nav" href="${plantStartHref}">Plant</a>
       <button class="icon-button" type="button" data-theme-toggle aria-label="Use dark mode" title="Use dark mode"><svg class="theme-sun" viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="4"></circle><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"></path></svg><svg class="theme-moon" viewBox="0 0 24 24" aria-hidden="true"><path d="M20.5 15.2A8.5 8.5 0 0 1 8.8 3.5 8.5 8.5 0 1 0 20.5 15.2Z"></path></svg></button>
-      <a class="btn primary header-cta" href="/contact/">Start a workflow</a>
+      <a class="btn primary header-cta" href="/contact/">Talk to us</a>
     </nav>
   </header>
 </div>

--- a/tools/verify_public_enterprise_visual_contract.mjs
+++ b/tools/verify_public_enterprise_visual_contract.mjs
@@ -23,7 +23,7 @@ const shopStartHref = 'https://app.supermega.dev/?demo=shop&amp;returnTo=%2Fstar
 const plantStartHref = 'https://app.supermega.dev/?demo=plant&amp;returnTo=%2Fstart'
 
 for (const [relativePath, html] of pages) {
-  for (const required of ['data-theme="light"', 'data-theme="dark"', 'prefers-color-scheme', 'prefers-reduced-motion', 'data-theme-toggle', 'min-width: 44px;\n    min-height: 44px;', '>Start a workflow</a>']) {
+  for (const required of ['data-theme="light"', 'data-theme="dark"', 'prefers-color-scheme', 'prefers-reduced-motion', 'data-theme-toggle', 'min-width: 44px;\n    min-height: 44px;', '>Talk to us</a>']) {
     if (!html.includes(required)) fail('public_page_missing_theme_contract', { relativePath, required })
   }
   for (const required of [shopStartHref, plantStartHref]) {

--- a/tools/verify_public_release_live.mjs
+++ b/tools/verify_public_release_live.mjs
@@ -45,7 +45,7 @@ async function get(url, accept) {
 const retiredPublicContent = ['MegaOS', 'DeskPOS', 'File Analyst', 'Payment Reconciler', 'data-clean-report-agent', 'supermega-machine.vercel.app/workcell', 'href="/reconcile/"', 'target="_blank"', 'target=_blank', 'window.open(', '>SM<']
 
 function verifySharedPage(html, label) {
-  for (const required of ['data-theme="light"', 'data-theme="dark"', 'data-theme-toggle', 'class="terminal-mark"', 'supermega<span class="domain">.dev</span>', '>Start a workflow</a>']) {
+  for (const required of ['data-theme="light"', 'data-theme="dark"', 'data-theme-toggle', 'class="terminal-mark"', 'supermega<span class="domain">.dev</span>', '>Talk to us</a>']) {
     assert(html.includes(required), `${label}_missing_${required.slice(0, 32)}`)
   }
   for (const forbidden of retiredPublicContent) {

--- a/tools/verify_public_vercel_output.mjs
+++ b/tools/verify_public_vercel_output.mjs
@@ -149,7 +149,7 @@ const retiredCatalogContent = [
 ]
 
 for (const [relativePath, html] of pages) {
-  for (const required of ['data-theme="light"', 'data-theme="dark"', 'prefers-color-scheme', 'prefers-reduced-motion', 'data-theme-toggle', '>Start a workflow</a>']) {
+  for (const required of ['data-theme="light"', 'data-theme="dark"', 'prefers-color-scheme', 'prefers-reduced-motion', 'data-theme-toggle', '>Talk to us</a>']) {
     if (!html.includes(required)) fail('public_page_missing_theme_contract', { relativePath, required })
   }
   for (const required of ['class="terminal-mark"', '<img src="/favicon.svg" alt="" width="64" height="64" />', 'backdrop-filter: blur(24px)', 'supermega<span class="domain">.dev</span>']) {


### PR DESCRIPTION
## What changed\n- Change the public primary CTA from Start a workflow to Talk to us.\n- Keep it same-tab to /contact/; no new account or workflow is implied.\n- Update generated-artifact, visual, and live-release contracts.\n\n## Verification\n- 
pm run public:prebuilt passed: 40-file / 0.97 MB artifact, public visual/output/intake contracts, contact handoff, 66 connectors / 923 calls / 0 violations.\n- Local browser: CTA reached /contact/ in one tab; 390px had no horizontal overflow or console errors.