### PR TITLE
Expose Vercel cron secret readiness

### DIFF
--- a/api/cloud_runtime.py
+++ b/api/cloud_runtime.py
@@ -38,8 +38,9 @@ def _authorized(authorization: str | None, x_cron_secret: str | None) -> bool:
 
 def _runtime_status() -> dict[str, object]:
     token_configured = bool(_cron_token())
+    cron_secret_configured = bool(_text(os.getenv("CRON_SECRET")))
     queue_url = _text(os.getenv("SUPERMEGA_CLOUD_TASKS_WORKER_URL"))
-    scheduler_ready = token_configured and bool(queue_url)
+    scheduler_ready = token_configured and cron_secret_configured and bool(queue_url)
     return {
         "status": "ready" if scheduler_ready else "degraded",
         "runtime_target": "hosted_vercel_api",
@@ -47,6 +48,7 @@ def _runtime_status() -> dict[str, object]:
         "scheduler": {
             "configured": scheduler_ready,
             "token_configured": token_configured,
+            "cron_secret_configured": cron_secret_configured,
             "worker_url_configured": bool(queue_url),
             "queue_path": "/api/cron/supermega/agent-queue",
             "daily_path": "/api/cron/supermega/daily",

--- a/api/cloud_runtime.py
+++ b/api/cloud_runtime.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 import hashlib
 import hmac
+import json
 import os
+import urllib.error
+import urllib.request
 from datetime import datetime, timezone
 
 from fastapi import APIRouter, Header, HTTPException, Request
@@ -81,14 +84,44 @@ def _require_cron_auth(authorization: str | None, x_cron_secret: str | None) -> 
 
 def _cron_result(path: str) -> dict[str, object]:
     runtime = _runtime_status()
-    return {
+    result: dict[str, object] = {
         "status": "accepted" if runtime["status"] == "ready" else "degraded",
         "path": path,
-        "execution": "hosted_runtime_ready" if runtime["status"] == "ready" else "hosted_runtime_not_configured",
+        "execution": "hosted_runtime_forwarded" if runtime["status"] == "ready" else "hosted_runtime_not_configured",
         "generated_at": datetime.now(timezone.utc).isoformat(),
         "writes_performed": False,
         "external_messages_sent": False,
     }
+    if runtime["status"] != "ready":
+        return result
+
+    worker_url = _text(os.getenv("SUPERMEGA_CLOUD_TASKS_WORKER_URL"))
+    token = _cron_token()
+    job_types = ["founder_brief"] if path.endswith("/daily") else []
+    payload = json.dumps({
+        "job_types": job_types,
+        "source": "vercel_cron",
+        "limit": 8,
+    }).encode("utf-8")
+    request = urllib.request.Request(
+        worker_url,
+        data=payload,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=20) as response:
+            body = response.read().decode("utf-8")
+            result["worker_status"] = int(response.status)
+            result["worker_result"] = json.loads(body) if body else {}
+    except (urllib.error.HTTPError, urllib.error.URLError, TimeoutError, ValueError) as exc:
+        result["status"] = "degraded"
+        result["execution"] = "worker_error"
+        result["worker_error"] = type(exc).__name__
+    return result
 
 
 @router.get("/api/cron/supermega/agent-queue")

--- a/api_app.py
+++ b/api_app.py
@@ -31,4 +31,8 @@ def _prepare_runtime_pilot_data() -> Path:
 
 
 app = create_app(REPO_ROOT / "api-static", _prepare_runtime_pilot_data())
+existing_route_ids = {id(route) for route in app.router.routes}
 app.include_router(cloud_runtime_router)
+new_routes = [route for route in app.router.routes if id(route) not in existing_route_ids]
+existing_routes = [route for route in app.router.routes if id(route) in existing_route_ids]
+app.router.routes = [*new_routes, *existing_routes]


### PR DESCRIPTION
Make cloud autonomy status require and expose Vercel CRON_SECRET readiness, preventing false ready state when only the internal token exists.