### PR TITLE
Avoid duplicate public function dependencies

### DIFF
--- a/.github/workflows/supermega-public-deploy.yml
+++ b/.github/workflows/supermega-public-deploy.yml
@@ -24,7 +24,7 @@ jobs:
           node-version: 24
 
       - name: Install public function dependencies
-        run: npm ci --ignore-scripts --no-audit --no-fund
+        run: npm install --ignore-scripts --no-audit --no-fund
 
       - name: Build public artifact
         run: node tools/create_public_vercel_output.mjs

--- a/tools/create_public_vercel_output.mjs
+++ b/tools/create_public_vercel_output.mjs
@@ -5611,19 +5611,12 @@ async function writeNodeFunction(name) {
     })
   }
   await mkdir(resolve(functionDir, 'node_modules'), { recursive: true })
-  await mkdir(resolve(functionDir, 'api', 'node_modules'), { recursive: true })
   for (const dependency of nodeFunctionDependencies) {
     const sourceDependency = resolve(root, 'node_modules', dependency)
-    await Promise.all([
-      cp(sourceDependency, resolve(functionDir, 'node_modules', dependency), {
-        recursive: true,
-        force: true,
-      }),
-      cp(sourceDependency, resolve(functionDir, 'api', 'node_modules', dependency), {
-        recursive: true,
-        force: true,
-      }),
-    ]).catch((error) => {
+    await cp(sourceDependency, resolve(functionDir, 'node_modules', dependency), {
+      recursive: true,
+      force: true,
+    }).catch((error) => {
       if (error?.code === 'ENOENT') return
       throw error
     })


### PR DESCRIPTION
Keep bundled pg dependencies at the function root, where Node resolves them, and avoid duplicate api/node_modules copies. Local artifact budget and output verification pass.