### PR TITLE
fix: complete public behavior endpoint release

### DIFF
--- a/api/behavior-events.js
+++ b/api/behavior-events.js
@@ -385,6 +385,17 @@ function behaviorSummaryDegraded(reason, detail = {}) {
   }
 }
 
+function storageReadiness() {
+  const postgres = datastore.postgresConfigured()
+  const supabase = supabaseConfig()
+  const supabaseConfigured = Boolean(supabase.url && supabase.serviceRoleKey)
+  return {
+    status: postgres || supabaseConfigured ? 'configured' : 'not_configured',
+    primary: postgres ? 'vercel_postgres_neon' : 'unconfigured',
+    fallback: supabaseConfigured ? 'supabase' : 'unconfigured',
+  }
+}
+
 function buildAdaptationQueue(topTemplates, eventCounts) {
   if (!topTemplates.length) {
     return [{
@@ -722,6 +733,7 @@ module.exports = async function handler(req, res) {
       endpoint: 'behavior-events',
       allowed_events: Array.from(allowedEventTypes),
       privacy: 'coarse_first_party_events_only',
+      storage: storageReadiness(),
       summary_endpoint: '/api/behavior-events?summary=1',
       summary_auth: 'SUPERMEGA_OPS_KEY bearer token required',
     })
@@ -755,9 +767,10 @@ module.exports = async function handler(req, res) {
   const record = buildBehaviorRecord({ payload: { ...payload, event_type: eventType }, req })
   const ledger = await saveBehaviorEvent(record)
 
-  json(res, 200, {
-    status: 'ready',
-    message: 'Behavior event captured.',
+  const persisted = ledger.status === 'ready'
+  json(res, persisted ? 200 : 503, {
+    status: persisted ? 'ready' : 'degraded',
+    message: persisted ? 'Behavior event captured.' : 'Behavior event was not durably stored.',
     event: {
       event_id: record.event_id,
       event_type: record.event_type,
@@ -766,5 +779,6 @@ module.exports = async function handler(req, res) {
       recorded_at: record.recorded_at,
     },
     ledger,
+    storage: storageReadiness(),
   })
 }

--- a/tools/create_public_vercel_output.mjs
+++ b/tools/create_public_vercel_output.mjs
@@ -1036,6 +1036,8 @@ const vercelConfig = {
       headers: { Location: '/' },
     },
     { src: '^/c/([^/]+)/?$', status: 308, headers: { Location: '/' } },
+    { src: '^/api/behavior-events/?$', dest: '/api/behavior-events.js' },
+    { src: '^/api/behavior-events/status/?$', dest: '/api/behavior-events.js' },
     { src: '^/(?:favicon\\.svg|site\\.webmanifest|robots\\.txt|sitemap\\.xml|sw\\.js)$', headers: { 'cache-control': 'public, max-age=31536000, immutable' }, continue: true },
     { handle: 'filesystem' },
     { src: '^/(.*)$', status: 404, dest: '/404.html' },
@@ -1121,6 +1123,7 @@ await writeStatic('site.webmanifest', `${JSON.stringify({
 }, null, 2)}\n`)
 
 await writeNodeFunction('health.js')
+await writeNodeFunction('behavior-events.js')
 await writeNodeFunction('contact-submissions.js')
 await writeNodeFunction('not-found.js')
 await writeFile(resolve(outputDir, 'config.json'), `${JSON.stringify(vercelConfig, null, 2)}\n`, 'utf8')

--- a/tools/create_public_vercel_output.mjs
+++ b/tools/create_public_vercel_output.mjs
@@ -1054,7 +1054,11 @@ async function writeNodeFunction(name) {
   const functionDir = resolve(functionsDir, `${name}.func`)
   await mkdir(resolve(functionDir, 'api'), { recursive: true })
   await cp(resolve(root, 'api', name), resolve(functionDir, 'api', name), { force: true })
-  await cp(resolve(root, 'api', 'lib'), resolve(functionDir, 'api', 'lib'), { recursive: true, force: true })
+  if (name !== 'behavior-events.js') {
+    await cp(resolve(root, 'api', 'lib'), resolve(functionDir, 'api', 'lib'), { recursive: true, force: true })
+  } else {
+    await mkdir(resolve(functionDir, 'api', 'lib'), { recursive: true })
+  }
   await writeFile(resolve(functionDir, 'api', 'lib', 'supermega-datastore.js'), publicDatastoreShim, 'utf8')
   if (name === 'contact-submissions.js') {
     const blobEntry = resolve(functionDir, 'api', 'lib', 'vercel-blob-entry.mjs')

--- a/tools/verify_public_vercel_artifact_budget.mjs
+++ b/tools/verify_public_vercel_artifact_budget.mjs
@@ -57,7 +57,7 @@ for (const entry of readdirSync(functionsApiDir, { withFileTypes: true })) {
 }
 
 const worstFunction = functionBudgets.sort((a, b) => b.files - a.files)[0]
-const expectedFunctions = new Set(['contact-submissions.js.func', 'health.js.func', 'not-found.js.func'])
+const expectedFunctions = new Set(['behavior-events.js.func', 'contact-submissions.js.func', 'health.js.func', 'not-found.js.func'])
 const actualFunctions = new Set(functionBudgets.map((entry) => entry.name))
 
 for (const name of actualFunctions) {
@@ -69,10 +69,11 @@ for (const name of expectedFunctions) {
 
 if (duplicateApiNodeModules > 0) fail('duplicate_api_node_modules_present', { duplicateApiNodeModules })
 if (totalFiles > 60) fail('public_output_file_budget_exceeded', { totalFiles, maxFiles: 60, worstFunction })
-if (totalBytes > 1024 * 1024) {
+const maxBytes = 1.1 * 1024 * 1024
+if (totalBytes > maxBytes) {
   fail('public_output_size_budget_exceeded', {
     totalMb: Number((totalBytes / 1024 / 1024).toFixed(2)),
-    maxMb: 1,
+    maxMb: 1.1,
     worstFunction,
   })
 }

--- a/tools/verify_public_vercel_output.mjs
+++ b/tools/verify_public_vercel_output.mjs
@@ -33,6 +33,10 @@ const configPath = resolve(outputDir, 'config.json')
 if (!existsSync(configPath)) fail('missing_public_config')
 const config = JSON.parse(readFileSync(configPath, 'utf8'))
 const routes = Array.isArray(config.routes) ? config.routes : []
+for (const src of ['^/api/behavior-events/?$', '^/api/behavior-events/status/?$']) {
+  const route = findRoute(routes, src)
+  if (route?.dest !== '/api/behavior-events.js') fail('behavior_events_route_missing', { src, route })
+}
 
 const expectedStaticEntries = new Set(['404.html', 'contact', 'favicon.svg', 'index.html', 'live-plant-mobile.png', 'live-plant-workspace.png', 'live-shop-mobile.png', 'live-shop-workspace.png', 'privacy', 'robots.txt', 'site.webmanifest', 'sitemap.xml', 'sw.js', 'work'])
 const actualStaticEntries = readdirSync(staticDir)
@@ -65,7 +69,7 @@ for (const [entry, approvedHash] of approvedCaptureHashes) {
   if (actualHash !== approvedHash) fail('public_capture_not_reviewed', { entry, approvedHash, actualHash })
 }
 
-const expectedFunctions = new Set(['contact-submissions.js.func', 'health.js.func', 'not-found.js.func'])
+const expectedFunctions = new Set(['behavior-events.js.func', 'contact-submissions.js.func', 'health.js.func', 'not-found.js.func'])
 const actualFunctions = readdirSync(functionsDir, { withFileTypes: true })
   .filter((entry) => entry.isDirectory())
   .map((entry) => entry.name)


### PR DESCRIPTION
Completes the canonical public release after PR 187 exposed the endpoint but exceeded the artifact budget. The behavior function now uses only the required datastore shim, and the budget is raised from 1.0MB to 1.1MB to accommodate the durable learning endpoint. Full public:prebuilt verification passes locally.