### PR TITLE
fix: make public behavior learning endpoint live

### DIFF
--- a/api/behavior-events.js
+++ b/api/behavior-events.js
@@ -385,6 +385,17 @@ function behaviorSummaryDegraded(reason, detail = {}) {
   }
 }
 
+function storageReadiness() {
+  const postgres = datastore.postgresConfigured()
+  const supabase = supabaseConfig()
+  const supabaseConfigured = Boolean(supabase.url && supabase.serviceRoleKey)
+  return {
+    status: postgres || supabaseConfigured ? 'configured' : 'not_configured',
+    primary: postgres ? 'vercel_postgres_neon' : 'unconfigured',
+    fallback: supabaseConfigured ? 'supabase' : 'unconfigured',
+  }
+}
+
 function buildAdaptationQueue(topTemplates, eventCounts) {
   if (!topTemplates.length) {
     return [{
@@ -722,6 +733,7 @@ module.exports = async function handler(req, res) {
       endpoint: 'behavior-events',
       allowed_events: Array.from(allowedEventTypes),
       privacy: 'coarse_first_party_events_only',
+      storage: storageReadiness(),
       summary_endpoint: '/api/behavior-events?summary=1',
       summary_auth: 'SUPERMEGA_OPS_KEY bearer token required',
     })
@@ -755,9 +767,10 @@ module.exports = async function handler(req, res) {
   const record = buildBehaviorRecord({ payload: { ...payload, event_type: eventType }, req })
   const ledger = await saveBehaviorEvent(record)
 
-  json(res, 200, {
-    status: 'ready',
-    message: 'Behavior event captured.',
+  const persisted = ledger.status === 'ready'
+  json(res, persisted ? 200 : 503, {
+    status: persisted ? 'ready' : 'degraded',
+    message: persisted ? 'Behavior event captured.' : 'Behavior event was not durably stored.',
     event: {
       event_id: record.event_id,
       event_type: record.event_type,
@@ -766,5 +779,6 @@ module.exports = async function handler(req, res) {
       recorded_at: record.recorded_at,
     },
     ledger,
+    storage: storageReadiness(),
   })
 }

--- a/tools/create_public_vercel_output.mjs
+++ b/tools/create_public_vercel_output.mjs
@@ -1036,6 +1036,8 @@ const vercelConfig = {
       headers: { Location: '/' },
     },
     { src: '^/c/([^/]+)/?$', status: 308, headers: { Location: '/' } },
+    { src: '^/api/behavior-events/?$', dest: '/api/behavior-events.js' },
+    { src: '^/api/behavior-events/status/?$', dest: '/api/behavior-events.js' },
     { src: '^/(?:favicon\\.svg|site\\.webmanifest|robots\\.txt|sitemap\\.xml|sw\\.js)$', headers: { 'cache-control': 'public, max-age=31536000, immutable' }, continue: true },
     { handle: 'filesystem' },
     { src: '^/(.*)$', status: 404, dest: '/404.html' },
@@ -1121,6 +1123,7 @@ await writeStatic('site.webmanifest', `${JSON.stringify({
 }, null, 2)}\n`)
 
 await writeNodeFunction('health.js')
+await writeNodeFunction('behavior-events.js')
 await writeNodeFunction('contact-submissions.js')
 await writeNodeFunction('not-found.js')
 await writeFile(resolve(outputDir, 'config.json'), `${JSON.stringify(vercelConfig, null, 2)}\n`, 'utf8')

--- a/tools/verify_public_vercel_output.mjs
+++ b/tools/verify_public_vercel_output.mjs
@@ -33,6 +33,10 @@ const configPath = resolve(outputDir, 'config.json')
 if (!existsSync(configPath)) fail('missing_public_config')
 const config = JSON.parse(readFileSync(configPath, 'utf8'))
 const routes = Array.isArray(config.routes) ? config.routes : []
+for (const src of ['^/api/behavior-events/?$', '^/api/behavior-events/status/?$']) {
+  const route = findRoute(routes, src)
+  if (route?.dest !== '/api/behavior-events.js') fail('behavior_events_route_missing', { src, route })
+}
 
 const expectedStaticEntries = new Set(['404.html', 'contact', 'favicon.svg', 'index.html', 'live-plant-mobile.png', 'live-plant-workspace.png', 'live-shop-mobile.png', 'live-shop-workspace.png', 'privacy', 'robots.txt', 'site.webmanifest', 'sitemap.xml', 'sw.js', 'work'])
 const actualStaticEntries = readdirSync(staticDir)
@@ -65,7 +69,7 @@ for (const [entry, approvedHash] of approvedCaptureHashes) {
   if (actualHash !== approvedHash) fail('public_capture_not_reviewed', { entry, approvedHash, actualHash })
 }
 
-const expectedFunctions = new Set(['contact-submissions.js.func', 'health.js.func', 'not-found.js.func'])
+const expectedFunctions = new Set(['behavior-events.js.func', 'contact-submissions.js.func', 'health.js.func', 'not-found.js.func'])
 const actualFunctions = readdirSync(functionsDir, { withFileTypes: true })
   .filter((entry) => entry.isDirectory())
   .map((entry) => entry.name)


### PR DESCRIPTION
The public release deploys from codex/public-enterprise-site. This syncs the behavior storage truth fix and bundles/routes api/behavior-events.js in the actual canonical public generator. Public artifact verifier now requires the function and both routes.