### PR TITLE
Install public function dependencies before bundling

### DIFF
--- a/.github/workflows/supermega-public-deploy.yml
+++ b/.github/workflows/supermega-public-deploy.yml
@@ -23,6 +23,9 @@ jobs:
         with:
           node-version: 24
 
+      - name: Install public function dependencies
+        run: npm ci --ignore-scripts --no-audit --no-fund
+
       - name: Build public artifact
         run: node tools/create_public_vercel_output.mjs
 


### PR DESCRIPTION
Ensure pg and related datastore dependencies are present when the public Build Output API functions are generated, preventing live pg_dependency_missing failures.