### PR TITLE
Retire public agent intake surface

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "vercel:deploy": "node tools/deny_direct_public_deploy.mjs",
     "vercel:deploy:prod": "node tools/deny_direct_public_deploy.mjs",
     "public:build": "node tools/create_public_vercel_output.mjs",
-    "public:verify": "node tools/verify_public_vercel_artifact_budget.mjs && node tools/verify_public_vercel_output.mjs && node tools/verify_public_enterprise_visual_contract.mjs && node tools/verify_public_agent_intake_contract.mjs && node tools/verify_contact_ops_intake_handoff.mjs && node tools/test_connector_resilience.mjs",
+    "public:verify": "node tools/verify_public_vercel_artifact_budget.mjs && node tools/verify_public_vercel_output.mjs && node tools/verify_public_enterprise_visual_contract.mjs && node tools/enforce_current_public_product_output.mjs && node tools/verify_public_agent_intake_contract.mjs && node tools/verify_contact_ops_intake_handoff.mjs && node tools/test_connector_resilience.mjs",
     "public:prebuilt": "npm run public:build && npm run public:verify",
     "public:verify:live": "node tools/verify_public_release_live.mjs",
     "_public:verify:RETIRED": "source-to-screen/workcell/intake/contact-order + operator-retainer contracts retired 2026-07-09 — they enforced the discontinued 'source-to-screen / AI Workcell' model the founder removed. Kept only artifact-budget + vercel-output structural checks.",

