### PR TITLE
Fix public demo route

### DIFF
--- a/tools/create_public_vercel_output.mjs
+++ b/tools/create_public_vercel_output.mjs
@@ -5545,6 +5545,13 @@ const config = {
       dest: '/api/public-app-handoff.js',
     },
     {
+      src: '^/demo/?$',
+      status: 308,
+      headers: {
+        Location: 'https://demo.supermega.dev/',
+      },
+    },
+    {
       src: '^/(?:agentops|agentops-toolbox|ai-back-office|back-office-operator|back-office-workflow-desk|openclaw|office-operator)/?$',
       status: 308,
       headers: {

--- a/tools/verify_public_vercel_output.mjs
+++ b/tools/verify_public_vercel_output.mjs
@@ -30,6 +30,14 @@ if (productsRoute?.dest !== '/products/index.html') {
   fail('products_route_not_static_page', { expected: { dest: '/products/index.html' }, actual: productsRoute })
 }
 
+const demoRoute = (config.routes || []).find((route) => route.src === '^/demo/?$')
+if (demoRoute?.status !== 308 || demoRoute?.headers?.Location !== 'https://demo.supermega.dev/') {
+  fail('demo_route_contract_missing', {
+    expected: { status: 308, Location: 'https://demo.supermega.dev/' },
+    actual: demoRoute,
+  })
+}
+
 for (const src of [
   '^/(?:agentops|agentops-toolbox|ai-back-office|back-office-operator|back-office-workflow-desk|openclaw|office-operator)/?$',
   '^/products/(?:agentops|agentops-toolbox|ai-agent-operator|ai-back-office|back-office-operator|back-office-workflow-desk|openclaw)/?$',


### PR DESCRIPTION
Superseded: current main ships a working /demo/ fallback and the live route returns 200.