### PR TITLE
fix: target public behavior event endpoint

### DIFF
--- a/showroom/src/lib/analytics.ts
+++ b/showroom/src/lib/analytics.ts
@@ -44,7 +44,7 @@ function recordFirstPartyEvent(event: string) {
     component: event,
     user_device_mode: window.innerWidth < 640 ? 'phone' : window.innerWidth < 1024 ? 'tablet' : 'desktop',
   }
-  void fetch('/api/behavior-events', {
+  void fetch('https://supermega.dev/api/behavior-events', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
     body: JSON.stringify(payload),


### PR DESCRIPTION
Targets the canonical public behavior event endpoint. The app host returns 404 for this route; the public endpoint is live and protected. Keeps the privacy-safe learning loop functional after the initial merge.