### PR TITLE
fix(public): restore contact handoff health audit

### DIFF
--- a/tools/audit_lead_ledger.mjs
+++ b/tools/audit_lead_ledger.mjs
@@ -1,0 +1,62 @@
+const args = process.argv.slice(2)
+const baseUrlFlag = args.indexOf('--base-url')
+const baseUrl = baseUrlFlag >= 0 && args[baseUrlFlag + 1]
+  ? args[baseUrlFlag + 1]
+  : 'https://supermega.dev'
+
+function fail(reason) {
+  console.error(JSON.stringify({
+    ok: false,
+    contract: 'supermega_public_contact_handoff_health',
+    reason,
+    durable_write: 'not_asserted',
+    writes_performed: false,
+  }))
+  process.exit(1)
+}
+
+function assert(condition, reason) {
+  if (!condition) fail(reason)
+}
+
+async function request(pathname) {
+  const response = await fetch(new URL(pathname, baseUrl), {
+    headers: { Accept: 'application/json' },
+    redirect: 'error',
+    signal: AbortSignal.timeout(8000),
+  })
+  const body = await response.json().catch(() => null)
+  return { response, body }
+}
+
+try {
+  const normalizedBaseUrl = new URL(baseUrl)
+  assert(['http:', 'https:'].includes(normalizedBaseUrl.protocol), 'base_url_protocol_invalid')
+
+  const [status, diagnostics] = await Promise.all([
+    request('/api/contact-submissions/status'),
+    request('/api/contact-submissions/status?detail=1'),
+  ])
+
+  assert(status.response.status === 200, `contact_status_http_${status.response.status}`)
+  assert(Object.keys(status.body || {}).sort().join(',') === 'service,status', 'contact_status_exposes_internal_fields')
+  assert(status.body?.status === 'ready', 'contact_status_not_ready')
+  assert(status.body?.service === 'supermega-contact', 'contact_status_wrong_service')
+
+  assert(diagnostics.response.status === 401, 'contact_diagnostics_not_protected')
+  assert(Object.keys(diagnostics.body || {}).sort().join(',') === 'reason,status', 'contact_diagnostics_exposes_internal_fields')
+  assert(diagnostics.body?.status === 'error', 'contact_diagnostics_wrong_status')
+  assert(diagnostics.body?.reason === 'operator_auth_required', 'contact_diagnostics_wrong_reason')
+
+  console.log(JSON.stringify({
+    ok: true,
+    contract: 'supermega_public_contact_handoff_health',
+    base_url: normalizedBaseUrl.origin,
+    capture_status: status.body.status,
+    diagnostics: 'protected',
+    durable_write: 'not_asserted',
+    writes_performed: false,
+  }))
+} catch (error) {
+  fail(error?.message || 'contact_handoff_probe_failed')
+}


### PR DESCRIPTION
Restores the missing npm run audit:lead-ledger implementation. The read-only check confirms public capture is ready and diagnostics stay protected, while explicitly reporting that it does not prove a durable customer write. Verification: npm run public:prebuilt; npm run audit:lead-ledger; npm run public:verify:live. No contact submission, lead, email, account, payment, or customer data was created.