### PR TITLE
fix: install uv in cloud app release

### DIFF
--- a/.github/workflows/supermega-app-deploy.yml
+++ b/.github/workflows/supermega-app-deploy.yml
@@ -41,6 +41,11 @@ jobs:
         with:
           python-version: '3.12'
 
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          version: 'latest'
+
       - name: Install frontend dependencies
         working-directory: showroom
         run: npm ci


### PR DESCRIPTION
Adds the official uv setup step before Vercel Build. The previous deployment failed with spawn uv ENOENT. This branch is based directly on current main.