### PR TITLE
Fix safe Vercel production promotion

### DIFF
--- a/.github/workflows/supermega-app-deploy.yml
+++ b/.github/workflows/supermega-app-deploy.yml
@@ -19,6 +19,7 @@ on:
       - 'tools/verify_app_release_live.mjs'
       - 'tools/verify_app_security_contract.mjs'
       - 'tools/verify_vercel_project_state.mjs'
+      - 'tools/resolve_vercel_rollback_target.mjs'
       - 'tools/validate_supermega_database_url.py'
       - 'tools/activate_supermega_database.ps1'
       - 'site-manifest.json'
@@ -112,37 +113,35 @@ jobs:
           SUPERMEGA_RELEASE_COMMIT: ${{ github.sha }}
         run: npx --yes vercel@56.1.0 build --prod --yes --token="$VERCEL_TOKEN"
 
-      - name: Deploy isolated preview
+      - name: Capture current production rollback target
+        id: rollback-target
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: |
+          PREVIOUS_URL="$(npx --yes vercel@56.1.0 inspect https://app.supermega.dev --format=json --token="$VERCEL_TOKEN" | node tools/resolve_vercel_rollback_target.mjs app.supermega.dev)"
+          printf 'url=%s\n' "$PREVIOUS_URL" >> "$GITHUB_OUTPUT"
+
+      - name: Deploy isolated production candidate
         id: deploy
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
         run: |
