### PR TITLE
Use install for lockfile-free public build

### DIFF
--- a/.github/workflows/supermega-public-deploy.yml
+++ b/.github/workflows/supermega-public-deploy.yml
@@ -23,6 +23,9 @@ jobs:
         with:
           node-version: 24
 
+      - name: Install public function dependencies
+        run: npm ci --ignore-scripts --no-audit --no-fund
+
       - name: Build public artifact
         run: node tools/create_public_vercel_output.mjs
 

--- a/.github/workflows/supermega-public-deploy.yml
+++ b/.github/workflows/supermega-public-deploy.yml
@@ -24,7 +24,7 @@ jobs:
           node-version: 24
 
       - name: Install public function dependencies
-        run: npm ci --ignore-scripts --no-audit --no-fund
+        run: npm install --ignore-scripts --no-audit --no-fund
 
       - name: Build public artifact
         run: node tools/create_public_vercel_output.mjs


### PR DESCRIPTION
Superseded: current main already installs public function dependencies with npm install.