### PR TITLE
Fix verified Vercel release workflows

### DIFF
--- a/.github/workflows/supermega-app-deploy.yml
+++ b/.github/workflows/supermega-app-deploy.yml
@@ -60,12 +60,17 @@ jobs:
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 24
-          package-manager-cache: false
 
       - name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.12'
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          version: '0.11.30'
+          enable-cache: false
 
       - name: Verify canonical API contracts
         run: |

--- a/.github/workflows/supermega-public-live-health.yml
+++ b/.github/workflows/supermega-public-live-health.yml
@@ -33,7 +33,6 @@ jobs:
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 24
-          package-manager-cache: false
 
       - name: Verify current public release
         env:

--- a/.github/workflows/supermega-public-release.yml
+++ b/.github/workflows/supermega-public-release.yml
@@ -54,7 +54,6 @@ jobs:
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 24
-          package-manager-cache: false
 
       - name: Require production deploy credential
         env:

--- a/tools/verify_app_deploy_workflow.mjs
+++ b/tools/verify_app_deploy_workflow.mjs
@@ -34,6 +34,7 @@ requireContract('production environment gate', /environment:\s*production/.test(
 requireContract('production is main-only in the canonical repository', workflow.includes("if: ${{ github.ref == 'refs/heads/main' && github.repository == 'swanhtet01/swanhtet01.github.io' }}"))
 requireContract('deployment metadata uses the guarded runtime ref', workflow.includes('githubCommitRef=${{ github.ref_name }}') && !workflow.includes('githubCommitRef=main'))
 requireContract('release actions are commit-pinned', !/uses:\s+[^\s#]+@v\d+/m.test(workflow) && /uses:\s+actions\/checkout@[0-9a-f]{40}/.test(workflow))
+requireContract('uv build tool is immutable', workflow.includes('astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9') && workflow.includes("version: '0.11.30'"))
 requireContract('stale Cloud Run release authority is retired', !existsSync(resolve(root, '.github/workflows/supermega-app-cloud-run.yml')))
 
 const expectedCrons = ['/api/cron/supermega/agent-queue', '/api/cron/supermega/daily'].sort()
@@ -61,4 +62,4 @@ if (failures.length) {
   process.exit(1)
 }
 
-console.log(JSON.stringify({ ok: true, contract: 'supermega_app_release_workflow', checks: 26 }, null, 2))
+console.log(JSON.stringify({ ok: true, contract: 'supermega_app_release_workflow', checks: 27 }, null, 2))

--- a/tools/verify_public_deploy_guard.mjs
+++ b/tools/verify_public_deploy_guard.mjs
@@ -26,6 +26,7 @@ if (existsSync(resolve(root, '.github/workflows/supermega-public-deploy.yml'))) 
 if (vercelConfig.git?.deploymentEnabled !== false) failures.push('native_git_deployments_not_disabled')
 if (!previewVerifier.includes('preview_contact_not_accepting')) failures.push('preview_contact_readiness_not_verified')
 if (!previewVerifier.includes('deployment_function_surface_wrong')) failures.push('preview_function_inventory_not_verified')
+if (!previewVerifier.includes('const maxAttempts = 6') || !previewVerifier.includes('protected_preview_retry:')) failures.push('preview_propagation_retry_missing')
 for (const token of ['SUPERMEGA_CONTACT_IDEMPOTENCY_SECRET', 'idempotency_key_required', 'rate_limited', 'resolution=ignore-duplicates,return=representation', "'idempotency-key'"]) {
   if (!publicGenerator.includes(token)) failures.push(`contact_abuse_control_missing:${token}`)
 }

--- a/tools/verify_public_preview_live.mjs
+++ b/tools/verify_public_preview_live.mjs
@@ -6,8 +6,19 @@ const manifest = JSON.parse(await readFile(new URL('../site-manifest.json', impo
 const baseUrl = String(process.env.PUBLIC_BASE_URL || '').replace(/\/$/, '')
 const expectedCommit = String(process.env.EXPECTED_RELEASE_COMMIT || '').toLowerCase()
 const vercelToken = String(process.env.VERCEL_CLI_TOKEN || '').trim()
+const maxAttempts = 6
+const retryWaitBuffer = new Int32Array(new SharedArrayBuffer(4))
 
 if (!baseUrl.startsWith('https://')) throw new Error('public_preview_url_required')
+
+function describeFailure(error) {
+  const status = Number.isInteger(error?.status) ? error.status : 'unknown'
+  let stderr = String(error?.stderr || '').trim()
+  if (vercelToken) stderr = stderr.replaceAll(vercelToken, '[redacted]')
+  stderr = stderr.replace(/([?&](?:token|secret|key)=)[^&\s]+/gi, '$1[redacted]')
+  const lastLine = stderr.split(/\r?\n/).map((line) => line.trim()).filter(Boolean).at(-1)
+  return `exit=${status}${lastLine ? ` message=${lastLine.slice(0, 240)}` : ''}`
+}
 
 function get(path) {
   const tokenArgs = vercelToken ? ['--token', vercelToken] : []
@@ -16,16 +27,24 @@ function get(path) {
   const executableArgs = process.platform === 'win32'
     ? [resolve(dirname(process.execPath), 'node_modules', 'npm', 'bin', 'npx-cli.js'), ...npxArgs]
     : npxArgs
-  try {
-    return execFileSync(executable, executableArgs, {
-      encoding: 'utf8',
-      env: process.env,
-      maxBuffer: 8 * 1024 * 1024,
-      stdio: ['ignore', 'pipe', 'pipe'],
-    })
-  } catch {
-    throw new Error(`protected_preview_request_failed:${path}`)
+  let lastFailure = 'unknown'
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    try {
+      return execFileSync(executable, executableArgs, {
+        encoding: 'utf8',
+        env: process.env,
+        maxBuffer: 8 * 1024 * 1024,
+        stdio: ['ignore', 'pipe', 'pipe'],
+      })
+    } catch (error) {
+      lastFailure = describeFailure(error)
+      if (attempt < maxAttempts) {
+        console.error(`protected_preview_retry:${path}:attempt=${attempt}:${lastFailure}`)
+        Atomics.wait(retryWaitBuffer, 0, 0, attempt * 2000)
+      }
+    }
   }
+  throw new Error(`protected_preview_request_failed:${path}:attempts=${maxAttempts}:${lastFailure}`)
 }
 
 for (const page of manifest.pages) {


### PR DESCRIPTION
## Root cause

- The app release completed its application build and 27/30 contract checks, then Vercel's local Python builder failed because `uv` was absent from the GitHub runner.
- The public release produced a READY preview with the exact three-function surface, but deployment-protection propagation was not ready for the verifier's first request.
- `actions/setup-node` also reported an unsupported `package-manager-cache` input.

## Fix

- Install `uv` through SHA-pinned `astral-sh/setup-uv` v9.0.0 and pin uv 0.11.30.
- Retry protected preview reads six times with bounded 30-second backoff, preserve terminal failure, and redact token material from diagnostics.
- Remove the unsupported setup-node input from all affected workflows.
- Extend release guards to enforce the uv pin and preview retry contract.

## Verification

- App production build contract passes: 6 routes, 27 workflow checks, 30 security checks.
- Public prebuilt contract passes: 7 routes, 3 functions, 45 contact checks.
- The patched verifier passes against the exact failed-run preview and merge commit `f8c5299`.
- No mutable action refs or unsupported setup-node inputs remain.
- Independent six-file audit: PASS.

Managed Supabase trial writes remain locked and are unaffected by this change.