--- a/tools/create_public_vercel_output.mjs
+++ b/tools/create_public_vercel_output.mjs
@@ -835,7 +835,6 @@ const contactHtml = documentHtml({
   if(!form)return;
   var search=new URLSearchParams(window.location.search);
   var entryIntent=search.get('from')||'';
-  var agentIntent=entryIntent==='ai-agent-solution';
   var workspaceProduct=entryIntent==='shop-workspace'?'Shop':entryIntent==='plant-workspace'?'Plant':'';
   var privateSetupIntent=entryIntent==='homepage-private-setup';
   var submit=form.querySelector('[data-contact-submit]');
@@ -874,17 +873,7 @@ const contactHtml = documentHtml({
     set('referrer',document.referrer||'');
     ['utm_source','utm_medium','utm_campaign','utm_content','utm_term'].forEach(function(key){set(key,search.get(key)||'');});
   }
-  if(agentIntent){
-    form.dataset.intake='ai-agent-solution';
-    text('[data-contact-command]','>_ contact / start');
-    text('[data-contact-heading]','What do you want to improve?');
-    text('[data-contact-intro]','Tell us what repeats today and what a useful result looks like. We will reply with the clearest place to start.');
-    text('[data-contact-form-heading]','Start here');
-    text('[data-contact-goal-label]','What should work better?');
-    text('[data-contact-policy]','We start with one reviewed example. No account, data connection, or external action is made before you approve it.');
-    idleSubmitLabel='Contact us';
-    if(submit)submit.textContent=idleSubmitLabel;
-  }else if(workspaceProduct||privateSetupIntent){
+  if(workspaceProduct||privateSetupIntent){
     form.dataset.intake=workspaceProduct?entryIntent:'private-workspace';
     text('[data-contact-command]','>_ contact / workspace');
     if(workspaceProduct){

--- a/tools/enforce_current_public_product_output.mjs
+++ b/tools/enforce_current_public_product_output.mjs
@@ -2,8 +2,7 @@ import { existsSync, readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 
 const root = process.cwd()
-const outputRoot = resolve(root, '.vercel', 'output')
-const staticDir = resolve(outputRoot, 'static')
+const staticDir = resolve(root, '.vercel', 'output', 'static')
 
 function fail(message, extra = {}) {
   console.error(JSON.stringify({ status: 'error', message, ...extra }, null, 2))
@@ -23,80 +22,48 @@ function requireTokens(label, text, tokens) {
 
 const home = readStatic('index.html')
 const contact = readStatic('contact/index.html')
-const sitemap = readStatic('sitemap.xml')
-const configPath = resolve(outputRoot, 'config.json')
-if (!existsSync(configPath)) fail('missing_public_config')
-const config = JSON.parse(readFileSync(configPath, 'utf8'))
 
 requireTokens('home', home, [
-  '<title>supermega.dev | Shop and Plant</title>',
-  '<h1 id="portfolio-heading">Run the operation. See what matters.</h1>',
+  '<title>supermega.dev | Shop and Plant, ready for real work.</title>',
+  '<h1 id="portfolio-heading">Run the day. Keep the handoffs.</h1>',
   'supermega<span class="domain">.dev</span>',
-  '&gt;_</span>',
+  'terminal-cursor">_</span>',
   'https://app.supermega.dev/?demo=shop',
   'https://app.supermega.dev/?demo=plant',
-  'Two working products',
-  'Try first. Add data later.',
-  '<strong>Shop</strong>',
-  '<strong>Plant</strong>',
-  'AI Agent Solutions',
-  'Need a repeated task handled?',
-  '>Contact us</a>',
+  '>Talk to us</a>',
+  'No signup',
+  'Private setup',
   'src="/live-shop-workspace.png"',
+  "src:'/live-plant-workspace.png'",
   '/favicon.svg',
 ])
 
-for (const forbidden of [
-  '<figure class="site-hero-screen"',
-  '<img src="/site/shots/live-product-',
-  'Explore products',
-  '>Products<',
-  '>Pricing<',
-  '>AI workers<',
-  'supermega-portal-card.png',
-  'https://demo.supermega.dev/',
-  'The intelligent workspace for daily operations.',
-  'Explore live demos',
-  'Open workspace',
-  'target="_blank"',
-  'rotate(',
-  'data-hero-media',
-  'Current build',
-  'Build an agent solution',
-  '>Agent solution<',
-]) {
-  if (home.includes(forbidden)) fail('catalog_copy_or_stale_product_visual_on_home', { forbidden })
-}
+requireTokens('contact', contact, [
+  '<title>Contact | supermega.dev</title>',
+  'What should run better?',
+  'Choose the first workspace',
+  'action="/api/contact-submissions"',
+  'name="name"',
+  'name="email"',
+  'name="company"',
+  'name="goal"',
+  'No account or data connection is made before you approve it.',
+])
 
-for (const forbidden of ['placeholder="Drive folder', 'placeholder="Example:', '14-day money-back guarantee', 'Source link or system', 'Upload files', 'custom AI worker']) {
-  if (contact.includes(forbidden)) fail('contact_surface_is_not_blank_or_honest', { forbidden })
-}
-
-const legacyCatalogRoute = (config.routes || []).find(
-  (route) => route.src === '^/(?:products|product|offers|pricing|plans|packages|agent-templates|ai-agents|work|operator|machine|card|megaos-preview|free)(?:/.*)?$',
-)
-if (legacyCatalogRoute?.status !== 308 || legacyCatalogRoute?.headers?.Location !== '/') {
-  fail('legacy_catalog_route_not_retired', { actual: legacyCatalogRoute })
-}
-const demoRoute = (config.routes || []).find((route) => route.src === '^/demo/?$')
-if (demoRoute?.status !== 308 || demoRoute?.headers?.Location !== 'https://demo.supermega.dev/') {
-  fail('legacy_demo_route_not_forwarded', { actual: demoRoute })
-}
-
-for (const src of [
-  '^/(?:agentops|agentops-toolbox|ai-back-office|back-office-operator|back-office-workflow-desk|openclaw|office-operator|try|book|setup|get-started|intake|free-tools|free-tool|builder|tool-builder|scan|calculator|workflow-scan|daily-close|payment-close|close-checker|mmqr|store-tool|agent-builder|agent-scope|ai-agent|agent-tool|agents|about|demos|demo-center|enterprise-demo|modules|portal-types|implementation|how-it-works|portfolio|tools|value|proof|platform|solutions|find-companies|company-list|task-list|receiving-log)/?$',
-]) {
-  const route = (config.routes || []).find((entry) => entry.src === src)
-  if (route?.status !== 308 || route?.headers?.Location !== '/') {
-    fail('retired_catalog_alias_not_redirected_home', { src, actual: route })
+for (const [label, text] of [['home', home], ['contact', contact]]) {
+  for (const forbidden of [
+    'AI Agent Solutions',
+    'Build an agent solution',
+    '>Agent solution<',
+    'Need a repeated task handled?',
+    'custom AI worker',
+    'ai-agent-solution',
+    'MegaOS',
+    'DeskPOS',
+    'target="_blank"',
+  ]) {
+    if (text.includes(forbidden)) fail('retired_public_product_copy_returned', { label, forbidden })
   }
 }
 
-for (const allowed of ['https://supermega.dev/', 'https://supermega.dev/contact/', 'https://supermega.dev/privacy/']) {
-  if (!sitemap.includes(allowed)) fail('front_door_sitemap_missing_entry', { allowed })
-}
-for (const retired of ['/products/', '/offers/', '/agent-templates/', '/ai-agents/', '/work/']) {
-  if (sitemap.includes(`https://supermega.dev${retired}`)) fail('retired_catalog_route_in_sitemap', { retired })
-}
-
-console.log('[public-front-door-guard] simplified public front door verified')
+console.log('[public-front-door-guard] Shop and Plant public surface verified')

--- a/tools/verify_public_agent_intake_contract.mjs
+++ b/tools/verify_public_agent_intake_contract.mjs
@@ -20,21 +20,22 @@ const contact = await readFile(resolve('.vercel/output/static/contact/index.html
 for (const required of [
   'data-contact-heading',
   'data-contact-goal-label',
-  "entryIntent==='ai-agent-solution'",
-  'What do you want to improve?',
-  'Start here',
-  'What should work better?',
-  "idleSubmitLabel='Contact us'",
-  'one reviewed example',
   "entryIntent==='shop-workspace'?'Shop':entryIntent==='plant-workspace'?'Plant':''",
   "text('[data-contact-heading]','Request a private '+workspaceProduct+' workspace.')",
   "text('[data-contact-goal-label]','What should be ready first?')",
   "idleSubmitLabel='Request workspace'",
+  'Choose the first workspace',
 ]) {
-  assert.ok(contact.includes(required), `missing agent intake copy: ${required}`)
+  assert.ok(contact.includes(required), `missing workspace intake copy: ${required}`)
 }
 
 for (const forbidden of [
+  'ai-agent-solution',
+  'AI Agent Solutions',
+  'What do you want to improve?',
+  'Start here',
+  "idleSubmitLabel='Contact us'",
+  'one reviewed example',
   'name="workflow"',
   'name="requested_package"',
   'name="product_area"',
@@ -42,7 +43,7 @@ for (const forbidden of [
   'name="source_links"',
   '/site/agent-templates/',
 ]) {
-  assert.equal(contact.includes(forbidden), false, `retired intake field or path returned: ${forbidden}`)
+  assert.equal(contact.includes(forbidden), false, `retired public intake copy or field returned: ${forbidden}`)
 }
 
 assert.match(contact, /name="name" required/)
@@ -55,18 +56,14 @@ for (const source of [...contact.matchAll(/<script>([\s\S]*?)<\/script>/g)].map(
   new Function(source)
 }
 
-assert.equal(contactEntryIntent({ page_path: '/contact/?from=ai-agent-solution' }), 'ai-agent-solution')
-assert.equal(contactEntryIntent({ source_url: 'https://www.supermega.dev/contact/?from=ai-agent-solution' }), 'ai-agent-solution')
 assert.equal(contactEntryIntent({ page_path: '/contact/?from=shop-workspace' }), 'shop-workspace')
 assert.equal(contactEntryIntent({ source_url: 'https://www.supermega.dev/contact/?from=plant-workspace' }), 'plant-workspace')
-assert.equal(contactEntryIntent({ page_path: '/contact/?from=shop' }), '')
-assert.equal(contactEntryIntent({ source_url: 'https://example.com/contact/?from=ai-agent-solution' }), '')
 assert.equal(contactEntryIntent({ source_url: 'https://example.com/contact/?from=shop-workspace' }), '')
 
 function lead(payload = {}) {
   return buildLeadRecord({
-    leadId: 'LEAD-AGENT-INTAKE',
-    taskId: 'TASK-AGENT-INTAKE',
+    leadId: 'LEAD-WORKSPACE-INTAKE',
+    taskId: 'TASK-WORKSPACE-INTAKE',
     payload: {
       name: 'Test Buyer',
       email: 'buyer@example.com',
@@ -78,19 +75,6 @@ function lead(payload = {}) {
   })
 }
 
-const vagueAgentLead = lead({ page_path: '/contact/?from=ai-agent-solution' })
-assert.equal(vagueAgentLead.workflow, 'AI Agent Solutions discovery')
-assert.equal(vagueAgentLead.requested_package, 'AI Agent Solutions')
-assert.equal(vagueAgentLead.product_area, 'Custom Solutions & AI Agents')
-assert.match(vagueAgentLead.first_proof_target, /one redacted approved sample/i)
-
-const vagueAgentRoute = buildSolutionRoute(vagueAgentLead)
-assert.equal(vagueAgentRoute.template_id, 'agent-solution-discovery')
-assert.equal(vagueAgentRoute.delivery_lane, 'agent_solution_discovery')
-assert.equal(vagueAgentRoute.status, 'needs_operator_review')
-assert.equal(vagueAgentRoute.starter_kit_url, '')
-assert.deepEqual(vagueAgentRoute.matched_keywords, [])
-
 const shopWorkspaceLead = lead({ page_path: '/contact/?from=shop-workspace' })
 assert.equal(shopWorkspaceLead.workflow, 'Shop private workspace request')
 assert.equal(shopWorkspaceLead.requested_package, 'Shop private workspace')
@@ -100,65 +84,38 @@ assert.equal(shopWorkspaceLead.template_id, 'shop-private-workspace')
 assert.equal(shopWorkspaceLead.onboarding_stage, 'workspace_request')
 assert.equal(shopWorkspaceLead.access_policy, 'approval_required')
 assert.equal(shopWorkspaceLead.workspace_status, 'not_created_until_approved')
-assert.equal(shopWorkspaceLead.lead_stage, 'qualified')
-assert.match(shopWorkspaceLead.first_proof_target, /buyer-approved starting data/i)
 const shopWorkspaceRoute = buildSolutionRoute(shopWorkspaceLead)
 assert.equal(shopWorkspaceRoute.template_id, 'shop-private-workspace')
 assert.equal(shopWorkspaceRoute.delivery_lane, 'shop_workspace_setup')
-assert.equal(shopWorkspaceRoute.status, 'route_ready')
 const shopWorkspaceTask = buildFirstProofTaskPayload(shopWorkspaceLead)
-assert.equal(shopWorkspaceTask.template_id, 'shop-private-workspace')
 assert.equal(shopWorkspaceTask.product_area, 'Shop')
-assert.equal(shopWorkspaceTask.solution_route.delivery_lane, 'shop_workspace_setup')
-assert.match(shopWorkspaceTask.operator_brief, /Shop private workspace first proof/i)
 assert.ok(shopWorkspaceTask.implementation_blueprint_pack.modules.includes('register_shift'))
-assert.ok(shopWorkspaceTask.implementation_blueprint_pack.modules.includes('receivables'))
 assert.equal(shopWorkspaceTask.approval_required, true)
 
 const plantWorkspaceLead = lead({ source_url: 'https://supermega.dev/contact/?from=plant-workspace' })
 assert.equal(plantWorkspaceLead.workflow, 'Plant private workspace request')
 assert.equal(plantWorkspaceLead.requested_package, 'Plant private workspace')
-assert.equal(plantWorkspaceLead.public_package, 'Plant private workspace')
 assert.equal(plantWorkspaceLead.product_area, 'Plant')
 assert.equal(plantWorkspaceLead.template_id, 'plant-private-workspace')
-assert.equal(plantWorkspaceLead.onboarding_stage, 'workspace_request')
-assert.equal(plantWorkspaceLead.lead_stage, 'qualified')
 const plantWorkspaceRoute = buildSolutionRoute(plantWorkspaceLead)
 assert.equal(plantWorkspaceRoute.template_id, 'plant-private-workspace')
 assert.equal(plantWorkspaceRoute.delivery_lane, 'plant_workspace_setup')
-assert.equal(plantWorkspaceRoute.status, 'route_ready')
 const plantWorkspaceTask = buildFirstProofTaskPayload(plantWorkspaceLead)
-assert.equal(plantWorkspaceTask.template_id, 'plant-private-workspace')
 assert.equal(plantWorkspaceTask.product_area, 'Plant')
-assert.equal(plantWorkspaceTask.solution_route.delivery_lane, 'plant_workspace_setup')
-assert.match(plantWorkspaceTask.operator_brief, /Plant private workspace first proof/i)
 assert.ok(plantWorkspaceTask.implementation_blueprint_pack.modules.includes('shift_handoff'))
-assert.ok(plantWorkspaceTask.implementation_blueprint_pack.modules.includes('maintenance_schedule'))
 assert.equal(plantWorkspaceTask.approval_required, true)
 
-const neutralRoute = buildSolutionRoute(lead({ goal: 'We need help.' }))
+const neutralLead = lead({ goal: 'We need help.' })
+const neutralRoute = buildSolutionRoute(neutralLead)
 assert.equal(neutralRoute.template_id, 'outcome-discovery')
 assert.equal(neutralRoute.delivery_lane, 'operator_discovery')
 assert.equal(neutralRoute.status, 'needs_operator_review')
 
-const invalidExplicitRoute = buildSolutionRoute(lead({ template_id: '../../not-allowlisted' }))
-assert.equal(invalidExplicitRoute.template_id, 'outcome-discovery')
-assert.equal(invalidExplicitRoute.starter_kit_url, '')
-
-const proofTask = buildFirstProofTaskPayload(vagueAgentLead)
-assert.equal(proofTask.starter_kit_url, '')
-assert.equal(proofTask.template_id, 'agent-solution-discovery')
-assert.equal(proofTask.intake_job.source_manifest.some((item) => item.source_type === 'starter_kit'), false)
-assert.equal(proofTask.intake_job.source_manifest.some((item) => item.source_type === 'solution_route'), true)
-assert.equal(JSON.stringify(proofTask).includes('/site/agent-templates/'), false)
-assert.ok(proofTask.checklist.includes('Review the saved solution route and first-proof boundary.'))
-
 console.log(JSON.stringify({
   status: 'ok',
-  contract: 'public_agent_intake',
+  contract: 'public_workspace_intake',
   contextual_copy: true,
   visible_fields: 4,
-  fallback_route: vagueAgentRoute.template_id,
   workspace_routes: [shopWorkspaceRoute.template_id, plantWorkspaceRoute.template_id],
-  phantom_starter_kit_paths: 0,
+  retired_public_agent_copy: true,
 }))


### PR DESCRIPTION
## What changed
- Removes AI-agent wording and mode switching from the generated public contact page.
- Keeps Shop and Plant private-workspace requests and normal contact intact.
- Adds a current public-front-door guard to the verified release contract.
- Old ?from=ai-agent-solution links now render the neutral contact page instead of a third product surface.

## Verification
- 
pm run public:prebuilt (40 files, 0.97 MB; visual, contact, and 923 connector checks passing)