### PR TITLE
Guard public release against stale checkout

### DIFF
--- a/.github/workflows/supermega-public-live-health.yml
+++ b/.github/workflows/supermega-public-live-health.yml
@@ -8,15 +8,25 @@ on:
       - main
     paths:
       - .github/workflows/supermega-public-live-health.yml
+      - .github/workflows/supermega-public-release.yml
+      - package.json
       - tools/check_public_live_health.py
+      - tools/deny_stale_public_deploy.mjs
+      - tools/deploy_website_actions.ps1
       - tools/test_public_live_health.py
+      - tools/verify_public_deploy_guard.mjs
   pull_request:
     branches:
       - main
     paths:
       - .github/workflows/supermega-public-live-health.yml
+      - .github/workflows/supermega-public-release.yml
+      - package.json
       - tools/check_public_live_health.py
+      - tools/deny_stale_public_deploy.mjs
+      - tools/deploy_website_actions.ps1
       - tools/test_public_live_health.py
+      - tools/verify_public_deploy_guard.mjs
   workflow_dispatch:
   schedule:
     # 08:15 Asia/Rangoon daily.
@@ -39,6 +49,12 @@ jobs:
         with:
           python-version: '3.12'
 
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          package-manager-cache: false
+
       - name: Fetch checker from the triggering commit
         env:
           SOURCE_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
@@ -54,6 +70,37 @@ jobs:
             --retry 3 --retry-all-errors \
             "https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/${SOURCE_SHA}/tools/test_public_live_health.py" \
             --output "${RUNNER_TEMP}/test_public_live_health.py"
+
+          mkdir -p "${RUNNER_TEMP}/release-guard/.github/workflows" "${RUNNER_TEMP}/release-guard/tools"
+          curl --fail --silent --show-error --location \
+            --proto '=https' --proto-redir '=https' \
+            --retry 3 --retry-all-errors \
+            "https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/${SOURCE_SHA}/package.json" \
+            --output "${RUNNER_TEMP}/release-guard/package.json"
+          curl --fail --silent --show-error --location \
+            --proto '=https' --proto-redir '=https' \
+            --retry 3 --retry-all-errors \
+            "https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/${SOURCE_SHA}/.github/workflows/supermega-public-release.yml" \
+            --output "${RUNNER_TEMP}/release-guard/.github/workflows/supermega-public-release.yml"
+          curl --fail --silent --show-error --location \
+            --proto '=https' --proto-redir '=https' \
+            --retry 3 --retry-all-errors \
+            "https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/${SOURCE_SHA}/.github/workflows/supermega-public-live-health.yml" \
+            --output "${RUNNER_TEMP}/release-guard/.github/workflows/supermega-public-live-health.yml"
+          curl --fail --silent --show-error --location \
+            --proto '=https' --proto-redir '=https' \
+            --retry 3 --retry-all-errors \
+            "https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/${SOURCE_SHA}/tools/deploy_website_actions.ps1" \
+            --output "${RUNNER_TEMP}/release-guard/tools/deploy_website_actions.ps1"
+          curl --fail --silent --show-error --location \
+            --proto '=https' --proto-redir '=https' \
+            --retry 3 --retry-all-errors \
+            "https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/${SOURCE_SHA}/tools/verify_public_deploy_guard.mjs" \
+            --output "${RUNNER_TEMP}/release-guard/tools/verify_public_deploy_guard.mjs"
+
+      - name: Verify public release guard
+        working-directory: ${{ runner.temp }}/release-guard
+        run: node tools/verify_public_deploy_guard.mjs
 
       - name: Test portfolio health checker
         working-directory: ${{ runner.temp }}

--- a/package.json
+++ b/package.json
@@ -9,8 +9,9 @@
     "deploy:preview": "bash tools/deploy_preview.sh",
     "vercel:pull": "npx vercel pull --yes",
     "vercel:build": "npx vercel build --yes",
