### PR TITLE
Keep app behavior events same-origin

### DIFF
--- a/api/behavior-events.js
+++ b/api/behavior-events.js
@@ -1,7 +1,7 @@
 const crypto = require('crypto')
 const datastore = require('./lib/supermega-datastore')
 
-const defaultAllowedOrigins = 'https://supermega.dev,https://www.supermega.dev'
+const defaultAllowedOrigins = 'https://supermega.dev,https://www.supermega.dev,https://app.supermega.dev,https://ytf.supermega.dev'
 const rateLimitWindowMs = Number(process.env.SUPERMEGA_BEHAVIOR_RATE_WINDOW_MS || 15 * 60 * 1000)
 const rateLimitMax = Number(process.env.SUPERMEGA_BEHAVIOR_RATE_MAX || 120)
 const rateStore = globalThis.__supermegaBehaviorEventRateStore || new Map()

--- a/showroom/src/lib/analytics.ts
+++ b/showroom/src/lib/analytics.ts
@@ -54,7 +54,7 @@ function recordFirstPartyEvent(event: string) {
     utm_source: allowedEntrySource,
     user_device_mode: window.innerWidth < 640 ? 'phone' : window.innerWidth < 1024 ? 'tablet' : 'desktop',
   }
-  void fetch('https://supermega.dev/api/behavior-events', {
+  void fetch('/api/behavior-events', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
     body: JSON.stringify(payload),


### PR DESCRIPTION
## Summary
- post behavior events to the current app origin instead of hardcoding supermega.dev
- include app.supermega.dev and ytf.supermega.dev in the default behavior-events CORS allowlist
- removes the live app.supermega.dev console CORS failure seen on YTF and login routes

## Validation
- node --check api/behavior-events.js
- git diff --check -- api/behavior-events.js showroom/src/lib/analytics.ts
- npm --prefix showroom run build