### PR TITLE
Disable unconfigured app behavior events

### DIFF
--- a/showroom/src/lib/analytics.ts
+++ b/showroom/src/lib/analytics.ts
@@ -14,6 +14,7 @@ function sanitizeEventPayload(properties: EventPayload): EventPayload {
 
 const posthogKey = (import.meta.env.VITE_POSTHOG_KEY ?? '').trim()
 const posthogHost = (import.meta.env.VITE_POSTHOG_HOST ?? 'https://us.i.posthog.com').trim()
+const firstPartyEventsEndpoint = (import.meta.env.VITE_FIRST_PARTY_EVENTS_ENDPOINT ?? '').trim()
 
 let initialized = false
 let loadingPromise: Promise<void> | null = null
@@ -43,7 +44,7 @@ const FIRST_PARTY_EVENT_TYPES: Record<string, string> = {
 
 function recordFirstPartyEvent(event: string) {
   const eventType = FIRST_PARTY_EVENT_TYPES[event]
-  if (!eventType || typeof window === 'undefined') return
+  if (!eventType || typeof window === 'undefined' || !firstPartyEventsEndpoint) return
   const entrySource = new URLSearchParams(window.location.search).get('source')
   const allowedEntrySource = entrySource && ['agent-product', 'demo', 'public-site'].includes(entrySource) ? entrySource : undefined
   const payload = {
@@ -54,7 +55,7 @@ function recordFirstPartyEvent(event: string) {
     utm_source: allowedEntrySource,
     user_device_mode: window.innerWidth < 640 ? 'phone' : window.innerWidth < 1024 ? 'tablet' : 'desktop',
   }
-  void fetch('/api/behavior-events', {
+  void fetch(firstPartyEventsEndpoint, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
     body: JSON.stringify(payload),


### PR DESCRIPTION
## Summary
- make first-party behavior event posting opt-in for the React app shell
- prevent app.supermega.dev from POSTing to /api/behavior-events when that collector is not deployed on the app host
- keeps the public/YTF behavior-events API allowlist from #216 available for hosts that intentionally configure a collector endpoint

## Validation
- node tools/verify_commerce_machine_contract.mjs
- git diff --check -- showroom/src/lib/analytics.ts api/behavior-events.js

## Local note
- Local Windows Node build/lint commands hung after the previous production deploy; no code error was returned. This PR relies on GitHub/Vercel checks for full Linux build proof.