### PR TITLE
Redesign SuperMega company system

### DIFF
--- a/showroom/README.md
+++ b/showroom/README.md
@@ -1,17 +1,16 @@
 # >_ SuperMega product app
 
-This package is the canonical application for `app.supermega.dev`. It is a focused operating workspace for SuperMega Shop and Plant, not the public marketing site and not a client-specific deployment.
+This package is the canonical application for `app.supermega.dev`. It is the SuperMega company operating system: Command, Operations, governed Agents, and Settings in one product shell. It is not the public marketing site or a client-specific deployment.
 
 ## Routes
 
 - `/` — Command: priorities, work, evidence, and the five-role company agent desk.
-- `/shop/` — sales, catalogue, stock, orders, close, and exceptions.
-- `/plant/` — jobs, machines, materials, quality, maintenance, and handoffs.
-- `/assist/` — evidence-grounded briefs, drafts, and approval-ready recommendations.
-- `/setup/` — Shop/Plant template selection and bounded workspace configuration.
-- `/trust/` — demo boundaries, managed-trial gates, human authority, and controls.
+- `/operations/?view=shop` — sales, stock, local payments, close, and exceptions.
+- `/operations/?view=plant` — jobs, machines, output, issues, and handoffs.
+- `/agents/` — evidence-grounded briefs and approval-ready work.
+- `/settings/` — workspace setup, trial controls, runtime readiness, and authority boundaries.
 
-All routes share the `>_` terminal design system and responsive application shell.
+Legacy Shop, Plant, Assist, Setup, and Trust URLs redirect into these four canonical areas. All routes share the `>_ SUPERMEGA` terminal design system and responsive application shell.
 
 ## Core files
 
@@ -19,7 +18,7 @@ All routes share the `>_` terminal design system and responsive application shel
 - `src/core/core-app.css` — shared responsive visual system.
 - `src/App.tsx` — canonical app mount.
 - `src/main.tsx` and `src/index.css` — runtime and global foundation.
-- `scripts/prepare-static-routes.mjs` — six-route static shell preparation.
+- `scripts/prepare-static-routes.mjs` — four-route static shell preparation.
 
 ## Run and verify
 

--- a/showroom/index.html
+++ b/showroom/index.html
@@ -4,26 +4,26 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="shortcut icon" href="/favicon.svg" />
-    <link rel="mask-icon" href="/favicon.svg" color="#090d13" />
+    <link rel="mask-icon" href="/favicon.svg" color="#080a09" />
     <link rel="manifest" href="/site.webmanifest" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Command | SuperMega</title>
     <meta
       name="description"
-      content="SuperMega Shop and Plant operating software, with governed assistance inside the workflow."
+      content="SuperMega company operations and governed agents in one accountable system."
     />
-    <meta name="theme-color" content="#090d13" />
-    <meta property="og:title" content="SuperMega operating workspace" />
+    <meta name="theme-color" content="#080a09" />
+    <meta property="og:title" content="SuperMega Company OS" />
     <meta
       property="og:description"
-      content="Run commerce and production from one clear operating workspace."
+      content="Run operations and governed agents from one clear company system."
     />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary" />
-    <meta name="twitter:title" content="SuperMega operating workspace" />
+    <meta name="twitter:title" content="SuperMega Company OS" />
     <meta
       name="twitter:description"
-      content="Run commerce and production from one clear operating workspace."
+      content="Run operations and governed agents from one clear company system."
     />
   </head>
   <body>

--- a/showroom/scripts/prepare-static-routes.mjs
+++ b/showroom/scripts/prepare-static-routes.mjs
@@ -1,7 +1,7 @@
 import { mkdir, readFile, realpath, writeFile } from 'node:fs/promises'
 import { resolve } from 'node:path'
 
