### PR TITLE
Fix Vercel rollback alias resolution

### DIFF
--- a/.github/workflows/supermega-app-deploy.yml
+++ b/.github/workflows/supermega-app-deploy.yml
@@ -118,7 +118,9 @@ jobs:
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
         run: |
-          PREVIOUS_URL="$(npx --yes vercel@56.1.0 inspect https://app.supermega.dev --format=json --token="$VERCEL_TOKEN" | node tools/resolve_vercel_rollback_target.mjs app.supermega.dev)"
+          ROLLBACK_TARGET="$(npx --yes vercel@56.1.0 api "/now/aliases/app.supermega.dev" --raw --token="$VERCEL_TOKEN" | node tools/resolve_vercel_rollback_target.mjs alias app.supermega.dev prj_1GAMPH8qlSAXno5BhO1wkYx1jkGG)"
+          read -r PREVIOUS_URL PREVIOUS_ID <<< "$ROLLBACK_TARGET"
+          PREVIOUS_URL="$(npx --yes vercel@56.1.0 inspect "$PREVIOUS_URL" --format=json --token="$VERCEL_TOKEN" | node tools/resolve_vercel_rollback_target.mjs deployment "$PREVIOUS_URL" "$PREVIOUS_ID")"
           printf 'url=%s\n' "$PREVIOUS_URL" >> "$GITHUB_OUTPUT"
 
       - name: Deploy isolated production candidate

--- a/.github/workflows/supermega-public-release.yml
+++ b/.github/workflows/supermega-public-release.yml
@@ -86,7 +86,9 @@ jobs:
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
         run: |
-          PREVIOUS_URL="$(npx --yes vercel@56.1.0 inspect https://supermega.dev --format=json --token="$VERCEL_TOKEN" | node tools/resolve_vercel_rollback_target.mjs supermega.dev)"
+          ROLLBACK_TARGET="$(npx --yes vercel@56.1.0 api "/now/aliases/supermega.dev" --raw --token="$VERCEL_TOKEN" | node tools/resolve_vercel_rollback_target.mjs alias supermega.dev prj_Yaf0cZYbiFXcLkMcKaAm4alPWMhR)"
+          read -r PREVIOUS_URL PREVIOUS_ID <<< "$ROLLBACK_TARGET"
+          PREVIOUS_URL="$(npx --yes vercel@56.1.0 inspect "$PREVIOUS_URL" --format=json --token="$VERCEL_TOKEN" | node tools/resolve_vercel_rollback_target.mjs deployment "$PREVIOUS_URL" "$PREVIOUS_ID")"
           printf 'url=%s\n' "$PREVIOUS_URL" >> "$GITHUB_OUTPUT"
 
       - name: Deploy isolated production candidate

--- a/tools/resolve_vercel_rollback_target.mjs
+++ b/tools/resolve_vercel_rollback_target.mjs
@@ -1,33 +1,80 @@
-const expectedAlias = String(process.argv[2] || '').trim().toLowerCase()
+const mode = String(process.argv[2] || '').trim().toLowerCase()
 
 function fail(reason) {
   console.error(`vercel_rollback_target_invalid:${reason}`)
   process.exit(1)
 }
 