-          DEPLOYMENT_URL="$(npx --yes vercel@56.1.0 deploy --prebuilt --yes --token="$VERCEL_TOKEN" --meta "githubCommitSha=${{ github.sha }}" --meta "githubCommitRef=${{ github.ref_name }}")"
+          DEPLOYMENT_URL="$(npx --yes vercel@56.1.0 deploy --prebuilt --prod --skip-domain --yes --token="$VERCEL_TOKEN" --meta "githubCommitSha=${{ github.sha }}" --meta "githubCommitRef=${{ github.ref_name }}")"
           if ! [[ "$DEPLOYMENT_URL" =~ ^https:// ]]; then
             echo "::error::Vercel did not return a deployment URL."
             exit 1
           fi
           printf 'url=%s\n' "$DEPLOYMENT_URL" >> "$GITHUB_OUTPUT"
 
-      - name: Inspect and verify preview
+      - name: Inspect and verify candidate
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-          VERCEL_CLI_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_PROTECTED_PREVIEW: '1'
           APP_BASE_URL: ${{ steps.deploy.outputs.url }}
           EXPECTED_RELEASE_COMMIT: ${{ github.sha }}
         run: |
           npx --yes vercel@56.1.0 inspect "$APP_BASE_URL" --token="$VERCEL_TOKEN"
           node tools/verify_app_release_live.mjs
-
-      - name: Capture current production rollback target
-        id: rollback-target
-        env:
-          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-        run: |
-          DEPLOYMENTS="$(npx --yes vercel@56.1.0 ls megaos --environment production --status READY --limit 1 --format json --token="$VERCEL_TOKEN")"
-          PREVIOUS_URL="$(printf '%s' "$DEPLOYMENTS" | node -e "let s='';process.stdin.on('data',d=>s+=d).on('end',()=>{const d=JSON.parse(s).deployments?.[0];if(!d?.url)process.exit(1);process.stdout.write('https://'+d.url)})")"
-          printf 'url=%s\n' "$PREVIOUS_URL" >> "$GITHUB_OUTPUT"
 
       - name: Promote the verified artifact
         id: promote

--- a/.github/workflows/supermega-public-release.yml
+++ b/.github/workflows/supermega-public-release.yml
@@ -17,6 +17,7 @@ on:
       - tools/verify_public_preview_live.mjs
       - tools/verify_vercel_project_state.mjs
       - tools/verify_public_firewall_state.mjs
+      - tools/resolve_vercel_rollback_target.mjs
       - tools/deny_stale_public_deploy.mjs
       - tools/deploy_website_actions.ps1
       - vercel.json
@@ -80,38 +81,37 @@ jobs:
       - name: Generate and verify the prebuilt artifact
         run: npm run public:prebuilt
 
-      - name: Deploy immutable preview artifact
+      - name: Capture current production rollback target
+        id: rollback-target
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: |
+          PREVIOUS_URL="$(npx --yes vercel@56.1.0 inspect https://supermega.dev --format=json --token="$VERCEL_TOKEN" | node tools/resolve_vercel_rollback_target.mjs supermega.dev)"
+          printf 'url=%s\n' "$PREVIOUS_URL" >> "$GITHUB_OUTPUT"
+
+      - name: Deploy isolated production candidate
         id: deploy
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
         run: |
-          DEPLOYMENT_URL="$(npx --yes vercel@56.1.0 deploy --prebuilt --yes --token="$VERCEL_TOKEN" --meta "githubCommitSha=${{ github.sha }}" --meta "githubCommitRef=${{ github.ref_name }}")"
+          DEPLOYMENT_URL="$(npx --yes vercel@56.1.0 deploy --prebuilt --prod --skip-domain --yes --token="$VERCEL_TOKEN" --meta "githubCommitSha=${{ github.sha }}" --meta "githubCommitRef=${{ github.ref_name }}")"
           if ! [[ "$DEPLOYMENT_URL" =~ ^https:// ]]; then
             echo "::error::Vercel did not return a deployment URL."
             exit 1
           fi
           printf 'url=%s\n' "$DEPLOYMENT_URL" >> "$GITHUB_OUTPUT"
 
-      - name: Inspect preview deployment
+      - name: Inspect candidate deployment
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
         run: npx --yes vercel@56.1.0 inspect "${{ steps.deploy.outputs.url }}" --token="$VERCEL_TOKEN"
 
-      - name: Verify protected preview content
+      - name: Verify protected candidate content
         env:
-          VERCEL_CLI_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           PUBLIC_BASE_URL: ${{ steps.deploy.outputs.url }}
           EXPECTED_RELEASE_COMMIT: ${{ github.sha }}
         run: node tools/verify_public_preview_live.mjs
-
-      - name: Capture current production rollback target
-        id: rollback-target
-        env:
-          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-        run: |
-          DEPLOYMENTS="$(npx --yes vercel@56.1.0 ls supermega-public --environment production --status READY --limit 1 --format json --token="$VERCEL_TOKEN")"
-          PREVIOUS_URL="$(printf '%s' "$DEPLOYMENTS" | node -e "let s='';process.stdin.on('data',d=>s+=d).on('end',()=>{const d=JSON.parse(s).deployments?.[0];if(!d?.url)process.exit(1);process.stdout.write('https://'+d.url)})")"
-          printf 'url=%s\n' "$PREVIOUS_URL" >> "$GITHUB_OUTPUT"
 
       - name: Promote the verified artifact
         id: promote

--- a/tools/resolve_vercel_rollback_target.mjs
+++ b/tools/resolve_vercel_rollback_target.mjs
@@ -1,0 +1,33 @@
+const expectedAlias = String(process.argv[2] || '').trim().toLowerCase()
+
+function fail(reason) {
+  console.error(`vercel_rollback_target_invalid:${reason}`)
+  process.exit(1)
+}
+
+if (!/^(?:[a-z0-9-]+\.)+[a-z]{2,}$/i.test(expectedAlias)) fail('alias')
+
+let input = ''
+for await (const chunk of process.stdin) input += chunk
+
+let deployment
+try {
+  deployment = JSON.parse(input)
+} catch {
+  fail('json')
+}
+
+const aliases = Array.isArray(deployment.aliases)
+  ? deployment.aliases.map((alias) => String(alias).toLowerCase())
+  : []
+const deploymentHost = String(deployment.url || '')
+  .replace(/^https?:\/\//i, '')
+  .replace(/\/$/, '')
+
+if (!String(deployment.id || '').startsWith('dpl_')) fail('id')
+if (deployment.target !== 'production') fail('target')
+if (deployment.readyState !== 'READY') fail('state')
+if (!aliases.includes(expectedAlias)) fail('live_alias')
+if (!/^[a-z0-9-]+(?:\.[a-z0-9-]+)*\.vercel\.app$/i.test(deploymentHost)) fail('url')
+
+process.stdout.write(`https://${deploymentHost}`)

--- a/tools/verify_app_deploy_workflow.mjs
+++ b/tools/verify_app_deploy_workflow.mjs
@@ -6,6 +6,7 @@ const root = resolve(import.meta.dirname, '..')
 const workflow = await readFile(resolve(root, '.github/workflows/supermega-app-deploy.yml'), 'utf8')
 const generator = await readFile(resolve(root, 'tools/write_app_vercel_config.mjs'), 'utf8')
 const verifier = await readFile(resolve(root, 'tools/verify_app_release_live.mjs'), 'utf8')
+const rollbackResolver = await readFile(resolve(root, 'tools/resolve_vercel_rollback_target.mjs'), 'utf8')
 const config = JSON.parse(await readFile(resolve(root, 'vercel.json'), 'utf8'))
 const failures = []
 
@@ -27,8 +28,10 @@ requireContract('all API tests trigger and execute', workflow.includes("- 'tests
 requireContract('runtime package changes trigger release', workflow.includes("- 'supermega_runtime/**'"))
 requireContract('database activation controls trigger release', workflow.includes("- 'tools/validate_supermega_database_url.py'") && workflow.includes("- 'tools/activate_supermega_database.ps1'"))
 requireContract('protected preview verification', workflow.includes("VERCEL_PROTECTED_PREVIEW: '1'") && verifier.includes("'curl', path, '--deployment'") && verifier.includes("deploymentFunctions") && verifier.includes("JSON.stringify(['api/app'])") && verifier.includes('hosted_agent_runtime_contract_wrong'))
+requireContract('isolated production candidate deployment', workflow.includes('deploy --prebuilt --prod --skip-domain --yes'))
+requireContract('cross-platform protected deployment requests', !verifier.includes("'--silent'") && !verifier.includes("'--show-error'") && !verifier.includes("'--location'") && !verifier.includes("'--token'") && verifier.includes('describeCliFailure'))
 requireContract('live project state verified', workflow.includes('verify_vercel_project_state.mjs app'))
-requireContract('production rollback target captured', workflow.includes('Capture current production rollback target') && workflow.includes('ls megaos --environment production'))
+requireContract('production rollback target captured from live alias', workflow.includes("- 'tools/resolve_vercel_rollback_target.mjs'") && workflow.includes('inspect https://app.supermega.dev --format=json') && workflow.includes('resolve_vercel_rollback_target.mjs app.supermega.dev') && !workflow.includes('ls megaos --environment production') && rollbackResolver.includes("deployment.target !== 'production'") && rollbackResolver.includes('aliases.includes(expectedAlias)'))
 requireContract('failed production verification rolls back', workflow.includes('Roll back a failed production verification') && workflow.includes('vercel@56.1.0 rollback'))
 requireContract('production environment gate', /environment:\s*production/.test(workflow))
 requireContract('production is main-only in the canonical repository', workflow.includes("if: ${{ github.ref == 'refs/heads/main' && github.repository == 'swanhtet01/swanhtet01.github.io' }}"))
@@ -46,9 +49,9 @@ requireContract('no POS route', !/\/pos\/login/i.test(combined))
 requireContract('no YTF schedule', !/\/api\/cron\/ytf/i.test(combined))
 
 const orderedSteps = [
-  'Deploy isolated preview',
-  'Inspect and verify preview',
   'Capture current production rollback target',
+  'Deploy isolated production candidate',
+  'Inspect and verify candidate',
   'Promote the verified artifact',
   'Verify app.supermega.dev exact release',
   'Verify production project controls',
@@ -62,4 +65,4 @@ if (failures.length) {
   process.exit(1)
 }
 
-console.log(JSON.stringify({ ok: true, contract: 'supermega_app_release_workflow', checks: 27 }, null, 2))
+console.log(JSON.stringify({ ok: true, contract: 'supermega_app_release_workflow', checks: 29 }, null, 2))

--- a/tools/verify_app_release_live.mjs
+++ b/tools/verify_app_release_live.mjs
@@ -4,25 +4,34 @@ import { dirname, resolve } from 'node:path'
 const baseUrl = String(process.env.APP_BASE_URL || 'https://app.supermega.dev').replace(/\/$/, '')
 const expectedCommit = String(process.env.EXPECTED_RELEASE_COMMIT || '').trim()
 const protectedPreview = process.env.VERCEL_PROTECTED_PREVIEW === '1'
-const vercelToken = String(process.env.VERCEL_CLI_TOKEN || '').trim()
+const vercelToken = String(process.env.VERCEL_TOKEN || '').trim()
+const cliEnv = vercelToken ? { ...process.env, VERCEL_TOKEN: vercelToken } : process.env
 const routes = ['/', '/shop/', '/plant/', '/assist/', '/setup/', '/trust/']
 
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
+
+function describeCliFailure(error) {
+  const status = Number.isInteger(error?.status) ? error.status : 'unknown'
+  let stderr = String(error?.stderr || '').trim()
+  if (vercelToken) stderr = stderr.replaceAll(vercelToken, '[redacted]')
+  stderr = stderr.replace(/([?&](?:token|secret|key)=)[^&\s]+/gi, '$1[redacted]')
+  const lines = stderr.split(/\r?\n/).map((line) => line.trim()).filter(Boolean).slice(-3)
+  return `exit=${status}${lines.length ? ` message=${lines.join(' | ').slice(0, 480)}` : ''}`
+}
 
 async function get(path, attempts = 7) {
   let lastError
   for (let attempt = 1; attempt <= attempts; attempt += 1) {
     try {
       if (protectedPreview) {
-        const tokenArgs = vercelToken ? ['--token', vercelToken] : []
-        const npxArgs = ['--yes', 'vercel@56.1.0', 'curl', path, '--deployment', baseUrl, ...tokenArgs, '--', '--silent', '--show-error', '--fail', '--location']
+        const npxArgs = ['--yes', 'vercel@56.1.0', 'curl', path, '--deployment', baseUrl]
         const executable = process.platform === 'win32' ? process.execPath : 'npx'
         const executableArgs = process.platform === 'win32'
           ? [resolve(dirname(process.execPath), 'node_modules', 'npm', 'bin', 'npx-cli.js'), ...npxArgs]
           : npxArgs
         const body = execFileSync(executable, executableArgs, {
           encoding: 'utf8',
-          env: process.env,
+          env: cliEnv,
           maxBuffer: 8 * 1024 * 1024,
           stdio: ['ignore', 'pipe', 'pipe'],
         })
@@ -33,12 +42,7 @@ async function get(path, attempts = 7) {
       return { response, body: await response.text() }
     } catch (error) {
       if (protectedPreview) {
-        const detail = String(error?.stderr || error?.message || error)
-          .trim()
-          .split(/\r?\n/)
-          .slice(-3)
-          .join(' | ')
-        lastError = new Error(`protected_preview_request_failed:${path}:${detail || 'unknown_error'}`)
+        lastError = new Error(`protected_preview_request_failed:${path}:${describeCliFailure(error)}`)
       } else {
         lastError = error
       }
@@ -87,18 +91,23 @@ for (const forbidden of ['pos.supermega.dev', 'ytf.supermega.dev', 'Yangon Tyre'
 
 let deploymentFunctions = null
 if (protectedPreview) {
-  const tokenArgs = vercelToken ? ['--token', vercelToken] : []
-  const npxArgs = ['--yes', 'vercel@56.1.0', 'inspect', baseUrl, '--format=json', ...tokenArgs]
+  const npxArgs = ['--yes', 'vercel@56.1.0', 'inspect', baseUrl, '--format=json']
   const executable = process.platform === 'win32' ? process.execPath : 'npx'
   const executableArgs = process.platform === 'win32'
     ? [resolve(dirname(process.execPath), 'node_modules', 'npm', 'bin', 'npx-cli.js'), ...npxArgs]
     : npxArgs
-  const deployment = JSON.parse(execFileSync(executable, executableArgs, {
-    encoding: 'utf8',
-    env: process.env,
-    maxBuffer: 8 * 1024 * 1024,
-    stdio: ['ignore', 'pipe', 'pipe'],
-  }))
+  let deploymentOutput
+  try {
+    deploymentOutput = execFileSync(executable, executableArgs, {
+      encoding: 'utf8',
+      env: cliEnv,
+      maxBuffer: 8 * 1024 * 1024,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+  } catch (error) {
+    throw new Error(`protected_preview_inspect_failed:${describeCliFailure(error)}`)
+  }
+  const deployment = JSON.parse(deploymentOutput)
   deploymentFunctions = (deployment.builds || [])
     .flatMap((build) => build.output || [])
     .filter((output) => output.type === 'lambda')

--- a/tools/verify_public_deploy_guard.mjs
+++ b/tools/verify_public_deploy_guard.mjs
@@ -9,6 +9,7 @@ const vercelConfig = JSON.parse(read('vercel.json'))
 const releaseWorkflow = read('.github/workflows/supermega-public-release.yml')
 const healthWorkflow = read('.github/workflows/supermega-public-live-health.yml')
 const previewVerifier = read('tools/verify_public_preview_live.mjs')
+const rollbackResolver = read('tools/resolve_vercel_rollback_target.mjs')
 const firewallVerifier = read('tools/verify_public_firewall_state.mjs')
 const publicGenerator = read('tools/create_public_vercel_output.mjs')
 const releaseWrapper = read('tools/deploy_website_actions.ps1')
@@ -27,6 +28,9 @@ if (vercelConfig.git?.deploymentEnabled !== false) failures.push('native_git_dep
 if (!previewVerifier.includes('preview_contact_not_accepting')) failures.push('preview_contact_readiness_not_verified')
 if (!previewVerifier.includes('deployment_function_surface_wrong')) failures.push('preview_function_inventory_not_verified')
 if (!previewVerifier.includes('const maxAttempts = 6') || !previewVerifier.includes('protected_preview_retry:')) failures.push('preview_propagation_retry_missing')
+if (previewVerifier.includes("'--silent'") || previewVerifier.includes("'--show-error'") || previewVerifier.includes("'--location'")) failures.push('preview_verifier_uses_platform_specific_curl_flags')
+if (previewVerifier.includes("'--token'") || !previewVerifier.includes('protected_preview_inspect_failed:') || !previewVerifier.includes('process.env.VERCEL_TOKEN')) failures.push('preview_verifier_credential_handling_unsafe')
+if (!rollbackResolver.includes("deployment.target !== 'production'") || !rollbackResolver.includes('aliases.includes(expectedAlias)') || !rollbackResolver.includes("deployment.readyState !== 'READY'")) failures.push('rollback_alias_resolver_incomplete')
 for (const token of ['SUPERMEGA_CONTACT_IDEMPOTENCY_SECRET', 'idempotency_key_required', 'rate_limited', 'resolution=ignore-duplicates,return=representation', "'idempotency-key'"]) {
   if (!publicGenerator.includes(token)) failures.push(`contact_abuse_control_missing:${token}`)
 }
@@ -56,7 +60,11 @@ for (const token of [
   'npx --yes vercel@56.1.0 pull',
   'npm run public:prebuilt',
   'tools/test_public_contact_function.mjs',
+  'tools/resolve_vercel_rollback_target.mjs',
+  'inspect https://supermega.dev --format=json',
+  'resolve_vercel_rollback_target.mjs supermega.dev',
   'npx --yes vercel@56.1.0 deploy --prebuilt',
+  'deploy --prebuilt --prod --skip-domain --yes',
   'npx --yes vercel@56.1.0 inspect',
   'node tools/verify_public_preview_live.mjs',
   'node tools/verify_vercel_project_state.mjs public',
@@ -72,10 +80,10 @@ for (const token of [
 ]) requireToken(releaseWorkflow, token, 'release_workflow_missing')
 
 const orderedReleaseSteps = [
-  'Deploy immutable preview artifact',
-  'Inspect preview deployment',
-  'Verify protected preview content',
   'Capture current production rollback target',
+  'Deploy isolated production candidate',
+  'Inspect candidate deployment',
+  'Verify protected candidate content',
   'Promote the verified artifact',
   'Verify production aliases and exact release',
   'Verify production project controls',
@@ -83,6 +91,7 @@ const orderedReleaseSteps = [
 ]
 const releasePositions = orderedReleaseSteps.map((step) => releaseWorkflow.indexOf(step))
 if (!releasePositions.every((position) => position >= 0) || !releasePositions.every((position, index) => index === 0 || position > releasePositions[index - 1])) failures.push('public_release_steps_out_of_order')
+if (releaseWorkflow.includes('ls supermega-public --environment production')) failures.push('rollback_target_can_select_unaliased_candidate')
 
 for (const token of ['workflow_dispatch:', 'schedule:', 'npm run public:verify:live']) requireToken(healthWorkflow, token, 'health_workflow_missing')
 if (/vercel@\S+\s+(?:deploy|promote)/.test(healthWorkflow)) failures.push('health_workflow_can_deploy')

--- a/tools/verify_public_preview_live.mjs
+++ b/tools/verify_public_preview_live.mjs
@@ -5,7 +5,8 @@ import { dirname, resolve } from 'node:path'
 const manifest = JSON.parse(await readFile(new URL('../site-manifest.json', import.meta.url), 'utf8'))
 const baseUrl = String(process.env.PUBLIC_BASE_URL || '').replace(/\/$/, '')
 const expectedCommit = String(process.env.EXPECTED_RELEASE_COMMIT || '').toLowerCase()
-const vercelToken = String(process.env.VERCEL_CLI_TOKEN || '').trim()
+const vercelToken = String(process.env.VERCEL_TOKEN || '').trim()
+const cliEnv = vercelToken ? { ...process.env, VERCEL_TOKEN: vercelToken } : process.env
 const maxAttempts = 6
 const retryWaitBuffer = new Int32Array(new SharedArrayBuffer(4))
 
@@ -21,8 +22,7 @@ function describeFailure(error) {
 }
 
 function get(path) {
-  const tokenArgs = vercelToken ? ['--token', vercelToken] : []
-  const npxArgs = ['--yes', 'vercel@56.1.0', 'curl', path, '--deployment', baseUrl, ...tokenArgs, '--', '--silent', '--show-error', '--fail', '--location']
+  const npxArgs = ['--yes', 'vercel@56.1.0', 'curl', path, '--deployment', baseUrl]
   const executable = process.platform === 'win32' ? process.execPath : 'npx'
   const executableArgs = process.platform === 'win32'
     ? [resolve(dirname(process.execPath), 'node_modules', 'npm', 'bin', 'npx-cli.js'), ...npxArgs]
@@ -32,7 +32,7 @@ function get(path) {
     try {
       return execFileSync(executable, executableArgs, {
         encoding: 'utf8',
-        env: process.env,
+        env: cliEnv,
         maxBuffer: 8 * 1024 * 1024,
         stdio: ['ignore', 'pipe', 'pipe'],
       })
@@ -70,18 +70,23 @@ const contact = JSON.parse(get('/api/contact-submissions/status'))
 if (contact.status !== 'ready' || contact.service !== 'supermega-contact' || contact.accepting !== true) throw new Error('preview_contact_not_accepting')
 if (contact.controls?.idempotency !== 'required' || contact.controls?.edge_rate_limit !== 'required') throw new Error('preview_contact_controls_wrong')
 
-const tokenArgs = vercelToken ? ['--token', vercelToken] : []
-const inspectArgs = ['--yes', 'vercel@56.1.0', 'inspect', baseUrl, '--format=json', ...tokenArgs]
+const inspectArgs = ['--yes', 'vercel@56.1.0', 'inspect', baseUrl, '--format=json']
 const inspectExecutable = process.platform === 'win32' ? process.execPath : 'npx'
 const inspectExecutableArgs = process.platform === 'win32'
   ? [resolve(dirname(process.execPath), 'node_modules', 'npm', 'bin', 'npx-cli.js'), ...inspectArgs]
   : inspectArgs
-const deployment = JSON.parse(execFileSync(inspectExecutable, inspectExecutableArgs, {
-  encoding: 'utf8',
-  env: process.env,
-  maxBuffer: 8 * 1024 * 1024,
-  stdio: ['ignore', 'pipe', 'pipe'],
-}))
+let deploymentOutput
+try {
+  deploymentOutput = execFileSync(inspectExecutable, inspectExecutableArgs, {
+    encoding: 'utf8',
+    env: cliEnv,
+    maxBuffer: 8 * 1024 * 1024,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+} catch (error) {
+  throw new Error(`protected_preview_inspect_failed:${describeFailure(error)}`)
+}
+const deployment = JSON.parse(deploymentOutput)
 const deploymentFunctions = (deployment.builds || [])
   .flatMap((build) => build.output || [])
   .filter((output) => output.type === 'lambda')


### PR DESCRIPTION
## Root cause

- The app's production-target prebuilt artifact was deployed without `--prod`, causing Vercel's target mismatch guard to stop the release.
- Raw curl flags passed through Linux `npx` produced curl exit 2 in protected-deployment verification.
- Selecting the latest production deployment after candidate creation could make an unaliased candidate its own rollback target.

## Fix

- Create a production-target candidate with `--prod --skip-domain`, verify its generated URL, then promote it.
- Resolve and validate the deployment currently serving each production alias before candidate creation.
- Remove platform-specific raw curl flags.
- Keep Vercel credentials in child-process environment only and sanitize all request/inspect failures.
- Extend app/public guards to enforce candidate, rollback, ordering, and credential contracts.

## Verification

- App: 6 routes, 29 workflow checks, 30 security checks.
- Public: 7 routes, 3 functions, 45 contact checks.
- Both existing protected deployments pass with the corrected cross-platform verifier.
- Live rollback resolution passes for `app.supermega.dev` and `supermega.dev`; a mismatched alias fails closed.
- Exact seven-file independent audit: PASS.

Managed Supabase trial writes remain locked and are unaffected.