-const routePaths = ['shop', 'plant', 'assist', 'setup', 'trust']
+const routePaths = ['operations', 'agents', 'settings']
 
 async function main() {
   const rootDir = await realpath(process.cwd())

--- a/showroom/src/App.tsx
+++ b/showroom/src/App.tsx
@@ -1,22 +1,20 @@
 import { BrowserRouter, Navigate, Route, Routes, useLocation } from 'react-router-dom'
 
 import {
-  AssistPage,
+  AgentsPage,
   CoreLayout,
+  OperationsPage,
   OverviewPage,
-  PlantPage,
-  SetupPage,
-  ShopPage,
-  TrustPage,
+  SettingsPage,
 } from './core/CoreApp'
 
-function LegacyRedirect() {
+function LegacyEntryRedirect() {
   const location = useLocation()
   const params = new URLSearchParams(location.search)
   const demo = params.get('demo')?.toLowerCase()
 
-  if (demo === 'shop' || demo === 'retail') return <Navigate replace to="/shop/" />
-  if (demo === 'plant' || demo === 'factory') return <Navigate replace to="/plant/" />
+  if (demo === 'plant' || demo === 'factory') return <Navigate replace to="/operations/?view=plant" />
+  if (demo === 'shop' || demo === 'retail') return <Navigate replace to="/operations/?view=shop" />
   return <Navigate replace to="/" />
 }
 
@@ -25,13 +23,16 @@ export default function App() {
     <BrowserRouter>
       <Routes>
         <Route element={<CoreLayout />}>
-          <Route element={<LegacyRedirect />} path="/legacy-entry" />
           <Route element={<OverviewPage />} index />
-          <Route element={<ShopPage />} path="shop/*" />
-          <Route element={<PlantPage />} path="plant/*" />
-          <Route element={<AssistPage />} path="assist/*" />
-          <Route element={<SetupPage />} path="setup/*" />
-          <Route element={<TrustPage />} path="trust/*" />
+          <Route element={<OperationsPage />} path="operations/*" />
+          <Route element={<AgentsPage />} path="agents/*" />
+          <Route element={<SettingsPage />} path="settings/*" />
+          <Route element={<LegacyEntryRedirect />} path="legacy-entry" />
+          <Route element={<Navigate replace to="/operations/?view=shop" />} path="shop/*" />
+          <Route element={<Navigate replace to="/operations/?view=plant" />} path="plant/*" />
+          <Route element={<Navigate replace to="/agents/" />} path="assist/*" />
+          <Route element={<Navigate replace to="/settings/" />} path="setup/*" />
+          <Route element={<Navigate replace to="/settings/#controls" />} path="trust/*" />
           <Route element={<Navigate replace to="/" />} path="app/*" />
           <Route element={<Navigate replace to="/" />} path="login" />
           <Route element={<Navigate replace to="/" />} path="signup" />

--- a/showroom/src/core/CoreApp.tsx
+++ b/showroom/src/core/CoreApp.tsx
@@ -1,5 +1,5 @@
 import { type FormEvent, type ReactNode, useEffect, useState } from 'react'
-import { Link, NavLink, Outlet, useLocation, useOutletContext } from 'react-router-dom'
+import { Link, NavLink, Outlet, useLocation, useOutletContext, useSearchParams } from 'react-router-dom'
 
 import './core-app.css'
 
@@ -218,19 +218,17 @@ function formatTime(value: string) {
 function Brand() {
   return (
     <Link className="core-brand" to="/" aria-label="SuperMega app home">
-      <img alt="" src="/favicon.svg" />
-      <span>SuperMega<span>.dev</span></span>
+      <span className="core-brand-mark" aria-hidden="true">&gt;_</span>
+      <span className="core-brand-name">SUPERMEGA <small>OS</small></span>
     </Link>
   )
 }
 
 const navigation = [
   { to: '/', label: 'Command', index: '01', end: true },
-  { to: '/shop/', label: 'Shop', index: '02', end: false },
-  { to: '/plant/', label: 'Plant', index: '03', end: false },
-  { to: '/assist/', label: 'Assist', index: '04', end: false },
-  { to: '/setup/', label: 'Setup', index: '05', end: false },
-  { to: '/trust/', label: 'Trust', index: '06', end: false },
+  { to: '/operations/', label: 'Operations', index: '02', end: false },
+  { to: '/agents/', label: 'Agents', index: '03', end: false },
+  { to: '/settings/', label: 'Settings', index: '04', end: false },
 ] as const
 
 type RuntimeStatus = 'checking' | 'enterprise' | 'demo'
@@ -291,7 +289,7 @@ function useRuntimeHealth() {
 }
 
 function RuntimeBadge({ status }: { status: RuntimeStatus }) {
-  return <span className={`runtime-badge ${status}`}><i />{status === 'checking' ? 'Checking runtime' : status === 'enterprise' ? 'Enterprise ready' : 'Isolated demo'}</span>
+  return <span className={`runtime-badge ${status}`}><i />{status === 'checking' ? 'Checking' : status === 'enterprise' ? 'Managed' : 'Local only'}</span>
 }
 
 export function CoreLayout() {
@@ -309,7 +307,7 @@ export function CoreLayout() {
       <a className="core-skip" href="#workspace-main">Skip to workspace</a>
       <aside className="core-sidebar">
         <Brand />
-        <div className="workspace-label"><span>Workspace</span><strong>Demo / Myanmar</strong></div>
+        <div className="workspace-label"><span>Workspace</span><strong>Local trial</strong></div>
         <nav className="core-nav" aria-label="Application">
           {navigation.map((item) => (
             <NavLink className={({ isActive }) => isActive ? 'active' : ''} end={item.end} key={item.to} to={item.to}>
@@ -319,14 +317,14 @@ export function CoreLayout() {
         </nav>
         <div className="sidebar-foot">
           <RuntimeBadge status={runtime.status} />
-          <p>Private demo state stays in this browser until a managed workspace is configured.</p>
-          <a href="https://supermega.dev/contact/">Configure a live workspace ↗</a>
+          <p>Records stay in this browser. This is not a customer system of record.</p>
+          <a href="https://supermega.dev/contact/">Configure a managed workspace &gt;</a>
         </div>
       </aside>
       <div className="core-stage">
         <header className="core-topbar">
           <div className="mobile-brand"><Brand /></div>
-          <div><span className="terminal-prompt">&gt;_</span><strong>Operating workspace</strong></div>
+          <div><span className="terminal-prompt">&gt;_</span><strong>Company operating system</strong></div>
           <div className="topbar-meta"><span>MMK</span><span>UTC+06:30</span><RuntimeBadge status={runtime.status} /></div>
         </header>
         <nav className="mobile-nav" aria-label="Mobile application">
@@ -405,32 +403,17 @@ export function OverviewPage() {
 
   return (
     <>
-      <PageHeading eyebrow="Command / 01" title="Run the company. Keep the proof." copy="A practical operations desk for accountable work across product, engineering, operations, growth, and finance. Role agents organize local demo records; a responsible person retains authority." actions={<Link className="core-button primary" to="/setup/">Configure workspace</Link>} />
+      <PageHeading eyebrow="Command / 01" title="Run the company. Keep the proof." copy="Coordinate accountable work across product, engineering, operations, growth, and finance. Agents organize local trial records; a responsible person retains authority." actions={<Link className="core-button primary" to="/settings/">Configure workspace</Link>} />
       <section className="metric-row" aria-label="Workspace overview">
         <Metric label="Open work" value={String(openTasks.length)} note="Role-owned Command tasks" />
         <Metric label="In progress" value={String(activeTasks.length)} note="Actively tracked local work" tone="green" />
         <Metric label="Open exceptions" value={String(exceptions)} note="Shop and Plant records needing review" tone="neutral" />
         <Metric label="Approval gate" value={String(pendingApprovals.length)} note="No external action runs automatically" tone="neutral" />
       </section>
-      <section className="core-panel command-roster-panel" aria-labelledby="command-roster-title">
-        <div className="panel-head">
-          <div><span className="core-eyebrow">Accountability roster</span><h2 id="command-roster-title">Five desks. Explicit authority.</h2></div>
-          <span className="panel-note">Human owner<br /><strong>{humanOwner}</strong></span>
-        </div>
-        <div className="command-roster-grid">
-          {roleWorkloads.map((role, index) => (
-            <article className="command-role-card" key={role.id}>
-              <div className="role-card-head">
-                <div><span>ROLE {String(index + 1).padStart(2, '0')}</span><h3>{role.label}</h3><small>{role.agent}</small></div>
-                <div className="role-load" aria-label={`${role.open} open tasks`}><strong>{role.open}</strong><span>open</span></div>
-              </div>
-              <p>{role.authority}</p>
-              <div className="role-boundary"><span>Boundary</span><p>{role.boundary}</p></div>
-              <small className="role-activity">{role.active} active · {role.done} done</small>
-            </article>
-          ))}
-        </div>
-        <p className="roster-guardrail"><strong>Human authority:</strong> {humanOwner} reviews external sends, payments, publishing, production changes, and approvals. These demo agents only organize browser-local work.</p>
+      <section className="core-panel command-lanes" aria-labelledby="command-lanes-title">
+        <div className="panel-head"><div><span className="core-eyebrow">Accountability</span><h2 id="command-lanes-title">Five operating lanes. One owner boundary.</h2></div><span className="panel-note">Responsible owner<br /><strong>{humanOwner}</strong></span></div>
+        <div className="lane-list">{roleWorkloads.map((role, index) => <article key={role.id}><span>0{index + 1}</span><div><strong>{role.label}</strong><small>{role.authority}</small></div><b>{role.open} open</b></article>)}</div>
+        <p className="roster-guardrail"><strong>Authority gate:</strong> {humanOwner} reviews external sends, payments, publishing, production changes, and approvals.</p>
       </section>
       <div className="workspace-grid command-grid">
         <section className="core-panel">
@@ -469,18 +452,28 @@ export function OverviewPage() {
           </div>
         </section>
       </div>
-      <section className="product-launch-grid">
-        <Link className="launch-card shop" to="/shop/">
-          <span className="card-index">02 / Commerce OS</span><h2>Shop</h2><p>Sell, control stock, review payments, and close the day from one record.</p><strong>Open Shop <span>→</span></strong>
-        </Link>
-        <Link className="launch-card plant" to="/plant/">
-          <span className="card-index">03 / Production OS</span><h2>Plant</h2><p>Track jobs, output, machine state, quality issues, and shift handoff.</p><strong>Open Plant <span>→</span></strong>
-        </Link>
-        <Link className="launch-card assist" to="/assist/">
-          <span className="card-index">04 / Governed assistance</span><h2>Assist</h2><p>Build an evidence-grounded brief and route draft actions through approval.</p><strong>Open Assist <span>→</span></strong>
-        </Link>
-      </section>
-      <section className="control-strip"><div><span className="core-eyebrow">Operating rule</span><h2>AI prepares. A responsible person approves.</h2></div><p>Shop and Plant remain the systems of record. Assistance reads their approved records, shows evidence, and cannot send, pay, publish, or change production on its own.</p></section>
+      <nav className="system-dock" aria-label="Workspace areas">
+        <Link to="/operations/?view=shop"><span>02</span><strong>Operations</strong><small>Shop and Plant records</small></Link>
+        <Link to="/agents/"><span>03</span><strong>Agents</strong><small>Briefs and approval queue</small></Link>
+        <Link to="/settings/"><span>04</span><strong>Settings</strong><small>Workspace and controls</small></Link>
+      </nav>
+      <section className="control-strip"><div><span className="core-eyebrow">Operating rule</span><h2>Agents prepare. A responsible person approves.</h2></div><p>Operations remains the system of record. Agents read approved records, show evidence, and cannot send, pay, publish, or change production on their own.</p></section>
+    </>
+  )
+}
+
+export function OperationsPage() {
+  const [searchParams, setSearchParams] = useSearchParams()
+  const view = searchParams.get('view') === 'plant' ? 'plant' : 'shop'
+
+  return (
+    <>
+      <div className="mode-switch" role="group" aria-label="Operations mode">
+        <span>OPERATIONS MODE</span>
+        <button aria-pressed={view === 'shop'} type="button" onClick={() => setSearchParams({ view: 'shop' }, { replace: true })}>Shop</button>
+        <button aria-pressed={view === 'plant'} type="button" onClick={() => setSearchParams({ view: 'plant' }, { replace: true })}>Plant</button>
+      </div>
+      {view === 'shop' ? <ShopPage /> : <PlantPage />}
     </>
   )
 }
@@ -520,9 +513,9 @@ export function ShopPage() {
 
   return (
     <>
-      <PageHeading eyebrow="Shop / 02" title="Counter to close, one record." copy="A focused commerce workspace for sales, local payments, stock, and daily control." actions={<button className="core-button" onClick={closeDay} type="button">Close day</button>} />
+      <PageHeading eyebrow="Operations / Shop" title="Counter to close, one record." copy="Commerce operations for sales, local payments, stock, exceptions, and daily control." actions={<button className="core-button" onClick={closeDay} type="button">Close day</button>} />
       <section className="metric-row compact">
-        <Metric label="Revenue" value={formatMoney(revenue)} note="Current demo ledger" />
+        <Metric label="Revenue" value={formatMoney(revenue)} note="Current local ledger" />
         <Metric label="Transactions" value={String(shop.sales.length)} note="Each sale updates stock" tone="green" />
         <Metric label="Low stock" value={String(lowStock.length)} note="At or below reorder point" tone={lowStock.length ? 'neutral' : 'green'} />
         <Metric label="Close snapshots" value={String(shop.closes.length)} note="Reviewable daily checkpoints" tone="neutral" />
@@ -535,11 +528,11 @@ export function ShopPage() {
             <div className="form-row"><label>Quantity<input min="1" max={selected?.onHand ?? 1} type="number" value={quantity} onChange={(event) => setQuantity(Number(event.target.value))} /></label><label>Payment<select value={payment} onChange={(event) => setPayment(event.target.value)}><option>KBZPay</option><option>WavePay</option><option>Cash</option><option>Card</option></select></label></div>
             <div className="sale-total"><span>Total</span><strong>{formatMoney((selected?.price ?? 0) * Math.max(quantity, 0))}</strong></div>
             <button className="core-button primary wide" type="submit">Record sale</button>
-            <p className="form-notice" aria-live="polite">{notice || 'Demo actions are stored only in this browser.'}</p>
+            <p className="form-notice" aria-live="polite">{notice || 'Trial actions are stored only in this browser.'}</p>
           </form>
         </section>
         <section className="core-panel span-two">
-          <div className="panel-head"><div><span className="core-eyebrow">Stock control</span><h2>Inventory</h2></div><span className="panel-note">Receive +10 is an isolated demo action</span></div>
+          <div className="panel-head"><div><span className="core-eyebrow">Stock control</span><h2>Inventory</h2></div><span className="panel-note">Receive +10 updates local trial state</span></div>
           <div className="data-table" role="table" aria-label="Shop inventory">
             <div className="data-row table-head" role="row"><span>Item</span><span>On hand</span><span>Reorder</span><span>Price</span><span>Action</span></div>
             {shop.items.map((item) => <div className="data-row" role="row" key={item.sku}><span><strong>{item.name}</strong><small>{item.sku}</small></span><span className={item.onHand <= item.reorderAt ? 'warning-text' : ''}>{item.onHand}</span><span>{item.reorderAt}</span><span>{formatMoney(item.price)}</span><span><button className="table-action" type="button" onClick={() => restock(item.sku)}>Receive +10</button></span></div>)}
@@ -603,12 +596,12 @@ export function PlantPage() {
 
   return (
     <>
-      <PageHeading eyebrow="Plant / 03" title="Plan, run, confirm, hand off." copy="A generic production workspace for job output, machine state, exceptions, and management review—without client data or client branding." />
+      <PageHeading eyebrow="Operations / Plant" title="Plan, run, confirm, hand off." copy="Production operations for output, machine state, exceptions, and management review using local trial records." />
       <section className="metric-row compact">
         <Metric label="Output" value={output.toLocaleString()} note={`${Math.round((output / target) * 100)}% of current target`} tone="green" />
         <Metric label="Target" value={target.toLocaleString()} note="Across active jobs" />
         <Metric label="Open issues" value={String(openIssues.length)} note="Requires human ownership" tone={openIssues.length ? 'neutral' : 'green'} />
-        <Metric label="Machines running" value={`${plant.machines.filter((item) => item.state === 'running').length} / ${plant.machines.length}`} note="Demo state, not telemetry" tone="neutral" />
+        <Metric label="Machines running" value={`${plant.machines.filter((item) => item.state === 'running').length} / ${plant.machines.length}`} note="Local state, not telemetry" tone="neutral" />
       </section>
       <div className="workspace-grid plant-grid">
         <section className="core-panel span-two">
@@ -619,7 +612,7 @@ export function PlantPage() {
         <section className="core-panel">
           <div className="panel-head"><div><span className="core-eyebrow">Equipment</span><h2>Machine state</h2></div></div>
           <div className="machine-list">{plant.machines.map((machine) => <button key={machine.id} type="button" onClick={() => cycleMachine(machine.id)}><span className={`machine-dot ${machine.state}`} /><span><strong>{machine.name}</strong><small>{machine.id}</small></span><b>{machine.state}</b></button>)}</div>
-          <p className="panel-footnote">Select a machine to cycle its isolated demo state. A live workspace accepts state only from authorized operators or approved telemetry.</p>
+          <p className="panel-footnote">Select a machine to cycle its local trial state. A managed workspace accepts state only from authorized operators or approved telemetry.</p>
         </section>
         <section className="core-panel">
           <div className="panel-head"><div><span className="core-eyebrow">Exception</span><h2>Open an issue</h2></div></div>
@@ -634,7 +627,7 @@ export function PlantPage() {
   )
 }
 
-export function AssistPage() {
+export function AgentsPage() {
   const [shop] = useStoredState(SHOP_KEY, seedShop)
   const [plant] = useStoredState(PLANT_KEY, seedPlant)
   const [approvals, setApprovals] = useStoredState<Approval[]>(APPROVAL_KEY, [])
@@ -669,20 +662,20 @@ export function AssistPage() {
 
   return (
     <>
-      <PageHeading eyebrow="Assist / 04" title="Evidence first. Authority last." copy="Build a deterministic operating brief from Shop and Plant records, then route any proposed action through a visible approval gate." actions={<button className="core-button primary" onClick={buildBrief} type="button">Build current brief</button>} />
+      <PageHeading eyebrow="Agents / 03" title="Prepare the work. Preserve authority." copy="Agents inspect approved operating records, build evidence-backed briefs, and route proposed actions through a visible approval gate." actions={<button className="core-button primary" onClick={buildBrief} type="button">Build operating brief</button>} />
       <div className="assist-grid">
         <section className="core-panel assist-output">
           <div className="panel-head"><div><span className="core-eyebrow">Operating brief</span><h2>Current evidence</h2></div><span className="status-pill bounded">Bounded</span></div>
-          {brief.length ? <div className="brief-output"><div className="brief-command"><span>&gt;</span> summarize approved operational records</div>{brief.map((line) => <p key={line}>{line}</p>)}<div className="evidence-box"><strong>Sources used</strong><span>Shop inventory ledger</span><span>Shop sales ledger</span><span>Plant job records</span><span>Plant issue register</span></div><button className="core-button" onClick={requestApproval} type="button">Create approval request</button></div> : <Empty>Build a brief to inspect the current browser workspace. No external model is called in this transparent demo mode.</Empty>}
+          {brief.length ? <div className="brief-output"><div className="brief-command"><span>&gt;</span> summarize approved operational records</div>{brief.map((line) => <p key={line}>{line}</p>)}<div className="evidence-box"><strong>Sources used</strong><span>Shop inventory ledger</span><span>Shop sales ledger</span><span>Plant job records</span><span>Plant issue register</span></div><button className="core-button" onClick={requestApproval} type="button">Create approval request</button></div> : <Empty>Build a brief from this browser workspace. No external model is called in local trial mode.</Empty>}
         </section>
         <aside className="core-panel guardrail-panel">
-          <span className="core-eyebrow">Authority boundary</span><h2>What Assist can do</h2>
-          <ul className="control-list"><li><i>✓</i><span><strong>Read</strong> approved demo records</span></li><li><i>✓</i><span><strong>Summarize</strong> observable state</span></li><li><i>✓</i><span><strong>Draft</strong> a review request</span></li><li className="blocked"><i>×</i><span><strong>Cannot</strong> send, pay, publish, or alter production</span></li></ul>
-          <p>Model-backed assistance is activated only in a configured workspace with server-held credentials, source controls, evaluation, and audit.</p>
+          <span className="core-eyebrow">Authority boundary</span><h2>What Agents can do</h2>
+          <ul className="control-list"><li><i>✓</i><span><strong>Read</strong> approved trial records</span></li><li><i>✓</i><span><strong>Summarize</strong> observable state</span></li><li><i>✓</i><span><strong>Draft</strong> a review request</span></li><li className="blocked"><i>×</i><span><strong>Cannot</strong> send, pay, publish, or alter production</span></li></ul>
+          <p>This local trial uses a transparent deterministic brief. Model-backed agents require a configured workspace, server-held credentials, source controls, evaluation, and audit.</p>
         </aside>
       </div>
       <section className="core-panel ledger-panel">
-        <div className="panel-head"><div><span className="core-eyebrow">Human control</span><h2>Approval queue</h2></div><span className="panel-note">Approval records intent; it triggers no external side effect in demo mode.</span></div>
+        <div className="panel-head"><div><span className="core-eyebrow">Human control</span><h2>Approval queue</h2></div><span className="panel-note">Approval records intent; it triggers no external side effect in local trial mode.</span></div>
         {approvals.length ? <div className="approval-list">{approvals.map((approval) => <article key={approval.id}><div><span className={`status-pill ${approval.status}`}>{approval.status}</span><strong>{approval.title}</strong><small>{approval.id} · {formatTime(approval.createdAt)} · {approval.evidence.length} evidence sources</small></div>{approval.status === 'pending' ? <div><button className="table-action" type="button" onClick={() => setApprovalStatus(approval.id, 'declined')}>Decline</button><button className="core-button compact" type="button" onClick={() => setApprovalStatus(approval.id, 'approved')}>Approve record</button></div> : null}</article>)}</div> : <Empty>No approval requests yet.</Empty>}
       </section>
     </>
@@ -694,7 +687,8 @@ const setupTemplates = {
   plant: ['Production control', 'Maintenance and downtime', 'Quality and traceability', 'Material receiving'],
 }
 
-export function SetupPage() {
+export function SettingsPage() {
+  const runtime = useOutletContext<RuntimeHealth>()
   const [setup, setSetup] = useStoredState<SetupState>(SETUP_KEY, { product: 'shop', template: setupTemplates.shop[0], workspace: '', owner: '' })
   const [shop] = useStoredState(SHOP_KEY, seedShop)
   const [plant] = useStoredState(PLANT_KEY, seedPlant)
@@ -734,7 +728,7 @@ export function SetupPage() {
 
   return (
     <>
-      <PageHeading eyebrow="Setup / 05" title="Start with one accountable workflow." copy="Choose the operating base, name the workspace owner, and preserve a handoff that can be reviewed before any live data is connected." />
+      <PageHeading eyebrow="Settings / 04" title="Configure the workspace. Keep the boundary visible." copy="Choose the operating base, name the responsible owner, and preserve a reviewable handoff before any live data is connected." />
       <div className="setup-layout">
         <form className="core-panel setup-form" onSubmit={save}>
           <div className="panel-head"><div><span className="core-eyebrow">Workspace draft</span><h2>Configuration</h2></div></div>
@@ -745,41 +739,26 @@ export function SetupPage() {
           <button className="core-button primary wide" type="submit">Save setup draft</button>
           <p className="form-notice" aria-live="polite">{notice || (setup.savedAt ? `Last saved ${formatTime(setup.savedAt)}` : 'Draft data stays in this browser.')}</p>
         </form>
-        <aside className="core-panel lifecycle-panel"><span className="core-eyebrow">Go-live lifecycle</span><h2>From demo to dependable operation</h2><ol><li><span>01</span><div><strong>Map</strong><p>Confirm roles, records, decisions, and the acceptance boundary.</p></div></li><li><span>02</span><div><strong>Configure</strong><p>Set product template, workspace rules, and approved source contract.</p></div></li><li><span>03</span><div><strong>Trial</strong><p>Use isolated data; test daily close, handoff, backup, and recovery.</p></div></li><li><span>04</span><div><strong>Activate</strong><p>Connect managed persistence only after access and evidence checks pass.</p></div></li><li><span>05</span><div><strong>Improve</strong><p>Add governed assistance after the workflow is stable and measurable.</p></div></li></ol><a className="core-button" href="https://supermega.dev/contact/">Request implementation ↗</a></aside>
+        <aside className="core-panel lifecycle-panel"><span className="core-eyebrow">Go-live lifecycle</span><h2>From local trial to dependable operation</h2><ol><li><span>01</span><div><strong>Map</strong><p>Confirm roles, records, decisions, and the acceptance boundary.</p></div></li><li><span>02</span><div><strong>Configure</strong><p>Set the operating template, workspace rules, and approved source contract.</p></div></li><li><span>03</span><div><strong>Trial</strong><p>Use isolated data; test daily close, handoff, backup, and recovery.</p></div></li><li><span>04</span><div><strong>Activate</strong><p>Connect managed persistence only after access and evidence checks pass.</p></div></li><li><span>05</span><div><strong>Improve</strong><p>Add governed agents after the workflow is stable and measurable.</p></div></li></ol><a className="core-button" href="https://supermega.dev/contact/">Request implementation &gt;</a></aside>
       </div>
       <section className="core-panel trial-control-panel">
-        <div><span className="core-eyebrow">Trial controls</span><h2>Keep the evidence. Reset deliberately.</h2><p>Export the complete browser workspace for review, or explicitly reset all demo records back to the sample state.</p></div>
+        <div><span className="core-eyebrow">Trial controls</span><h2>Keep the evidence. Reset deliberately.</h2><p>Export the complete browser workspace for review, or explicitly reset all local trial records back to the sample state.</p></div>
         <div className="trial-actions">
           <a className="core-button" download={evidenceFilename} href={evidenceHref} onClick={() => setNotice('Trial evidence exported. Review the JSON before sharing it.')}>Export trial evidence</a>
-          {resetArmed ? <><button className="table-action" onClick={() => setResetArmed(false)} type="button">Cancel</button><button className="core-button danger" onClick={resetDemoWorkspace} type="button">Confirm reset</button></> : <button className="table-action danger-text" onClick={() => setResetArmed(true)} type="button">Reset demo workspace</button>}
+          {resetArmed ? <><button className="table-action" onClick={() => setResetArmed(false)} type="button">Cancel</button><button className="core-button danger" onClick={resetDemoWorkspace} type="button">Confirm reset</button></> : <button className="table-action danger-text" onClick={() => setResetArmed(true)} type="button">Reset local trial</button>}
         </div>
       </section>
-    </>
-  )
-}
-
-export function TrustPage() {
-  const runtime = useOutletContext<RuntimeHealth>()
-  const controls = [
-    ['Private demo boundary', 'This public app uses isolated browser state and contains no client workspace or client data.'],
-    ['Managed system of record', 'Production activation requires managed Postgres, explicit workspace ownership, and tested recovery.'],
-    ['Role and row boundaries', 'Every production read and write must be limited by workspace and role; exposed Supabase tables require RLS.'],
-    ['Server-held credentials', 'Service-role and model credentials stay on the server and are never included in the browser bundle.'],
-    ['Human approval', 'External sends, payments, publishing, production changes, and irreversible actions require accountable approval.'],
-    ['Observable release', 'Build identity, health, route checks, and rollback ownership are part of promotion—not post-launch cleanup.'],
-  ]
-  return (
-    <>
-      <PageHeading eyebrow="Trust / 06" title="Authority is earned, bounded, and reviewable." copy="The demo proves the interaction model. Production readiness is a separate gate covering identity, data, evidence, recovery, and release ownership." />
-      <section className="readiness-grid" aria-label="Runtime readiness">
-        <article className="core-panel readiness-card"><span>Runtime</span><strong>{runtime.serviceStatus}</strong><small>Health endpoint status</small></article>
-        <article className="core-panel readiness-card"><span>Managed data</span><strong>{runtime.enterpriseDbReady ? 'Ready' : 'Not connected'}</strong><small>Tenant system of record</small></article>
-        <article className="core-panel readiness-card"><span>Security gate</span><strong>{runtime.securityReady ? 'Ready' : 'Not ready'}</strong><small>Production identity boundary</small></article>
-        <article className="core-panel readiness-card"><span>Source coverage</span><strong>{runtime.coverageScore}%</strong><small>Approved operational sources</small></article>
+      <section className="settings-readiness" id="controls" aria-labelledby="controls-title">
+        <div className="settings-section-head"><span className="core-eyebrow">System boundary</span><h2 id="controls-title">Readiness is reported, not implied.</h2><p>The interface remains in local-only mode until managed data, identity, source coverage, and recovery controls are proven.</p></div>
+        <div className="readiness-grid" aria-label="Runtime readiness">
+          <article className="core-panel readiness-card"><span>Runtime</span><strong>{runtime.serviceStatus}</strong><small>Health endpoint status</small></article>
+          <article className="core-panel readiness-card"><span>Managed data</span><strong>{runtime.enterpriseDbReady ? 'Ready' : 'Not connected'}</strong><small>Tenant system of record</small></article>
+          <article className="core-panel readiness-card"><span>Security gate</span><strong>{runtime.securityReady ? 'Ready' : 'Not ready'}</strong><small>Production identity boundary</small></article>
+          <article className="core-panel readiness-card"><span>Source coverage</span><strong>{runtime.coverageScore}%</strong><small>Approved operational sources</small></article>
+        </div>
+        {runtime.status !== 'enterprise' ? <section className="core-panel requirement-panel"><div><span className="core-eyebrow">Activation requirements</span><h2>Managed mode remains locked.</h2></div><ul>{(runtime.requirements.length ? runtime.requirements : ['Configure managed tenant persistence.', 'Verify production identity and source coverage.']).map((requirement) => <li key={requirement}>{requirement}</li>)}</ul></section> : null}
+        <section className="control-strip"><div><span className="core-eyebrow">Authority gate</span><h2>Agents prepare. Responsible people approve.</h2></div><p>External sends, payments, publishing, access changes, and production writes stay behind explicit approval and auditable ownership.</p></section>
       </section>
-      {runtime.status !== 'enterprise' ? <section className="core-panel requirement-panel"><div><span className="core-eyebrow">Activation requirements</span><h2>Enterprise mode remains locked.</h2></div><ul>{(runtime.requirements.length ? runtime.requirements : ['Configure managed tenant persistence.', 'Verify production identity and source coverage.']).map((requirement) => <li key={requirement}>{requirement}</li>)}</ul></section> : null}
-      <section className="trust-grid">{controls.map(([title, copy], index) => <article className="core-panel" key={title}><span>0{index + 1}</span><h2>{title}</h2><p>{copy}</p></article>)}</section>
-      <section className="control-strip"><div><span className="core-eyebrow">Current environment</span><h2>Demo-ready is not enterprise-ready.</h2></div><p>The live health boundary must continue to report managed persistence and source coverage truthfully. Until those checks pass, this app is an isolated product demonstration—not a customer system of record.</p></section>
     </>
   )
 }

--- a/showroom/src/core/core-app.css
+++ b/showroom/src/core/core-app.css
@@ -1,26 +1,25 @@
 :root {
-  --core-bg: #090d13;
-  --core-panel: #10161f;
-  --core-panel-raised: #141c27;
-  --core-ink: #f4f7fb;
-  --core-muted: #a7b1c0;
-  --core-quiet: #748194;
-  --core-line: rgba(230, 238, 255, .12);
-  --core-line-strong: rgba(230, 238, 255, .22);
-  --core-blue: #6b95ff;
-  --core-blue-soft: rgba(107, 149, 255, .12);
-  --core-green: #3dd6a2;
-  --core-green-soft: rgba(61, 214, 162, .1);
+  --core-bg: #080a09;
+  --core-panel: #101411;
+  --core-panel-raised: #151a16;
+  --core-ink: #f2f5f1;
+  --core-muted: #a3ada6;
+  --core-quiet: #707b73;
+  --core-line: rgba(225, 238, 229, .12);
+  --core-line-strong: rgba(225, 238, 229, .22);
+  --core-blue: #7cf5b4;
+  --core-blue-soft: rgba(124, 245, 180, .1);
+  --core-green: #7cf5b4;
+  --core-green-soft: rgba(124, 245, 180, .1);
   --core-warn: #ffb86b;
   --core-danger: #ff7b8d;
-  --core-radius: 18px;
+  --core-radius: 10px;
   --core-mono: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
 }
 
 body {
   background:
-    radial-gradient(circle at 42% -12%, rgba(107, 149, 255, .14), transparent 30%),
-    radial-gradient(circle at 100% 8%, rgba(61, 214, 162, .07), transparent 24%),
+    radial-gradient(circle at 72% -14%, rgba(124, 245, 180, .1), transparent 32%),
     var(--core-bg);
   color: var(--core-ink);
 }
@@ -39,44 +38,45 @@ body::before {
   content: "";
 }
 
-.core-shell { min-height: 100svh; display: grid; grid-template-columns: 248px minmax(0, 1fr); }
-.core-sidebar { position: fixed; inset: 0 auto 0 0; z-index: 30; width: 248px; display: flex; flex-direction: column; border-right: 1px solid var(--core-line); padding: 22px 16px 18px; background: rgba(8, 12, 18, .91); backdrop-filter: blur(22px); }
+.core-shell { min-height: 100svh; display: grid; grid-template-columns: 232px minmax(0, 1fr); }
+.core-sidebar { position: fixed; inset: 0 auto 0 0; z-index: 30; width: 232px; display: flex; flex-direction: column; border-right: 1px solid var(--core-line); padding: 24px 16px 18px; background: rgba(8, 10, 9, .93); backdrop-filter: blur(22px); }
 .core-stage { min-width: 0; grid-column: 2; }
 .core-main { width: min(calc(100% - 64px), 1440px); margin: 0 auto; padding: 54px 0 84px; }
 
 .core-skip { position: fixed; z-index: 100; top: -60px; left: 270px; border: 1px solid var(--core-blue); border-radius: 10px; padding: 10px 14px; background: var(--core-panel); text-decoration: none; }
 .core-skip:focus { top: 12px; }
 
-.core-brand { display: inline-flex; align-items: center; gap: 11px; text-decoration: none; font-size: 16px; font-weight: 790; letter-spacing: -.025em; }
-.core-brand img { width: 36px; height: 36px; }
-.core-brand > span > span { color: var(--core-quiet); font-weight: 650; }
+.core-brand { min-height: 36px; display: inline-flex; align-items: center; gap: 12px; text-decoration: none; }
+.core-brand-mark { color: var(--core-green); font-family: var(--core-mono); font-size: 20px; font-weight: 800; letter-spacing: -.12em; }
+.core-brand-name { color: var(--core-ink); font-size: 12px; font-weight: 820; letter-spacing: .08em; }
+.core-brand-name small { color: var(--core-quiet); font-size: 9px; }
 .core-topbar .mobile-brand { display: none; }
 
 .workspace-label { display: grid; gap: 3px; margin: 34px 8px 12px; }
 .workspace-label span { color: var(--core-quiet); font-family: var(--core-mono); font-size: 10px; text-transform: uppercase; letter-spacing: .08em; }
 .workspace-label strong { font-size: 12px; font-weight: 690; }
 .core-nav { display: grid; gap: 4px; }
-.core-nav a { min-height: 46px; display: flex; align-items: center; gap: 12px; border: 1px solid transparent; border-radius: 11px; padding: 0 12px; color: var(--core-muted); font-size: 13px; font-weight: 700; text-decoration: none; transition: 150ms ease; }
+.core-nav a { min-height: 46px; display: flex; align-items: center; gap: 12px; border: 1px solid transparent; border-radius: 5px; padding: 0 12px; color: var(--core-muted); font-size: 13px; font-weight: 700; text-decoration: none; transition: 150ms ease; }
 .core-nav a span { width: 22px; color: var(--core-quiet); font-family: var(--core-mono); font-size: 10px; }
 .core-nav a:hover { background: rgba(255, 255, 255, .035); color: var(--core-ink); }
-.core-nav a.active { border-color: rgba(107, 149, 255, .24); background: var(--core-blue-soft); color: var(--core-ink); }
+.core-nav a.active { border-color: rgba(124, 245, 180, .22); background: var(--core-green-soft); color: var(--core-ink); }
 .core-nav a.active span { color: var(--core-blue); }
 .sidebar-foot { display: grid; gap: 12px; margin-top: auto; padding: 18px 8px 0; border-top: 1px solid var(--core-line); }
 .sidebar-foot p { margin: 0; color: var(--core-quiet); font-size: 10px; line-height: 1.6; }
 .sidebar-foot a { min-height: 36px; display: inline-flex; align-items: center; color: var(--core-muted); font-size: 11px; font-weight: 720; text-decoration: none; }
 .sidebar-foot a:hover { color: var(--core-blue); }
 
-.core-topbar { position: sticky; top: 0; z-index: 20; min-height: 66px; display: flex; align-items: center; justify-content: space-between; gap: 18px; border-bottom: 1px solid var(--core-line); padding: 0 32px; background: rgba(9, 13, 19, .82); backdrop-filter: blur(20px); }
+.core-topbar { position: sticky; top: 0; z-index: 20; min-height: 66px; display: flex; align-items: center; justify-content: space-between; gap: 18px; border-bottom: 1px solid var(--core-line); padding: 0 32px; background: rgba(8, 10, 9, .86); backdrop-filter: blur(20px); }
 .core-topbar > div { display: flex; align-items: center; gap: 10px; }
 .core-topbar strong { font-size: 12px; font-weight: 720; }
 .terminal-prompt { color: var(--core-green); font-family: var(--core-mono); font-size: 14px; font-weight: 800; }
 .topbar-meta { color: var(--core-quiet); font-family: var(--core-mono); font-size: 10px; }
 .topbar-meta > span { border-right: 1px solid var(--core-line); padding-right: 10px; }
-.runtime-badge { min-height: 28px; display: inline-flex; align-items: center; gap: 7px; border: 1px solid var(--core-line); border-radius: 999px; padding: 0 9px; color: var(--core-muted); font-family: var(--core-mono); font-size: 9px; font-weight: 720; text-transform: uppercase; }
+.runtime-badge { min-height: 28px; display: inline-flex; align-items: center; gap: 7px; border: 1px solid var(--core-line); border-radius: 4px; padding: 0 9px; color: var(--core-muted); font-family: var(--core-mono); font-size: 9px; font-weight: 720; text-transform: uppercase; }
 .runtime-badge i { width: 6px; height: 6px; border-radius: 50%; background: var(--core-quiet); }
-.runtime-badge.enterprise { border-color: rgba(61, 214, 162, .22); background: var(--core-green-soft); color: var(--core-green); }
+.runtime-badge.enterprise { border-color: rgba(124, 245, 180, .22); background: var(--core-green-soft); color: var(--core-green); }
 .runtime-badge.enterprise i { background: var(--core-green); box-shadow: 0 0 12px currentColor; }
-.runtime-badge.demo { border-color: rgba(107, 149, 255, .2); background: var(--core-blue-soft); color: var(--core-blue); }
+.runtime-badge.demo { border-color: rgba(124, 245, 180, .2); background: var(--core-green-soft); color: var(--core-green); }
 .runtime-badge.demo i { background: var(--core-blue); }
 .mobile-nav { display: none; }
 
@@ -88,10 +88,10 @@ body::before {
 .page-heading p { max-width: 760px; margin: 0; color: var(--core-muted); font-size: 16px; line-height: 1.65; }
 .heading-actions { flex: 0 0 auto; padding-bottom: 2px; }
 
-.core-button { min-height: 45px; display: inline-flex; align-items: center; justify-content: center; gap: 8px; border: 1px solid var(--core-line-strong); border-radius: 11px; padding: 0 15px; background: rgba(255, 255, 255, .035); color: var(--core-ink); font-size: 12px; font-weight: 760; text-decoration: none; transition: 150ms ease; }
+.core-button { min-height: 45px; display: inline-flex; align-items: center; justify-content: center; gap: 8px; border: 1px solid var(--core-line-strong); border-radius: 5px; padding: 0 15px; background: rgba(255, 255, 255, .025); color: var(--core-ink); font-size: 12px; font-weight: 760; text-decoration: none; transition: 150ms ease; }
 .core-button:hover { transform: translateY(-1px); border-color: rgba(255, 255, 255, .35); background: rgba(255, 255, 255, .07); }
-.core-button.primary { border-color: var(--core-blue); background: var(--core-blue); color: #07101f; box-shadow: 0 14px 34px rgba(107, 149, 255, .18); }
-.core-button.primary:hover { background: #8cacff; }
+.core-button.primary { border-color: var(--core-green); background: var(--core-green); color: #07100a; box-shadow: 0 14px 34px rgba(124, 245, 180, .12); }
+.core-button.primary:hover { background: #a0ffcb; }
 .core-button.wide { width: 100%; }
 .core-button.compact { min-height: 36px; padding-inline: 12px; }
 
@@ -116,7 +116,7 @@ body::before {
 .launch-card > strong { display: flex; justify-content: space-between; margin-top: auto; color: var(--core-blue); font-size: 12px; }
 .launch-card.plant > strong { color: var(--core-green); }
 
-.control-strip { display: grid; grid-template-columns: minmax(0, .9fr) minmax(0, 1.1fr); gap: 40px; align-items: center; margin-top: 22px; border: 1px solid rgba(107, 149, 255, .22); border-radius: var(--core-radius); padding: 28px; background: linear-gradient(120deg, rgba(107, 149, 255, .1), rgba(61, 214, 162, .035)); }
+.control-strip { display: grid; grid-template-columns: minmax(0, .9fr) minmax(0, 1.1fr); gap: 40px; align-items: center; margin-top: 22px; border: 1px solid rgba(124, 245, 180, .2); border-radius: var(--core-radius); padding: 28px; background: linear-gradient(120deg, rgba(124, 245, 180, .08), rgba(124, 245, 180, .02)); }
 .control-strip h2 { margin: 10px 0 0; font-size: 24px; letter-spacing: -.035em; }
 .control-strip p { margin: 0; color: var(--core-muted); font-size: 12px; line-height: 1.7; }
 
@@ -133,14 +133,14 @@ body::before {
 .panel-footnote { margin: 16px 0 0; color: var(--core-quiet); font-size: 10px; line-height: 1.55; }
 .status-pill { min-height: 27px; display: inline-flex; align-items: center; gap: 7px; border: 1px solid var(--core-line); border-radius: 999px; padding: 0 9px; color: var(--core-muted); font-family: var(--core-mono); font-size: 9px; font-weight: 720; text-transform: uppercase; }
 .status-pill::before { width: 5px; height: 5px; border-radius: 50%; background: currentColor; content: ""; }
-.status-pill.ready, .status-pill.approved { border-color: rgba(61, 214, 162, .24); background: var(--core-green-soft); color: var(--core-green); }
-.status-pill.bounded, .status-pill.pending { border-color: rgba(107, 149, 255, .24); background: var(--core-blue-soft); color: var(--core-blue); }
+.status-pill.ready, .status-pill.approved { border-color: rgba(124, 245, 180, .24); background: var(--core-green-soft); color: var(--core-green); }
+.status-pill.bounded, .status-pill.pending { border-color: rgba(124, 245, 180, .22); background: var(--core-green-soft); color: var(--core-green); }
 .status-pill.declined { border-color: rgba(255, 123, 141, .22); color: var(--core-danger); }
 
 .core-form { display: grid; gap: 15px; }
 .core-form label, .inline-form label, .setup-form > label { display: grid; gap: 7px; color: var(--core-muted); font-size: 10px; font-weight: 700; }
-.core-form input, .core-form select, .core-form textarea, .inline-form input, .inline-form select, .setup-form input, .setup-form select { width: 100%; min-width: 0; border: 1px solid var(--core-line); border-radius: 10px; padding: 11px 12px; background: #0b1017; color: var(--core-ink); outline: none; }
-.core-form input:focus, .core-form select:focus, .core-form textarea:focus, .inline-form input:focus, .inline-form select:focus, .setup-form input:focus, .setup-form select:focus { border-color: var(--core-blue); box-shadow: 0 0 0 3px rgba(107, 149, 255, .1); }
+.core-form input, .core-form select, .core-form textarea, .inline-form input, .inline-form select, .setup-form input, .setup-form select { width: 100%; min-width: 0; border: 1px solid var(--core-line); border-radius: 5px; padding: 11px 12px; background: #0b0e0c; color: var(--core-ink); outline: none; }
+.core-form input:focus, .core-form select:focus, .core-form textarea:focus, .inline-form input:focus, .inline-form select:focus, .setup-form input:focus, .setup-form select:focus { border-color: var(--core-green); box-shadow: 0 0 0 3px rgba(124, 245, 180, .09); }
 .core-form textarea { min-height: 96px; resize: vertical; }
 .form-row { display: grid; grid-template-columns: .75fr 1fr; gap: 12px; }
 .sale-total { display: flex; align-items: flex-end; justify-content: space-between; gap: 12px; border-top: 1px solid var(--core-line); padding-top: 16px; }
@@ -236,7 +236,7 @@ body::before {
 .role-activity { margin-top: 12px; }
 .roster-guardrail { margin: 16px 0 0; border-left: 2px solid var(--core-green); padding-left: 12px; color: var(--core-quiet); font-size: 9px; line-height: 1.55; }
 .roster-guardrail strong { color: var(--core-green); }
-.assignment-scope { display: grid; gap: 5px; border: 1px solid rgba(107, 149, 255, .2); border-radius: 11px; padding: 13px; background: var(--core-blue-soft); }
+.assignment-scope { display: grid; gap: 5px; border: 1px solid rgba(124, 245, 180, .2); border-radius: 5px; padding: 13px; background: var(--core-green-soft); }
 .assignment-scope > span { color: var(--core-blue); font-family: var(--core-mono); font-size: 8px; font-weight: 760; text-transform: uppercase; }
 .assignment-scope strong { color: var(--core-ink); font-size: 10px; line-height: 1.5; }
 .assignment-scope small { color: var(--core-quiet); font-size: 8px; line-height: 1.5; }
@@ -250,9 +250,33 @@ body::before {
 .command-list small { color: var(--core-quiet); font-family: var(--core-mono); font-size: 8px; }
 .task-controls { min-width: 132px; display: grid; gap: 7px; }
 .task-controls label { display: grid; gap: 4px; color: var(--core-quiet); font-family: var(--core-mono); font-size: 7px; text-transform: uppercase; }
-.task-controls select { width: 100%; min-width: 0; height: 32px; border: 1px solid var(--core-line); border-radius: 8px; padding: 0 8px; background: #0b1017; color: var(--core-muted); font-size: 9px; outline: none; }
-.task-controls select:focus { border-color: var(--core-blue); box-shadow: 0 0 0 3px rgba(107, 149, 255, .1); }
+.task-controls select { width: 100%; min-width: 0; height: 32px; border: 1px solid var(--core-line); border-radius: 4px; padding: 0 8px; background: #0b0e0c; color: var(--core-muted); font-size: 9px; outline: none; }
+.task-controls select:focus { border-color: var(--core-green); box-shadow: 0 0 0 3px rgba(124, 245, 180, .09); }
 .task-controls .table-action { width: 100%; }
+
+.mode-switch { min-height: 50px; display: flex; align-items: center; gap: 6px; margin-bottom: 28px; border-bottom: 1px solid var(--core-line); padding-bottom: 14px; }
+.mode-switch > span { margin-right: auto; color: var(--core-quiet); font-family: var(--core-mono); font-size: 9px; letter-spacing: .08em; }
+.mode-switch button { min-height: 34px; border: 1px solid var(--core-line); border-radius: 4px; padding: 0 14px; background: transparent; color: var(--core-muted); font-size: 10px; font-weight: 760; }
+.mode-switch button[aria-pressed="true"] { border-color: var(--core-green); background: var(--core-green-soft); color: var(--core-green); }
+.command-lanes { margin-bottom: 14px; }
+.lane-list { display: grid; grid-template-columns: repeat(5, minmax(0, 1fr)); border-top: 1px solid var(--core-line); }
+.lane-list article { min-width: 0; min-height: 128px; display: flex; flex-direction: column; gap: 12px; border-right: 1px solid var(--core-line); padding: 16px; }
+.lane-list article:last-child { border-right: 0; }
+.lane-list article > span { color: var(--core-green); font-family: var(--core-mono); font-size: 9px; }
+.lane-list article > div { display: grid; gap: 5px; }
+.lane-list strong { font-size: 12px; }
+.lane-list small { color: var(--core-quiet); font-size: 9px; line-height: 1.45; }
+.lane-list b { margin-top: auto; color: var(--core-muted); font-family: var(--core-mono); font-size: 8px; font-weight: 680; text-transform: uppercase; }
+.system-dock { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 10px; margin-top: 14px; }
+.system-dock a { min-height: 116px; display: grid; grid-template-columns: 28px 1fr; grid-template-rows: auto auto; gap: 5px 10px; align-content: center; border: 1px solid var(--core-line); border-radius: var(--core-radius); padding: 18px; background: rgba(255, 255, 255, .018); text-decoration: none; transition: 150ms ease; }
+.system-dock a:hover { border-color: var(--core-line-strong); background: rgba(255, 255, 255, .035); transform: translateY(-1px); }
+.system-dock span { grid-row: 1 / 3; color: var(--core-green); font-family: var(--core-mono); font-size: 9px; }
+.system-dock strong { font-size: 14px; }
+.system-dock small { color: var(--core-quiet); font-size: 9px; }
+.settings-readiness { margin-top: 54px; scroll-margin-top: 88px; }
+.settings-section-head { max-width: 720px; margin-bottom: 24px; }
+.settings-section-head h2 { margin: 12px 0 9px; font-size: 32px; letter-spacing: -.04em; }
+.settings-section-head p { margin: 0; color: var(--core-muted); font-size: 12px; line-height: 1.65; }
 
 .setup-layout { display: grid; grid-template-columns: minmax(0, 1fr) minmax(340px, .72fr); gap: 14px; align-items: start; }
 .setup-form { display: grid; gap: 17px; }
@@ -294,6 +318,8 @@ body::before {
 
 @media (max-width: 1160px) {
   .metric-row { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .lane-list { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+  .lane-list article { border-bottom: 1px solid var(--core-line); }
   .command-roster-grid { grid-template-columns: repeat(3, minmax(0, 1fr)); }
   .product-launch-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
   .launch-card.assist { grid-column: 1 / -1; min-height: 240px; }
@@ -308,8 +334,8 @@ body::before {
   .core-topbar { padding-inline: 18px; }
   .core-topbar .mobile-brand { display: block; }
   .core-topbar { justify-content: flex-start; }
-  .mobile-brand .core-brand > span { display: none; }
-  .mobile-brand .core-brand img { width: 32px; height: 32px; }
+  .mobile-brand .core-brand-name { display: none; }
+  .core-topbar .terminal-prompt { display: none; }
   .topbar-meta { display: none !important; }
   .mobile-nav { position: sticky; top: 66px; z-index: 19; display: flex; overflow-x: auto; border-bottom: 1px solid var(--core-line); padding: 7px 14px; background: rgba(9, 13, 19, .9); scrollbar-width: none; }
   .mobile-nav a { min-height: 38px; display: inline-flex; flex: 0 0 auto; align-items: center; border-radius: 9px; padding: 0 11px; color: var(--core-quiet); font-size: 10px; font-weight: 720; text-decoration: none; }
@@ -334,6 +360,11 @@ body::before {
   .page-heading p { font-size: 13px; }
   .heading-actions, .heading-actions .core-button { width: 100%; }
   .metric-row { grid-template-columns: 1fr 1fr; gap: 8px; }
+  .lane-list, .system-dock { grid-template-columns: 1fr; }
+  .lane-list article { min-height: 96px; border-right: 0; }
+  .mode-switch { align-items: stretch; flex-wrap: wrap; }
+  .mode-switch > span { width: 100%; margin-bottom: 4px; }
+  .mode-switch button { flex: 1; }
   .metric-card { min-height: 112px; padding: 15px; }
   .metric-card > strong { font-size: 19px; }
   .metric-card small { font-size: 8px; }

--- a/showroom/src/index.css
+++ b/showroom/src/index.css
@@ -1,14 +1,14 @@
 :root {
-  color: #f4f7fb;
-  background: #090d13;
+  color: #f2f5f1;
+  background: #080a09;
   font-family: Geist, Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   color-scheme: dark;
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
-  --sm-bg: #090d13;
-  --sm-blue: #6b95ff;
-  --sm-green: #3dd6a2;
+  --sm-bg: #080a09;
+  --sm-blue: #7cf5b4;
+  --sm-green: #7cf5b4;
 }
 
 *, *::before, *::after { box-sizing: border-box; }
@@ -19,6 +19,6 @@ button, a { -webkit-tap-highlight-color: transparent; }
 button { cursor: pointer; }
 a { color: inherit; }
 img, svg { display: block; max-width: 100%; }
-::selection { background: rgba(107, 149, 255, .3); }
+::selection { background: rgba(124, 245, 180, .28); }
 :where(a, button, input, select, textarea):focus-visible { outline: 2px solid var(--sm-blue); outline-offset: 3px; }
 #root { min-height: 100vh; }

--- a/site-manifest.json
+++ b/site-manifest.json
@@ -1,37 +1,37 @@
 {
   "schemaVersion": "supermega.site-context.v1",
-  "contextVersion": "2026-07-22",
-  "catalogVersion": "2026-07-22.1",
+  "contextVersion": "2026-07-22.2",
+  "catalogVersion": "2026-07-22.2",
   "brand": {
     "name": "SuperMega",
     "domain": "supermega.dev",
-    "version": "terminal-2026-07",
+    "version": "terminal-v2-2026-07",
     "mark": "terminal",
     "colors": {
-      "background": "#090d13",
-      "blue": "#6b95ff",
-      "green": "#3dd6a2"
+      "background": "#080a09",
+      "accent": "#7cf5b4",
+      "ink": "#f2f5f1"
     }
   },
   "company": {
-    "positioning": "Operating software for Myanmar businesses.",
-    "statement": "SuperMega builds Shop and Plant—operating software for Myanmar businesses, with governed AI assistance inside the workflows.",
-    "headline": "Run your shop or plant from one clear system.",
-    "supporting": "Connect daily work, local payments, inventory, production, and approvals—with AI helping inside the workflow.",
+    "positioning": "The operating layer for ambitious companies.",
+    "statement": "SuperMega brings operations, governed agents, and accountable decisions into one company system.",
+    "headline": "Run the company from one clear system.",
+    "supporting": "Connect commerce, production, company work, and governed agents without losing ownership or evidence.",
     "publicPricing": false
   },
   "products": [
     {
       "id": "shop",
       "name": "Shop",
-      "route": "/shop/",
-      "status": "live-demo",
-      "eyebrow": "Commerce operating system",
-      "headline": "One operating system for the counter and the back office.",
-      "description": "Run sales, stock, customers, bookings, purchasing, payments, reports, and daily close without stitching together separate tools.",
+      "route": "/solutions/#shop",
+      "status": "available-in-app",
+      "eyebrow": "Commerce operations",
+      "headline": "One operating record from counter to close.",
+      "description": "Run sales, stock, local payments, purchasing, exceptions, and daily close without rebuilding context across separate tools.",
       "primaryCta": {
-        "label": "Open the Shop demo",
-        "url": "https://app.supermega.dev/shop/"
+        "label": "Open Shop workspace",
+        "url": "https://app.supermega.dev/operations/?view=shop"
       },
       "secondaryCta": {
         "label": "Configure Shop",
@@ -40,7 +40,7 @@
       "modules": [
         "Register and local payments",
         "Stock and purchasing",
-        "Customers and bookings",
+        "Customers and service",
         "Reports and daily close",
         "Roles, audit, backup and recovery",
         "Governed summaries and draft actions"
@@ -71,14 +71,14 @@
     {
       "id": "plant",
       "name": "Plant",
-      "route": "/plant/",
-      "status": "live-demo",
-      "eyebrow": "Production operating system",
+      "route": "/solutions/#plant",
+      "status": "available-in-app",
+      "eyebrow": "Production operations",
       "headline": "Give the factory floor one operational memory.",
-      "description": "Connect production plans, machine state, materials, quality, maintenance, issues, and management handoffs in one controlled system.",
+      "description": "Connect plans, machine state, materials, quality, maintenance, exceptions, and management handoffs in one controlled system.",
       "primaryCta": {
-        "label": "Open the Plant demo",
-        "url": "https://app.supermega.dev/plant/"
+        "label": "Open Plant workspace",
+        "url": "https://app.supermega.dev/operations/?view=plant"
       },
       "secondaryCta": {
         "label": "Configure Plant",
@@ -117,21 +117,22 @@
     }
   ],
   "pages": [
-    { "route": "/", "file": "index.html", "title": "SuperMega | Shop and Plant operating software" },
-    { "route": "/shop/", "file": "shop/index.html", "title": "Shop | SuperMega" },
-    { "route": "/plant/", "file": "plant/index.html", "title": "Plant | SuperMega" },
-    { "route": "/templates/", "file": "templates/index.html", "title": "Templates | SuperMega" },
+    { "route": "/", "file": "index.html", "title": "SuperMega | Company operating system" },
+    { "route": "/solutions/", "file": "solutions/index.html", "title": "System | SuperMega" },
     { "route": "/trust/", "file": "trust/index.html", "title": "Trust | SuperMega" },
     { "route": "/contact/", "file": "contact/index.html", "title": "Contact | SuperMega" },
     { "route": "/privacy/", "file": "privacy/index.html", "title": "Privacy | SuperMega" }
   ],
   "redirects": [
-    { "source": "^/work(?:/.*)?$", "destination": "/plant/" },
-    { "source": "^/(?:products?|offers|pricing|plans|packages)/?$", "destination": "/" },
-    { "source": "^/products/(?:retail|restaurant|store|shop)/?.*$", "destination": "/shop/" },
-    { "source": "^/products/(?:factory|operations|erp|plant)/?.*$", "destination": "/plant/" },
-    { "source": "^/(?:ai-agent-solutions|ai-agents|agents|agent-templates|workcell|machine|agentops)/?.*$", "destination": "/trust/#governed-ai" },
-    { "source": "^/(?:find-clients|company-list|receiving-control|receiving-log|founder-brief|reconcile)/?.*$", "destination": "/templates/" },
+    { "source": "^/shop(?:/.*)?$", "destination": "/solutions/#shop" },
+    { "source": "^/plant(?:/.*)?$", "destination": "/solutions/#plant" },
+    { "source": "^/templates(?:/.*)?$", "destination": "/solutions/#templates" },
+    { "source": "^/work(?:/.*)?$", "destination": "/solutions/#plant" },
+    { "source": "^/(?:products?|offers|pricing|plans|packages)/?$", "destination": "/solutions/" },
+    { "source": "^/products/(?:retail|restaurant|store|shop)/?.*$", "destination": "/solutions/#shop" },
+    { "source": "^/products/(?:factory|operations|erp|plant)/?.*$", "destination": "/solutions/#plant" },
+    { "source": "^/(?:ai-agent-solutions|ai-agents|agents|agent-templates|workcell|machine|agentops)/?.*$", "destination": "/solutions/#agents" },
+    { "source": "^/(?:find-clients|company-list|receiving-control|receiving-log|founder-brief|reconcile)/?.*$", "destination": "/solutions/#templates" },
     { "source": "^/(?:start|book|setup|get-started|intake)/?.*$", "destination": "/contact/" },
     { "source": "^/(?:app|login|clients)/?.*$", "destination": "https://app.supermega.dev/" },
     { "source": "^/demo/?$", "destination": "https://demo.supermega.dev/" }
@@ -141,7 +142,6 @@
     "Arcane",
     "Capsule",
     "M-rune",
-    "AI Agent Solutions",
     "Find Clients",
     "Company List",
     "Receiving Control",

--- a/tools/create_public_vercel_output.mjs
+++ b/tools/create_public_vercel_output.mjs
@@ -21,9 +21,6 @@ assert(Array.isArray(manifest.products) && manifest.products.length === 2, 'site
 assert(manifest.products.map((product) => product.id).join(',') === 'shop,plant', 'site_manifest_product_order_changed')
 assert(manifest.company?.publicPricing === false, 'public_pricing_must_remain_hidden')
 
-const products = new Map(manifest.products.map((product) => [product.id, product]))
-const shop = products.get('shop')
-const plant = products.get('plant')
 const brand = manifest.brand
 
 function escapeHtml(value) {
@@ -63,50 +60,50 @@ const release = {
   generatedAt: new Date().toISOString(),
 }
 
-const faviconSvg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="SuperMega terminal mark" shape-rendering="geometricPrecision"><rect x="2.5" y="2.5" width="59" height="59" rx="12" fill="${brand.colors.background}"/><rect x="3.25" y="3.25" width="57.5" height="57.5" rx="11.25" fill="none" stroke="#fff" stroke-opacity=".18"/><path d="M15 19 29 32 15 45" fill="none" stroke="${brand.colors.blue}" stroke-width="4.25" stroke-linecap="round" stroke-linejoin="round"/><path d="M36 45h14" fill="none" stroke="${brand.colors.green}" stroke-width="4.25" stroke-linecap="round"/></svg>\n`
+const faviconSvg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="SuperMega terminal mark" shape-rendering="geometricPrecision"><rect width="64" height="64" rx="8" fill="${brand.colors.background}"/><rect x="1" y="1" width="62" height="62" rx="7" fill="none" stroke="${brand.colors.ink}" stroke-opacity=".16"/><path d="M13 18 27 32 13 46" fill="none" stroke="${brand.colors.accent}" stroke-width="4.5" stroke-linecap="square" stroke-linejoin="miter"/><path d="M34 46h17" fill="none" stroke="${brand.colors.ink}" stroke-width="4.5" stroke-linecap="square"/></svg>\n`
 
 const sharedStyle = `
   :root {
     color-scheme: dark;
-    --bg: #080b10;
-    --bg-raised: #0d121a;
-    --panel: rgba(18, 25, 35, .82);
-    --panel-solid: #121923;
-    --panel-soft: #101720;
-    --ink: #f4f7fb;
-    --muted: #a4afbe;
-    --quiet: #748193;
-    --line: rgba(231, 239, 255, .13);
-    --line-strong: rgba(231, 239, 255, .23);
-    --blue: #6b95ff;
-    --blue-strong: #8cacff;
-    --green: #3dd6a2;
-    --green-soft: rgba(61, 214, 162, .12);
-    --blue-soft: rgba(107, 149, 255, .12);
-    --shadow: 0 30px 90px rgba(0, 0, 0, .38);
-    --radius: 22px;
+    --bg: #080a09;
+    --bg-raised: #0d100e;
+    --panel: rgba(15, 19, 16, .9);
+    --panel-solid: #101411;
+    --panel-soft: #0c100d;
+    --ink: #f2f5f1;
+    --muted: #a3ada6;
+    --quiet: #707b73;
+    --line: rgba(225, 238, 229, .13);
+    --line-strong: rgba(225, 238, 229, .24);
+    --blue: #7cf5b4;
+    --blue-strong: #a0ffcb;
+    --green: #7cf5b4;
+    --green-soft: rgba(124, 245, 180, .1);
+    --blue-soft: rgba(124, 245, 180, .1);
+    --shadow: 0 30px 90px rgba(0, 0, 0, .44);
+    --radius: 10px;
   }
   * { box-sizing: border-box; }
   html { min-width: 320px; scroll-behavior: smooth; background: var(--bg); }
   body { min-width: 320px; margin: 0; overflow-x: hidden; background: var(--bg); color: var(--ink); font-family: Geist, Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; line-height: 1.55; text-rendering: optimizeLegibility; }
-  body::before { position: fixed; inset: 0; z-index: -2; background: radial-gradient(circle at 18% -12%, rgba(107,149,255,.17), transparent 32%), radial-gradient(circle at 92% 12%, rgba(61,214,162,.09), transparent 25%), linear-gradient(180deg, #0a0e14 0, #080b10 42%, #090d13 100%); content: ""; }
-  body::after { position: fixed; inset: 0; z-index: -1; opacity: .18; pointer-events: none; background-image: linear-gradient(rgba(255,255,255,.025) 1px, transparent 1px), linear-gradient(90deg, rgba(255,255,255,.025) 1px, transparent 1px); background-size: 48px 48px; mask-image: linear-gradient(to bottom, #000, transparent 76%); content: ""; }
+  body::before { position: fixed; inset: 0; z-index: -2; background: radial-gradient(circle at 74% -18%, rgba(124,245,180,.1), transparent 34%), linear-gradient(180deg, #0a0d0b 0, #080a09 48%, #090c0a 100%); content: ""; }
+  body::after { position: fixed; inset: 0; z-index: -1; opacity: .16; pointer-events: none; background-image: linear-gradient(rgba(255,255,255,.025) 1px, transparent 1px), linear-gradient(90deg, rgba(255,255,255,.025) 1px, transparent 1px); background-size: 56px 56px; mask-image: linear-gradient(to bottom, #000, transparent 76%); content: ""; }
   a { color: inherit; }
   button, input, select, textarea { font: inherit; }
   img, svg { display: block; max-width: 100%; }
   .shell { min-height: 100svh; }
   .frame { width: min(calc(100% - 48px), 1200px); margin-inline: auto; }
-  .site-header { position: sticky; top: 0; z-index: 40; padding: 16px 0; background: linear-gradient(to bottom, rgba(8,11,16,.96), rgba(8,11,16,.72), transparent); backdrop-filter: blur(18px); }
-  .header-inner { min-height: 62px; display: flex; align-items: center; justify-content: space-between; gap: 18px; border: 1px solid var(--line); border-radius: 18px; padding: 8px 9px 8px 13px; background: rgba(13,18,26,.78); box-shadow: inset 0 1px rgba(255,255,255,.04), 0 18px 50px rgba(0,0,0,.2); }
-  .brand { display: inline-flex; min-height: 44px; align-items: center; gap: 11px; text-decoration: none; font-size: 17px; font-weight: 790; letter-spacing: -.02em; }
-  .brand img { width: 36px; height: 36px; }
-  .brand-domain { color: var(--quiet); font-weight: 620; }
+  .site-header { position: sticky; top: 0; z-index: 40; border-bottom: 1px solid var(--line); background: rgba(8,10,9,.88); backdrop-filter: blur(18px); }
+  .header-inner { min-height: 72px; display: flex; align-items: center; justify-content: space-between; gap: 18px; }
+  .brand { display: inline-flex; min-height: 44px; align-items: center; gap: 12px; text-decoration: none; font-size: 13px; font-weight: 820; letter-spacing: .08em; }
+  .brand-mark { color: var(--green); font-family: "SFMono-Regular", Consolas, monospace; font-size: 20px; letter-spacing: -.12em; }
+  .brand-name { color: var(--ink); }
   .nav { display: flex; min-width: 0; align-items: center; justify-content: flex-end; gap: 4px; }
   .nav-link { min-height: 44px; display: inline-flex; align-items: center; border-radius: 10px; padding: 0 11px; color: var(--muted); font-size: 13px; font-weight: 720; text-decoration: none; }
   .nav-link:hover, .nav-link[aria-current="page"] { background: rgba(255,255,255,.05); color: var(--ink); }
-  .button { min-height: 48px; display: inline-flex; align-items: center; justify-content: center; gap: 9px; border: 1px solid var(--line-strong); border-radius: 12px; padding: 0 18px; background: rgba(255,255,255,.035); color: var(--ink); font-size: 14px; font-weight: 780; text-decoration: none; transition: transform 160ms ease, border-color 160ms ease, background 160ms ease; }
+  .button { min-height: 48px; display: inline-flex; align-items: center; justify-content: center; gap: 9px; border: 1px solid var(--line-strong); border-radius: 6px; padding: 0 18px; background: rgba(255,255,255,.025); color: var(--ink); font-size: 13px; font-weight: 780; text-decoration: none; transition: transform 160ms ease, border-color 160ms ease, background 160ms ease; }
   .button:hover { transform: translateY(-1px); border-color: rgba(255,255,255,.34); background: rgba(255,255,255,.07); }
-  .button.primary { border-color: var(--blue); background: var(--blue); color: #07101f; box-shadow: 0 14px 34px rgba(107,149,255,.22); }
+  .button.primary { border-color: var(--green); background: var(--green); color: #07100a; box-shadow: 0 14px 34px rgba(124,245,180,.12); }
   .button.primary:hover { background: var(--blue-strong); }
   .button.compact { min-height: 44px; padding-inline: 15px; }
   .eyebrow { display: inline-flex; align-items: center; gap: 9px; color: var(--green); font-family: "SFMono-Regular", Consolas, monospace; font-size: 12px; font-weight: 760; letter-spacing: .04em; text-transform: uppercase; }
@@ -136,7 +133,7 @@ const sharedStyle = `
   .workspace-title { display: flex; align-items: flex-start; justify-content: space-between; gap: 12px; margin-bottom: 22px; }
   .workspace-title strong { font-size: 18px; }
   .workspace-title small { display: block; margin-top: 4px; color: var(--quiet); }
-  .live-pill, .status-pill { display: inline-flex; min-height: 28px; align-items: center; gap: 7px; border: 1px solid rgba(61,214,162,.24); border-radius: 999px; padding: 0 10px; background: var(--green-soft); color: var(--green); font-size: 10px; font-weight: 760; text-transform: uppercase; }
+  .live-pill, .status-pill { display: inline-flex; min-height: 28px; align-items: center; gap: 7px; border: 1px solid rgba(124,245,180,.24); border-radius: 4px; padding: 0 10px; background: var(--green-soft); color: var(--green); font-size: 10px; font-weight: 760; text-transform: uppercase; }
   .live-pill::before, .status-pill::before { width: 6px; height: 6px; border-radius: 50%; background: currentColor; content: ""; }
   .metric-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 10px; }
   .metric { min-height: 94px; border: 1px solid var(--line); border-radius: 13px; padding: 14px; background: rgba(255,255,255,.025); }
@@ -170,7 +167,7 @@ const sharedStyle = `
   .template-card p { color: var(--muted); }
   .template-card .card-link { margin-top: auto; }
   .product-label { display: inline-flex; min-height: 30px; align-items: center; border: 1px solid var(--line); border-radius: 999px; padding: 0 10px; color: var(--muted); font-size: 11px; font-weight: 760; }
-  .callout { display: grid; grid-template-columns: 1fr auto; gap: 34px; align-items: center; border: 1px solid rgba(107,149,255,.28); border-radius: var(--radius); padding: 36px; background: linear-gradient(120deg, rgba(107,149,255,.13), rgba(61,214,162,.055)); }
+  .callout { display: grid; grid-template-columns: 1fr auto; gap: 34px; align-items: center; border: 1px solid rgba(124,245,180,.25); border-radius: var(--radius); padding: 36px; background: linear-gradient(120deg, rgba(124,245,180,.09), rgba(124,245,180,.025)); }
   .callout p { max-width: 700px; margin: 0; color: var(--muted); }
   .steps { counter-reset: step; display: grid; gap: 0; border-top: 1px solid var(--line); }
   .step { counter-increment: step; display: grid; grid-template-columns: 54px 1fr; gap: 22px; border-bottom: 1px solid var(--line); padding: 25px 0; }
@@ -197,7 +194,7 @@ const sharedStyle = `
   label { display: grid; gap: 7px; color: var(--muted); font-size: 12px; font-weight: 700; }
   label.wide { grid-column: 1/-1; }
   input, select, textarea { width: 100%; min-width: 0; border: 1px solid var(--line); border-radius: 11px; padding: 13px 14px; background: #0c1118; color: var(--ink); outline: none; }
-  input:focus, select:focus, textarea:focus { border-color: var(--blue); box-shadow: 0 0 0 3px rgba(107,149,255,.13); }
+  input:focus, select:focus, textarea:focus { border-color: var(--green); box-shadow: 0 0 0 3px rgba(124,245,180,.1); }
   textarea { min-height: 150px; resize: vertical; }
   .form-note, .form-status { margin: 0; color: var(--quiet); font-size: 12px; }
   .form-status { min-height: 1.5em; color: var(--green); }
@@ -209,15 +206,34 @@ const sharedStyle = `
   .footer-links { display: flex; flex-wrap: wrap; justify-content: flex-end; gap: 18px; }
   .footer-links a { min-height: 44px; display: inline-flex; align-items: center; text-decoration: none; }
   .footer-links a:hover { color: var(--ink); }
-  :focus-visible { outline: 3px solid rgba(107,149,255,.46); outline-offset: 3px; }
+  .system-preview { transform: none; border-radius: 8px; }
+  .system-preview-body { padding: 28px; }
+  .system-kicker { margin-bottom: 18px; color: var(--quiet); font-family: "SFMono-Regular", Consolas, monospace; font-size: 10px; letter-spacing: .1em; }
+  .system-flow { display: grid; border-top: 1px solid var(--line); }
+  .system-row { min-height: 66px; display: grid; grid-template-columns: 34px 112px minmax(0, 1fr) 10px; gap: 12px; align-items: center; border-bottom: 1px solid var(--line); }
+  .system-row > span { color: var(--green); font-family: "SFMono-Regular", Consolas, monospace; font-size: 10px; }
+  .system-row strong { font-size: 13px; }
+  .system-row small { color: var(--quiet); font-size: 10px; }
+  .system-row i { width: 7px; height: 7px; background: var(--green); box-shadow: 0 0 14px rgba(124,245,180,.55); }
+  .system-boundary { display: grid; gap: 5px; margin-top: 22px; border-left: 2px solid var(--green); padding: 4px 0 4px 14px; }
+  .system-boundary span { color: var(--green); font-family: "SFMono-Regular", Consolas, monospace; font-size: 9px; letter-spacing: .08em; }
+  .system-boundary strong { color: var(--muted); font-size: 11px; font-weight: 650; }
+  .solution-stack { display: grid; gap: 16px; }
+  .solution-block { display: grid; grid-template-columns: minmax(0, .9fr) minmax(340px, 1.1fr); gap: 56px; align-items: start; border: 1px solid var(--line); border-radius: var(--radius); padding: 40px; background: rgba(255,255,255,.018); }
+  .solution-block h3 { margin-top: 24px; font-size: clamp(30px, 4vw, 48px); }
+  .solution-block p { color: var(--muted); }
+  .solution-modules { display: grid; border-top: 1px solid var(--line); }
+  .solution-modules span { min-height: 48px; display: grid; grid-template-columns: 32px 1fr; gap: 10px; align-items: center; border-bottom: 1px solid var(--line); color: var(--muted); font-size: 12px; }
+  .solution-modules i { color: var(--green); font-family: "SFMono-Regular", Consolas, monospace; font-size: 9px; font-style: normal; }
+  :focus-visible { outline: 3px solid rgba(124,245,180,.42); outline-offset: 3px; }
   @media (prefers-reduced-motion: reduce) { html { scroll-behavior: auto; } *, *::before, *::after { transition-duration: .01ms !important; } }
-  @media (max-width: 980px) { .hero { grid-template-columns: 1fr; gap: 48px; padding-top: 68px; } .hero-copy { max-width: 820px; } .workspace { transform: none; } .split { grid-template-columns: 1fr; gap: 42px; } .sticky-copy { position: static; } .principle-grid { grid-template-columns: repeat(2,minmax(0,1fr)); } .contact-layout { grid-template-columns: 1fr; gap: 42px; } }
-  @media (max-width: 760px) { .frame { width: min(calc(100% - 30px), 1200px); } .site-header { padding-top: 9px; } .header-inner { min-height: 58px; border-radius: 15px; padding-left: 10px; } .brand span { display: none; } .brand img { width: 34px; height: 34px; } .nav-link { padding-inline: 8px; } .nav-optional { display: none; } .header-cta { min-height: 42px; padding-inline: 13px; } .hero, .page-hero { padding-top: 64px; } .hero { padding-bottom: 78px; } .workspace-body { grid-template-columns: 1fr; min-height: 0; } .workspace-nav { display: none; } .workspace-main { padding: 16px; } .metric-grid { grid-template-columns: 1fr; } .metric { min-height: 76px; } .product-grid, .template-grid, .module-grid, .principle-grid, .case-grid { grid-template-columns: 1fr; } .section { padding: 76px 0; } .callout { grid-template-columns: 1fr; padding: 26px; } .contact-form { padding: 20px; } .field-grid { grid-template-columns: 1fr; } label.wide { grid-column: auto; } .prose section { grid-template-columns: 1fr; gap: 6px; } .footer-inner { display: grid; } .footer-links { justify-content: flex-start; } }
+  @media (max-width: 980px) { .hero { grid-template-columns: 1fr; gap: 48px; padding-top: 68px; } .hero-copy { max-width: 820px; } .workspace { transform: none; } .split, .solution-block { grid-template-columns: 1fr; gap: 42px; } .sticky-copy { position: static; } .principle-grid { grid-template-columns: repeat(2,minmax(0,1fr)); } .contact-layout { grid-template-columns: 1fr; gap: 42px; } }
+  @media (max-width: 760px) { .frame { width: min(calc(100% - 30px), 1200px); } .header-inner { min-height: 62px; } .brand-name { display: none; } .nav-link { padding-inline: 8px; } .nav-optional { display: none; } .header-cta { min-height: 42px; padding-inline: 13px; } .hero, .page-hero { padding-top: 64px; } .hero { padding-bottom: 78px; } .workspace-body { grid-template-columns: 1fr; min-height: 0; } .workspace-nav { display: none; } .workspace-main { padding: 16px; } .metric-grid { grid-template-columns: 1fr; } .metric { min-height: 76px; } .product-grid, .template-grid, .module-grid, .principle-grid, .case-grid { grid-template-columns: 1fr; } .solution-block { padding: 24px; } .system-preview-body { padding: 20px; } .system-row { grid-template-columns: 28px 92px minmax(0, 1fr); } .system-row i { display: none; } .section { padding: 76px 0; } .callout { grid-template-columns: 1fr; padding: 26px; } .contact-form { padding: 20px; } .field-grid { grid-template-columns: 1fr; } label.wide { grid-column: auto; } .prose section { grid-template-columns: 1fr; gap: 6px; } .footer-inner { display: grid; } .footer-links { justify-content: flex-start; } }
   @media (max-width: 420px) { .nav-link { display: none; } h1 { font-size: 43px; } .product-card { padding: 24px; } }
 `
 
 function brandHtml() {
-  return `<a class="brand" href="/" aria-label="SuperMega home"><img src="/favicon.svg" width="64" height="64" alt="" /><span>supermega<span class="brand-domain">.dev</span></span></a>`
+  return `<a class="brand" href="/" aria-label="SuperMega home"><span class="brand-mark" aria-hidden="true">&gt;_</span><span class="brand-name">SUPERMEGA</span></a>`
 }
 
 function navLink(route, label, currentRoute, optional = false) {
@@ -226,11 +242,11 @@ function navLink(route, label, currentRoute, optional = false) {
 }
 
 function headerHtml(currentRoute) {
-  return `<header class="site-header"><div class="frame header-inner">${brandHtml()}<nav class="nav" aria-label="Primary">${navLink(shop.route, 'Shop', currentRoute)}${navLink(plant.route, 'Plant', currentRoute)}${navLink('/templates/', 'Templates', currentRoute, true)}<a class="nav-link nav-optional" href="https://app.supermega.dev/assist/">Assist</a><a class="button primary compact header-cta" href="/contact/">Talk to us</a></nav></div></header>`
+  return `<header class="site-header"><div class="frame header-inner">${brandHtml()}<nav class="nav" aria-label="Primary">${navLink('/solutions/', 'System', currentRoute)}${navLink('/contact/', 'Contact', currentRoute, true)}<a class="button primary compact header-cta" href="https://app.supermega.dev/">Open app</a></nav></div></header>`
 }
 
 function footerHtml() {
-  return `<footer class="site-footer"><div class="frame footer-inner"><span>© ${new Date().getUTCFullYear()} SuperMega · Operating software for Myanmar businesses.</span><span class="footer-links"><a href="/shop/">Shop</a><a href="/plant/">Plant</a><a href="/templates/">Templates</a><a href="/trust/">Trust</a><a href="/contact/">Contact</a><a href="/privacy/">Privacy</a></span></div></footer>`
+  return `<footer class="site-footer"><div class="frame footer-inner"><span>© ${new Date().getUTCFullYear()} SuperMega · Company systems with accountable automation.</span><span class="footer-links"><a href="/solutions/">System</a><a href="/trust/">Trust</a><a href="/contact/">Contact</a><a href="/privacy/">Privacy</a><a href="https://app.supermega.dev/">App</a></span></div></footer>`
 }
 
 function documentHtml({ route, title, description, content, robots = 'index,follow' }) {
@@ -263,56 +279,46 @@ function documentHtml({ route, title, description, content, robots = 'index,foll
 </html>`
 }
 
-function workspacePreview(product) {
-  const isShop = product.id === 'shop'
-  const nav = isShop ? ['Register', 'Stock', 'Customers', 'Bookings', 'Reports', 'Daily close'] : ['Overview', 'Production', 'Machines', 'Materials', 'Quality', 'Handoff']
-  const metrics = isShop ? ['Counter ready', 'Stock connected', 'Close controlled'] : ['Plan visible', 'State recorded', 'Handoff ready']
-  const rows = isShop ? ['Sales and payment flow', 'Stock and reorder review', 'Owner close and exceptions'] : ['Production plan and output', 'Machine state and downtime', 'Material, quality and issues']
-  return `<div class="workspace" aria-label="${escapeHtml(product.name)} demonstration workspace">
-    <div class="workspace-bar"><span>&gt;_ ${escapeHtml(product.id)} / demo-workspace</span><span class="workspace-dots"><i></i><i></i><i></i></span></div>
-    <div class="workspace-body"><aside class="workspace-nav"><strong>${escapeHtml(product.name)}</strong>${nav.map((item, index) => `<span class="${index === 0 ? 'active' : ''}">${escapeHtml(item)}</span>`).join('')}</aside>
-    <div class="workspace-main"><div class="workspace-title"><div><strong>${escapeHtml(isShop ? 'Today’s operating view' : 'Current plant view')}</strong><small>Demonstration interface · no client data</small></div><span class="live-pill">Ready</span></div>
-    <div class="metric-grid">${metrics.map((item) => `<div class="metric"><span>Control</span><strong>${escapeHtml(item)}</strong></div>`).join('')}</div>
-    <div class="work-list">${rows.map((item, index) => `<div class="work-row"><span>${escapeHtml(item)}</span><span class="progress"><i style="width:${[88, 68, 78][index]}%"></i></span></div>`).join('')}</div></div></div>
+function workspacePreview() {
+  const rows = [
+    ['01', 'Command', 'Accountable work and decisions'],
+    ['02', 'Operations', 'Commerce and production records'],
+    ['03', 'Agents', 'Draft, inspect, and escalate'],
+    ['04', 'Controls', 'Approval, evidence, and recovery'],
+  ]
+  return `<div class="workspace system-preview" aria-label="SuperMega operating system preview">
+    <div class="workspace-bar"><span>&gt;_ supermega / company-system</span><span class="live-pill">Local trial</span></div>
+    <div class="system-preview-body">
+      <div class="system-kicker">ONE OPERATING LAYER</div>
+      <div class="system-flow">${rows.map(([index, title, copy]) => `<div class="system-row"><span>${index}</span><strong>${title}</strong><small>${copy}</small><i></i></div>`).join('')}</div>
+      <div class="system-boundary"><span>HUMAN CONTROL</span><strong>External sends · payments · publishing · production changes</strong></div>
+    </div>
   </div>`
-}
-
-function productCard(product, index) {
-  return `<article class="product-card ${escapeHtml(product.id)}"><span class="card-index">0${index + 1} / ${escapeHtml(product.status)}</span><h3>${escapeHtml(product.name)}</h3><p>${escapeHtml(product.description)}</p><a class="card-link" href="${escapeHtml(product.route)}">Explore ${escapeHtml(product.name)}</a></article>`
 }
 
 const homeHtml = documentHtml({
   route: '/',
-  title: 'SuperMega | Shop and Plant operating software',
+  title: 'SuperMega | Company operating system',
   description: manifest.company.statement,
   content: `<main>
-    <section class="frame hero"><div class="hero-copy"><span class="eyebrow">${escapeHtml(manifest.company.positioning)}</span><h1>${escapeHtml(manifest.company.headline)}</h1><p class="lede">${escapeHtml(manifest.company.supporting)}</p><div class="actions"><a class="button primary" href="/shop/">Explore Shop</a><a class="button" href="/plant/">Explore Plant</a></div><div class="hero-note"><span>Configured around real workflows</span><span>Human approval for consequential actions</span><span>No public pricing theatre</span></div></div>${workspacePreview(shop)}</section>
-    <section class="frame section" aria-labelledby="products-heading"><div class="section-head"><span class="eyebrow">Two operating systems</span><h2 id="products-heading">Start with the system closest to the work.</h2><p>One consistent SuperMega foundation, configured for commerce or production. Each implementation begins with a proven template and ends with an owned operating system.</p></div><div class="product-grid">${manifest.products.map(productCard).join('')}</div></section>
-    <section class="frame section"><div class="split"><div class="sticky-copy"><span class="eyebrow">Embedded intelligence</span><h2>AI helps inside the workflow.</h2><p class="lede">It can summarize, detect anomalies, prepare decisions, and draft next actions. Operators stay in control of sends, approvals, payments, and irreversible changes.</p><div class="actions"><a class="button" href="/trust/#governed-ai">See the trust boundary</a></div></div><div class="module-grid">${['Source-grounded summaries','Exception and anomaly review','Draft actions with evidence','Role-aware operating briefs','Approval before external action','Audit history and recovery'].map((item, index) => `<article class="module-card"><span>0${index + 1}</span><strong>${escapeHtml(item)}</strong></article>`).join('')}</div></div></section>
-    <section class="frame section"><div class="callout"><div><h2>Bring one workflow that still breaks.</h2><p>We will map it to Shop or Plant, choose the smallest useful template, and define a controlled path from demo to live operations.</p></div><a class="button primary" href="/contact/">Start the conversation</a></div></section>
+    <section class="frame hero"><div class="hero-copy"><span class="eyebrow">${escapeHtml(manifest.company.positioning)}</span><h1>${escapeHtml(manifest.company.headline)}</h1><p class="lede">${escapeHtml(manifest.company.supporting)}</p><div class="actions"><a class="button primary" href="https://app.supermega.dev/">Open the app</a><a class="button" href="/solutions/">See the system</a></div><div class="hero-note"><span>Real operating workflows</span><span>Evidence before action</span><span>Human authority where it matters</span></div></div>${workspacePreview()}</section>
+    <section class="frame section" aria-labelledby="system-heading"><div class="section-head"><span class="eyebrow">One system</span><h2 id="system-heading">Operations and agents share the same truth.</h2><p>Commerce and production records feed a company command layer. Governed agents inspect that evidence, prepare work, and stop at explicit authority boundaries.</p></div><div class="product-grid"><article class="product-card"><span class="card-index">01 / OPERATIONS</span><h3>Run the work</h3><p>Shop and Plant keep sales, stock, output, machines, issues, and handoffs in reviewable operating records.</p><a class="card-link" href="/solutions/#operations">Explore operations</a></article><article class="product-card plant"><span class="card-index">02 / AGENTS</span><h3>Scale the team</h3><p>Role-based agents organize, summarize, draft, and escalate while consequential actions remain owner-gated.</p><a class="card-link" href="/solutions/#agents">Explore agents</a></article></div></section>
+    <section class="frame section"><div class="split"><div class="sticky-copy"><span class="eyebrow">Built for control</span><h2>Move faster without pretending autonomy is authority.</h2><p class="lede">Every capability has a source boundary, a named owner, visible evidence, and a clear stop condition.</p><div class="actions"><a class="button" href="/trust/">Review the control model</a></div></div><div class="module-grid">${['Command queue','Commerce records','Production records','Governed agent briefs','Approval gates','Export and recovery'].map((item, index) => `<article class="module-card"><span>0${index + 1}</span><strong>${escapeHtml(item)}</strong></article>`).join('')}</div></div></section>
+    <section class="frame section"><div class="callout"><div><h2>Start with one broken workflow.</h2><p>We map the records, owners, decisions, and controls, then configure the smallest system that can prove the outcome.</p></div><a class="button primary" href="/contact/">Talk to SuperMega</a></div></section>
   </main>`,
 })
 
-function productPage(product) {
-  const isShop = product.id === 'shop'
-  return documentHtml({
-    route: product.route,
-    title: `${product.name} | SuperMega`,
-    description: product.description,
-    content: `<main><section class="frame hero"><div class="hero-copy"><span class="eyebrow">${escapeHtml(product.eyebrow)}</span><h1>${escapeHtml(product.headline)}</h1><p class="lede">${escapeHtml(product.description)}</p><div class="actions"><a class="button primary" href="${escapeHtml(product.primaryCta.url)}">${escapeHtml(product.primaryCta.label)}</a><a class="button" href="${escapeHtml(product.secondaryCta.url)}">${escapeHtml(product.secondaryCta.label)}</a></div><div class="hero-note"><span>Live isolated product demo</span><span>Configured for roles and approvals</span><span>Measured acceptance before go-live</span></div></div>${workspacePreview(product)}</section>
-      <section class="frame section"><div class="split"><div class="sticky-copy"><span class="eyebrow">Core system</span><h2>One flow from activity to control.</h2><p class="lede">The modules share the same records, roles, evidence, and operating history. Teams stop rebuilding context at every handoff.</p></div><div class="module-grid">${product.modules.map((module, index) => `<article class="module-card"><span>0${index + 1}</span><strong>${escapeHtml(module)}</strong></article>`).join('')}</div></div></section>
-      <section class="frame section"><div class="section-head"><span class="eyebrow">${escapeHtml(product.name)} templates</span><h2>Start proven. Configure the difference.</h2><p>Templates provide the initial information model, screens, roles, and acceptance path. Your actual workflow decides the final system.</p></div><div class="template-grid">${product.templates.map((template) => `<article class="template-card"><span class="product-label">${escapeHtml(product.name)}</span><h3>${escapeHtml(template.name)}</h3><p>${escapeHtml(template.outcome)}</p><a class="card-link" href="/contact/?product=${escapeHtml(product.id)}&amp;template=${escapeHtml(template.id)}">Configure this template</a></article>`).join('')}</div><div class="actions"><a class="button" href="/templates/">Compare every template</a></div></section>
-      <section class="frame section"><div class="split"><div><span class="eyebrow">Lifecycle</span><h2>Demo to dependable operation.</h2></div><div class="steps">${(isShop ? ['Choose the closest Shop template and branch model.','Configure catalogue, roles, local payments, rules, and opening data.','Validate register, stock, close, backup, and recovery with real operators.','Go live with monitoring and a named support boundary.','Add governed assistance after the workflow is stable.'] : ['Map plants, lines, machines, products, shifts, and approval roles.','Configure planning, records, materials, quality, maintenance, and handoff.','Run role-based acceptance with approved operational data.','Go live by plant or line with audit and recovery controls.','Add governed summaries and anomaly review after the workflow is stable.']).map((step) => `<article class="step"><div><strong>${escapeHtml(step)}</strong><p>Evidence and approval are recorded before the next stage.</p></div></article>`).join('')}</div></div></section>
-      <section class="frame section"><div class="callout"><div><h2>${isShop ? 'Open Shop now.' : 'Open the isolated Plant workspace.'}</h2><p>${isShop ? 'Use the live retail workspace, then tell us what your real counter, branch, and close need.' : 'Use generic production records to test jobs, output, machine state, issues, and handoff. No client data enters the public demo.'}</p></div><a class="button primary" href="${escapeHtml(product.primaryCta.url)}">${escapeHtml(product.primaryCta.label)}</a></div></section>
-    </main>`,
-  })
-}
-
-const templatesHtml = documentHtml({
-  route: '/templates/',
-  title: 'Templates | SuperMega',
-  description: 'Starting structures for Shop and Plant, configured around real operating workflows.',
-  content: `<main><section class="frame page-hero"><span class="eyebrow">Template library</span><h1>Starting structures, not boxed software.</h1><p class="lede">Choose the closest operating pattern. SuperMega configures data, roles, screens, approvals, integrations, and acceptance around how your team actually works.</p></section>${manifest.products.map((product) => `<section class="frame section"><div class="section-head"><span class="eyebrow">${escapeHtml(product.name)}</span><h2>${escapeHtml(product.eyebrow)}</h2><p>${escapeHtml(product.description)}</p></div><div class="template-grid">${product.templates.map((template) => `<article class="template-card"><span class="product-label">${escapeHtml(product.name)}</span><h3>${escapeHtml(template.name)}</h3><p>${escapeHtml(template.outcome)}</p><a class="card-link" href="/contact/?product=${escapeHtml(product.id)}&amp;template=${escapeHtml(template.id)}">Use this starting point</a></article>`).join('')}</div></section>`).join('')}<section class="frame section"><div class="callout"><div><h2>Your workflow does not need a perfect label.</h2><p>Send one example, screenshot, spreadsheet, or handoff. We will choose the closest base and show what needs configuration.</p></div><a class="button primary" href="/contact/?product=guide">Help me choose</a></div></section></main>`,
+const solutionsHtml = documentHtml({
+  route: '/solutions/',
+  title: 'System | SuperMega',
+  description: 'SuperMega unifies company command, commerce, production, governed agents, and control.',
+  content: `<main>
+    <section class="frame page-hero"><span class="eyebrow">The SuperMega system</span><h1>One operating layer. Four clear surfaces.</h1><p class="lede">Command coordinates the company. Operations holds the records. Agents prepare reviewable work. Controls preserve authority, evidence, and recovery.</p><div class="actions"><a class="button primary" href="https://app.supermega.dev/">Open the local trial</a><a class="button" href="/contact/">Configure a workspace</a></div></section>
+    <section class="frame section" id="operations"><div class="section-head"><span class="eyebrow">Operations</span><h2>Shop and Plant are operating modes, not separate brands.</h2><p>They share one visual system, one command layer, one approval model, and one implementation lifecycle.</p></div><div class="solution-stack">${manifest.products.map((product, index) => `<article class="solution-block" id="${escapeHtml(product.id)}"><div><span class="card-index">0${index + 1} / ${escapeHtml(product.eyebrow)}</span><h3>${escapeHtml(product.headline)}</h3><p>${escapeHtml(product.description)}</p><div class="actions"><a class="button primary" href="${escapeHtml(product.primaryCta.url)}">${escapeHtml(product.primaryCta.label)}</a><a class="button" href="${escapeHtml(product.secondaryCta.url)}">${escapeHtml(product.secondaryCta.label)}</a></div></div><div class="solution-modules">${product.modules.map((module, moduleIndex) => `<span><i>0${moduleIndex + 1}</i>${escapeHtml(module)}</span>`).join('')}</div></article>`).join('')}</div></section>
+    <section class="frame section" id="agents"><div class="split"><div class="sticky-copy"><span class="eyebrow">Governed agents</span><h2>A team machine with explicit boundaries.</h2><p class="lede">Product, engineering, operations, growth, and finance agents can organize queues, inspect approved sources, prepare drafts, and escalate uncertainty. They do not silently acquire authority.</p><div class="actions"><a class="button" href="https://app.supermega.dev/agents/">Open Agents</a><a class="button" href="/trust/#governed-ai">See the boundary</a></div></div><div class="steps"><article class="step"><div><strong>Observe approved records</strong><p>Sources and workspace scope are explicit.</p></div></article><article class="step"><div><strong>Prepare evidence-backed work</strong><p>Drafts retain the inputs used to produce them.</p></div></article><article class="step"><div><strong>Escalate uncertainty</strong><p>Missing data and conflicts become visible exceptions.</p></div></article><article class="step"><div><strong>Wait at the authority gate</strong><p>Sends, payments, publishing, and production changes require approval.</p></div></article></div></div></section>
+    <section class="frame section" id="templates"><div class="section-head"><span class="eyebrow">Starting templates</span><h2>Configure the difference. Keep the foundation.</h2><p>Templates accelerate discovery without pretending every business works the same way.</p></div><div class="template-grid">${manifest.products.flatMap((product) => product.templates.map((template) => `<article class="template-card"><span class="product-label">${escapeHtml(product.name)}</span><h3>${escapeHtml(template.name)}</h3><p>${escapeHtml(template.outcome)}</p><a class="card-link" href="/contact/?product=${escapeHtml(product.id)}&amp;template=${escapeHtml(template.id)}">Configure this base</a></article>`)).join('')}</div></section>
+    <section class="frame section"><div class="callout"><div><h2>Your workflow does not need a perfect label.</h2><p>Bring one example, screenshot, spreadsheet, or handoff. We will map it to the right operating base and control boundary.</p></div><a class="button primary" href="/contact/?product=guide">Map my workflow</a></div></section>
+  </main>`,
 })
 
 const trustHtml = documentHtml({
@@ -320,7 +326,7 @@ const trustHtml = documentHtml({
   title: 'Trust | SuperMega',
   description: 'How SuperMega handles governance, privacy, approvals, audit, and production rollout.',
   content: `<main><section class="frame page-hero"><span class="eyebrow">Trust and control</span><h1>Automation earns authority.</h1><p class="lede">Shop and Plant begin with clear data, role, approval, and recovery boundaries. Assistance expands only after the underlying workflow is observable and accepted.</p></section><section class="frame section"><div class="principle-grid">${[
-    ['Private by default','Client records and production workspaces are not public demo content.'],
+    ['Private by default','Client records and production workspaces are not public trial content.'],
     ['Least authority','People and automated helpers receive only the access required for the current task.'],
     ['Human approval','External sends, payments, approvals, and irreversible writes remain behind an explicit gate.'],
     ['Source grounded','Summaries and draft actions identify the records and evidence used to produce them.'],
@@ -329,13 +335,13 @@ const trustHtml = documentHtml({
   ].map(([title, body], index) => `<article class="principle-card"><span class="card-index">0${index + 1}</span><h3>${escapeHtml(title)}</h3><p>${escapeHtml(body)}</p></article>`).join('')}</div></section><section class="frame section" id="governed-ai"><div class="split"><div><span class="eyebrow">Governed assistance</span><h2>AI is a capability, not an unsupervised employee.</h2><p class="lede">It helps teams inspect, summarize, compare, and prepare. The system preserves evidence and routes consequential actions to the responsible person.</p></div><div class="steps"><article class="step"><div><strong>Read approved sources</strong><p>The source boundary is explicit and can be revoked.</p></div></article><article class="step"><div><strong>Prepare reviewable output</strong><p>Claims, exceptions, and proposed actions retain their supporting context.</p></div></article><article class="step"><div><strong>Escalate uncertainty</strong><p>Missing evidence and conflicting data become visible exceptions.</p></div></article><article class="step"><div><strong>Wait for approval</strong><p>Consequential work does not silently cross the human control boundary.</p></div></article></div></div></section><section class="frame section"><div class="callout"><div><h2>Need a security or deployment review?</h2><p>Tell us the systems, data classes, roles, and controls your implementation must satisfy.</p></div><a class="button primary" href="/contact/?from=trust">Talk through the boundary</a></div></section></main>`,
 })
 
-const contactScript = `<script>(function(){var form=document.querySelector('[data-contact-form]');if(!form)return;var query=new URLSearchParams(location.search),status=form.querySelector('[data-form-status]'),submit=form.querySelector('button[type="submit"]'),product=form.querySelector('[name="product"]'),template=form.querySelector('[name="template"]'),requestKey=form.querySelector('[name="idempotency_key"]'),source=form.querySelector('[name="source_url"]'),referrer=form.querySelector('[name="referrer"]');function newKey(){if(window.crypto&&crypto.randomUUID)return crypto.randomUUID();var bytes=new Uint8Array(24);crypto.getRandomValues(bytes);return Array.from(bytes,function(value){return value.toString(16).padStart(2,'0')}).join('')}if(query.get('product')&&product)product.value=query.get('product');if(query.get('template')&&template)template.value=query.get('template');form.addEventListener('submit',async function(event){event.preventDefault();status.textContent='Sending…';submit.disabled=true;if(!requestKey.value)requestKey.value=newKey();source.value=location.href;referrer.value=document.referrer||'';var payload=Object.fromEntries(new FormData(form).entries());try{var response=await fetch('/api/contact-submissions',{method:'POST',headers:{'content-type':'application/json','accept':'application/json','x-idempotency-key':requestKey.value},body:JSON.stringify(payload)});var body=await response.json().catch(function(){return {};});if(!response.ok)throw new Error(body.reason||'send_failed');form.reset();requestKey.value='';status.textContent='Request received. We will reply with the clearest next step.';}catch(error){status.textContent=error&&error.message==='rate_limited'?'Too many requests from this connection. Please wait ten minutes or email swanhtet@supermega.dev.':'Could not route the request here. Email swanhtet@supermega.dev.';}finally{submit.disabled=false;}});})();</script>`
+const contactScript = `<script>(function(){var form=document.querySelector('[data-contact-form]');if(!form)return;var query=new URLSearchParams(location.search),status=form.querySelector('[data-form-status]'),submit=form.querySelector('button[type="submit"]'),product=form.querySelector('[name="product"]'),template=form.querySelector('[name="template"]'),requestKey=form.querySelector('[name="idempotency_key"]'),source=form.querySelector('[name="source_url"]'),referrer=form.querySelector('[name="referrer"]');function newKey(){if(window.crypto&&crypto.randomUUID)return crypto.randomUUID();var bytes=new Uint8Array(24);crypto.getRandomValues(bytes);return Array.from(bytes,function(value){return value.toString(16).padStart(2,'0')}).join('')}if(query.get('product')&&product)product.value=query.get('product');if(query.get('template')&&template)template.value=query.get('template');form.addEventListener('submit',async function(event){event.preventDefault();status.textContent='Sending...';submit.disabled=true;if(!requestKey.value)requestKey.value=newKey();source.value=location.href;referrer.value=document.referrer||'';var payload=Object.fromEntries(new FormData(form).entries());try{var response=await fetch('/api/contact-submissions',{method:'POST',headers:{'content-type':'application/json','accept':'application/json','x-idempotency-key':requestKey.value},body:JSON.stringify(payload)});var body=await response.json().catch(function(){return {};});if(!response.ok)throw new Error(body.reason||'send_failed');form.reset();requestKey.value='';status.textContent='Request received. We will reply with the clearest next step.';}catch(error){status.textContent=error&&error.message==='rate_limited'?'Too many requests from this connection. Please wait ten minutes or email swanhtet@supermega.dev.':'Could not route the request here. Email swanhtet@supermega.dev.';}finally{submit.disabled=false;}});})();</script>`
 
 const contactHtml = documentHtml({
   route: '/contact/',
   title: 'Contact | SuperMega',
-  description: 'Tell SuperMega which Shop or Plant workflow should run better.',
-  content: `<main class="frame"><section class="page-hero"><span class="eyebrow">Direct contact</span><h1>What should run better?</h1><p class="lede">Send one real workflow, screenshot, spreadsheet, or recurring handoff. We will reply with the smallest useful next step.</p></section><section class="contact-layout"><div class="contact-copy"><h2>Start with the work.</h2><p>No account, data connection, automation, or external action begins from this form. We first identify the product, template, and approval boundary.</p><div class="direct-links"><a href="mailto:swanhtet@supermega.dev"><span>Email</span><strong>swanhtet@supermega.dev →</strong></a><a href="tel:+9595000721"><span>Phone</span><strong>+95 9 500 0721 →</strong></a></div></div><form class="contact-form" action="/api/contact-submissions" method="post" data-contact-form><h3>Send the workflow</h3><div class="field-grid"><label>Name<input name="name" autocomplete="name" required maxlength="120" /></label><label>Work email<input name="email" type="email" autocomplete="email" required maxlength="180" /></label><label class="wide">Company<input name="company" autocomplete="organization" required maxlength="180" /></label><label>Starting point<select name="product"><option value="guide">Help me choose</option><option value="shop">Shop</option><option value="plant">Plant</option></select></label><label>Template, if known<input name="template" maxlength="120" /></label><label class="wide">What happens now, and what should be better?<textarea name="goal" required maxlength="4000"></textarea></label></div><input type="hidden" name="source_url" /><input type="hidden" name="referrer" /><input type="hidden" name="idempotency_key" /><input name="website" tabindex="-1" autocomplete="off" style="position:absolute;left:-9999px" /><button class="button primary" type="submit">Send request</button><p class="form-note">Your note is used only to respond and prepare the agreed next step.</p><p class="form-status" data-form-status aria-live="polite"></p></form></section></main>${contactScript}`,
+  description: 'Tell SuperMega which company workflow should run better.',
+  content: `<main class="frame"><section class="page-hero"><span class="eyebrow">Start a system</span><h1>What should run better?</h1><p class="lede">Send one real workflow, screenshot, spreadsheet, or recurring handoff. We will reply with the smallest useful system step.</p></section><section class="contact-layout"><div class="contact-copy"><h2>Start with the work.</h2><p>No account, data connection, automation, or external action begins from this form. We first identify the operating records, owner, acceptance test, and authority boundary.</p><div class="direct-links"><a href="mailto:swanhtet@supermega.dev"><span>Email</span><strong>swanhtet@supermega.dev &gt;</strong></a><a href="tel:+9595000721"><span>Phone</span><strong>+95 9 500 0721 &gt;</strong></a></div></div><form class="contact-form" action="/api/contact-submissions" method="post" data-contact-form><h3>Send the workflow</h3><div class="field-grid"><label>Name<input name="name" autocomplete="name" required maxlength="120" /></label><label>Work email<input name="email" type="email" autocomplete="email" required maxlength="180" /></label><label class="wide">Company<input name="company" autocomplete="organization" required maxlength="180" /></label><label>Starting point<select name="product"><option value="guide">Help me choose</option><option value="company-system">Company system</option><option value="shop">Shop operations</option><option value="plant">Plant operations</option><option value="agents">Governed agents</option></select></label><label>Template, if known<input name="template" maxlength="120" /></label><label class="wide">What happens now, and what should be better?<textarea name="goal" required maxlength="4000"></textarea></label></div><input type="hidden" name="source_url" /><input type="hidden" name="referrer" /><input type="hidden" name="idempotency_key" /><input name="website" tabindex="-1" autocomplete="off" style="position:absolute;left:-9999px" /><button class="button primary" type="submit">Send workflow</button><p class="form-note">Your note is used only to respond and prepare the agreed next step.</p><p class="form-status" data-form-status aria-live="polite"></p></form></section></main>${contactScript}`,
 })
 
 const privacyHtml = documentHtml({
@@ -350,7 +356,7 @@ const notFoundHtml = documentHtml({
   title: 'Page not found | SuperMega',
   description: 'The requested SuperMega route does not exist.',
   robots: 'noindex,nofollow',
-  content: `<main class="frame"><section class="page-hero"><span class="eyebrow">404 / route retired</span><h1>That page is no longer part of SuperMega.</h1><p class="lede">Return to the current company site, Shop, Plant, or the template library.</p><div class="actions"><a class="button primary" href="/">Home</a><a class="button" href="/shop/">Shop</a><a class="button" href="/plant/">Plant</a></div></section></main>`,
+  content: `<main class="frame"><section class="page-hero"><span class="eyebrow">404 / route retired</span><h1>That page is no longer part of SuperMega.</h1><p class="lede">Return to the company site, review the system, or open the app.</p><div class="actions"><a class="button primary" href="/">Home</a><a class="button" href="/solutions/">System</a><a class="button" href="https://app.supermega.dev/">Open app</a></div></section></main>`,
 })
 
 const healthFunction = `'use strict'
@@ -424,7 +430,7 @@ function normalizePayload(payload) {
     name: text(payload.name, 120),
     email: text(payload.email, 180).toLowerCase(),
     company: text(payload.company, 180),
-    product: ['shop', 'plant', 'guide'].includes(requestedProduct) ? requestedProduct : 'guide',
+    product: ['shop', 'plant', 'agents', 'company-system', 'guide'].includes(requestedProduct) ? requestedProduct : 'guide',
     template: text(payload.template, 120),
     goal: text(payload.goal, 4000),
     source_url: text(payload.source_url, 700),
@@ -595,9 +601,7 @@ module.exports = async function handler(req, res) {
 
 const pageFiles = new Map([
   ['index.html', homeHtml],
-  ['shop/index.html', productPage(shop)],
-  ['plant/index.html', productPage(plant)],
-  ['templates/index.html', templatesHtml],
+  ['solutions/index.html', solutionsHtml],
   ['trust/index.html', trustHtml],
   ['contact/index.html', contactHtml],
   ['privacy/index.html', privacyHtml],

--- a/tools/verify_app_build.mjs
+++ b/tools/verify_app_build.mjs
@@ -20,7 +20,7 @@ async function walk(directory) {
   return files
 }
 
-for (const route of ['', 'shop', 'plant', 'assist', 'setup', 'trust']) {
+for (const route of ['', 'operations', 'agents', 'settings']) {
   const page = resolve(dist, route, 'index.html')
   if (!await exists(page)) fail(`missing_route:${route || '/'}`)
 }
@@ -38,18 +38,18 @@ const manifestPath = resolve(dist, 'site.webmanifest')
 if (!await exists(faviconPath)) fail('missing_terminal_favicon')
 else {
   const favicon = await readFile(faviconPath, 'utf8')
-  if (!favicon.includes('SuperMega terminal mark') || !favicon.includes('#6b95ff') || !favicon.includes('#3dd6a2')) fail('wrong_terminal_favicon')
+  if (!favicon.includes('SuperMega terminal mark') || !favicon.includes('#7cf5b4') || !favicon.includes('#f2f5f1')) fail('wrong_terminal_favicon')
 }
 if (!await exists(manifestPath)) fail('missing_app_webmanifest')
 else {
   const webmanifest = JSON.parse(await readFile(manifestPath, 'utf8'))
-  if (webmanifest.name !== 'SuperMega Operating Workspace' || webmanifest.icons?.[0]?.src !== '/favicon.svg') fail('wrong_app_webmanifest')
+  if (webmanifest.name !== 'SuperMega Company OS' || webmanifest.icons?.[0]?.src !== '/favicon.svg') fail('wrong_app_webmanifest')
 }
 
 const files = await walk(dist)
 const textFiles = files.filter((path) => /\.(?:html|js|css|json|svg)$/.test(path))
 const corpus = (await Promise.all(textFiles.map((path) => readFile(path, 'utf8')))).join('\n')
-for (const required of ['SuperMega', 'Shop', 'Plant', 'Evidence first', '#6b95ff', '#3dd6a2']) {
+for (const required of ['SUPERMEGA', 'Operations', 'Agents', 'Local trial', '#7cf5b4', '#f2f5f1']) {
   if (!corpus.includes(required)) fail(`missing_context:${required}`)
 }
 for (const forbidden of ['pos.supermega.dev', 'ytf.supermega.dev', 'Yangon Tyre', 'ytf-plant-a', 'Company Systems That Replace Tool Sprawl']) {
@@ -66,4 +66,4 @@ if (failures.length) {
   console.error(JSON.stringify({ ok: false, contract: 'supermega_app_build', failures }, null, 2))
   process.exit(1)
 }
-console.log(JSON.stringify({ ok: true, contract: 'supermega_app_build', routes: 6, bytes }, null, 2))
+console.log(JSON.stringify({ ok: true, contract: 'supermega_app_build', routes: 4, bytes }, null, 2))

--- a/tools/verify_app_release_live.mjs
+++ b/tools/verify_app_release_live.mjs
@@ -6,7 +6,7 @@ const expectedCommit = String(process.env.EXPECTED_RELEASE_COMMIT || '').trim()
 const protectedPreview = process.env.VERCEL_PROTECTED_PREVIEW === '1'
 const vercelToken = String(process.env.VERCEL_TOKEN || '').trim()
 const cliEnv = vercelToken ? { ...process.env, VERCEL_TOKEN: vercelToken } : process.env
-const routes = ['/', '/shop/', '/plant/', '/assist/', '/setup/', '/trust/']
+const routes = ['/', '/operations/', '/agents/', '/settings/']
 
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
 
@@ -82,7 +82,7 @@ const rootHtml = pages.get('/')
 const scriptPaths = [...rootHtml.matchAll(/<script[^>]+src="([^"]+)"/g)].map((match) => match[1])
 const cssPaths = [...rootHtml.matchAll(/<link[^>]+href="([^"]+\.css)"/g)].map((match) => match[1])
 const assetCorpus = (await Promise.all([...scriptPaths, ...cssPaths].map(async (path) => (await get(path)).body))).join('\n')
-for (const required of ['Shop', 'Plant', 'Evidence first', '#6b95ff', '#3dd6a2']) {
+for (const required of ['Operations', 'Agents', 'Local trial', '#7cf5b4', '#f2f5f1']) {
   if (!assetCorpus.includes(required)) throw new Error(`missing_live_context:${required}`)
 }
 for (const forbidden of ['pos.supermega.dev', 'ytf.supermega.dev', 'Yangon Tyre', 'ytf-plant-a']) {

--- a/tools/verify_public_release_live.mjs
+++ b/tools/verify_public_release_live.mjs
@@ -41,9 +41,9 @@ async function readPage(route) {
     `meta name="supermega-brand-version" content="${manifest.brand.version}"`,
     `meta name="supermega-context-version" content="${manifest.contextVersion}"`,
     'aria-label="SuperMega home"',
-    'href="/shop/"',
-    'href="/plant/"',
-    'href="/contact/">Talk to us</a>',
+    '<span class="brand-mark" aria-hidden="true">&gt;_</span>',
+    'href="/solutions/"',
+    'href="https://app.supermega.dev/">Open app</a>',
   ]) assert(html.includes(token), 'page_shared_contract_missing', { route, token })
   for (const token of manifest.retiredPublicNames) assert(!html.toLowerCase().includes(token.toLowerCase()), 'retired_context_live', { route, token })
   return html
@@ -68,9 +68,10 @@ async function verifyOnce() {
   const pageResults = await Promise.all(manifest.pages.map(async (page) => [page.route, await readPage(page.route)]))
   const pages = new Map(pageResults)
   assert(pages.get('/')?.includes(manifest.company.headline), 'homepage_headline_wrong')
-  assert(pages.get('/shop/')?.includes('https://app.supermega.dev/shop/'), 'shop_live_demo_wrong')
-  assert(pages.get('/plant/')?.includes('https://app.supermega.dev/plant/'), 'plant_live_demo_wrong')
-  assert(pages.get('/templates/')?.includes('Starting structures, not boxed software.'), 'template_catalog_missing')
+  assert(pages.get('/solutions/')?.includes('https://app.supermega.dev/operations/?view=shop'), 'shop_workspace_wrong')
+  assert(pages.get('/solutions/')?.includes('https://app.supermega.dev/operations/?view=plant'), 'plant_workspace_wrong')
+  assert(pages.get('/solutions/')?.includes('Configure the difference. Keep the foundation.'), 'template_catalog_missing')
+  assert(pages.get('/solutions/')?.includes('https://app.supermega.dev/agents/'), 'agents_workspace_wrong')
   assert(pages.get('/trust/')?.includes('id="governed-ai"'), 'governed_ai_boundary_missing')
 
   const [{ body: release, headers: releaseHeaders }, { body: health }, { body: contact }] = await Promise.all([
@@ -89,10 +90,10 @@ async function verifyOnce() {
   assert(contact.controls?.idempotency === 'required' && contact.controls?.edge_rate_limit === 'required', 'contact_controls_wrong', contact)
 
   await Promise.all([
-    verifyRedirect('/products/shop/', '/shop/'),
-    verifyRedirect('/products/factory/', '/plant/'),
-    verifyRedirect('/ai-agent-solutions/', '/trust/#governed-ai'),
-    verifyRedirect('/offers/', '/'),
+    verifyRedirect('/products/shop/', '/solutions/#shop'),
+    verifyRedirect('/products/factory/', '/solutions/#plant'),
+    verifyRedirect('/ai-agent-solutions/', '/solutions/#agents'),
+    verifyRedirect('/offers/', '/solutions/'),
   ])
 
   const www = await fetch('https://www.supermega.dev/', { redirect: 'follow', cache: 'no-store', headers: { 'user-agent': 'SuperMegaVerifiedRelease/2.0' }, signal: AbortSignal.timeout(timeoutMs) })

--- a/tools/verify_public_vercel_output.mjs
+++ b/tools/verify_public_vercel_output.mjs
@@ -58,14 +58,12 @@ const sharedRequired = [
   `data-brand-version="${manifest.brand.version}"`,
   'href="/favicon.svg?v=',
   'aria-label="SuperMega home"',
-  '<span>supermega<span class="brand-domain">.dev</span></span>',
-  'href="/shop/"',
-  'href="/plant/"',
-  'href="/templates/"',
-  'href="https://app.supermega.dev/assist/"',
-  'href="/contact/">Talk to us</a>',
+  '<span class="brand-mark" aria-hidden="true">&gt;_</span>',
+  '<span class="brand-name">SUPERMEGA</span>',
+  'href="/solutions/"',
+  'href="https://app.supermega.dev/">Open app</a>',
   'href="/trust/">Trust</a>',
-  'Operating software for Myanmar businesses.',
+  'Company systems with accountable automation.',
 ]
 
 const forbiddenCopy = [
@@ -104,48 +102,31 @@ const home = pages.get('/')?.html || ''
 for (const token of [
   manifest.company.headline,
   manifest.company.supporting,
-  'Two operating systems',
-  'Explore Shop',
-  'Explore Plant',
-  'AI helps inside the workflow.',
-  'Human approval for consequential actions',
-  'Bring one workflow that still breaks.',
+  'Operations and agents share the same truth.',
+  'Run the work',
+  'Scale the team',
+  'Move faster without pretending autonomy is authority.',
+  'Start with one broken workflow.',
 ]) {
   if (!home.includes(token)) fail('homepage_contract_missing', { token })
 }
 
-const shop = pages.get('/shop/')?.html || ''
+const solutions = pages.get('/solutions/')?.html || ''
 for (const token of [
-  'One operating system for the counter and the back office.',
-  'https://app.supermega.dev/shop/',
-  'Open the Shop demo',
-  'Live isolated product demo',
-  'Register and local payments',
-  'Roles, audit, backup and recovery',
+  'One operating layer. Four clear surfaces.',
+  'Shop and Plant are operating modes, not separate brands.',
+  'https://app.supermega.dev/operations/?view=shop',
+  'https://app.supermega.dev/operations/?view=plant',
+  'https://app.supermega.dev/agents/',
+  'A team machine with explicit boundaries.',
+  'Configure the difference. Keep the foundation.',
 ]) {
-  if (!shop.includes(token)) fail('shop_contract_missing', { token })
+  if (!solutions.includes(token)) fail('solutions_contract_missing', { token })
 }
-if (shop.includes('pos.supermega.dev')) fail('shop_points_to_retired_pos')
-
-const plant = pages.get('/plant/')?.html || ''
-for (const token of [
-  'Give the factory floor one operational memory.',
-  'Open the Plant demo',
-  'https://app.supermega.dev/plant/',
-  '/contact/?product=plant',
-  'Live isolated product demo',
-  'Quality and traceability',
-  'No client data enters the public demo.',
-]) {
-  if (!plant.includes(token)) fail('plant_contract_missing', { token })
-}
-if (/https:\/(?:\/)?(?:ytf|pos)\.supermega\.dev/i.test(plant)) fail('plant_exposes_retired_workspace')
-
-const templates = pages.get('/templates/')?.html || ''
 for (const product of manifest.products) {
   for (const template of product.templates) {
     for (const token of [template.name, template.outcome, `product=${product.id}&amp;template=${template.id}`]) {
-      if (!templates.includes(token)) fail('template_catalog_missing', { product: product.id, template: template.id, token })
+      if (!solutions.includes(token)) fail('template_catalog_missing', { product: product.id, template: template.id, token })
     }
   }
 }
@@ -166,7 +147,7 @@ for (const token of ['Contact requests', 'Product data', 'AI processing', 'Delet
 }
 
 const favicon = readStatic('favicon.svg')
-for (const token of ['SuperMega terminal mark', manifest.brand.colors.background, manifest.brand.colors.blue, manifest.brand.colors.green]) {
+for (const token of ['SuperMega terminal mark', manifest.brand.colors.background, manifest.brand.colors.accent, manifest.brand.colors.ink]) {
   if (!favicon.includes(token)) fail('brand_mark_contract_missing', { token })
 }
 

--- a/tools/write_app_release_metadata.mjs
+++ b/tools/write_app_release_metadata.mjs
@@ -15,20 +15,20 @@ const release = {
 }
 
 const favicon = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="SuperMega terminal mark" shape-rendering="geometricPrecision">
-  <rect x="2.5" y="2.5" width="59" height="59" rx="12" fill="#090d13" />
-  <rect x="3.25" y="3.25" width="57.5" height="57.5" rx="11.25" fill="none" stroke="#fff" stroke-opacity=".18" />
-  <path d="M15 19 29 32 15 45" fill="none" stroke="#6b95ff" stroke-width="4.25" stroke-linecap="round" stroke-linejoin="round" />
-  <path d="M36 45h14" fill="none" stroke="#3dd6a2" stroke-width="4.25" stroke-linecap="round" />
+  <rect width="64" height="64" rx="8" fill="${manifest.brand.colors.background}" />
+  <rect x="1" y="1" width="62" height="62" rx="7" fill="none" stroke="${manifest.brand.colors.ink}" stroke-opacity=".16" />
+  <path d="M13 18 27 32 13 46" fill="none" stroke="${manifest.brand.colors.accent}" stroke-width="4.5" stroke-linecap="square" stroke-linejoin="miter" />
+  <path d="M34 46h17" fill="none" stroke="${manifest.brand.colors.ink}" stroke-width="4.5" stroke-linecap="square" />
 </svg>
 `
 const webmanifest = {
-  name: 'SuperMega Operating Workspace',
+  name: 'SuperMega Company OS',
   short_name: 'SuperMega',
-  description: 'Shop and Plant operating software with governed assistance.',
+  description: 'Company operations and governed agents in one accountable system.',
   start_url: '/',
   display: 'standalone',
-  background_color: '#090d13',
-  theme_color: '#090d13',
+  background_color: manifest.brand.colors.background,
+  theme_color: manifest.brand.colors.background,
   icons: [{ src: '/favicon.svg', sizes: 'any', type: 'image/svg+xml', purpose: 'any' }],
 }
 


### PR DESCRIPTION
## What
- replaces the stale orange/blue identity with the shared `>_ SUPERMEGA` system
- reduces the public site to five routes and the operating app to four areas
- combines Shop, Plant, agent work, and controls into one honest company-system story
- redirects legacy URLs and updates release verification to enforce the new information architecture

## Why
The domains were correctly routed, but the source UI was inconsistent, over-expanded, and made the app feel like a disconnected demo. This fixes the product and release contracts at their source.

## Validation
- `npm.cmd --prefix showroom run lint`
- `npm.cmd run app:build` (31 workflow + 30 security checks)
- `npm.cmd run public:prebuilt` (45 contact checks)
- `npm.cmd run vercel:guard`
- `.venv\Scripts\python.exe -m unittest discover -s tests -p 'test_*.py' -v` (42 tests)
- desktop/mobile visual audit and full Shop -> Agents -> Settings workflow audit