-if (!/^(?:[a-z0-9-]+\.)+[a-z]{2,}$/i.test(expectedAlias)) fail('alias')
+function normalizeHostname(value) {
+  const raw = String(value || '').trim()
+  if (!raw) return ''
+
+  try {
+    const url = new URL(/^https:\/\//i.test(raw) ? raw : `https://${raw}`)
+    if (
+      url.protocol !== 'https:' ||
+      url.username ||
+      url.password ||
+      url.port ||
+      url.pathname !== '/' ||
+      url.search ||
+      url.hash
+    ) return ''
+    return url.hostname.toLowerCase()
+  } catch {
+    return ''
+  }
+}
+
+function isDomain(hostname) {
+  return /^(?:[a-z0-9-]+\.)+[a-z]{2,}$/i.test(hostname)
+}
+
+function isVercelDeployment(hostname) {
+  return /^[a-z0-9-]+(?:\.[a-z0-9-]+)*\.vercel\.app$/i.test(hostname)
+}
 
 let input = ''
 for await (const chunk of process.stdin) input += chunk
 
-let deployment
+let state
 try {
-  deployment = JSON.parse(input)
+  state = JSON.parse(input)
 } catch {
   fail('json')
 }
 
-const aliases = Array.isArray(deployment.aliases)
-  ? deployment.aliases.map((alias) => String(alias).toLowerCase())
-  : []
-const deploymentHost = String(deployment.url || '')
-  .replace(/^https?:\/\//i, '')
-  .replace(/\/$/, '')
+if (mode === 'alias') {
+  const expectedAlias = normalizeHostname(process.argv[3])
+  const expectedProjectId = String(process.argv[4] || '').trim()
+  if (!isDomain(expectedAlias)) fail('alias_argument')
+  if (!/^prj_[a-z0-9]+$/i.test(expectedProjectId)) fail('project_argument')
 
-if (!String(deployment.id || '').startsWith('dpl_')) fail('id')
-if (deployment.target !== 'production') fail('target')
-if (deployment.readyState !== 'READY') fail('state')
-if (!aliases.includes(expectedAlias)) fail('live_alias')
-if (!/^[a-z0-9-]+(?:\.[a-z0-9-]+)*\.vercel\.app$/i.test(deploymentHost)) fail('url')
+  const liveAlias = normalizeHostname(state.alias)
+  const deploymentId = String(state.deploymentId || '')
+  const nestedDeploymentId = String(state.deployment?.id || '')
+  const deploymentHost = normalizeHostname(state.deployment?.url)
 
-process.stdout.write(`https://${deploymentHost}`)
+  if (liveAlias !== expectedAlias) fail('live_alias')
+  if (state.projectId !== expectedProjectId) fail('project')
+  if (state.redirect) fail('redirect')
+  if (!/^dpl_[a-z0-9]+$/i.test(deploymentId)) fail('id')
+  if (nestedDeploymentId !== deploymentId) fail('deployment_identity')
+  if (!isVercelDeployment(deploymentHost)) fail('url')
+
+  process.stdout.write(`https://${deploymentHost} ${deploymentId}`)
+} else if (mode === 'deployment') {
+  const expectedDeploymentHost = normalizeHostname(process.argv[3])
+  const expectedDeploymentId = String(process.argv[4] || '').trim()
+  const inspectedDeploymentHost = normalizeHostname(state.url)
+  if (!isVercelDeployment(expectedDeploymentHost)) fail('url_argument')
+  if (!/^dpl_[a-z0-9]+$/i.test(expectedDeploymentId)) fail('id_argument')
+  if (state.id !== expectedDeploymentId) fail('deployment_identity')
+  if (state.target !== 'production') fail('target')
+  if (state.readyState !== 'READY') fail('state')
+  if (inspectedDeploymentHost !== expectedDeploymentHost) fail('deployment_url')
+
+  process.stdout.write(`https://${inspectedDeploymentHost}`)
+} else {
+  fail('mode')
+}

--- a/tools/verify_app_deploy_workflow.mjs
+++ b/tools/verify_app_deploy_workflow.mjs
@@ -1,6 +1,7 @@
 import { existsSync } from 'node:fs'
 import { readFile } from 'node:fs/promises'
 import { resolve } from 'node:path'
+import { spawnSync } from 'node:child_process'
 
 const root = resolve(import.meta.dirname, '..')
 const workflow = await readFile(resolve(root, '.github/workflows/supermega-app-deploy.yml'), 'utf8')
@@ -13,6 +14,39 @@ const failures = []
 function requireContract(name, condition) {
   if (!condition) failures.push(name)
 }
+
+function runRollbackResolver(args, payload) {
+  return spawnSync(
+    process.execPath,
+    [resolve(root, 'tools/resolve_vercel_rollback_target.mjs'), ...args],
+    { input: JSON.stringify(payload), encoding: 'utf8' },
+  )
+}
+
+const fixtureUrl = 'https://megaos-release-fixture.vercel.app'
+const aliasFixture = {
+  alias: 'app.supermega.dev',
+  deploymentId: 'dpl_fixture123',
+  deployment: { id: 'dpl_fixture123', url: 'megaos-release-fixture.vercel.app' },
+  projectId: 'prj_1GAMPH8qlSAXno5BhO1wkYx1jkGG',
+  redirect: null,
+}
+const validAliasResolution = runRollbackResolver(
+  ['alias', 'app.supermega.dev', 'prj_1GAMPH8qlSAXno5BhO1wkYx1jkGG'],
+  aliasFixture,
+)
+const invalidAliasResolution = runRollbackResolver(
+  ['alias', 'app.supermega.dev', 'prj_1GAMPH8qlSAXno5BhO1wkYx1jkGG'],
+  { ...aliasFixture, deploymentId: 'dpl_wrong' },
+)
+const validDeploymentResolution = runRollbackResolver(
+  ['deployment', fixtureUrl, 'dpl_fixture123'],
+  { id: 'dpl_fixture123', url: 'megaos-release-fixture.vercel.app', target: 'production', readyState: 'READY' },
+)
+const invalidDeploymentResolution = runRollbackResolver(
+  ['deployment', fixtureUrl, 'dpl_fixture123'],
+  { id: 'dpl_different', url: 'megaos-release-fixture.vercel.app', target: 'production', readyState: 'READY' },
+)
 
 requireContract('canonical project id', workflow.includes('prj_1GAMPH8qlSAXno5BhO1wkYx1jkGG'))
 requireContract('canonical project name', workflow.includes('megaos'))
@@ -31,7 +65,9 @@ requireContract('protected preview verification', workflow.includes("VERCEL_PROT
 requireContract('isolated production candidate deployment', workflow.includes('deploy --prebuilt --prod --skip-domain --yes'))
 requireContract('cross-platform protected deployment requests', !verifier.includes("'--silent'") && !verifier.includes("'--show-error'") && !verifier.includes("'--location'") && !verifier.includes("'--token'") && verifier.includes('describeCliFailure'))
 requireContract('live project state verified', workflow.includes('verify_vercel_project_state.mjs app'))
-requireContract('production rollback target captured from live alias', workflow.includes("- 'tools/resolve_vercel_rollback_target.mjs'") && workflow.includes('inspect https://app.supermega.dev --format=json') && workflow.includes('resolve_vercel_rollback_target.mjs app.supermega.dev') && !workflow.includes('ls megaos --environment production') && rollbackResolver.includes("deployment.target !== 'production'") && rollbackResolver.includes('aliases.includes(expectedAlias)'))
+requireContract('production rollback target captured from exact live alias', workflow.includes("- 'tools/resolve_vercel_rollback_target.mjs'") && workflow.includes('api "/now/aliases/app.supermega.dev" --raw') && workflow.includes('resolve_vercel_rollback_target.mjs alias app.supermega.dev prj_1GAMPH8qlSAXno5BhO1wkYx1jkGG') && workflow.includes('read -r PREVIOUS_URL PREVIOUS_ID') && workflow.includes('resolve_vercel_rollback_target.mjs deployment "$PREVIOUS_URL" "$PREVIOUS_ID"') && !workflow.includes('ls megaos --environment production') && rollbackResolver.includes("mode === 'alias'") && rollbackResolver.includes("mode === 'deployment'") && rollbackResolver.includes("state.projectId !== expectedProjectId") && rollbackResolver.includes("nestedDeploymentId !== deploymentId") && rollbackResolver.includes("state.id !== expectedDeploymentId") && rollbackResolver.includes("state.target !== 'production'") && rollbackResolver.includes("state.readyState !== 'READY'"))
+requireContract('rollback alias resolver fixtures', validAliasResolution.status === 0 && validAliasResolution.stdout === `${fixtureUrl} dpl_fixture123` && invalidAliasResolution.status !== 0 && invalidAliasResolution.stderr.includes('deployment_identity'))
+requireContract('rollback deployment resolver fixtures', validDeploymentResolution.status === 0 && validDeploymentResolution.stdout === fixtureUrl && invalidDeploymentResolution.status !== 0 && invalidDeploymentResolution.stderr.includes('deployment_identity'))
 requireContract('failed production verification rolls back', workflow.includes('Roll back a failed production verification') && workflow.includes('vercel@56.1.0 rollback'))
 requireContract('production environment gate', /environment:\s*production/.test(workflow))
 requireContract('production is main-only in the canonical repository', workflow.includes("if: ${{ github.ref == 'refs/heads/main' && github.repository == 'swanhtet01/swanhtet01.github.io' }}"))
@@ -65,4 +101,4 @@ if (failures.length) {
   process.exit(1)
 }
 
-console.log(JSON.stringify({ ok: true, contract: 'supermega_app_release_workflow', checks: 29 }, null, 2))
+console.log(JSON.stringify({ ok: true, contract: 'supermega_app_release_workflow', checks: 31 }, null, 2))

--- a/tools/verify_public_deploy_guard.mjs
+++ b/tools/verify_public_deploy_guard.mjs
@@ -30,7 +30,7 @@ if (!previewVerifier.includes('deployment_function_surface_wrong')) failures.pus
 if (!previewVerifier.includes('const maxAttempts = 6') || !previewVerifier.includes('protected_preview_retry:')) failures.push('preview_propagation_retry_missing')
 if (previewVerifier.includes("'--silent'") || previewVerifier.includes("'--show-error'") || previewVerifier.includes("'--location'")) failures.push('preview_verifier_uses_platform_specific_curl_flags')
 if (previewVerifier.includes("'--token'") || !previewVerifier.includes('protected_preview_inspect_failed:') || !previewVerifier.includes('process.env.VERCEL_TOKEN')) failures.push('preview_verifier_credential_handling_unsafe')
-if (!rollbackResolver.includes("deployment.target !== 'production'") || !rollbackResolver.includes('aliases.includes(expectedAlias)') || !rollbackResolver.includes("deployment.readyState !== 'READY'")) failures.push('rollback_alias_resolver_incomplete')
+if (!rollbackResolver.includes("mode === 'alias'") || !rollbackResolver.includes("mode === 'deployment'") || !rollbackResolver.includes("state.projectId !== expectedProjectId") || !rollbackResolver.includes("nestedDeploymentId !== deploymentId") || !rollbackResolver.includes("state.id !== expectedDeploymentId") || !rollbackResolver.includes("state.target !== 'production'") || !rollbackResolver.includes("state.readyState !== 'READY'")) failures.push('rollback_alias_resolver_incomplete')
 for (const token of ['SUPERMEGA_CONTACT_IDEMPOTENCY_SECRET', 'idempotency_key_required', 'rate_limited', 'resolution=ignore-duplicates,return=representation', "'idempotency-key'"]) {
   if (!publicGenerator.includes(token)) failures.push(`contact_abuse_control_missing:${token}`)
 }
@@ -61,8 +61,10 @@ for (const token of [
   'npm run public:prebuilt',
   'tools/test_public_contact_function.mjs',
   'tools/resolve_vercel_rollback_target.mjs',
-  'inspect https://supermega.dev --format=json',
-  'resolve_vercel_rollback_target.mjs supermega.dev',
+  'api "/now/aliases/supermega.dev" --raw',
+  'resolve_vercel_rollback_target.mjs alias supermega.dev prj_Yaf0cZYbiFXcLkMcKaAm4alPWMhR',
+  'read -r PREVIOUS_URL PREVIOUS_ID',
+  'resolve_vercel_rollback_target.mjs deployment "$PREVIOUS_URL" "$PREVIOUS_ID"',
   'npx --yes vercel@56.1.0 deploy --prebuilt',
   'deploy --prebuilt --prod --skip-domain --yes',
   'npx --yes vercel@56.1.0 inspect',


### PR DESCRIPTION
## Summary
- resolve each production custom alias through Vercel's exact alias record
- require the canonical project ID plus matching alias and deployment IDs
- inspect that exact deployment and require production + READY before recording rollback output
- add fail-closed resolver fixtures and workflow guards for both SuperMega projects

## Validation
- app release workflow guard: 31 checks pass
- public release authority guard: pass
- public prebuilt artifact and 45 contact behavior checks: pass
- showroom production build: pass
- Python runtime/security suite: 42 tests pass
- both current live aliases pass exact alias/project/deployment/production/READY validation
- workflow YAML parse and credential scan: pass

Managed Supabase writes remain locked and are not changed by this PR.