### PR TITLE
fix: bundle behavior events in public deployment

### DIFF
--- a/tools/create_public_vercel_output.mjs
+++ b/tools/create_public_vercel_output.mjs
@@ -5554,6 +5554,14 @@ const config = {
       dest: '/c/index.html',
     },
     {
+      src: '^/api/behavior-events/?$',
+      dest: '/api/behavior-events.js',
+    },
+    {
+      src: '^/api/behavior-events/status/?$',
+      dest: '/api/behavior-events.js',
+    },
+    {
       src: '^/machine/?$',
       dest: '/machine/index.html',
     },
@@ -6394,6 +6402,7 @@ self.addEventListener('activate', (event) => {
   'utf8',
 )
 await writeNodeFunction('health.js')
+await writeNodeFunction('behavior-events.js')
 await writeNodeFunction('contact-submissions.js')
 await writeNodeFunction('campaign-clicks.js')
 await writeNodeFunction('commercial-control.js')

--- a/tools/verify_public_vercel_output.mjs
+++ b/tools/verify_public_vercel_output.mjs
@@ -19,6 +19,8 @@ const routes = new Map((config.routes || []).filter((route) => route.src).map((r
 for (const [src, dest] of [
   ['^/api/contact-submissions$', '/api/contact-submissions.js'],
   ['^/api/contact-submissions/status$', '/api/contact-submissions.js'],
+  ['^/api/behavior-events/?$', '/api/behavior-events.js'],
+  ['^/api/behavior-events/status/?$', '/api/behavior-events.js'],
 ]) {
   if (routes.get(src) !== dest) fail('route_contract_missing', { src, expected: dest, actual: routes.get(src) })
 }
@@ -38,7 +40,7 @@ for (const src of [
   }
 }
 
-for (const entry of ['contact-submissions.js.func', 'health.js.func', 'not-found.js.func', 'public-app-handoff.js.func']) {
+for (const entry of ['behavior-events.js.func', 'contact-submissions.js.func', 'health.js.func', 'not-found.js.func', 'public-app-handoff.js.func']) {
   const rootPath = resolve(outputRoot, 'functions', entry)
   const apiPath = resolve(outputRoot, 'functions', 'api', entry)
   if (!existsSync(rootPath) && !existsSync(apiPath)) fail('missing_function_output', { entry })


### PR DESCRIPTION
Adds the behavior event routes and bundles the canonical behavior-events function in the public deployment generator. Verifier coverage prevents the endpoint from silently falling back to stale behavior.