### PR TITLE
fix: build Vercel artifact for production target

### DIFF
--- a/.github/workflows/supermega-app-deploy.yml
+++ b/.github/workflows/supermega-app-deploy.yml
@@ -62,7 +62,7 @@ jobs:
         run: npm run build
 
       - name: Build Vercel output
-        run: npx vercel build --yes --token="${VERCEL_TOKEN}"
+        run: npx vercel build --prod --yes --token="${VERCEL_TOKEN}"
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
 


### PR DESCRIPTION
The cloud workflow produced a preview-targeted Vercel artifact and production deploy rejected it. Builds with --prod so the prebuilt target matches the production deploy.