### PR TITLE
Bind public deploy workflow to canonical project

### DIFF
--- a/.github/workflows/supermega-public-deploy.yml
+++ b/.github/workflows/supermega-public-deploy.yml
@@ -11,6 +11,9 @@ permissions:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    env:
+      VERCEL_ORG_ID: team_wI4l7ZgSxcEztQPSlCCYVeJ5
+      VERCEL_PROJECT_ID: prj_Yaf0cZYbiFXcLkMcKaAm4alPWMhR
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -26,8 +29,13 @@ jobs:
       - name: Verify public artifact
         run: node tools/verify_public_vercel_artifact_budget.mjs && node tools/verify_public_vercel_output.mjs
 
+      - name: Bind canonical public Vercel project
+        run: |
+          mkdir -p .vercel
+          printf '{"projectId":"%s","orgId":"%s","projectName":"supermega-public"}\n' "$VERCEL_PROJECT_ID" "$VERCEL_ORG_ID" > .vercel/project.json
+
       - name: Deploy public production
-        run: npx vercel deploy --prebuilt --prod --yes --token="${VERCEL_TOKEN}"
+        run: npx vercel deploy --prebuilt --prod --yes --token="${VERCEL_TOKEN}" --project "$VERCEL_PROJECT_ID"
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
 
@@ -39,6 +47,7 @@ jobs:
               'https://supermega.dev/': 'Shop',
               'https://supermega.dev/products/': 'Open Shop',
               'https://supermega.dev/offers/': 'Talk to us',
+              'https://supermega.dev/ai-agent-solutions/': 'AI Agent Solutions',
           }
           for url, token in checks.items():
               request = urllib.request.Request(url, headers={'User-Agent': 'supermega-public-deploy/1.0'})

--- a/tools/create_public_vercel_output.mjs
+++ b/tools/create_public_vercel_output.mjs
@@ -5574,6 +5574,10 @@ const config = {
       handle: 'filesystem',
     },
     {
+      src: '^/ai-agent-solutions/?$',
+      dest: '/ai-agent-solutions/index.html',
+    },
+    {
       src: '^/(.*)$',
       status: 404,
       dest: '/404.html',


### PR DESCRIPTION
Fixes the push deploy workflow so public releases target supermega-public instead of the repository default Vercel project, and verifies the AI Agent Solutions route.