-    "vercel:deploy": "npx vercel deploy --prebuilt -y",
-    "vercel:deploy:prod": "npx vercel deploy --prebuilt --prod -y",
+    "vercel:deploy": "node tools/deny_stale_public_deploy.mjs",
+    "vercel:deploy:prod": "node tools/deny_stale_public_deploy.mjs",
+    "public:release:guard": "node tools/verify_public_deploy_guard.mjs",
     "smoke:local": "bash tools/run_local_smoke.sh",
     "smoke:public": "python3 tools/smoke_test_public_site.py"
   }

--- a/tools/deny_stale_public_deploy.mjs
+++ b/tools/deny_stale_public_deploy.mjs
@@ -1,0 +1,11 @@
+const canonicalBranch = 'codex/public-enterprise-site'
+
+console.error(
+  [
+    'Direct Vercel deployment is disabled from this checkout.',
+    `supermega.dev releases only from ${canonicalBranch} through .github/workflows/supermega-public-release.yml.`,
+    'Open a pull request to the canonical branch, or run tools/deploy_website_actions.ps1 to dispatch the verified release.',
+  ].join('\n'),
+)
+
+process.exitCode = 1

--- a/tools/verify_public_deploy_guard.mjs
+++ b/tools/verify_public_deploy_guard.mjs
@@ -1,0 +1,41 @@
+import { readFile } from 'node:fs/promises'
+
+const packageJson = JSON.parse(await readFile(new URL('../package.json', import.meta.url), 'utf8'))
+const deployWorkflow = (await readFile(new URL('../.github/workflows/supermega-public-release.yml', import.meta.url), 'utf8')).replace(/\r\n/g, '\n')
+const healthWorkflow = (await readFile(new URL('../.github/workflows/supermega-public-live-health.yml', import.meta.url), 'utf8')).replace(/\r\n/g, '\n')
+const releaseScript = (await readFile(new URL('./deploy_website_actions.ps1', import.meta.url), 'utf8')).replace(/\r\n/g, '\n')
+const failures = []
+
+for (const name of ['vercel:deploy', 'vercel:deploy:prod']) {
+  if (packageJson.scripts?.[name] !== 'node tools/deny_stale_public_deploy.mjs') {
+    failures.push(`direct_public_deploy_not_guarded:${name}`)
+  }
+}
+
+if (packageJson.scripts?.['public:release:guard'] !== 'node tools/verify_public_deploy_guard.mjs') {
+  failures.push('public_release_guard_not_exposed')
+}
+
+for (const token of [
+  "branches:\n      - codex/public-enterprise-site",
+  'refs/heads/codex/public-enterprise-site',
+  '--meta "githubCommitRef=codex/public-enterprise-site"',
+  'npx --yes vercel@56.1.0 deploy --prebuilt --prod',
+]) {
+  if (!deployWorkflow.includes(token)) failures.push(`canonical_workflow_missing:${token}`)
+}
+
+for (const token of ['source_ref = "codex/public-enterprise-site"', 'workflow = $workflowFile', 'dispatch_ref = "main"']) {
+  if (!releaseScript.includes(token)) failures.push(`release_dispatch_missing:${token}`)
+}
+
+for (const token of ['tools/verify_public_deploy_guard.mjs', 'Verify public release guard', 'node tools/verify_public_deploy_guard.mjs']) {
+  if (!healthWorkflow.includes(token)) failures.push(`health_guard_missing:${token}`)
+}
+
+if (failures.length) {
+  console.error(JSON.stringify({ ok: false, contract: 'public_deploy_guard', failures }, null, 2))
+  process.exit(1)
+}
+
+console.log(JSON.stringify({ ok: true, contract: 'public_deploy_guard', canonicalBranch: 'codex/public-enterprise-site' }))


### PR DESCRIPTION
## What changed
- Blocks direct root Vercel deploy scripts that can use the stale public generator on main.
- Documents the canonical public branch and verified GitHub release workflow in a machine-checked guard.
- Runs the guard from the existing public live-health workflow.

## Verification
- 
ode tools/verify_public_deploy_guard.mjs
- guarded deploy exits before Vercel access
- python -m unittest -v tools/test_public_live_health.py (27 passing)