### PR TITLE
Ship controlled Ecommerce completion and bounded Agent Teams

### DIFF
--- a/CURRENT.md
+++ b/CURRENT.md
@@ -11,7 +11,7 @@ SuperMega competes on implementation readiness, local operating context, evidenc
 
 The portfolio has three operating products and two local product prototypes inside one application:
 
-1. **Company system** — Today plus Product, Engineering, Growth, and Finance team workspaces.
+1. **Company system** — Today plus Product, Engineering, Growth, and Finance team workspaces, including an internal bounded-agent roster and handoff view.
 2. **Website** — finite page/content workflow, responsive preview, evidence, and explicit publish approval; currently local prototype only.
 3. **Ecommerce & Orders** — website/channel intake, catalogue, stock, fulfilment, payment status, and audit; currently local prototype only.
 4. **Commerce** — customer channel, order, stock, fulfilment, payment, follow-up, and close.
@@ -32,7 +32,8 @@ AI is an embedded execution capability. It may inspect approved records, organiz
 Canonical host: `app.supermega.dev`
 
 - `/` — **Today**: company work, customer orders, production exceptions, release readiness, briefs, and owner decisions.
-- `/work/?team=product&view=board` — **Teams**: Product, Engineering, Growth, and Finance workspaces.
+- `/work/?team=product&view=work` — **Teams**: accountable work for Product, Engineering, Growth, and Finance.
+- `/work/?team=engineering&view=agents` — **Agent Teams**: internal role, capability, assignment, evidence, human-owner, and approval-boundary records inside Teams; not another product or public route.
 - `/products/website/` — **Website**: lazy-loaded local content, navigation, preview, readiness, and approval prototype.
 - `/products/ecommerce/` — **Ecommerce & Orders**: lazy-loaded local order, catalogue, fulfilment, payment-status, and guided-demo prototype.
 - `/operations/commerce/?tab=today` — **Commerce**: channel orders, fulfilment, stock, local payment, and daily close.
@@ -53,7 +54,7 @@ Product is the first complete company-team workspace:
 4. **Release** — pass explicit checks and preserve release identity.
 5. **Learn** — record usage evidence and the next decision.
 
-Every team uses the same work contract: observable outcome, named owner, explicit state, structured evidence with provenance and verification status, reviewable brief, and human approval for consequential action. A work record cannot become done and a release check cannot become complete without verified evidence. Product proposals cannot become accepted decisions without a named human reviewer, decision note, and evidence reference.
+Every team uses the same work contract: observable outcome, named owner, explicit state, structured evidence with provenance and verification status, reviewable brief, and human approval for consequential action. A work record cannot become done and a release check cannot become complete without evidence verified by an attributed human reviewer. Product proposals cannot become accepted decisions without a named human reviewer, decision note, and evidence reference. Delegated roles can be assigned existing team work and prepare evidence; they cannot send, pay, publish, merge, deploy, change access, or write to production from the browser-local roster.
 
 ## Template model
 
@@ -69,7 +70,7 @@ Templates configure the starting records and workflow while preserving the share
 ## Data and authority boundary
 
 - The default application remains an isolated browser-local trial, not a customer system of record.
-- Team, Website, Ecommerce, Commerce, Production, approval, and setup records can be exercised locally. Website and Ecommerce explicitly remain browser-local prototypes; the core evidence export v8 covers the existing team and operating records until their contracts are accepted for integration.
+- Team, bounded-agent, Website, Ecommerce, Commerce, Production, approval, and setup records can be exercised locally. Website and Ecommerce explicitly remain browser-local prototypes; core evidence export v9 includes the team roster and operating records while preserving the isolated-demo boundary.
 - The Website-to-Ecommerce handoff carries only an approved local revision reference, SKU, and quantity. Ecommerce revalidates the source, requires a bounded human operator ID, and atomically records one accepted local intake plus its audit event. A separate explicit step creates one deterministic browser-local `ecommerce_order_draft.v1` with an immutable MMK catalogue snapshot and visible missing customer, fulfilment, and payment fields. A locked, attributable completion can migrate that valid draft to one `ecommerce_order_record.v1` in `ready_for_confirmation`, using a system-generated opaque customer reference, bounded fulfilment/payment methods, exact-retry idempotency, conflict rejection, and a second audit event. It does not insert into Commerce, confirm a customer, reserve stock, start payment, send a message, or write externally.
 - Managed readiness must not be implied until tenant persistence, identity, workspace isolation, source coverage, backup, recovery, audit, and runtime-role checks pass.
 - External sends, payments, publishing, access changes, and production writes remain owner-approved and auditable.

--- a/CURRENT.md
+++ b/CURRENT.md
@@ -1,6 +1,6 @@
 # SuperMega current direction
 
-Last confirmed: 2026-07-22
+Last confirmed: 2026-07-23
 Authority: this file, `site-manifest.json`, and `hq/portfolio.json`
 
 SuperMega is operating software for real company work. It connects accountable company delivery, website delivery, ecommerce and channel-to-fulfilment operations, production control, evidence, and owner decisions without turning every capability into a separate public page or deployment.
@@ -70,7 +70,7 @@ Templates configure the starting records and workflow while preserving the share
 
 - The default application remains an isolated browser-local trial, not a customer system of record.
 - Team, Website, Ecommerce, Commerce, Production, approval, and setup records can be exercised locally. Website and Ecommerce explicitly remain browser-local prototypes; the core evidence export v8 covers the existing team and operating records until their contracts are accepted for integration.
-- The Website-to-Ecommerce handoff carries only an approved local revision reference, SKU, and quantity. Ecommerce revalidates the source, requires a bounded human operator ID, and atomically records one accepted local intake plus its audit event. A separate explicit step can create one deterministic browser-local `ecommerce_order_draft.v1` with an immutable MMK catalogue snapshot and visible missing customer, fulfilment, and payment fields; it does not confirm an order, reserve stock, start payment, send a message, or store customer data.
+- The Website-to-Ecommerce handoff carries only an approved local revision reference, SKU, and quantity. Ecommerce revalidates the source, requires a bounded human operator ID, and atomically records one accepted local intake plus its audit event. A separate explicit step creates one deterministic browser-local `ecommerce_order_draft.v1` with an immutable MMK catalogue snapshot and visible missing customer, fulfilment, and payment fields. A locked, attributable completion can migrate that valid draft to one `ecommerce_order_record.v1` in `ready_for_confirmation`, using a system-generated opaque customer reference, bounded fulfilment/payment methods, exact-retry idempotency, conflict rejection, and a second audit event. It does not insert into Commerce, confirm a customer, reserve stock, start payment, send a message, or write externally.
 - Managed readiness must not be implied until tenant persistence, identity, workspace isolation, source coverage, backup, recovery, audit, and runtime-role checks pass.
 - External sends, payments, publishing, access changes, and production writes remain owner-approved and auditable.
 - The managed trial contract is `/api/trial/v1`; it fails closed until additive private schema v2, a high-entropy v2 signed actor identity, matching typed membership, audit, capability, and write gates pass. Approval proposals must use `decision_packet.v1` with a versioned subject, fact-or-analysis claims, source and capture provenance, verification state, uncertainty, visibility, baseline, target, current result, acceptance rule, and artifact reference. Verified claims require a digest; terminal decisions require a named human and a trimmed nonblank note; agent, service, unknown, and legacy identities cannot make them.

--- a/hq/NOW.md
+++ b/hq/NOW.md
@@ -1,6 +1,6 @@
 # HQ now
 
-Updated: 2026-07-22
+Updated: 2026-07-23
 Owner: founder / CEO
 Mode: guarded release; canonical `__release.json` metadata is the live authority
 
@@ -35,7 +35,7 @@ Prove one complete company workflow in which a real customer or operator starts 
 
 - Candidate identity is brand `terminal-v4-2026-07`, context `2026-07-22.7`, and catalogue `2026-07-22.6`.
 - Six workflow profiles, 47 coordinated-release checks, 36 security checks, eleven Vercel contract checks, 73 contact checks, six RLS checks, six paired-identity checks, HQ, product-inclusive lint, strict TypeScript, YAML, and 46 Python tests pass locally.
-- Website and Ecommerce desktop, full-route 390 px, reload, preview, guided approval, and audit paths pass without horizontal overflow or browser errors. Their non-PII handoff revalidates source approval, needs an `OP-` human ID, and records one local audit atomically. An accepted handoff can create one idempotent local order draft with an immutable MMK price snapshot and three visible missing fields; it confirms no order and triggers no stock, payment, send, or external write.
+- Website and Ecommerce desktop and 390 px paths pass without overflow or browser errors. Their `OP-`-gated handoff records one local audit, and its deterministic draft preserves the MMK price. A locked completion generates an opaque reference, captures bounded methods and evidence, rejects conflicts, and creates one `ready_for_confirmation` record plus a second audit. It changes no scenario order and performs no confirmation, stock, payment, send, Commerce, or external write.
 - Core desktop and 390 px layouts remain verified. Operations, Product decisions, and `decision_packet.v1` reviews require attributable human evidence; stale authority reopens safely.
 - Historical schema v1 is unchanged; additive v2 preserves old actors and decisions as `legacy`, requires reclassification, and enforces nonblank human decisions before readiness.
 - Contact intake stores a SHA-256 payload fingerprint; changed cold-start replays conflict and ambiguous persistence fails closed.
@@ -63,7 +63,7 @@ Prove one complete company workflow in which a real customer or operator starts 
 
 ## Next evidence
 
-- Repeat the accepted non-PII Website-to-Ecommerce intake and local draft with one named user; measure handling time and correction effort before customer data, reservation, confirmation, or connectors.
+- Repeat the complete non-PII Website-to-Ecommerce intake, draft, and ready-record flow with one named user; measure handling time and correction effort before customer data, reservation, confirmation, or connectors.
 - Approve a narrow Vercel environment cleanup from the audited name-only inventory; do not copy or expose values.
 - Activate managed trial persistence only after v1 then v2 migration rehearsal, the read-only database role/RLS validator, backup, and restore evidence pass on non-production data.
 - Complete one pilot intake containing channel, current record, owner, baseline, target outcome, authority boundary, and acceptance evidence.

--- a/hq/NOW.md
+++ b/hq/NOW.md
@@ -6,64 +6,53 @@ Mode: guarded release; canonical `__release.json` metadata is the live authority
 
 ## North-star outcome
 
-Prove one complete company workflow in which a real customer or operator starts through an existing channel, SuperMega maintains the operating record, a responsible owner resolves the exceptions, and the business can measure the result.
+Prove one real workflow in which SuperMega keeps the operating record, a responsible owner resolves exceptions, and the business measures the result.
 
 ## Current outcomes
 
-1. **Product** — validate the Website and Ecommerce & Orders prototypes without expanding the primary Today, Teams, and Operations navigation.
-2. **Pilot** — select one Website-to-order, Commerce, or Production workflow with a named owner, baseline, acceptance test, and evidence plan.
-3. **Managed mode** — keep activation locked until tenant persistence, signed identity, membership, audit, recovery, runtime role, and source coverage pass.
+1. **Company system** — validate the simpler Today, Teams, and Operations shell plus one bounded internal agent handoff.
+2. **Product** — validate Website and Ecommerce & Orders without expanding primary navigation.
+3. **Pilot** — choose one Website-to-order, Commerce, or Production workflow with an owner, baseline, target, authority boundary, and evidence plan.
+4. **Managed mode** — keep activation locked until tenant data, identity, membership, audit, recovery, runtime role, and source coverage pass.
 
-## Confirmed facts
+## Current system
 
-- The canonical implementation repository is this checkout, not the OneDrive HQ archive.
-- Today, Teams, and Operations remain the primary application navigation; Settings remains a utility.
-- Website and Ecommerce & Orders are slash-addressable, lazy-loaded local prototypes at `/products/website/` and `/products/ecommerce/`, linked from Operations rather than added to the primary navigation.
-- Commerce and Production use the canonical module paths `/operations/commerce/` and `/operations/production/`; legacy Shop and Plant URLs redirect into them.
-- Product uses Discover, Define, Build, Release, and Learn.
-- Settings captures the pilot entry point, current record, baseline, target, owner, authority boundary, and acceptance evidence without adding another route.
-- One manifest defines three executable workflow profiles for each operational product; the application consumes it directly and HQ references it without copying template lists.
-- Commerce covers channel order, stock, fulfilment, payment, and close.
-- Production covers plan, output, quality, maintenance, materials, equipment, and issues.
-- Switching products starts a clean pilot draft so workflow-specific evidence cannot be relabelled accidentally.
-- The browser-local trial is useful for workflow validation but is not a managed customer system of record.
-- Production release must run through the single coordinated GitHub workflow; the app workflow is a non-deploying guard.
-- Vercel owns the real canonical mappings: `app.supermega.dev` to `megaos`, and `supermega.dev` plus `www.supermega.dev` to `supermega-public`.
-- Both Vercel projects have native Git deployments disabled, protected preview automation configured, and bounded cron ownership.
+- Today, Teams, and Operations are the only primary destinations; Settings is a utility.
+- Teams has one team picker and three views: Work, Agents, and Review. Agent records carry a role, human owner, bounded capabilities, one assignment, evidence, and a human approval boundary. They coordinate work only.
+- Website and Ecommerce are lazy-loaded local prototypes at `/products/website/` and `/products/ecommerce/`; Operations launches them without making them operating modes.
+- Commerce and Production remain `/operations/commerce/` and `/operations/production/`; legacy Shop and Plant paths redirect.
+- Product uses Discover, Define, Build, Release, and Learn. One shared manifest defines six executable Commerce/Production workflow profiles.
+- The browser-local trial is not a customer system of record. Sends, payments, publishing, merges, deployments, access changes, and production writes require responsible human authority.
+- Vercel canonical mappings remain `app.supermega.dev` → `megaos`, and `supermega.dev` plus `www.supermega.dev` → `supermega-public`.
+- The OneDrive `codex_hq` archive is unpinned/offline and is not current authority.
 
 ## Latest verification
 
-- Candidate identity is brand `terminal-v4-2026-07`, context `2026-07-22.7`, and catalogue `2026-07-22.6`.
-- Six workflow profiles, 47 coordinated-release checks, 36 security checks, eleven Vercel contract checks, 73 contact checks, six RLS checks, six paired-identity checks, HQ, product-inclusive lint, strict TypeScript, YAML, and 46 Python tests pass locally.
-- Website and Ecommerce desktop and 390 px paths pass without overflow or browser errors. Their `OP-`-gated handoff records one local audit, and its deterministic draft preserves the MMK price. A locked completion generates an opaque reference, captures bounded methods and evidence, rejects conflicts, and creates one `ready_for_confirmation` record plus a second audit. It changes no scenario order and performs no confirmation, stock, payment, send, Commerce, or external write.
-- Core desktop and 390 px layouts remain verified. Operations, Product decisions, and `decision_packet.v1` reviews require attributable human evidence; stale authority reopens safely.
-- Historical schema v1 is unchanged; additive v2 preserves old actors and decisions as `legacy`, requires reclassification, and enforces nonblank human decisions before readiness.
-- Contact intake stores a SHA-256 payload fingerprint; changed cold-start replays conflict and ambiguous persistence fails closed.
-- Read-only Vercel project, environment, domain, firewall, and cron contracts pass. One coordinated workflow verifies and rolls back both canonical domains as a pair.
-- The product app remains `isolated_demo` until managed data, identity, and writes pass; no local or preview result can imply managed readiness.
+- Candidate identity remains brand `terminal-v4-2026-07`, context `2026-07-22.7`, and catalogue `2026-07-22.6`.
+- Product-inclusive lint, strict TypeScript, HQ, six workflow profiles, 12 Ecommerce completion checks, 47 release checks, 36 security checks, eleven Vercel contract checks, and six RLS checks pass locally.
+- Core desktop and 390 px paths have no browser errors or horizontal overflow. Query-view navigation resets scroll, mobile Settings stays available, and Operations separates modes from product launches.
+- Team evidence and Product decisions require an attributed human reviewer. Agent handoffs cannot satisfy terminal authority.
+- Website-to-Ecommerce intake remains non-PII and operator-gated. Its locked completion produces one idempotent `ready_for_confirmation` record without confirmation, stock reservation, payment, send, Commerce insertion, or external write.
+- Production release still requires review, owner authorization, and the coordinated `main` workflow; a local pass or pushed branch is not a release.
 
-## Blockers and unknowns
+## Blockers
 
-- Vercel environment audit identifies three obsolete app variables and 54 unused public-project variables. They are reported, not deleted, until a recoverable cleanup is approved.
-- Separate noncanonical legacy hostnames still serve from older projects; they are outside this release and need an explicit redirect or retirement decision.
-- Managed trial activation still requires a separately validated database runtime URL, the additive schema v2 migration proven on non-production data, a high-entropy signing secret of at least 32 bytes, and the explicit writes flag.
-- No current pilot customer, managed tenant, revenue result, or time-saved baseline is verified in this repository.
-- The OneDrive `codex_hq` archive is unpinned/offline on this Ally and cannot serve as dependable live authority.
-- Durable workflow, AI SDK, telemetry, dense-table, and realtime candidates remain adoption-gated until current architecture gaps are measured.
+- Managed activation still needs a separately validated runtime database URL, v1→v2 migration rehearsal on non-production data, backup/restore evidence, a high-entropy signing secret, and explicit writes enablement.
+- No pilot customer, managed tenant, revenue result, or time-saved baseline is verified.
+- Vercel audit reports obsolete/unused variable names and separate legacy hosts; no value is exposed and no cleanup or retirement is authorized here.
+- Durable workflow, AI SDK, telemetry, dense-table, and realtime candidates remain adoption-gated.
 
 ## Decisions in force
 
-- One company system; no public agent catalogue, internal-console product, or collection of demo domains.
-- A pushed branch or local pass is not a release; review, explicit owner authorization, and the coordinated `main` workflow are mandatory.
-- Company system, Commerce, and Production are operating entries; Website and Ecommerce & Orders are explicitly labelled local prototypes until their next evidence gates pass.
+- One company system; no public agent catalogue, internal-console product, or demo-domain collection.
+- Company system, Commerce, and Production are operating entries. Website and Ecommerce remain labelled local prototypes.
 - AI prepares bounded work from approved records; responsible owners retain consequential authority.
-- Social and open-source discovery must become a tested workflow, implementation recipe, or explicit rejection before entering the product.
-- The long-term decision and implementation layer remains an HQ/R&D direction; a public resource catalogue is deferred behind proof from the core operational products.
-- Do not add a second CRM, queue, orchestrator, or agent runtime while existing Supabase and hosted-worker contracts can satisfy the requirement.
+- Agent Teams is an internal coordination module, not proof of an autonomous runtime.
+- Do not add another CRM, queue, orchestrator, or agent runtime until a measured gap proves it necessary.
 
 ## Next evidence
 
-- Repeat the complete non-PII Website-to-Ecommerce intake, draft, and ready-record flow with one named user; measure handling time and correction effort before customer data, reservation, confirmation, or connectors.
-- Approve a narrow Vercel environment cleanup from the audited name-only inventory; do not copy or expose values.
-- Activate managed trial persistence only after v1 then v2 migration rehearsal, the read-only database role/RLS validator, backup, and restore evidence pass on non-production data.
-- Complete one pilot intake containing channel, current record, owner, baseline, target outcome, authority boundary, and acceptance evidence.
+- Repeat the complete Website-to-Ecommerce ready-record flow with one named user and measure handling time and correction effort.
+- Exercise one agent assignment from accountable work through attributed evidence and human review.
+- Complete one pilot definition and run its acceptance test.
+- Activate managed persistence only after migration, RLS, backup, and restore rehearsal passes on non-production data.

--- a/hq/portfolio.json
+++ b/hq/portfolio.json
@@ -9,9 +9,9 @@
       "status": "core",
       "path": "/",
       "job": "Turn company priorities, product delivery, evidence, exceptions, and owner decisions into one shared operating record.",
-      "surfaces": ["Today", "Product", "Engineering", "Growth", "Finance / Risk"],
+      "surfaces": ["Today", "Product", "Engineering", "Growth", "Finance / Risk", "Agent teams (internal)"],
       "lifecycle": ["discover", "define", "build", "release", "learn"],
-      "nextGate": "Prove one end-to-end Product workflow with acceptance and usage evidence."
+      "nextGate": "Prove one end-to-end Product workflow and one bounded agent handoff with attributed human acceptance and usage evidence."
     },
     {
       "id": "website",

--- a/hq/portfolio.json
+++ b/hq/portfolio.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "supermega.hq.portfolio.v1",
-  "updatedAt": "2026-07-22",
+  "updatedAt": "2026-07-23",
   "northStar": "One real workflow reaches a measurable outcome through an accountable operating record.",
   "portfolio": [
     {
@@ -29,7 +29,7 @@
       "path": "/products/ecommerce/",
       "job": "Convert website or channel demand into controlled order, catalogue, stock, fulfilment, payment-status, and audit records.",
       "surfaces": ["Orders", "Catalog", "Fulfilment", "Payments"],
-      "nextGate": "Repeat the non-PII Website intake and idempotent local draft with one named user, then prove controlled completion, reservation, reconciliation, and close."
+      "nextGate": "Repeat the non-PII Website intake, idempotent draft, and controlled ready record with one named user, then prove reservation, reconciliation, and close."
     },
     {
       "id": "commerce",

--- a/showroom/src/core/AgentTeamsPanel.tsx
+++ b/showroom/src/core/AgentTeamsPanel.tsx
@@ -1,0 +1,200 @@
+import { type Dispatch, type FormEvent, type SetStateAction, useState } from 'react'
+
+import {
+  agentApprovalBoundaries,
+  agentCapabilities,
+  agentStates,
+  createTeamId,
+  defaultAgentCapabilities,
+  formatTime,
+  type AgentApprovalBoundary,
+  type AgentCapability,
+  type AgentState,
+  type DelegatedAgent,
+  type TeamId,
+  type TeamWorkspaceState,
+} from './team-work'
+
+type AgentTeamsPanelProps = {
+  activeTeam: TeamId
+  workspace: TeamWorkspaceState
+  setWorkspace: Dispatch<SetStateAction<TeamWorkspaceState>>
+}
+
+function agentStateLabel(state: AgentState) {
+  return agentStates.find((entry) => entry.id === state)?.label ?? state
+}
+
+export function AgentTeamsPanel({ activeTeam, workspace, setWorkspace }: AgentTeamsPanelProps) {
+  const teamAgents = workspace.agents.filter((agent) => agent.team === activeTeam)
+  const teamItems = workspace.items.filter((item) => item.team === activeTeam && item.status !== 'done')
+  const [selectedAgentId, setSelectedAgentId] = useState('')
+  const [name, setName] = useState('')
+  const [role, setRole] = useState('')
+  const [humanOwner, setHumanOwner] = useState('')
+  const [evidenceSummary, setEvidenceSummary] = useState('')
+  const [evidenceReference, setEvidenceReference] = useState('')
+  const [notice, setNotice] = useState('')
+  const selectedAgent = teamAgents.find((agent) => agent.id === selectedAgentId) ?? teamAgents[0]
+
+  function updateAgent(agentId: string, patch: Partial<DelegatedAgent>) {
+    const updatedAt = new Date().toISOString()
+    setWorkspace((current) => ({
+      ...current,
+      agents: current.agents.map((agent) => agent.id === agentId ? { ...agent, ...patch, updatedAt } : agent),
+    }))
+  }
+
+  function addAgent(event: FormEvent) {
+    event.preventDefault()
+    if (!name.trim() || !role.trim() || !humanOwner.trim()) return
+    const timestamp = new Date().toISOString()
+    const agent: DelegatedAgent = {
+      id: createTeamId('AGT'),
+      createdAt: timestamp,
+      updatedAt: timestamp,
+      name: name.trim(),
+      team: activeTeam,
+      role: role.trim(),
+      humanOwner: humanOwner.trim(),
+      state: 'available',
+      capabilities: defaultAgentCapabilities[activeTeam],
+      approvalBoundary: activeTeam === 'engineering' ? 'local_change_review' : 'prepare_only',
+    }
+    setWorkspace((current) => ({ ...current, agents: [agent, ...current.agents] }))
+    setSelectedAgentId(agent.id)
+    setName('')
+    setRole('')
+    setHumanOwner('')
+    setNotice(`${agent.name} added as a local delegation record.`)
+  }
+
+  function assignWork(workItemId: string) {
+    if (!selectedAgent) return
+    updateAgent(selectedAgent.id, {
+      assignedWorkItemId: workItemId || undefined,
+      state: workItemId ? selectedAgent.state === 'available' ? 'assigned' : selectedAgent.state : 'available',
+    })
+    setNotice(workItemId ? `${selectedAgent.name} assigned to ${workItemId}.` : `${selectedAgent.name} returned to available.`)
+  }
+
+  function changeState(state: AgentState) {
+    if (!selectedAgent) return
+    if (state !== 'available' && !selectedAgent.assignedWorkItemId) {
+      setNotice('Assign accountable work before changing this role state.')
+      return
+    }
+    if (state === 'waiting_review' && !selectedAgent.lastEvidence) {
+      setNotice('Record evidence before requesting human review.')
+      return
+    }
+    updateAgent(selectedAgent.id, { state })
+    setNotice(`${selectedAgent.name} moved to ${agentStateLabel(state)}.`)
+  }
+
+  function toggleCapability(capability: AgentCapability) {
+    if (!selectedAgent) return
+    const hasCapability = selectedAgent.capabilities.includes(capability)
+    if (hasCapability && selectedAgent.capabilities.length === 1) {
+      setNotice('Keep at least one bounded capability on every delegated role.')
+      return
+    }
+    updateAgent(selectedAgent.id, {
+      capabilities: hasCapability
+        ? selectedAgent.capabilities.filter((entry) => entry !== capability)
+        : [...selectedAgent.capabilities, capability],
+    })
+  }
+
+  function recordEvidence(event: FormEvent) {
+    event.preventDefault()
+    if (!selectedAgent || !evidenceSummary.trim() || !evidenceReference.trim()) return
+    updateAgent(selectedAgent.id, {
+      lastEvidence: {
+        capturedAt: new Date().toISOString(),
+        summary: evidenceSummary.trim(),
+        reference: evidenceReference.trim(),
+      },
+    })
+    setEvidenceSummary('')
+    setEvidenceReference('')
+    setNotice(`Evidence recorded for ${selectedAgent.name}; human review is still required.`)
+  }
+
+  const assignedCount = teamAgents.filter((agent) => agent.state === 'assigned').length
+  const reviewCount = teamAgents.filter((agent) => agent.state === 'waiting_review').length
+  const blockedCount = teamAgents.filter((agent) => agent.state === 'blocked').length
+
+  return (
+    <div className="agent-team-workspace">
+      <section className="agent-boundary-banner" aria-label="Agent delegation boundary">
+        <div><span className="core-eyebrow">Delegation control</span><strong>Roles prepare work; named humans keep authority.</strong></div>
+        <p>No agent can send, pay, publish, merge, deploy, or write to production from this local roster.</p>
+      </section>
+      <section className="agent-summary" aria-label="Agent team summary">
+        <span><small>Roles</small><strong>{teamAgents.length}</strong></span>
+        <span><small>Assigned</small><strong>{assignedCount}</strong></span>
+        <span><small>Needs review</small><strong>{reviewCount}</strong></span>
+        <span><small>Blocked</small><strong>{blockedCount}</strong></span>
+      </section>
+      <div className="split-workspace agent-team-view">
+        <section className="core-panel agent-roster-panel">
+          <div className="panel-head">
+            <div><span className="core-eyebrow">Team roster</span><h2>Delegated roles</h2></div>
+            <details className="compact-disclosure">
+              <summary>Add role</summary>
+              <form className="core-form agent-create-form" onSubmit={addAgent}>
+                <label>Name<input maxLength={80} required value={name} onChange={(event) => setName(event.target.value)} placeholder="e.g. QA operator" /></label>
+                <label>Role<input maxLength={140} required value={role} onChange={(event) => setRole(event.target.value)} placeholder="One bounded responsibility" /></label>
+                <label>Human owner<input maxLength={80} required value={humanOwner} onChange={(event) => setHumanOwner(event.target.value)} placeholder="Accountable person or role" /></label>
+                <button className="core-button primary compact" type="submit">Add local role</button>
+              </form>
+            </details>
+          </div>
+          <div className="agent-roster" role="list">
+            {teamAgents.map((agent) => (
+              <button aria-current={selectedAgent?.id === agent.id ? 'true' : undefined} key={agent.id} onClick={() => setSelectedAgentId(agent.id)} type="button">
+                <span className={`record-status ${agent.state === 'waiting_review' ? 'review' : agent.state === 'assigned' ? 'in_progress' : agent.state}`} />
+                <span><strong>{agent.name}</strong><small>{agent.role}</small></span>
+                <span><b>{agentStateLabel(agent.state)}</b><small>{agent.assignedWorkItemId ?? 'Unassigned'}</small></span>
+              </button>
+            ))}
+            {!teamAgents.length ? <p className="panel-copy">No delegated role exists for this team yet.</p> : null}
+          </div>
+        </section>
+        <section className="core-panel agent-detail-panel">
+          {selectedAgent ? <>
+            <div className="record-detail-head">
+              <div><span className="core-eyebrow">{selectedAgent.id}</span><h2>{selectedAgent.name}</h2><p>{selectedAgent.role}</p></div>
+              <span className={`status-pill ${selectedAgent.state === 'waiting_review' ? 'pending' : selectedAgent.state === 'blocked' ? 'pending' : 'bounded'}`}>{agentStateLabel(selectedAgent.state)}</span>
+            </div>
+            <div className="agent-control-grid">
+              <label>Human owner<input maxLength={80} value={selectedAgent.humanOwner} onChange={(event) => updateAgent(selectedAgent.id, { humanOwner: event.target.value })} /></label>
+              <label>Assignment<select value={selectedAgent.assignedWorkItemId ?? ''} onChange={(event) => assignWork(event.target.value)}><option value="">Available</option>{teamItems.map((item) => <option key={item.id} value={item.id}>{item.id} · {item.title}</option>)}</select></label>
+              <label>State<select value={selectedAgent.state} onChange={(event) => changeState(event.target.value as AgentState)}>{agentStates.map((state) => <option key={state.id} value={state.id}>{state.label}</option>)}</select></label>
+              <label>Approval boundary<select value={selectedAgent.approvalBoundary} onChange={(event) => updateAgent(selectedAgent.id, { approvalBoundary: event.target.value as AgentApprovalBoundary })}>{agentApprovalBoundaries.map((boundary) => <option key={boundary.id} value={boundary.id}>{boundary.label}</option>)}</select></label>
+            </div>
+            <p className="agent-boundary-copy">{agentApprovalBoundaries.find((boundary) => boundary.id === selectedAgent.approvalBoundary)?.description}</p>
+            <fieldset className="capability-fieldset">
+              <legend>Bounded capabilities</legend>
+              <div>{agentCapabilities.map((capability) => <label key={capability.id}><input checked={selectedAgent.capabilities.includes(capability.id)} onChange={() => toggleCapability(capability.id)} type="checkbox" /><span>{capability.label}</span></label>)}</div>
+            </fieldset>
+            <section className="agent-evidence-card">
+              <div><span>Latest evidence</span>{selectedAgent.lastEvidence ? <small>{formatTime(selectedAgent.lastEvidence.capturedAt)}</small> : null}</div>
+              {selectedAgent.lastEvidence ? <><strong>{selectedAgent.lastEvidence.summary}</strong><small>{selectedAgent.lastEvidence.reference}</small></> : <p>No evidence has been attributed to this role.</p>}
+              <details className="compact-disclosure evidence-disclosure">
+                <summary>Record evidence</summary>
+                <form className="core-form agent-evidence-form" onSubmit={recordEvidence}>
+                  <label>Finding<input maxLength={240} required value={evidenceSummary} onChange={(event) => setEvidenceSummary(event.target.value)} placeholder="What was completed or learned?" /></label>
+                  <label>Reference<input maxLength={180} required value={evidenceReference} onChange={(event) => setEvidenceReference(event.target.value)} placeholder="Test, file, task, or source reference" /></label>
+                  <button className="core-button compact" type="submit">Record</button>
+                </form>
+              </details>
+            </section>
+            <p className="form-notice" aria-live="polite">{notice || `Updated ${formatTime(selectedAgent.updatedAt)} · local record only.`}</p>
+          </> : <p className="panel-copy">Add a bounded role to begin delegating work for this team.</p>}
+        </section>
+      </div>
+    </div>
+  )
+}

--- a/showroom/src/core/CoreApp.tsx
+++ b/showroom/src/core/CoreApp.tsx
@@ -3,7 +3,7 @@ import { Link, NavLink, Outlet, useLocation, useNavigate, useOutletContext, useS
 
 import siteManifest from '../../../site-manifest.json'
 import './core-app.css'
-import { TEAM_WORK_KEY, formatTime, teamDefinitions, useTeamWorkspace } from './team-work'
+import { LEGACY_TEAM_WORK_KEYS, TEAM_WORK_KEY, formatTime, teamDefinitions, useTeamWorkspace } from './team-work'
 
 type CommerceItem = {
   sku: string
@@ -355,9 +355,9 @@ const checkingRuntime: RuntimeHealth = {
 }
 
 const navigation = [
-  { to: '/', label: 'Today', index: '01', end: true },
-  { to: '/work/', label: 'Teams', index: '02', end: false },
-  { to: '/operations/', label: 'Operations', index: '03', end: false },
+  { to: '/', label: 'Today', end: true },
+  { to: '/work/', label: 'Teams', end: false },
+  { to: '/operations/', label: 'Operations', end: false },
 ] as const
 
 const commerceTabs: Array<{ id: CommerceTab; label: string }> = [
@@ -685,28 +685,27 @@ function RuntimeBadge({ status }: { status: RuntimeStatus }) {
 export function CoreLayout() {
   const location = useLocation()
   const runtime = useRuntimeHealth()
+  const routeName = location.pathname.startsWith('/settings/')
+    ? 'Settings'
+    : navigation.find((item) => item.to !== '/' && location.pathname.startsWith(item.to))?.label ?? 'Today'
 
   useEffect(() => {
-    const routeName = location.pathname.startsWith('/settings/')
-      ? 'Settings'
-      : navigation.find((item) => item.to !== '/' && location.pathname.startsWith(item.to))?.label ?? 'Today'
     document.title = `${routeName} | SuperMega`
     window.scrollTo({ top: 0, behavior: 'instant' })
-  }, [location.pathname])
+  }, [location.pathname, location.search, routeName])
 
   return (
     <div className="core-shell">
       <a className="core-skip" href="#workspace-main">Skip to workspace</a>
       <aside className="core-sidebar">
         <Brand />
-        <div className="workspace-label"><span>Company</span><strong>SuperMega HQ</strong></div>
         <nav className="core-nav" aria-label="Application">
-          {navigation.map((item) => <NavLink className={({ isActive }) => isActive ? 'active' : ''} end={item.end} key={item.to} to={item.to}><span>{item.index}</span>{item.label}</NavLink>)}
+          {navigation.map((item) => <NavLink className={({ isActive }) => isActive ? 'active' : ''} end={item.end} key={item.to} to={item.to}>{item.label}</NavLink>)}
         </nav>
-        <div className="sidebar-foot"><RuntimeBadge status={runtime.status} /><p>Browser-local working records. Managed mode stays locked until identity, data, audit, and recovery pass.</p><NavLink to="/settings/">Settings</NavLink></div>
+        <div className="sidebar-foot"><RuntimeBadge status={runtime.status} /><NavLink to="/settings/">Settings</NavLink></div>
       </aside>
       <div className="core-stage">
-        <header className="core-topbar"><div className="mobile-brand"><Brand /></div><div className="topbar-title"><span className="terminal-prompt">&gt;_</span><strong>Company operating system</strong></div><div className="topbar-meta"><span>MMK</span><span>UTC+06:30</span><NavLink to="/settings/">Settings</NavLink><RuntimeBadge status={runtime.status} /></div></header>
+        <header className="core-topbar"><div className="mobile-brand"><Brand /></div><div className="topbar-title"><strong>{routeName}</strong><span>SuperMega HQ</span></div><div className="topbar-meta"><NavLink to="/settings/">Settings</NavLink><RuntimeBadge status={runtime.status} /></div></header>
         <nav className="mobile-nav" aria-label="Mobile application">{navigation.map((item) => <NavLink className={({ isActive }) => isActive ? 'active' : ''} end={item.end} key={item.to} to={item.to}>{item.label}</NavLink>)}</nav>
         <main id="workspace-main" className="core-main"><Outlet context={runtime} /></main>
       </div>
@@ -773,19 +772,22 @@ export function OverviewPage() {
   const openWork = workspace.items.filter((item) => item.status !== 'done')
   const activeWork = workspace.items.filter((item) => ['in_progress', 'review'].includes(item.status))
   const blockedWork = workspace.items.filter((item) => item.status === 'blocked')
+  const visibleWork = workspace.items.filter((item) => ['in_progress', 'review', 'blocked'].includes(item.status))
   const pendingApprovals = approvals.filter((item) => item.status === 'pending')
   const lowStock = commerce.items.filter((item) => item.onHand <= item.reorderAt)
   const openProductionIssues = production.issues.filter((issue) => issue.status === 'open')
   const openOrders = commerce.orders.filter((order) => order.status !== 'completed')
+  const agentHandoffs = workspace.agents.filter((agent) => ['waiting_review', 'blocked'].includes(agent.state) && !blockedWork.some((item) => item.id === agent.assignedWorkItemId))
   const releaseComplete = workspace.release.checks.filter((check) => check.complete).length
   const releasePercent = Math.round((releaseComplete / workspace.release.checks.length) * 100)
   const isPilotReady = pilotReady(setup)
-  const ownerAttention = blockedWork.length + pendingApprovals.length + (isPilotReady ? 0 : 1)
+  const operatingExceptions = lowStock.length + openProductionIssues.length
+  const ownerAttention = blockedWork.length + pendingApprovals.length + agentHandoffs.length + operatingExceptions + (isPilotReady ? 0 : 1)
   const selectedApproval = pendingApprovals.find((approval) => approval.id === selectedApprovalId)
 
   function prepareCompanyBrief() {
     setBrief([
-      `${openWork.length} company work items remain open; ${activeWork.length} are in delivery or review.`,
+      `${openWork.length} company work items remain open; ${activeWork.length} are in delivery or review across ${workspace.agents.length} delegated role records.`,
       `${openOrders.length} Commerce orders, ${lowStock.length} stock exceptions, and ${openProductionIssues.length} Production issues need operating attention.`,
       `${workspace.release.name} is ${releasePercent}% ready from ${workspace.release.checks.length} explicit checks.`,
       isPilotReady ? `${setup.workspace} pilot starts from ${setup.entryPoint}; baseline: ${setup.baseline}; target: ${setup.targetOutcome}.` : `Pilot definition is ${pilotProgress(setup)}% complete and still needs a baseline, target, authority boundary, and acceptance evidence.`,
@@ -845,30 +847,30 @@ export function OverviewPage() {
 
   return (
     <div className="workspace-screen command-screen">
-      <PageHeading eyebrow="Today" title="The work that needs attention." copy="Company delivery, customer operations, production exceptions, and owner decisions in one bounded view." />
-      <section className="summary-strip" aria-label="Workspace summary"><span><small>Open work</small><strong>{openWork.length}</strong></span><span><small>In delivery</small><strong>{activeWork.length}</strong></span><span><small>Open orders</small><strong>{openOrders.length}</strong></span><span><small>Exceptions</small><strong>{lowStock.length + openProductionIssues.length}</strong></span><span><small>Needs owner</small><strong>{ownerAttention}</strong></span></section>
+      <PageHeading eyebrow="Today" title="Decide what moves next." copy="Active work and owner attention, without another dashboard." />
+      <section className="summary-strip compact-summary" aria-label="Workspace summary"><span><small>In progress</small><strong>{activeWork.length}</strong></span><span><small>Needs owner</small><strong>{ownerAttention}</strong></span><span><small>Operating exceptions</small><strong>{operatingExceptions}</strong></span></section>
       <div className="command-grid">
         <section className="core-panel command-queue-panel">
-          <div className="panel-head"><div><span className="core-eyebrow">Company queue</span><h2>Work in motion</h2></div><Link className="text-link" to="/work/?team=product&view=board">Open Teams</Link></div>
-          <div className="record-list">{openWork.map((item) => { const team = teamDefinitions.find((definition) => definition.id === item.team); return <Link className="record-row" key={item.id} to={`/work/?team=${item.team}&view=board`}><span className={`record-status ${item.status}`} /><span><strong>{item.title}</strong><small>{team?.label ?? item.team} · {item.owner} · {item.evidence.length} evidence</small></span><span><b>{item.priority}</b><small>{item.status.replace('_', ' ')}</small></span></Link> })}</div>
+          <div className="panel-head"><div><span className="core-eyebrow">Company queue</span><h2>Work in motion</h2></div><Link className="text-link" to="/work/?team=product&view=work">Open Teams</Link></div>
+          <div className="record-list">{visibleWork.map((item) => { const team = teamDefinitions.find((definition) => definition.id === item.team); return <Link className="record-row" key={item.id} to={`/work/?team=${item.team}&view=work`}><span className={`record-status ${item.status}`} /><span><strong>{item.title}</strong><small>{team?.label ?? item.team} / {item.owner} / {item.evidence.length} evidence</small></span><span><b>{item.priority}</b><small>{item.status.replace('_', ' ')}</small></span></Link> })}</div>
         </section>
         <section className="core-panel attention-panel">
-          <div className="panel-head"><div><span className="core-eyebrow">Needs owner</span><h2>{ownerAttention + lowStock.length + openProductionIssues.length} exceptions</h2></div></div>
+          <div className="panel-head"><div><span className="core-eyebrow">Needs owner</span><h2>{ownerAttention} decisions</h2></div></div>
           <div className="attention-list">
             {!isPilotReady ? <Link to="/settings/"><span>Pilot</span><strong>Define the measurable workflow</strong><small>{pilotProgress(setup)}% complete · baseline and acceptance required</small></Link> : null}
-            {blockedWork.map((item) => <Link key={item.id} to={`/work/?team=${item.team}&view=board`}><span>Work</span><strong>{item.title}</strong><small>{item.owner}</small></Link>)}
+            {blockedWork.map((item) => <Link key={item.id} to={`/work/?team=${item.team}&view=work`}><span>Work</span><strong>{item.title}</strong><small>{item.owner}</small></Link>)}
+            {agentHandoffs.map((agent) => <Link key={agent.id} to={`/work/?team=${agent.team}&view=agents`}><span>Agent</span><strong>{agent.name} {agent.state === 'waiting_review' ? 'needs review' : 'is blocked'}</strong><small>{agent.humanOwner} / {agent.assignedWorkItemId ?? 'unassigned'}</small></Link>)}
             {pendingApprovals.map((approval) => <button className="attention-action" key={approval.id} onClick={() => setSelectedApprovalId(approval.id)} type="button"><span>Approval</span><strong>{approval.title}</strong><small>{approval.packet.claims.length} claims · {formatTime(approval.createdAt)}</small><b>Review</b></button>)}
             {lowStock.map((item) => <Link key={item.sku} to="/operations/commerce/?tab=inventory"><span>Stock</span><strong>{item.name}</strong><small>{item.onHand} on hand · reorder at {item.reorderAt}</small></Link>)}
             {openProductionIssues.map((issue) => <Link key={issue.id} to="/operations/production/?tab=control"><span>{issue.kind}</span><strong>{issue.summary}</strong><small>{issue.area}</small></Link>)}
-            {isPilotReady && !blockedWork.length && !pendingApprovals.length && !lowStock.length && !openProductionIssues.length ? <Empty>No operating exception needs attention.</Empty> : null}
+            {!ownerAttention ? <Empty>No owner decision needs attention.</Empty> : null}
           </div>
         </section>
         <section className="core-panel release-brief-panel">
           <div className="release-line"><div><span className="core-eyebrow">Product release</span><h2>{workspace.release.name}</h2></div><strong>{releasePercent}%</strong></div>
           <div className="progress-track"><i style={{ width: `${releasePercent}%` }} /></div>
-          <div className="release-mini-checks">{workspace.release.checks.map((check) => <span className={check.complete ? 'complete' : ''} key={check.id}>{check.complete ? '✓' : '○'} {check.label}</span>)}</div>
-          <div className="brief-divider"><span>Company brief</span><button className="text-link" onClick={prepareCompanyBrief} type="button">Prepare brief</button></div>
-          {brief.length ? <div className="brief-output compact">{brief.map((line) => <p key={line}>{line}</p>)}<button className="core-button compact" onClick={requestBriefApproval} type="button">Request owner review</button></div> : <p className="panel-copy">Prepared locally from the visible work, release, Commerce, and Production records.</p>}
+          <Link className="release-review-link" to="/work/?team=product&view=review">Review release checks</Link>
+          <details className="company-brief-disclosure"><summary>Company brief</summary><button className="text-link" onClick={prepareCompanyBrief} type="button">Prepare brief</button>{brief.length ? <div className="brief-output compact">{brief.map((line) => <p key={line}>{line}</p>)}<button className="core-button compact" onClick={requestBriefApproval} type="button">Request owner review</button></div> : <p className="panel-copy">Prepared locally from visible work and operating records.</p>}</details>
         </section>
       </div>
       {selectedApproval ? <ApprovalReviewDialog approval={selectedApproval} onClose={() => setSelectedApprovalId('')} onDecision={(status, reviewer, note) => setApprovalStatus(selectedApproval.id, status, reviewer, note)} /> : null}
@@ -912,8 +914,11 @@ export function OperationsPage() {
 
   return (
     <div className="workspace-screen operations-screen">
-      <PageHeading eyebrow="Operations" title={view === 'commerce' ? 'Commerce' : 'Production'} copy={`${operationsCopy} Measure: ${profileMeasure}.`} actions={<div className="operations-profile"><span>{profileLabel}</span><strong>{activeTemplate.name}</strong><small>{activeTemplate.workflow.join(' → ')}</small><Link className="text-link" to="/settings/">Configure</Link></div>} />
-      <div className="workspace-toolbar"><div className="segmented-control" role="group" aria-label="Product workspace"><button aria-pressed={view === 'commerce'} onClick={() => setMode('commerce')} type="button">Commerce</button><Link to="/products/ecommerce/">Ecommerce</Link><Link to="/products/website/">Website</Link><button aria-pressed={view === 'production'} onClick={() => setMode('production')} type="button">Production</button></div><div className="view-tabs" role="tablist" aria-label="Module views">{tabs.map((tab) => <button aria-selected={activeTab === tab.id} key={tab.id} onClick={() => setTab(tab.id)} role="tab" type="button">{tab.label}</button>)}</div></div>
+      <PageHeading eyebrow="Operations" title={view === 'commerce' ? 'Commerce' : 'Production'} copy={`${operationsCopy} Measure: ${profileMeasure}.`} actions={<div className="operations-profile"><span>{profileLabel}</span><strong>{activeTemplate.name}</strong><Link className="text-link" to="/settings/">Configure</Link></div>} />
+      <div className="workspace-toolbar operations-toolbar">
+        <div className="segmented-control" role="group" aria-label="Operating workspace"><button aria-pressed={view === 'commerce'} onClick={() => setMode('commerce')} type="button">Commerce</button><button aria-pressed={view === 'production'} onClick={() => setMode('production')} type="button">Production</button></div>
+        <div className="operations-toolbar-actions"><nav className="view-tabs" aria-label="Module views">{tabs.map((tab) => <button aria-current={activeTab === tab.id ? 'page' : undefined} key={tab.id} onClick={() => setTab(tab.id)} type="button">{tab.label}</button>)}</nav><details className="product-app-launcher"><summary>Product apps</summary><div><Link to="/products/website/">Website</Link><Link to="/products/ecommerce/">Ecommerce</Link></div></details></div>
+      </div>
       <div className="workspace-view">{view === 'commerce' ? <CommercePage tab={commerceTab} /> : <ProductionPage tab={productionTab} />}</div>
     </div>
   )
@@ -1100,7 +1105,7 @@ export function SettingsPage() {
   const evidenceDate = new Intl.DateTimeFormat('sv-SE', { timeZone: 'Asia/Yangon' }).format(new Date())
   const evidenceFilename = `supermega-trial-evidence-${evidenceDate}.json`
   const managedApprovalRequests = approvals.map(toManagedApprovalRequest).filter((request): request is NonNullable<typeof request> => Boolean(request))
-  const evidenceHref = `data:application/json;charset=utf-8,${encodeURIComponent(JSON.stringify({ contract: 'supermega_trial_evidence', version: 8, exportedAt: new Date().toISOString(), environment: 'isolated_demo', pilotReady: isPilotReady, setup, workflowProfile: selectedTemplate, commerce, production, accountableActions: actions, approvals, managedApprovalRequests, teams: teamWorkspace }, null, 2))}`
+  const evidenceHref = `data:application/json;charset=utf-8,${encodeURIComponent(JSON.stringify({ contract: 'supermega_trial_evidence', version: 9, exportedAt: new Date().toISOString(), environment: 'isolated_demo', pilotReady: isPilotReady, setup, workflowProfile: selectedTemplate, commerce, production, accountableActions: actions, approvals, managedApprovalRequests, teams: teamWorkspace }, null, 2))}`
 
   function updateSetup(patch: Partial<SetupState>) {
     setSetup((current) => ({ ...current, ...patch, savedAt: undefined }))
@@ -1124,7 +1129,7 @@ export function SettingsPage() {
   }
 
   function resetDemoWorkspace() {
-    ;[COMMERCE_KEY, PRODUCTION_KEY, APPROVAL_KEY, SETUP_KEY, ACTION_KEY, TEAM_WORK_KEY, ...LEGACY_COMMERCE_KEYS, ...LEGACY_PRODUCTION_KEYS, ...LEGACY_APPROVAL_KEYS, ...LEGACY_SETUP_KEYS].forEach((key) => window.localStorage.removeItem(key))
+    ;[COMMERCE_KEY, PRODUCTION_KEY, APPROVAL_KEY, SETUP_KEY, ACTION_KEY, TEAM_WORK_KEY, ...LEGACY_TEAM_WORK_KEYS, ...LEGACY_COMMERCE_KEYS, ...LEGACY_PRODUCTION_KEYS, ...LEGACY_APPROVAL_KEYS, ...LEGACY_SETUP_KEYS].forEach((key) => window.localStorage.removeItem(key))
     window.location.assign('/')
   }
 

--- a/showroom/src/core/TeamWorkspace.tsx
+++ b/showroom/src/core/TeamWorkspace.tsx
@@ -1,6 +1,7 @@
-import { type FormEvent, useMemo, useState } from 'react'
+import { type FormEvent, useState } from 'react'
 import { useSearchParams } from 'react-router-dom'
 
+import { AgentTeamsPanel } from './AgentTeamsPanel'
 import { Empty, PageHeading } from './CoreApp'
 import {
   createTeamId,
@@ -8,10 +9,10 @@ import {
   formatTime,
   productStages,
   teamDefinitions,
-  type ProductDecision,
-  type ProductStage,
   type EvidenceKind,
   type EvidenceRecord,
+  type ProductDecision,
+  type ProductStage,
   type TeamId,
   type TeamWorkItem,
   type WorkPriority,
@@ -34,11 +35,11 @@ const teamPrefixes: Record<TeamId, string> = {
   finance: 'FIN',
 }
 
-type WorkspaceView = 'board' | 'intake' | 'review' | 'decisions'
+type WorkspaceView = 'work' | 'agents' | 'review'
 
-const baseViews: Array<{ id: WorkspaceView; label: string }> = [
-  { id: 'board', label: 'Board' },
-  { id: 'intake', label: 'New work' },
+const workspaceViews: Array<{ id: WorkspaceView; label: string }> = [
+  { id: 'work', label: 'Work' },
+  { id: 'agents', label: 'Agents' },
   { id: 'review', label: 'Review' },
 ]
 
@@ -53,17 +54,23 @@ function defaultProductStage(status: WorkStatus): ProductStage {
   return 'define'
 }
 
+function normalizeView(value: string | null): WorkspaceView {
+  if (value === 'agents' || value === 'review') return value
+  if (value === 'decisions') return 'review'
+  return 'work'
+}
+
 export function TeamsPage() {
   const [searchParams, setSearchParams] = useSearchParams()
   const requestedTeam = searchParams.get('team')
+  const requestedView = searchParams.get('view')
   const activeTeam = teamDefinitions.some((team) => team.id === requestedTeam) ? requestedTeam as TeamId : 'product'
   const activeDefinition = teamDefinitions.find((team) => team.id === activeTeam) ?? teamDefinitions[0]
-  const requestedView = searchParams.get('view') as WorkspaceView | null
-  const validViews = activeTeam === 'product' ? [...baseViews, { id: 'decisions' as const, label: 'Decisions' }] : baseViews
-  const activeView = validViews.some((view) => view.id === requestedView) ? requestedView as WorkspaceView : 'board'
+  const activeView = normalizeView(requestedView)
   const [workspace, setWorkspace] = useTeamWorkspace()
-  const teamItems = useMemo(() => workspace.items.filter((item) => item.team === activeTeam), [activeTeam, workspace.items])
+  const teamItems = workspace.items.filter((item) => item.team === activeTeam)
   const [selectedItemId, setSelectedItemId] = useState(teamItems[0]?.id ?? '')
+  const [showIntake, setShowIntake] = useState(requestedView === 'intake')
   const [title, setTitle] = useState('')
   const [owner, setOwner] = useState(`${activeDefinition.label} owner`)
   const [priority, setPriority] = useState<WorkPriority>('P1')
@@ -72,6 +79,8 @@ export function TeamsPage() {
   const [evidenceKind, setEvidenceKind] = useState<EvidenceKind>('test')
   const [evidenceReference, setEvidenceReference] = useState('')
   const [evidenceFinding, setEvidenceFinding] = useState('')
+  const [evidenceReviewId, setEvidenceReviewId] = useState('')
+  const [evidenceReviewer, setEvidenceReviewer] = useState('')
   const [decisionTitle, setDecisionTitle] = useState('')
   const [decisionRationale, setDecisionRationale] = useState('')
   const [reviewDecisionId, setReviewDecisionId] = useState('')
@@ -81,9 +90,10 @@ export function TeamsPage() {
   const [brief, setBrief] = useState<string[]>([])
   const [notice, setNotice] = useState('')
 
+  const intakeOpen = showIntake || requestedView === 'intake'
   const selectedItem = teamItems.find((item) => item.id === selectedItemId) ?? teamItems[0]
   const openItems = teamItems.filter((item) => item.status !== 'done')
-  const deliveryItems = teamItems.filter((item) => ['in_progress', 'review'].includes(item.status))
+  const activeItems = teamItems.filter((item) => ['in_progress', 'review'].includes(item.status))
   const blockedItems = teamItems.filter((item) => item.status === 'blocked')
   const evidenceCount = teamItems.reduce((total, item) => total + item.evidence.length, 0)
   const verifiedEvidenceCount = teamItems.reduce((total, item) => total + item.evidence.filter((entry) => entry.status === 'verified').length, 0)
@@ -99,13 +109,20 @@ export function TeamsPage() {
     const definition = teamDefinitions.find((item) => item.id === team) ?? teamDefinitions[0]
     setOwner(`${definition.label} owner`)
     setSelectedItemId(workspace.items.find((item) => item.team === team)?.id ?? '')
+    setShowIntake(false)
     setBrief([])
     setNotice('')
-    navigate(team, 'board')
+    navigate(team, activeView)
   }
 
   function selectView(view: WorkspaceView) {
+    setShowIntake(false)
     navigate(activeTeam, view)
+  }
+
+  function openNewWork() {
+    navigate(activeTeam, 'work')
+    setShowIntake(true)
   }
 
   function addWork(event: FormEvent) {
@@ -127,8 +144,9 @@ export function TeamsPage() {
     setTitle('')
     setOutcome('')
     setSelectedItemId(item.id)
+    setShowIntake(false)
     setNotice(`${item.id} added to ${activeDefinition.label}.`)
-    selectView('board')
+    navigate(activeTeam, 'work')
   }
 
   function updateWork(itemId: string, patch: Partial<Pick<TeamWorkItem, 'status' | 'owner' | 'priority' | 'productStage'>>) {
@@ -161,31 +179,33 @@ export function TeamsPage() {
     }
     setWorkspace((current) => ({
       ...current,
-      items: current.items.map((item) => item.id === selectedItem.id
-        ? { ...item, evidence: [...item.evidence, record] }
-        : item),
+      items: current.items.map((item) => item.id === selectedItem.id ? { ...item, evidence: [...item.evidence, record] } : item),
     }))
     setEvidenceReference('')
     setEvidenceFinding('')
-    setNotice(`${record.id} attached as observed evidence. Review it before verification.`)
+    setNotice(`${record.id} attached as observed evidence.`)
   }
 
-  function verifyEvidence(itemId: string, evidenceId: string) {
+  function verifyEvidence(event: FormEvent, itemId: string, evidenceId: string) {
+    event.preventDefault()
+    if (!evidenceReviewer.trim()) return
     const verifiedAt = new Date().toISOString()
     setWorkspace((current) => ({
       ...current,
       items: current.items.map((item) => item.id === itemId
-        ? { ...item, evidence: item.evidence.map((entry) => entry.id === evidenceId ? { ...entry, status: 'verified', verifiedAt } : entry) }
+        ? { ...item, evidence: item.evidence.map((entry) => entry.id === evidenceId ? { ...entry, status: 'verified', verifiedAt, verifiedBy: evidenceReviewer.trim(), verifiedActorKind: 'human' } : entry) }
         : item),
     }))
-    setNotice(`${evidenceId} marked verified in this local trial.`)
+    setEvidenceReviewId('')
+    setEvidenceReviewer('')
+    setNotice(`${evidenceId} verified by ${evidenceReviewer.trim()}.`)
   }
 
   function prepareBrief() {
     setBrief([
-      `${openItems.length} open ${activeDefinition.label} item${openItems.length === 1 ? '' : 's'}; ${deliveryItems.length} in delivery or review.`,
-      blockedItems.length ? `${blockedItems.length} blocked item${blockedItems.length === 1 ? '' : 's'} needs an owner decision.` : 'No blocked work is recorded.',
-      `${verifiedEvidenceCount} of ${evidenceCount} evidence record${evidenceCount === 1 ? '' : 's'} verified in this team workspace.`,
+      `${openItems.length} open ${activeDefinition.label} item${openItems.length === 1 ? '' : 's'}; ${activeItems.length} in progress or review.`,
+      blockedItems.length ? `${blockedItems.length} blocked item${blockedItems.length === 1 ? '' : 's'} needs a human owner.` : 'No blocked work is recorded.',
+      `${verifiedEvidenceCount} of ${evidenceCount} evidence record${evidenceCount === 1 ? '' : 's'} verified.`,
     ])
   }
 
@@ -230,7 +250,7 @@ export function TeamsPage() {
         acceptanceEvidenceReference: decisionEvidenceReference.trim(),
       } : decision),
     }))
-    setNotice(`${reviewDecision.id} accepted by ${decisionReviewer.trim()} with an evidence reference.`)
+    setNotice(`${reviewDecision.id} accepted by ${decisionReviewer.trim()}.`)
     setReviewDecisionId('')
     setDecisionReviewer('')
     setDecisionNote('')
@@ -247,7 +267,7 @@ export function TeamsPage() {
       ...current,
       release: {
         ...current.release,
-        checks: current.release.checks.map((check) => check.id === checkId ? { ...check, complete: !check.complete } : check),
+        checks: current.release.checks.map((entry) => entry.id === checkId ? { ...entry, complete: !entry.complete } : entry),
       },
     }))
   }
@@ -257,33 +277,43 @@ export function TeamsPage() {
       <PageHeading
         eyebrow="Teams"
         title={activeDefinition.label}
-        copy={activeDefinition.purpose}
-        actions={<button className="core-button primary compact" onClick={() => selectView('intake')} type="button">New work</button>}
+        copy="Accountable work, delegated roles, evidence, and human review in one workspace."
+        actions={<button className="core-button primary" onClick={openNewWork} type="button">New work</button>}
       />
-      <div className="workspace-toolbar">
-        <div className="segmented-control" role="group" aria-label="Team workspace">
-          {teamDefinitions.map((team) => <button aria-pressed={activeTeam === team.id} key={team.id} onClick={() => selectTeam(team.id)} type="button">{team.label}</button>)}
-        </div>
-        <div className="view-tabs" role="tablist" aria-label={`${activeDefinition.label} views`}>
-          {validViews.map((view) => <button aria-selected={activeView === view.id} key={view.id} onClick={() => selectView(view.id)} role="tab" type="button">{view.label}</button>)}
-        </div>
+      <div className="workspace-toolbar simple-toolbar">
+        <label className="team-picker"><span>Team</span><select aria-label="Team" value={activeTeam} onChange={(event) => selectTeam(event.target.value as TeamId)}>{teamDefinitions.map((team) => <option key={team.id} value={team.id}>{team.label}</option>)}</select></label>
+        <nav className="view-tabs" aria-label={`${activeDefinition.label} workspace views`}>
+          {workspaceViews.map((view) => <button aria-current={activeView === view.id ? 'page' : undefined} key={view.id} onClick={() => selectView(view.id)} type="button">{view.label}</button>)}
+        </nav>
       </div>
-      <section className="summary-strip" aria-label={`${activeDefinition.label} summary`}>
-        <span><small>Open</small><strong>{openItems.length}</strong></span>
-        <span><small>Delivery</small><strong>{deliveryItems.length}</strong></span>
+      {activeView !== 'agents' ? <section className="summary-strip compact-summary" aria-label={`${activeDefinition.label} summary`}>
+        <span><small>Active</small><strong>{activeItems.length}</strong></span>
         <span><small>Blocked</small><strong>{blockedItems.length}</strong></span>
-        <span><small>Verified evidence</small><strong>{verifiedEvidenceCount}/{evidenceCount}</strong></span>
-        {activeTeam === 'product' ? <span><small>Release</small><strong>{releasePercent}%</strong></span> : null}
-      </section>
+        <span><small>Verified</small><strong>{verifiedEvidenceCount}/{evidenceCount}</strong></span>
+      </section> : null}
 
       <div className="workspace-view">
-        {activeView === 'board' ? <div className="split-workspace team-board-view">
+        {activeView === 'work' && intakeOpen ? <div className="split-workspace intake-view focused-intake">
+          <section className="core-panel form-panel">
+            <div className="panel-head"><div><span className="core-eyebrow">New accountable work</span><h2>Define the result first.</h2></div></div>
+            <form className="core-form compact-form" onSubmit={addWork}>
+              <label>Work item<input maxLength={160} required value={title} onChange={(event) => setTitle(event.target.value)} placeholder={`What should ${activeDefinition.label} own?`} /></label>
+              <div className="form-row"><label>Owner<input maxLength={80} required value={owner} onChange={(event) => setOwner(event.target.value)} /></label><label>Priority<select value={priority} onChange={(event) => setPriority(event.target.value as WorkPriority)}><option>P0</option><option>P1</option><option>P2</option></select></label></div>
+              {activeTeam === 'product' ? <label>Lifecycle<select value={productStage} onChange={(event) => setProductStage(event.target.value as ProductStage)}>{productStages.map((stage) => <option key={stage.id} value={stage.id}>{stage.label}</option>)}</select></label> : null}
+              <label>Acceptance outcome<textarea maxLength={320} required value={outcome} onChange={(event) => setOutcome(event.target.value)} placeholder="What observable result makes this done?" /></label>
+              <div className="form-actions"><button className="core-button" onClick={() => selectView('work')} type="button">Cancel</button><button className="core-button primary" type="submit">Add work</button></div>
+            </form>
+          </section>
+          <aside className="core-panel guidance-panel"><span className="core-eyebrow">Definition of ready</span><h2>Outcome, owner, evidence, boundary.</h2><ol><li>Name the observable result.</li><li>Assign one accountable human.</li><li>State what evidence proves it.</li><li>Keep consequential authority human.</li></ol></aside>
+        </div> : null}
+
+        {activeView === 'work' && !intakeOpen ? <div className="split-workspace team-board-view">
           <section className="core-panel queue-panel">
-            <div className="panel-head"><div><span className="core-eyebrow">Owned work</span><h2>{openItems.length} active records</h2></div></div>
+            <div className="panel-head"><div><span className="core-eyebrow">Owned work</span><h2>{openItems.length} open</h2></div></div>
             {teamItems.length ? <div className="record-list" role="list">{teamItems.map((item) => (
               <button aria-current={selectedItem?.id === item.id ? 'true' : undefined} className="record-row" key={item.id} onClick={() => setSelectedItemId(item.id)} type="button">
                 <span className={`record-status ${item.status}`} />
-                <span><strong>{item.title}</strong><small>{item.id} · {item.owner}</small></span>
+                <span><strong>{item.title}</strong><small>{item.id} / {item.owner}</small></span>
                 <span><b>{item.priority}</b><small>{statusLabel(item.status)}</small></span>
               </button>
             ))}</div> : <Empty>No work is recorded for this team.</Empty>}
@@ -297,51 +327,38 @@ export function TeamsPage() {
                 <label>Priority<select value={selectedItem.priority} onChange={(event) => updateWork(selectedItem.id, { priority: event.target.value as WorkPriority })}><option>P0</option><option>P1</option><option>P2</option></select></label>
                 {activeTeam === 'product' ? <label>Lifecycle<select value={selectedItem.productStage ?? defaultProductStage(selectedItem.status)} onChange={(event) => updateWork(selectedItem.id, { productStage: event.target.value as ProductStage })}>{productStages.map((stage) => <option key={stage.id} value={stage.id}>{stage.label}</option>)}</select></label> : null}
               </div>
-              <div className="evidence-register"><div><span>Evidence register</span><small>{selectedItem.evidence.filter((entry) => entry.status === 'verified').length}/{selectedItem.evidence.length} verified</small></div>{selectedItem.evidence.length ? <div className="evidence-record-list">{selectedItem.evidence.map((entry) => <article key={entry.id}><div><span className={`status-pill ${entry.status === 'verified' ? 'approved' : 'pending'}`}>{entry.status}</span><b>{evidenceKinds.find((kind) => kind.id === entry.kind)?.label ?? entry.kind}</b></div><strong>{entry.finding}</strong><small>{entry.reference} · {formatTime(entry.createdAt)}</small>{entry.status === 'observed' ? <button className="text-link" onClick={() => verifyEvidence(selectedItem.id, entry.id)} type="button">Mark verified</button> : null}</article>)}</div> : <p>No evidence attached yet.</p>}</div>
-              <form className="inline-evidence" onSubmit={attachEvidence}><label><span className="sr-only">Evidence type</span><select aria-label="Evidence type" value={evidenceKind} onChange={(event) => setEvidenceKind(event.target.value as EvidenceKind)}>{evidenceKinds.map((kind) => <option key={kind.id} value={kind.id}>{kind.label}</option>)}</select></label><label><span className="sr-only">Evidence source or reference</span><input maxLength={180} required value={evidenceReference} onChange={(event) => setEvidenceReference(event.target.value)} placeholder="Source, file, test, URL, or record" /></label><label><span className="sr-only">Evidence finding</span><input maxLength={240} required value={evidenceFinding} onChange={(event) => setEvidenceFinding(event.target.value)} placeholder="What does this evidence prove?" /></label><button className="core-button compact" type="submit">Attach</button></form>
-              <p className="form-notice" aria-live="polite">{notice || `Updated ${formatTime(selectedItem.createdAt)} · changes stay in this browser.`}</p>
+              <details className="evidence-disclosure">
+                <summary><span>Evidence register</span><strong>{selectedItem.evidence.filter((entry) => entry.status === 'verified').length}/{selectedItem.evidence.length} verified</strong></summary>
+                {selectedItem.evidence.length ? <div className="evidence-record-list">{selectedItem.evidence.map((entry) => <article key={entry.id}><div><span className={`status-pill ${entry.status === 'verified' ? 'approved' : 'pending'}`}>{entry.status}</span><b>{evidenceKinds.find((kind) => kind.id === entry.kind)?.label ?? entry.kind}</b></div><strong>{entry.finding}</strong><small>{entry.reference} / {formatTime(entry.createdAt)}{entry.verifiedBy ? ` / verified by ${entry.verifiedBy}` : ''}</small>{entry.status === 'observed' ? evidenceReviewId === entry.id ? <form className="evidence-verification-form" onSubmit={(event) => verifyEvidence(event, selectedItem.id, entry.id)}><label><span className="sr-only">Human reviewer</span><input autoFocus maxLength={80} required value={evidenceReviewer} onChange={(event) => setEvidenceReviewer(event.target.value)} placeholder="Human reviewer" /></label><button className="core-button compact" type="submit">Verify</button><button className="text-link" onClick={() => setEvidenceReviewId('')} type="button">Cancel</button></form> : <button className="text-link" onClick={() => { setEvidenceReviewId(entry.id); setEvidenceReviewer('') }} type="button">Review</button> : null}</article>)}</div> : <p className="panel-copy">No evidence attached yet.</p>}
+                <form className="inline-evidence" onSubmit={attachEvidence}><label><span className="sr-only">Evidence type</span><select aria-label="Evidence type" value={evidenceKind} onChange={(event) => setEvidenceKind(event.target.value as EvidenceKind)}>{evidenceKinds.map((kind) => <option key={kind.id} value={kind.id}>{kind.label}</option>)}</select></label><label><span className="sr-only">Evidence source or reference</span><input maxLength={180} required value={evidenceReference} onChange={(event) => setEvidenceReference(event.target.value)} placeholder="Source or reference" /></label><label><span className="sr-only">Evidence finding</span><input maxLength={240} required value={evidenceFinding} onChange={(event) => setEvidenceFinding(event.target.value)} placeholder="What does it prove?" /></label><button className="core-button compact" type="submit">Attach</button></form>
+              </details>
+              <p className="form-notice" aria-live="polite">{notice || `Updated ${formatTime(selectedItem.createdAt)} / local record only.`}</p>
             </> : <Empty>Select a work record.</Empty>}
           </section>
         </div> : null}
 
-        {activeView === 'intake' ? <div className="split-workspace intake-view">
-          <section className="core-panel form-panel">
-            <div className="panel-head"><div><span className="core-eyebrow">New accountable work</span><h2>Define the result before the task.</h2></div></div>
-            <form className="core-form compact-form" onSubmit={addWork}>
-              <label>Work item<input maxLength={160} required value={title} onChange={(event) => setTitle(event.target.value)} placeholder={`What should ${activeDefinition.label} own?`} /></label>
-              <div className="form-row"><label>Owner<input maxLength={80} required value={owner} onChange={(event) => setOwner(event.target.value)} /></label><label>Priority<select value={priority} onChange={(event) => setPriority(event.target.value as WorkPriority)}><option>P0</option><option>P1</option><option>P2</option></select></label></div>
-              {activeTeam === 'product' ? <label>Product lifecycle stage<select value={productStage} onChange={(event) => setProductStage(event.target.value as ProductStage)}>{productStages.map((stage) => <option key={stage.id} value={stage.id}>{stage.label}</option>)}</select></label> : null}
-              <label>Acceptance outcome<textarea maxLength={320} required value={outcome} onChange={(event) => setOutcome(event.target.value)} placeholder="What observable result makes this done?" /></label>
-              <div className="form-actions"><button className="core-button" onClick={() => selectView('board')} type="button">Cancel</button><button className="core-button primary" type="submit">Add work</button></div>
-            </form>
-          </section>
-          <aside className="core-panel guidance-panel"><span className="core-eyebrow">Definition of ready</span><h2>One record should answer four questions.</h2><ol><li>What observable outcome changes?</li><li>Who owns the decision?</li><li>What evidence will prove it?</li><li>What authority remains human?</li></ol></aside>
-        </div> : null}
+        {activeView === 'agents' ? <AgentTeamsPanel activeTeam={activeTeam} setWorkspace={setWorkspace} workspace={workspace} /> : null}
 
-        {activeView === 'review' ? <div className="review-workspace">
-          {activeTeam === 'product' ? <section className="core-panel lifecycle-panel">
-            <div className="panel-head"><div><span className="core-eyebrow">Product lifecycle</span><h2>Discover → define → build → release → learn</h2></div></div>
-            <div className="lifecycle-grid">{productStages.map((stage) => { const stageItems = teamItems.filter((item) => (item.productStage ?? defaultProductStage(item.status)) === stage.id); return <article key={stage.id}><span>{stage.label}</span><strong>{stageItems.length}</strong><p>{stage.purpose}</p></article> })}</div>
-          </section> : null}
+        {activeView === 'review' ? <div className="review-workspace simplified-review">
           <div className="split-workspace review-grid">
             <section className="core-panel release-panel">
-              <div className="panel-head"><div><span className="core-eyebrow">{activeTeam === 'product' ? 'Release control' : 'Team review'}</span><h2>{activeTeam === 'product' ? workspace.release.name : `${activeDefinition.label} evidence`}</h2></div>{activeTeam === 'product' ? <span className="status-pill bounded">{releasePercent}% ready</span> : null}</div>
-              {activeTeam === 'product' ? <div className="release-checks">{workspace.release.checks.map((check) => <label key={check.id}><input checked={check.complete} onChange={() => toggleReleaseCheck(check.id)} type="checkbox" /><span>{check.label}</span></label>)}</div> : <div className="evidence-summary"><strong>{evidenceCount}</strong><p>Evidence references are attached across {teamItems.length} work records.</p></div>}
+              <div className="panel-head"><div><span className="core-eyebrow">{activeTeam === 'product' ? 'Release control' : 'Evidence review'}</span><h2>{activeTeam === 'product' ? workspace.release.name : activeDefinition.label}</h2></div>{activeTeam === 'product' ? <span className="status-pill bounded">{releasePercent}% ready</span> : null}</div>
+              {activeTeam === 'product' ? <div className="release-checks">{workspace.release.checks.map((check) => <label key={check.id}><input checked={check.complete} onChange={() => toggleReleaseCheck(check.id)} type="checkbox" /><span>{check.label}</span></label>)}</div> : <div className="evidence-summary"><strong>{verifiedEvidenceCount}/{evidenceCount}</strong><p>Verified evidence across {teamItems.length} work records.</p></div>}
             </section>
             <section className="core-panel brief-panel">
-              <div className="panel-head"><div><span className="core-eyebrow">Record brief</span><h2>Review what the evidence says.</h2></div><button className="core-button compact" onClick={prepareBrief} type="button">Prepare brief</button></div>
-              {brief.length ? <div className="brief-output"><div className="brief-command"><span>&gt;</span> summarize {activeDefinition.label.toLowerCase()} records</div>{brief.map((line) => <p key={line}>{line}</p>)}</div> : <Empty>The brief uses only this team’s recorded work and evidence.</Empty>}
-              <p className="authority-note">Preparation is not approval. Sends, payments, publishing, and production writes remain owner-controlled.</p>
+              <div className="panel-head"><div><span className="core-eyebrow">Team brief</span><h2>Review recorded facts.</h2></div><button className="core-button compact" onClick={prepareBrief} type="button">Prepare</button></div>
+              {brief.length ? <div className="brief-output">{brief.map((line) => <p key={line}>{line}</p>)}</div> : <Empty>The brief uses only recorded work and evidence.</Empty>}
+              <p className="authority-note">Preparation is not approval. Sends, payments, publishing, merges, deployments, and production writes remain human-controlled.</p>
             </section>
           </div>
-        </div> : null}
-
-        {activeView === 'decisions' && activeTeam === 'product' ? <div className="split-workspace decision-view">
-          <section className="core-panel decision-list-panel">
-            <div className="panel-head"><div><span className="core-eyebrow">Product decisions</span><h2>Rationale stays with the record.</h2></div></div>
-            <div className="decision-list">{workspace.decisions.map((decision) => <article key={decision.id}><div><span className={`status-pill ${decision.status === 'accepted' ? 'approved' : 'pending'}`}>{decision.status}</span><strong>{decision.title}</strong><p>{decision.rationale}</p><small>{decision.id} · {decision.owner} · {formatTime(decision.createdAt)}</small>{decision.status === 'accepted' ? <small>{decision.acceptedActorKind === 'human' && decision.acceptedBy ? `Accepted by ${decision.acceptedBy} · ${decision.acceptanceEvidenceReference}` : 'Legacy acceptance · reviewer attribution unavailable'}</small> : null}</div>{decision.status === 'proposed' ? <button className="core-button compact" onClick={() => startDecisionReview(decision.id)} type="button">Review</button> : null}</article>)}</div>
-          </section>
-          <section className="core-panel decision-form-panel">{reviewDecision ? <><span className="core-eyebrow">Human acceptance</span><h2>{reviewDecision.title}</h2><p className="panel-copy">{reviewDecision.rationale}</p><form className="core-form compact-form decision-acceptance-form" onSubmit={acceptDecision}><label>Human reviewer<input autoFocus maxLength={80} required value={decisionReviewer} onChange={(event) => setDecisionReviewer(event.target.value)} placeholder="Name or accountable role" /></label><label>Decision note<textarea maxLength={360} required value={decisionNote} onChange={(event) => setDecisionNote(event.target.value)} placeholder="Why this is accepted and what boundary remains." /></label><label>Evidence reference<input maxLength={240} required value={decisionEvidenceReference} onChange={(event) => setDecisionEvidenceReference(event.target.value)} placeholder="Record, test, source, or review URL" /></label><div className="form-actions"><button className="text-link" onClick={() => setReviewDecisionId('')} type="button">Cancel</button><button className="core-button primary" type="submit">Accept and record</button></div></form></> : <><span className="core-eyebrow">Proposal</span><h2>Record a decision.</h2><form className="core-form compact-form" onSubmit={addDecision}><label>Decision<input maxLength={160} required value={decisionTitle} onChange={(event) => setDecisionTitle(event.target.value)} /></label><label>Rationale<textarea maxLength={360} required value={decisionRationale} onChange={(event) => setDecisionRationale(event.target.value)} /></label><button className="core-button primary" type="submit">Record proposal</button></form></>}<p className="form-notice" aria-live="polite">{notice}</p></section>
+          {activeTeam === 'product' ? <details className="core-panel decision-workspace-disclosure" open={requestedView === 'decisions' ? true : undefined}>
+            <summary><span>Product decisions</span><strong>{workspace.decisions.length} records</strong></summary>
+            <div className="decision-workspace-content">
+              <div className="decision-list">{workspace.decisions.map((decision) => <article key={decision.id}><div><span className={`status-pill ${decision.status === 'accepted' ? 'approved' : 'pending'}`}>{decision.status}</span><strong>{decision.title}</strong><p>{decision.rationale}</p><small>{decision.id} / {decision.owner} / {formatTime(decision.createdAt)}</small>{decision.status === 'accepted' ? <small>{decision.acceptedActorKind === 'human' && decision.acceptedBy ? `Accepted by ${decision.acceptedBy} / ${decision.acceptanceEvidenceReference}` : 'Reviewer attribution unavailable'}</small> : null}</div>{decision.status === 'proposed' ? <button className="core-button compact" onClick={() => startDecisionReview(decision.id)} type="button">Review</button> : null}</article>)}</div>
+              <div className="decision-form-panel">{reviewDecision ? <><span className="core-eyebrow">Human acceptance</span><h2>{reviewDecision.title}</h2><form className="core-form compact-form" onSubmit={acceptDecision}><label>Human reviewer<input autoFocus maxLength={80} required value={decisionReviewer} onChange={(event) => setDecisionReviewer(event.target.value)} /></label><label>Decision note<textarea maxLength={360} required value={decisionNote} onChange={(event) => setDecisionNote(event.target.value)} /></label><label>Evidence reference<input maxLength={240} required value={decisionEvidenceReference} onChange={(event) => setDecisionEvidenceReference(event.target.value)} /></label><div className="form-actions"><button className="core-button" onClick={() => setReviewDecisionId('')} type="button">Cancel</button><button className="core-button primary" type="submit">Accept and record</button></div></form></> : <><span className="core-eyebrow">Proposal</span><h2>Record a decision.</h2><form className="core-form compact-form" onSubmit={addDecision}><label>Decision<input maxLength={160} required value={decisionTitle} onChange={(event) => setDecisionTitle(event.target.value)} /></label><label>Rationale<textarea maxLength={360} required value={decisionRationale} onChange={(event) => setDecisionRationale(event.target.value)} /></label><button className="core-button primary" type="submit">Record proposal</button></form></>}</div>
+            </div>
+          </details> : null}
+          <p className="form-notice" aria-live="polite">{notice}</p>
         </div> : null}
       </div>
     </div>

--- a/showroom/src/core/core-app.css
+++ b/showroom/src/core/core-app.css
@@ -12,7 +12,7 @@
   --core-green-soft: rgba(124, 245, 180, .1);
   --core-warn: #ffb86b;
   --core-danger: #ff7b8d;
-  --core-radius: 8px;
+  --core-radius: 10px;
   --core-mono: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
 }
 
@@ -26,99 +26,102 @@ button, a { -webkit-tap-highlight-color: transparent; }
 a { color: inherit; }
 .sr-only { position: absolute; width: 1px; height: 1px; overflow: hidden; clip: rect(0,0,0,0); white-space: nowrap; }
 
-.core-shell { height: 100svh; display: grid; grid-template-columns: 208px minmax(0, 1fr); }
-.core-sidebar { position: fixed; inset: 0 auto 0 0; z-index: 30; width: 208px; display: flex; flex-direction: column; border-right: 1px solid var(--core-line); padding: 20px 14px 16px; background: rgba(8,10,9,.94); backdrop-filter: blur(20px); }
-.core-stage { min-width: 0; min-height: 0; grid-column: 2; display: grid; grid-template-rows: 58px minmax(0,1fr); }
-.core-main { width: min(calc(100% - 36px), 1420px); height: 100%; min-width: 0; min-height: 0; margin: 0 auto; padding: 18px 0; overflow: hidden; }
+.core-shell { height: 100svh; display: grid; grid-template-columns: 184px minmax(0, 1fr); }
+.core-sidebar { position: fixed; inset: 0 auto 0 0; z-index: 30; width: 184px; display: flex; flex-direction: column; border-right: 1px solid var(--core-line); padding: 20px 16px 16px; background: rgba(8,10,9,.94); backdrop-filter: blur(20px); }
+.core-stage { min-width: 0; min-height: 0; grid-column: 2; display: grid; grid-template-rows: 56px minmax(0,1fr); }
+.core-main { width: min(calc(100% - 40px), 1420px); height: 100%; min-width: 0; min-height: 0; margin: 0 auto; padding: 20px 0; overflow: hidden; }
 .core-skip { position: fixed; z-index: 100; top: -60px; left: 230px; border: 1px solid var(--core-green); border-radius: 5px; padding: 9px 12px; background: var(--core-panel); text-decoration: none; }
 .core-skip:focus { top: 10px; }
 
 .core-brand { min-height: 38px; display: inline-flex; align-items: center; gap: 11px; text-decoration: none; }
-.core-brand-mark { color: var(--core-green); font-family: var(--core-mono); font-size: 20px; font-weight: 850; letter-spacing: -.14em; }
-.core-brand-name { color: var(--core-ink); font-size: 11px; font-weight: 850; letter-spacing: .1em; }
+.core-brand-mark { color: var(--core-green); font-family: var(--core-mono); font-size: 22px; font-weight: 850; letter-spacing: -.14em; }
+.core-brand-name { color: var(--core-ink); font-size: 12px; font-weight: 850; letter-spacing: .1em; }
 .workspace-label { display: grid; gap: 3px; margin: 28px 8px 10px; }
 .workspace-label span { color: var(--core-quiet); font-family: var(--core-mono); font-size: 8px; letter-spacing: .1em; text-transform: uppercase; }
 .workspace-label strong { font-size: 11px; }
-.core-nav { display: grid; gap: 3px; }
-.core-nav a { min-height: 42px; display: flex; align-items: center; gap: 11px; border: 1px solid transparent; border-radius: 5px; padding: 0 11px; color: var(--core-muted); font-size: 12px; font-weight: 720; text-decoration: none; }
+.core-nav { display: grid; gap: 5px; margin-top: 26px; }
+.core-nav a { min-height: 44px; display: flex; align-items: center; border: 1px solid transparent; border-radius: 6px; padding: 0 12px; color: var(--core-muted); font-size: 13px; font-weight: 720; text-decoration: none; }
 .core-nav a span { width: 20px; color: var(--core-quiet); font-family: var(--core-mono); font-size: 8px; }
 .core-nav a:hover { background: rgba(255,255,255,.035); color: var(--core-ink); }
 .core-nav a.active { border-color: rgba(124,245,180,.2); background: var(--core-green-soft); color: var(--core-ink); }
 .core-nav a.active span { color: var(--core-green); }
-.sidebar-foot { display: grid; gap: 9px; margin-top: auto; border-top: 1px solid var(--core-line); padding: 14px 7px 0; }
+.sidebar-foot { display: grid; gap: 8px; margin-top: auto; border-top: 1px solid var(--core-line); padding: 14px 4px 0; }
 .sidebar-foot p { margin: 0; color: var(--core-quiet); font-size: 8px; line-height: 1.55; }
-.sidebar-foot a { min-height: 30px; display: inline-flex; align-items: center; color: var(--core-muted); font-size: 10px; text-decoration: none; }
+.sidebar-foot a { min-height: 36px; display: inline-flex; align-items: center; color: var(--core-muted); font-size: 12px; text-decoration: none; }
 
-.core-topbar { position: relative; z-index: 20; display: flex; align-items: center; justify-content: space-between; gap: 14px; border-bottom: 1px solid var(--core-line); padding: 0 22px; background: rgba(8,10,9,.84); backdrop-filter: blur(18px); }
+.core-topbar { position: relative; z-index: 20; display: flex; align-items: center; justify-content: space-between; gap: 14px; border-bottom: 1px solid var(--core-line); padding: 0 20px; background: rgba(8,10,9,.84); backdrop-filter: blur(18px); }
 .core-topbar > div { display: flex; align-items: center; gap: 9px; }
 .mobile-brand { display: none !important; }
 .terminal-prompt { color: var(--core-green); font-family: var(--core-mono); font-size: 14px; font-weight: 850; }
-.topbar-title strong { font-size: 11px; }
-.topbar-meta { color: var(--core-quiet); font-family: var(--core-mono); font-size: 8px; }
+.topbar-title { min-width: 0; }
+.topbar-title strong { font-size: 13px; }
+.topbar-title span { color: var(--core-quiet); font-size: 10px; }
+.topbar-meta { color: var(--core-quiet); font-family: var(--core-mono); font-size: 10px; }
+.core-topbar .topbar-meta { display: none; }
 .topbar-meta > span { border-right: 1px solid var(--core-line); padding-right: 9px; }
 .topbar-meta a { color: var(--core-muted); text-decoration: none; }
 .topbar-meta a:hover { color: var(--core-green); }
 .mobile-nav { display: none; }
-.runtime-badge { min-height: 25px; display: inline-flex; align-items: center; gap: 6px; border: 1px solid var(--core-line); border-radius: 4px; padding: 0 8px; color: var(--core-muted); font-family: var(--core-mono); font-size: 8px; font-weight: 740; text-transform: uppercase; }
+.runtime-badge { min-height: 28px; display: inline-flex; align-items: center; gap: 6px; border: 1px solid var(--core-line); border-radius: 5px; padding: 0 9px; color: var(--core-muted); font-family: var(--core-mono); font-size: 9px; font-weight: 740; text-transform: uppercase; }
 .runtime-badge i { width: 5px; height: 5px; border-radius: 50%; background: var(--core-quiet); }
 .runtime-badge.demo, .runtime-badge.enterprise { border-color: rgba(124,245,180,.22); background: var(--core-green-soft); color: var(--core-green); }
 .runtime-badge.demo i, .runtime-badge.enterprise i { background: var(--core-green); }
 
-.workspace-screen { height: 100%; min-height: 0; display: flex; flex-direction: column; gap: 11px; }
-.page-heading { min-height: 52px; display: flex; align-items: flex-end; justify-content: space-between; gap: 22px; }
+.workspace-screen { height: 100%; min-height: 0; display: flex; flex-direction: column; gap: 14px; }
+.page-heading { min-height: 60px; display: flex; align-items: flex-end; justify-content: space-between; gap: 22px; }
 .page-heading > div:first-child { min-width: 0; }
-.core-eyebrow { display: inline-flex; align-items: center; gap: 7px; color: var(--core-green); font-family: var(--core-mono); font-size: 9px; font-weight: 760; letter-spacing: .09em; text-transform: uppercase; }
+.core-eyebrow { display: inline-flex; align-items: center; gap: 7px; color: var(--core-green); font-family: var(--core-mono); font-size: 10px; font-weight: 760; letter-spacing: .08em; text-transform: uppercase; }
 .core-eyebrow::before { width: 5px; height: 5px; border-radius: 50%; background: currentColor; box-shadow: 0 0 10px currentColor; content: ""; }
-.page-heading h1 { margin: 4px 0 2px; font-size: clamp(25px, 3.1vw, 38px); line-height: 1; letter-spacing: -.045em; }
-.page-heading p { max-width: 800px; margin: 0; overflow: hidden; color: var(--core-muted); font-size: 11px; line-height: 1.45; text-overflow: ellipsis; white-space: nowrap; }
+.page-heading h1 { margin: 5px 0 3px; font-size: clamp(28px, 3.1vw, 40px); line-height: 1; letter-spacing: -.045em; }
+.page-heading p { max-width: 800px; margin: 0; overflow: hidden; color: var(--core-muted); font-size: 13px; line-height: 1.45; text-overflow: ellipsis; white-space: nowrap; }
 .heading-actions { flex: 0 0 auto; }
-.operations-profile { width: min(430px,38vw); display: grid; grid-template-columns: auto minmax(0,1fr) auto; align-items: center; gap: 2px 8px; border-left: 1px solid var(--core-line); padding: 3px 0 3px 12px; }
-.operations-profile > span { color: var(--core-quiet); font-family: var(--core-mono); font-size: 7px; font-weight: 720; letter-spacing: .06em; text-transform: uppercase; }
-.operations-profile > strong { overflow: hidden; font-size: 10px; text-overflow: ellipsis; white-space: nowrap; }
-.operations-profile > small { grid-column: 1/3; overflow: hidden; color: var(--core-muted); font-size: 7px; text-overflow: ellipsis; white-space: nowrap; }
-.operations-profile .text-link { grid-column: 3; grid-row: 1/3; min-height: 26px; }
+.operations-profile { width: min(340px,35vw); display: grid; grid-template-columns: minmax(0,1fr) auto; align-items: center; gap: 3px 12px; border-left: 1px solid var(--core-line); padding: 3px 0 3px 14px; }
+.operations-profile > span { overflow: hidden; color: var(--core-quiet); font-family: var(--core-mono); font-size: 9px; font-weight: 720; letter-spacing: .05em; text-overflow: ellipsis; text-transform: uppercase; white-space: nowrap; }
+.operations-profile > strong { grid-column: 1; overflow: hidden; font-size: 11px; text-overflow: ellipsis; white-space: nowrap; }
+.operations-profile .text-link { grid-column: 2; grid-row: 1/3; min-height: 32px; }
 
-.core-button { min-height: 36px; display: inline-flex; align-items: center; justify-content: center; gap: 7px; border: 1px solid var(--core-line-strong); border-radius: 5px; padding: 0 13px; background: rgba(255,255,255,.025); color: var(--core-ink); font-size: 11px; font-weight: 760; text-decoration: none; cursor: pointer; }
+.core-button { min-height: 40px; display: inline-flex; align-items: center; justify-content: center; gap: 7px; border: 1px solid var(--core-line-strong); border-radius: 6px; padding: 0 14px; background: rgba(255,255,255,.025); color: var(--core-ink); font-size: 12px; font-weight: 760; text-decoration: none; cursor: pointer; }
 .core-button:hover { border-color: rgba(255,255,255,.34); background: rgba(255,255,255,.06); }
 .core-button.primary { border-color: var(--core-green); background: var(--core-green); color: #07100a; }
-.core-button.compact { min-height: 31px; padding-inline: 10px; font-size: 9px; }
+.core-button.compact { min-height: 36px; padding-inline: 11px; font-size: 11px; }
 .core-button.danger { border-color: rgba(255,123,141,.4); color: var(--core-danger); }
-.text-link { min-height: 30px; display: inline-flex; align-items: center; border: 0; padding: 0; background: transparent; color: var(--core-green); font-family: var(--core-mono); font-size: 9px; font-weight: 760; text-decoration: none; text-transform: uppercase; cursor: pointer; }
+.text-link { min-height: 34px; display: inline-flex; align-items: center; border: 0; padding: 0; background: transparent; color: var(--core-green); font-family: var(--core-mono); font-size: 10px; font-weight: 760; text-decoration: none; text-transform: uppercase; cursor: pointer; }
 .text-link:hover { color: var(--core-ink); }
 .danger-text { color: var(--core-danger); }
 
-.workspace-toolbar { min-height: 38px; display: flex; align-items: center; justify-content: space-between; gap: 12px; border-bottom: 1px solid var(--core-line); }
+.workspace-toolbar { min-height: 44px; display: flex; align-items: center; justify-content: space-between; gap: 14px; border-bottom: 1px solid var(--core-line); }
 .segmented-control, .view-tabs { display: flex; min-width: 0; align-items: center; gap: 3px; }
-.segmented-control button, .segmented-control a, .view-tabs button { min-height: 31px; border: 1px solid transparent; border-radius: 4px; padding: 0 10px; display: inline-flex; align-items: center; background: transparent; color: var(--core-quiet); font-size: 9px; font-weight: 720; text-decoration: none; cursor: pointer; white-space: nowrap; }
+.segmented-control button, .segmented-control a, .view-tabs button { min-height: 38px; border: 1px solid transparent; border-radius: 5px; padding: 0 12px; display: inline-flex; align-items: center; background: transparent; color: var(--core-quiet); font-size: 11px; font-weight: 720; text-decoration: none; cursor: pointer; white-space: nowrap; }
 .segmented-control button:hover, .segmented-control a:hover, .view-tabs button:hover { color: var(--core-ink); }
 .segmented-control button[aria-pressed="true"] { border-color: rgba(124,245,180,.22); background: var(--core-green-soft); color: var(--core-green); }
-.view-tabs button[aria-selected="true"] { border-bottom-color: var(--core-green); border-radius: 0; color: var(--core-ink); }
+.view-tabs button[aria-selected="true"], .view-tabs button[aria-current="page"] { border-bottom-color: var(--core-green); border-radius: 0; color: var(--core-ink); }
 .segmented-control.wide { display: grid; grid-template-columns: repeat(2,minmax(0,1fr)); }
 
-.summary-strip { min-height: 54px; display: grid; grid-template-columns: repeat(5,minmax(0,1fr)); overflow: hidden; border: 1px solid var(--core-line); border-radius: var(--core-radius); background: rgba(255,255,255,.018); }
+.summary-strip { min-height: 62px; display: grid; grid-template-columns: repeat(auto-fit,minmax(120px,1fr)); overflow: hidden; border: 1px solid var(--core-line); border-radius: var(--core-radius); background: rgba(255,255,255,.018); }
+.summary-strip.compact-summary { grid-template-columns: repeat(3,minmax(0,1fr)); }
 .summary-strip > span { min-width: 0; display: flex; align-items: center; justify-content: space-between; gap: 10px; border-right: 1px solid var(--core-line); padding: 0 14px; }
 .summary-strip > span:last-child { border-right: 0; }
-.summary-strip small { overflow: hidden; color: var(--core-quiet); font-family: var(--core-mono); font-size: 8px; text-overflow: ellipsis; text-transform: uppercase; white-space: nowrap; }
-.summary-strip strong { overflow: hidden; color: var(--core-ink); font-size: 15px; text-overflow: ellipsis; white-space: nowrap; }
+.summary-strip small { overflow: hidden; color: var(--core-quiet); font-family: var(--core-mono); font-size: 10px; text-overflow: ellipsis; text-transform: uppercase; white-space: nowrap; }
+.summary-strip strong { overflow: hidden; color: var(--core-ink); font-size: 18px; text-overflow: ellipsis; white-space: nowrap; }
 
 .workspace-view { min-height: 0; flex: 1; }
 .operation-module { height: 100%; min-height: 0; display: flex; flex-direction: column; gap: 11px; }
 .operation-module > .split-workspace, .operation-module > .module-today, .operation-module > .control-workspace, .operation-module > .inventory-panel { height: auto; min-height: 0; flex: 1; }
 .split-workspace { height: 100%; min-height: 0; display: grid; grid-template-columns: minmax(300px,.85fr) minmax(0,1.15fr); gap: 11px; }
-.core-panel { min-width: 0; min-height: 0; overflow: hidden; border: 1px solid var(--core-line); border-radius: var(--core-radius); padding: 16px; background: rgba(16,20,17,.88); box-shadow: inset 0 1px rgba(255,255,255,.025); }
+.core-panel { min-width: 0; min-height: 0; overflow: hidden; border: 1px solid var(--core-line); border-radius: var(--core-radius); padding: 18px; background: rgba(16,20,17,.88); box-shadow: inset 0 1px rgba(255,255,255,.025); }
 .panel-head { min-height: 35px; display: flex; align-items: flex-start; justify-content: space-between; gap: 14px; margin-bottom: 10px; }
-.panel-head h2, .core-panel > h2 { margin: 3px 0 0; font-size: 16px; line-height: 1.15; letter-spacing: -.025em; }
-.panel-head p { margin: 4px 0 0; color: var(--core-muted); font-size: 9px; }
-.panel-note { color: var(--core-quiet); font-family: var(--core-mono); font-size: 9px; text-align: right; }
-.panel-copy, .authority-note { margin: 10px 0 0; color: var(--core-quiet); font-size: 10px; line-height: 1.55; }
+.panel-head h2, .core-panel > h2 { margin: 4px 0 0; font-size: 18px; line-height: 1.15; letter-spacing: -.025em; }
+.panel-head p { margin: 4px 0 0; color: var(--core-muted); font-size: 11px; }
+.panel-note { color: var(--core-quiet); font-family: var(--core-mono); font-size: 10px; text-align: right; }
+.panel-copy, .authority-note { margin: 10px 0 0; color: var(--core-quiet); font-size: 11px; line-height: 1.55; }
 .authority-note { border-left: 2px solid var(--core-green); padding-left: 10px; }
-.status-pill { min-height: 23px; display: inline-flex; align-items: center; gap: 5px; border: 1px solid var(--core-line); border-radius: 999px; padding: 0 7px; color: var(--core-muted); font-family: var(--core-mono); font-size: 7px; font-weight: 740; text-transform: uppercase; white-space: nowrap; }
+.status-pill { min-height: 26px; display: inline-flex; align-items: center; gap: 5px; border: 1px solid var(--core-line); border-radius: 999px; padding: 0 8px; color: var(--core-muted); font-family: var(--core-mono); font-size: 9px; font-weight: 740; text-transform: uppercase; white-space: nowrap; }
 .status-pill::before { width: 4px; height: 4px; border-radius: 50%; background: currentColor; content: ""; }
 .status-pill.ready, .status-pill.approved, .status-pill.bounded { border-color: rgba(124,245,180,.22); background: var(--core-green-soft); color: var(--core-green); }
 .status-pill.pending { border-color: rgba(255,184,107,.28); color: var(--core-warn); }
 
 .record-list, .order-list, .issue-list, .decision-list, .attention-list, .approval-list, .job-list { min-height: 0; overflow: auto; scrollbar-color: rgba(124,245,180,.25) transparent; }
-.record-row { width: 100%; min-height: 55px; display: grid; grid-template-columns: 8px minmax(0,1fr) auto; gap: 10px; align-items: center; border: 0; border-bottom: 1px solid var(--core-line); padding: 7px 5px; background: transparent; color: var(--core-ink); text-align: left; text-decoration: none; cursor: pointer; }
+.record-row { width: 100%; min-height: 60px; display: grid; grid-template-columns: 8px minmax(0,1fr) auto; gap: 10px; align-items: center; border: 0; border-bottom: 1px solid var(--core-line); padding: 8px 6px; background: transparent; color: var(--core-ink); text-align: left; text-decoration: none; cursor: pointer; }
 .record-row:hover, .record-row[aria-current="true"] { background: rgba(124,245,180,.045); }
 .record-status { width: 5px; height: 5px; border-radius: 50%; background: var(--core-quiet); }
 .record-status.in_progress, .record-status.review { background: var(--core-green); box-shadow: 0 0 8px rgba(124,245,180,.4); }
@@ -127,19 +130,19 @@ a { color: inherit; }
 .record-row > span { min-width: 0; display: grid; gap: 3px; }
 .record-row > span:last-child { justify-items: end; }
 .record-row strong, .record-row small { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.record-row strong { font-size: 11px; }
-.record-row small { color: var(--core-quiet); font-size: 9px; }
-.record-row b { color: var(--core-green); font-family: var(--core-mono); font-size: 9px; }
+.record-row strong { font-size: 12px; }
+.record-row small { color: var(--core-quiet); font-size: 10px; }
+.record-row b { color: var(--core-green); font-family: var(--core-mono); font-size: 10px; }
 
 .queue-panel, .record-detail-panel, .decision-list-panel, .order-queue-panel, .job-panel { display: flex; flex-direction: column; }
 .queue-panel .record-list, .decision-list-panel .decision-list, .order-queue-panel .order-list, .job-panel .job-list { flex: 1; }
 .record-detail-panel { overflow: auto; }
 .record-detail-head { display: flex; align-items: flex-start; justify-content: space-between; gap: 14px; border-bottom: 1px solid var(--core-line); padding-bottom: 12px; }
 .record-detail-head h2 { margin: 5px 0; font-size: 18px; }
-.record-detail-head p { margin: 0; color: var(--core-muted); font-size: 10px; line-height: 1.5; }
+.record-detail-head p { margin: 0; color: var(--core-muted); font-size: 12px; line-height: 1.5; }
 .record-controls { display: grid; grid-template-columns: repeat(4,minmax(0,1fr)); gap: 8px; margin-top: 12px; }
-label { display: grid; gap: 5px; color: var(--core-muted); font-size: 9px; font-weight: 700; }
-input, select, textarea { width: 100%; min-width: 0; border: 1px solid var(--core-line); border-radius: 4px; padding: 8px 9px; background: #0a0d0b; color: var(--core-ink); outline: none; }
+label { display: grid; gap: 6px; color: var(--core-muted); font-size: 11px; font-weight: 700; }
+input, select, textarea { width: 100%; min-width: 0; min-height: 40px; border: 1px solid var(--core-line); border-radius: 5px; padding: 9px 10px; background: #0a0d0b; color: var(--core-ink); font-size: 12px; outline: none; }
 input:focus, select:focus, textarea:focus { border-color: var(--core-green); box-shadow: 0 0 0 2px rgba(124,245,180,.08); }
 textarea { min-height: 72px; resize: vertical; }
 .evidence-register { margin-top: 12px; border-top: 1px solid var(--core-line); padding-top: 10px; }
@@ -148,9 +151,9 @@ textarea { min-height: 72px; resize: vertical; }
 .evidence-record-list { max-height: 175px; display: grid !important; gap: 6px; overflow: auto; margin-top: 8px; }
 .evidence-record-list article { display: grid; grid-template-columns: minmax(0,1fr) auto; gap: 4px 10px; border: 1px solid var(--core-line); border-radius: 4px; padding: 7px 8px; background: rgba(124,245,180,.02); }
 .evidence-record-list article > div { display: flex; align-items: center; gap: 6px; }
-.evidence-record-list article > div b { color: var(--core-muted); font-family: var(--core-mono); font-size: 7px; text-transform: uppercase; }
-.evidence-record-list article > strong { grid-column: 1/-1; color: var(--core-ink); font-size: 9px; }
-.evidence-record-list article > small { min-width: 0; overflow: hidden; color: var(--core-quiet); font-size: 7px; text-overflow: ellipsis; white-space: nowrap; }
+.evidence-record-list article > div b { color: var(--core-muted); font-family: var(--core-mono); font-size: 9px; text-transform: uppercase; }
+.evidence-record-list article > strong { grid-column: 1/-1; color: var(--core-ink); font-size: 11px; }
+.evidence-record-list article > small { min-width: 0; overflow: hidden; color: var(--core-quiet); font-size: 9px; text-overflow: ellipsis; white-space: nowrap; }
 .evidence-record-list article > button { align-self: end; }
 .inline-evidence { display: grid; grid-template-columns: minmax(110px,.48fr) minmax(150px,.85fr) minmax(180px,1.15fr) auto; gap: 8px; margin-top: 10px; }
 .core-form { display: grid; gap: 10px; }
@@ -161,7 +164,7 @@ textarea { min-height: 72px; resize: vertical; }
 .template-contract strong { overflow: hidden; font-size: 8px; font-weight: 680; text-overflow: ellipsis; white-space: nowrap; }
 .template-contract small { grid-column: 2; color: var(--core-quiet); font-size: 7px; }
 .form-actions { display: flex; justify-content: flex-end; gap: 8px; }
-.form-notice { min-height: 14px; margin: 6px 0 0; color: var(--core-quiet); font-size: 7px; line-height: 1.45; }
+.form-notice { min-height: 16px; margin: 7px 0 0; color: var(--core-quiet); font-size: 10px; line-height: 1.45; }
 .accountable-action-gate { flex: 0 0 auto; display: grid; grid-template-columns: minmax(200px,.55fr) minmax(0,1.45fr); gap: 18px; align-items: end; border-color: rgba(124,245,180,.3); background: linear-gradient(110deg, rgba(124,245,180,.07), rgba(16,20,17,.96) 42%); }
 .action-change h2 { margin: 4px 0 8px; font-size: 15px; }
 .action-change p { display: flex; flex-wrap: wrap; align-items: center; gap: 7px; margin: 0; color: var(--core-quiet); font-family: var(--core-mono); font-size: 8px; }
@@ -184,7 +187,7 @@ textarea { min-height: 72px; resize: vertical; }
 .action-history-list article p { margin: 0; color: var(--core-green); font-family: var(--core-mono); font-size: 8px; }
 .action-history-list article > small { grid-column: 1/-1; }
 .form-panel, .guidance-panel, .order-form-panel, .output-panel, .decision-form-panel, .setup-form { overflow: auto; }
-.guidance-panel ol { display: grid; gap: 10px; margin: 18px 0 0; padding-left: 22px; color: var(--core-muted); font-size: 10px; }
+.guidance-panel ol { display: grid; gap: 10px; margin: 18px 0 0; padding-left: 22px; color: var(--core-muted); font-size: 12px; }
 
 .review-workspace, .control-workspace, .module-today { height: 100%; min-height: 0; display: flex; flex-direction: column; gap: 11px; }
 .lifecycle-panel { flex: 0 0 auto; }
@@ -205,7 +208,7 @@ textarea { min-height: 72px; resize: vertical; }
 .brief-command span { color: var(--core-green); }
 .empty-state { min-height: 90px; display: grid; place-content: center; justify-items: center; color: var(--core-quiet); text-align: center; }
 .empty-state span { color: var(--core-green); font-family: var(--core-mono); }
-.empty-state p { max-width: 300px; margin: 5px 0 0; font-size: 8px; }
+.empty-state p { max-width: 320px; margin: 6px 0 0; font-size: 11px; }
 .decision-list article { display: grid; grid-template-columns: 1fr auto; gap: 12px; align-items: center; border-bottom: 1px solid var(--core-line); padding: 10px 2px; }
 .decision-list article > div { min-width: 0; display: grid; gap: 5px; }
 .decision-list strong { font-size: 10px; }
@@ -330,6 +333,90 @@ textarea { min-height: 72px; resize: vertical; }
 .trial-control-panel p { margin: 0; color: var(--core-quiet); font-size: 8px; }
 .trial-actions { display: flex; flex-wrap: wrap; align-items: center; justify-content: flex-end; gap: 8px; }
 
+.simple-toolbar { justify-content: flex-start; }
+.team-picker { min-width: 220px; display: flex; align-items: center; gap: 9px; }
+.team-picker > span { color: var(--core-quiet); font-family: var(--core-mono); font-size: 10px; font-weight: 760; text-transform: uppercase; }
+.team-picker select { min-height: 38px; padding-block: 0; }
+.simple-toolbar .view-tabs { margin-left: auto; }
+
+.evidence-disclosure { margin-top: 14px; border-top: 1px solid var(--core-line); }
+.evidence-disclosure > summary, .decision-workspace-disclosure > summary, .company-brief-disclosure > summary { min-height: 42px; display: flex; align-items: center; justify-content: space-between; gap: 12px; color: var(--core-muted); font-size: 11px; cursor: pointer; list-style: none; }
+.evidence-disclosure > summary::-webkit-details-marker, .decision-workspace-disclosure > summary::-webkit-details-marker, .company-brief-disclosure > summary::-webkit-details-marker, .compact-disclosure > summary::-webkit-details-marker, .product-app-launcher > summary::-webkit-details-marker { display: none; }
+.evidence-disclosure > summary::before, .decision-workspace-disclosure > summary::before, .company-brief-disclosure > summary::before { color: var(--core-green); font-family: var(--core-mono); content: ">_"; }
+.evidence-disclosure > summary span, .decision-workspace-disclosure > summary span { margin-right: auto; color: var(--core-ink); font-weight: 760; }
+.evidence-disclosure > summary strong, .decision-workspace-disclosure > summary strong { color: var(--core-quiet); font-family: var(--core-mono); font-size: 10px; }
+.evidence-disclosure[open] > summary, .decision-workspace-disclosure[open] > summary { border-bottom: 1px solid var(--core-line); }
+
+.agent-team-workspace { height: 100%; min-height: 0; display: flex; flex-direction: column; gap: 11px; }
+.agent-boundary-banner { flex: 0 0 auto; display: flex; align-items: center; justify-content: space-between; gap: 18px; border: 1px solid rgba(124,245,180,.24); border-radius: var(--core-radius); padding: 11px 14px; background: rgba(124,245,180,.045); }
+.agent-boundary-banner > div { min-width: 0; display: grid; gap: 3px; }
+.agent-boundary-banner strong { font-size: 12px; }
+.agent-boundary-banner p { max-width: 560px; margin: 0; color: var(--core-muted); font-size: 10px; line-height: 1.45; text-align: right; }
+.agent-summary { flex: 0 0 auto; min-height: 50px; display: grid; grid-template-columns: repeat(4,minmax(0,1fr)); overflow: hidden; border: 1px solid var(--core-line); border-radius: var(--core-radius); }
+.agent-summary span { display: flex; align-items: center; justify-content: space-between; gap: 8px; border-right: 1px solid var(--core-line); padding: 0 13px; }
+.agent-summary span:last-child { border-right: 0; }
+.agent-summary small { color: var(--core-quiet); font-family: var(--core-mono); font-size: 9px; text-transform: uppercase; }
+.agent-summary strong { font-size: 16px; }
+.agent-team-view { flex: 1; }
+.agent-roster-panel, .agent-detail-panel { display: flex; flex-direction: column; }
+.agent-roster-panel { position: relative; }
+.agent-roster { min-height: 0; flex: 1; overflow: auto; }
+.agent-roster > button { width: 100%; min-height: 62px; display: grid; grid-template-columns: 8px minmax(0,1fr) auto; gap: 10px; align-items: center; border: 0; border-bottom: 1px solid var(--core-line); padding: 8px 5px; background: transparent; color: var(--core-ink); text-align: left; cursor: pointer; }
+.agent-roster > button:hover, .agent-roster > button[aria-current="true"] { background: rgba(124,245,180,.045); }
+.agent-roster > button > span { min-width: 0; display: grid; gap: 3px; }
+.agent-roster > button > span:last-child { justify-items: end; }
+.agent-roster strong, .agent-roster small, .agent-roster b { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.agent-roster strong { font-size: 12px; }
+.agent-roster small { color: var(--core-quiet); font-size: 9px; }
+.agent-roster b { color: var(--core-green); font-family: var(--core-mono); font-size: 9px; }
+.agent-detail-panel { overflow: auto; }
+.agent-control-grid { display: grid; grid-template-columns: repeat(2,minmax(0,1fr)); gap: 9px; margin-top: 13px; }
+.agent-boundary-copy { margin: 10px 0 0; border-left: 2px solid var(--core-green); padding-left: 10px; color: var(--core-muted); font-size: 10px; line-height: 1.45; }
+.capability-fieldset { margin: 13px 0 0; border: 1px solid var(--core-line); border-radius: 6px; padding: 10px; }
+.capability-fieldset legend { padding: 0 6px; color: var(--core-quiet); font-family: var(--core-mono); font-size: 9px; text-transform: uppercase; }
+.capability-fieldset > div { display: flex; flex-wrap: wrap; gap: 6px; }
+.capability-fieldset label { min-height: 32px; grid-template-columns: auto 1fr; align-items: center; border: 1px solid var(--core-line); border-radius: 999px; padding: 0 9px; color: var(--core-muted); font-size: 10px; cursor: pointer; }
+.capability-fieldset input { width: auto; min-height: 0; margin: 0; }
+.agent-evidence-card { display: grid; gap: 6px; margin-top: 12px; border-top: 1px solid var(--core-line); padding-top: 11px; }
+.agent-evidence-card > div { display: flex; align-items: center; justify-content: space-between; color: var(--core-muted); font-size: 10px; }
+.agent-evidence-card > strong { font-size: 11px; }
+.agent-evidence-card > small, .agent-evidence-card > p { margin: 0; color: var(--core-quiet); font-size: 9px; }
+.compact-disclosure { position: relative; }
+.compact-disclosure > summary { min-height: 34px; display: inline-flex; align-items: center; border: 1px solid var(--core-line-strong); border-radius: 5px; padding: 0 10px; color: var(--core-muted); font-size: 10px; font-weight: 760; cursor: pointer; list-style: none; }
+.compact-disclosure[open] > summary { border-color: var(--core-green); color: var(--core-ink); }
+.agent-create-form { position: absolute; z-index: 8; top: 42px; right: 0; width: 300px; border: 1px solid var(--core-line-strong); border-radius: 7px; padding: 12px; background: #0d120f; box-shadow: 0 18px 50px rgba(0,0,0,.45); }
+.evidence-disclosure .compact-disclosure { margin-top: 2px; }
+.evidence-disclosure .inline-evidence { margin-bottom: 3px; }
+.evidence-disclosure .evidence-record-list { max-height: 190px; }
+.evidence-disclosure .panel-copy { margin-bottom: 8px; }
+.evidence-disclosure .text-link { min-height: 28px; }
+.evidence-verification-form { grid-column: 1/-1; display: grid; grid-template-columns: minmax(150px,1fr) auto auto; gap: 7px; align-items: end; border-top: 1px solid var(--core-line); padding-top: 7px; }
+.evidence-verification-form input, .evidence-verification-form .core-button { min-height: 36px; }
+.evidence-disclosure[open] { padding-bottom: 4px; }
+.evidence-disclosure .inline-evidence { grid-template-columns: minmax(105px,.45fr) minmax(140px,.8fr) minmax(170px,1fr) auto; }
+.evidence-disclosure .inline-evidence input, .evidence-disclosure .inline-evidence select { min-height: 36px; font-size: 11px; }
+.evidence-disclosure .inline-evidence .core-button { min-height: 36px; }
+.agent-evidence-form { margin-top: 8px; }
+
+.decision-workspace-disclosure { flex: 0 0 auto; max-height: 300px; padding: 0 16px; }
+.decision-workspace-content { display: grid; grid-template-columns: minmax(0,1.25fr) minmax(280px,.75fr); gap: 14px; max-height: 245px; padding: 12px 0; }
+.decision-workspace-content .decision-list { overflow: auto; }
+.decision-form-panel { overflow: auto; border-left: 1px solid var(--core-line); padding-left: 14px; }
+.decision-form-panel > h2 { margin: 4px 0 10px; font-size: 16px; }
+
+.release-review-link { min-height: 34px; display: inline-flex; align-items: center; margin-top: 5px; color: var(--core-green); font-size: 10px; font-weight: 740; text-decoration: none; }
+.company-brief-disclosure { margin-top: 5px; border-top: 1px solid var(--core-line); }
+.company-brief-disclosure > summary { justify-content: flex-start; color: var(--core-ink); font-weight: 740; }
+.company-brief-disclosure > .text-link { min-height: 30px; }
+
+.operations-toolbar-actions { display: flex; align-items: center; gap: 10px; }
+.product-app-launcher { position: relative; }
+.product-app-launcher > summary { min-height: 36px; display: inline-flex; align-items: center; border: 1px solid var(--core-line); border-radius: 5px; padding: 0 10px; color: var(--core-muted); font-size: 10px; font-weight: 720; cursor: pointer; list-style: none; }
+.product-app-launcher[open] > summary { border-color: rgba(124,245,180,.3); color: var(--core-ink); }
+.product-app-launcher > div { position: absolute; z-index: 10; top: 42px; right: 0; width: 170px; display: grid; border: 1px solid var(--core-line-strong); border-radius: 7px; padding: 6px; background: #0d120f; box-shadow: 0 16px 45px rgba(0,0,0,.45); }
+.product-app-launcher a { min-height: 40px; display: flex; align-items: center; border-radius: 5px; padding: 0 10px; color: var(--core-muted); font-size: 11px; text-decoration: none; }
+.product-app-launcher a:hover { background: var(--core-green-soft); color: var(--core-ink); }
+
 :focus-visible { outline: 2px solid rgba(124,245,180,.5); outline-offset: 2px; }
 
 @media (max-width: 1120px) {
@@ -350,8 +437,10 @@ textarea { min-height: 72px; resize: vertical; }
   .core-sidebar { display: none; }
   .core-stage { min-height: 100svh; display: block; }
   .core-topbar { position: sticky; top: 0; min-height: 54px; padding-inline: 14px; }
+  .core-topbar .topbar-meta { display: flex; }
   .mobile-brand { display: flex !important; }
-  .topbar-title, .topbar-meta > span, .topbar-meta > a { display: none !important; }
+  .topbar-title, .topbar-meta > span { display: none !important; }
+  .topbar-meta > a { min-height: 38px; display: inline-flex; align-items: center; color: var(--core-muted); font-size: 10px; text-decoration: none; }
   .mobile-nav { position: sticky; top: 54px; z-index: 19; min-height: 42px; display: grid; grid-template-columns: repeat(3,1fr); border-bottom: 1px solid var(--core-line); background: rgba(8,10,9,.94); }
   .mobile-nav a { display: grid; place-items: center; color: var(--core-quiet); font-size: 9px; font-weight: 720; text-decoration: none; }
   .mobile-nav a.active { border-bottom: 2px solid var(--core-green); color: var(--core-ink); }
@@ -363,15 +452,20 @@ textarea { min-height: 72px; resize: vertical; }
   .operations-screen .heading-actions { width: 100%; }
   .operations-profile { width: 100%; max-width: none; border-top: 1px solid var(--core-line); border-left: 0; padding: 7px 0 0; }
   .workspace-toolbar { align-items: flex-start; overflow-x: auto; }
+  .operations-toolbar { overflow: visible; }
   .segmented-control, .view-tabs { flex: 0 0 auto; }
   .summary-strip { grid-template-columns: repeat(2,minmax(0,1fr)); }
+  .summary-strip.compact-summary { grid-template-columns: repeat(3,minmax(0,1fr)); }
   .summary-strip > span { min-height: 48px; border-bottom: 1px solid var(--core-line); }
   .summary-strip > span:nth-child(2n) { border-right: 0; }
-  .summary-strip > span:last-child { grid-column: 1/-1; border-bottom: 0; }
+  .summary-strip > span:last-child:nth-child(odd) { grid-column: 1/-1; border-bottom: 0; }
+  .summary-strip.compact-summary > span { border-bottom: 0; }
+  .summary-strip.compact-summary > span:nth-child(2n) { border-right: 1px solid var(--core-line); }
+  .summary-strip.compact-summary > span:last-child { grid-column: auto; border-right: 0; }
   .summary-strip small { font-size: 7px; }
   .split-workspace, .settings-grid, .command-grid { height: auto; display: grid; grid-template-columns: 1fr; grid-template-rows: auto; }
   .command-queue-panel { grid-row: auto; }
-  .core-panel { min-height: 180px; overflow: visible; }
+  .core-panel { min-height: 0; overflow: visible; }
   .record-list, .order-list, .issue-list, .decision-list, .attention-list, .approval-list, .job-list { max-height: 420px; }
   .queue-panel .record-list, .decision-list-panel .decision-list, .order-queue-panel .order-list, .job-panel .job-list { flex: none; }
   .workspace-view { overflow: visible !important; }
@@ -383,6 +477,14 @@ textarea { min-height: 72px; resize: vertical; }
   .lifecycle-grid { grid-template-columns: repeat(2,minmax(0,1fr)); }
   .settings-grid { min-height: 0; }
   .trial-control-panel { align-items: flex-start; }
+  .agent-team-workspace { height: auto; }
+  .agent-team-view { flex: none; }
+  .agent-roster { max-height: 360px; }
+  .agent-boundary-banner { align-items: flex-start; }
+  .agent-boundary-banner p { max-width: 360px; }
+  .decision-workspace-disclosure { max-height: none; }
+  .decision-workspace-content { grid-template-columns: 1fr; max-height: none; }
+  .decision-form-panel { border-top: 1px solid var(--core-line); border-left: 0; padding: 13px 0 0; }
 }
 
 @media (max-width: 560px) {
@@ -391,9 +493,18 @@ textarea { min-height: 72px; resize: vertical; }
   .page-heading h1 { font-size: 26px; }
   .heading-actions .core-button { min-height: 32px; padding-inline: 9px; }
   .workspace-toolbar { display: grid; justify-content: stretch; }
+  .summary-strip > span { display: grid; align-content: center; justify-content: stretch; gap: 3px; }
+  .summary-strip small { line-height: 1.25; white-space: normal; }
+  .summary-strip strong { font-size: 16px; }
   .segmented-control, .view-tabs { width: max-content; }
-  .team-screen .segmented-control { display: grid; width: 100%; grid-template-columns: repeat(2,minmax(0,1fr)); }
-  .team-screen .segmented-control button { white-space: normal; }
+  .simple-toolbar { grid-template-columns: 1fr; }
+  .team-picker { width: 100%; min-width: 0; }
+  .team-picker select { flex: 1; }
+  .simple-toolbar .view-tabs { width: 100%; display: grid; grid-template-columns: repeat(3,minmax(0,1fr)); margin-left: 0; }
+  .simple-toolbar .view-tabs button { justify-content: center; }
+  .operations-toolbar-actions { min-width: 0; align-items: center; justify-content: space-between; overflow: visible; }
+  .operations-toolbar-actions .view-tabs { min-width: 0; overflow-x: auto; }
+  .product-app-launcher { flex: 0 0 auto; }
   .form-row, .record-controls { grid-template-columns: 1fr; }
   .decision-dialog { inset: auto 0 0; width: 100%; max-height: 92svh; margin: 0 auto; border-radius: 10px 10px 0 0; padding: 15px; }
   .decision-packet-meta, .decision-outcomes, .decision-fields { grid-template-columns: 1fr; }
@@ -402,6 +513,7 @@ textarea { min-height: 72px; resize: vertical; }
   .action-confirm-form { grid-template-columns: 1fr; }
   .action-confirm-form .form-actions { grid-column: auto; justify-content: flex-start; }
   .inline-evidence { grid-template-columns: 1fr; }
+  .evidence-disclosure .inline-evidence { grid-template-columns: 1fr; }
   .lifecycle-grid { grid-template-columns: 1fr; }
   .data-table { min-width: 0; }
   .data-row.table-head { display: none; }
@@ -422,6 +534,17 @@ textarea { min-height: 72px; resize: vertical; }
   .order-list article > div:last-child { justify-items: start; }
   .trial-control-panel { display: grid; }
   .trial-actions { justify-content: flex-start; }
+  .agent-boundary-banner { display: grid; }
+  .agent-boundary-banner p { text-align: left; }
+  .agent-summary { grid-template-columns: repeat(2,minmax(0,1fr)); }
+  .agent-summary span { min-height: 46px; border-bottom: 1px solid var(--core-line); }
+  .agent-summary span:nth-child(2n) { border-right: 0; }
+  .agent-summary span:nth-last-child(-n+2) { border-bottom: 0; }
+  .agent-control-grid { grid-template-columns: 1fr; }
+  .agent-create-form { position: static; width: min(100%,300px); margin-top: 8px; }
+  .agent-roster-panel .panel-head { align-items: flex-start; }
+  .compact-disclosure > summary, .product-app-launcher > summary { min-height: 44px; }
+  .core-button, .core-button.compact, .segmented-control button, .segmented-control a, .view-tabs button, .mobile-nav a { min-height: 44px; }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/showroom/src/core/team-work.ts
+++ b/showroom/src/core/team-work.ts
@@ -6,6 +6,9 @@ export type WorkStatus = 'backlog' | 'in_progress' | 'blocked' | 'review' | 'don
 export type ProductStage = 'discover' | 'define' | 'build' | 'release' | 'learn'
 export type EvidenceKind = 'customer' | 'metric' | 'test' | 'release' | 'decision' | 'source'
 export type EvidenceStatus = 'observed' | 'verified'
+export type AgentState = 'available' | 'assigned' | 'waiting_review' | 'blocked'
+export type AgentCapability = 'research' | 'planning' | 'implementation' | 'verification' | 'analysis' | 'drafting'
+export type AgentApprovalBoundary = 'prepare_only' | 'local_change_review'
 
 export type EvidenceRecord = {
   id: string
@@ -15,6 +18,8 @@ export type EvidenceRecord = {
   reference: string
   status: EvidenceStatus
   verifiedAt?: string
+  verifiedBy?: string
+  verifiedActorKind?: 'human'
 }
 
 export type TeamWorkItem = {
@@ -51,13 +56,36 @@ export type ProductRelease = {
   checks: Array<{ id: string; label: string; complete: boolean }>
 }
 
+export type AgentEvidence = {
+  capturedAt: string
+  summary: string
+  reference: string
+}
+
+export type DelegatedAgent = {
+  id: string
+  createdAt: string
+  updatedAt: string
+  name: string
+  team: TeamId
+  role: string
+  humanOwner: string
+  state: AgentState
+  capabilities: AgentCapability[]
+  approvalBoundary: AgentApprovalBoundary
+  assignedWorkItemId?: string
+  lastEvidence?: AgentEvidence
+}
+
 export type TeamWorkspaceState = {
   items: TeamWorkItem[]
+  agents: DelegatedAgent[]
   decisions: ProductDecision[]
   release: ProductRelease
 }
 
-export const TEAM_WORK_KEY = 'supermega.team.workspace.v2'
+export const TEAM_WORK_KEY = 'supermega.team.workspace.v3'
+export const LEGACY_TEAM_WORK_KEYS = ['supermega.team.workspace.v2'] as const
 
 export const teamDefinitions = [
   { id: 'product', label: 'Product', purpose: 'Outcomes, backlog, acceptance, decisions, and release readiness.' },
@@ -83,11 +111,47 @@ export const evidenceKinds = [
   { id: 'source', label: 'Source' },
 ] as const satisfies ReadonlyArray<{ id: EvidenceKind; label: string }>
 
+export const agentStates = [
+  { id: 'available', label: 'Available' },
+  { id: 'assigned', label: 'Assigned' },
+  { id: 'waiting_review', label: 'Needs review' },
+  { id: 'blocked', label: 'Blocked' },
+] as const satisfies ReadonlyArray<{ id: AgentState; label: string }>
+
+export const agentCapabilities = [
+  { id: 'research', label: 'Research' },
+  { id: 'planning', label: 'Planning' },
+  { id: 'implementation', label: 'Implementation' },
+  { id: 'verification', label: 'Verification' },
+  { id: 'analysis', label: 'Analysis' },
+  { id: 'drafting', label: 'Drafting' },
+] as const satisfies ReadonlyArray<{ id: AgentCapability; label: string }>
+
+export const agentApprovalBoundaries = [
+  {
+    id: 'prepare_only',
+    label: 'Prepare only',
+    description: 'May research, analyse, and draft. A human performs any consequential action.',
+  },
+  {
+    id: 'local_change_review',
+    label: 'Local change + review',
+    description: 'May make bounded local changes. A human reviews before merge, send, payment, publish, or deploy.',
+  },
+] as const satisfies ReadonlyArray<{ id: AgentApprovalBoundary; label: string; description: string }>
+
+export const defaultAgentCapabilities: Record<TeamId, AgentCapability[]> = {
+  product: ['research', 'planning', 'analysis'],
+  engineering: ['implementation', 'verification', 'analysis'],
+  growth: ['research', 'analysis', 'drafting'],
+  finance: ['research', 'verification', 'analysis'],
+}
+
 const minutesAgo = (minutes: number) => new Date(Date.now() - minutes * 60 * 1000).toISOString()
 
 function seedEvidence(id: string, minutes: number, kind: EvidenceKind, finding: string, reference: string): EvidenceRecord {
   const timestamp = minutesAgo(minutes)
-  return { id, createdAt: timestamp, kind, finding, reference, status: 'verified', verifiedAt: timestamp }
+  return { id, createdAt: timestamp, kind, finding, reference, status: 'verified', verifiedAt: timestamp, verifiedBy: 'Workspace owner', verifiedActorKind: 'human' }
 }
 
 export const seedTeamWorkspace: TeamWorkspaceState = {
@@ -177,6 +241,65 @@ export const seedTeamWorkspace: TeamWorkspaceState = {
       evidence: [],
     },
   ],
+  agents: [
+    {
+      id: 'AGT-PROD-01',
+      createdAt: minutesAgo(66),
+      updatedAt: minutesAgo(32),
+      name: 'Product planner',
+      team: 'product',
+      role: 'Discovery, acceptance, and prioritisation',
+      humanOwner: 'Product lead',
+      state: 'assigned',
+      capabilities: [...defaultAgentCapabilities.product],
+      approvalBoundary: 'prepare_only',
+      assignedWorkItemId: 'PROD-102',
+    },
+    {
+      id: 'AGT-ENG-01',
+      createdAt: minutesAgo(61),
+      updatedAt: minutesAgo(27),
+      name: 'Build engineer',
+      team: 'engineering',
+      role: 'Bounded implementation and release verification',
+      humanOwner: 'Engineering lead',
+      state: 'waiting_review',
+      capabilities: [...defaultAgentCapabilities.engineering],
+      approvalBoundary: 'local_change_review',
+      assignedWorkItemId: 'ENG-201',
+      lastEvidence: {
+        capturedAt: minutesAgo(27),
+        summary: 'Canonical application build and release checks passed locally.',
+        reference: 'local://verification/app-build-contract',
+      },
+    },
+    {
+      id: 'AGT-GROW-01',
+      createdAt: minutesAgo(56),
+      updatedAt: minutesAgo(22),
+      name: 'Growth operator',
+      team: 'growth',
+      role: 'Positioning, onboarding, and follow-up drafts',
+      humanOwner: 'Growth lead',
+      state: 'assigned',
+      capabilities: [...defaultAgentCapabilities.growth],
+      approvalBoundary: 'prepare_only',
+      assignedWorkItemId: 'GROW-301',
+    },
+    {
+      id: 'AGT-FIN-01',
+      createdAt: minutesAgo(49),
+      updatedAt: minutesAgo(18),
+      name: 'Risk reviewer',
+      team: 'finance',
+      role: 'Spend controls, evidence checks, and escalation',
+      humanOwner: 'Finance owner',
+      state: 'blocked',
+      capabilities: [...defaultAgentCapabilities.finance],
+      approvalBoundary: 'prepare_only',
+      assignedWorkItemId: 'FIN-401',
+    },
+  ],
   decisions: [
     {
       id: 'DEC-101',
@@ -235,7 +358,8 @@ function normalizeEvidence(value: unknown, itemId: string, itemCreatedAt: string
 
   const candidate = value as Partial<EvidenceRecord>
   const kind = evidenceKinds.some((entry) => entry.id === candidate.kind) ? candidate.kind as EvidenceKind : 'source'
-  const status: EvidenceStatus = candidate.status === 'verified' ? 'verified' : 'observed'
+  const verifiedBy = String(candidate.verifiedBy || '').trim()
+  const status: EvidenceStatus = candidate.status === 'verified' && candidate.verifiedActorKind === 'human' && verifiedBy ? 'verified' : 'observed'
   const finding = String(candidate.finding || '').trim()
   const reference = String(candidate.reference || '').trim()
   if (!finding && !reference) return null
@@ -250,6 +374,8 @@ function normalizeEvidence(value: unknown, itemId: string, itemCreatedAt: string
     reference: reference || finding,
     status,
     verifiedAt,
+    verifiedBy: status === 'verified' ? verifiedBy : undefined,
+    verifiedActorKind: status === 'verified' ? 'human' : undefined,
   }
 }
 
@@ -282,9 +408,63 @@ function normalizeDecision(decision: ProductDecision): ProductDecision {
   }
 }
 
-function normalizeWorkspace(value: Partial<TeamWorkspaceState>): TeamWorkspaceState {
+function normalizeAgent(value: DelegatedAgent, index: number): DelegatedAgent | null {
+  if (!value || typeof value !== 'object') return null
+  const candidate = value as Partial<DelegatedAgent>
+  const team = teamDefinitions.some((entry) => entry.id === candidate.team) ? candidate.team as TeamId : null
+  const name = String(candidate.name || '').trim()
+  const role = String(candidate.role || '').trim()
+  const humanOwner = String(candidate.humanOwner || '').trim()
+  if (!team || !name || !role || !humanOwner) return null
+
+  const state = agentStates.some((entry) => entry.id === candidate.state) ? candidate.state as AgentState : 'blocked'
+  const capabilityCandidates = Array.isArray(candidate.capabilities) ? candidate.capabilities : null
+  const capabilities = capabilityCandidates
+    ? capabilityCandidates.filter((capability): capability is AgentCapability => agentCapabilities.some((entry) => entry.id === capability))
+    : []
+  if (capabilityCandidates && capabilities.length === 0) return null
+  const approvalBoundary = agentApprovalBoundaries.some((entry) => entry.id === candidate.approvalBoundary)
+    ? candidate.approvalBoundary as AgentApprovalBoundary
+    : 'prepare_only'
+  const createdAt = String(candidate.createdAt || new Date().toISOString())
+  const evidenceCandidate = candidate.lastEvidence
+  const evidenceSummary = String(evidenceCandidate?.summary || '').trim()
+  const evidenceReference = String(evidenceCandidate?.reference || '').trim()
+  const lastEvidence = evidenceSummary && evidenceReference ? {
+    capturedAt: String(evidenceCandidate?.capturedAt || candidate.updatedAt || createdAt),
+    summary: evidenceSummary,
+    reference: evidenceReference,
+  } : undefined
+
   return {
-    items: Array.isArray(value.items) ? value.items.map(normalizeWorkItem) : seedTeamWorkspace.items,
+    id: String(candidate.id || `AGT-${index + 1}`),
+    createdAt,
+    updatedAt: String(candidate.updatedAt || createdAt),
+    name,
+    team,
+    role,
+    humanOwner,
+    state,
+    capabilities: capabilities.length ? [...new Set(capabilities)] : [...defaultAgentCapabilities[team]],
+    approvalBoundary,
+    assignedWorkItemId: String(candidate.assignedWorkItemId || '').trim() || undefined,
+    lastEvidence,
+  }
+}
+
+function normalizeWorkspace(value: Partial<TeamWorkspaceState>): TeamWorkspaceState {
+  const items = Array.isArray(value.items) ? value.items.map(normalizeWorkItem) : seedTeamWorkspace.items
+  const agents = (Array.isArray(value.agents) ? value.agents.map(normalizeAgent).filter((agent): agent is DelegatedAgent => Boolean(agent)) : [])
+    .map((agent) => {
+      const assignedItem = items.find((item) => item.id === agent.assignedWorkItemId)
+      const hasValidAssignment = !agent.assignedWorkItemId || assignedItem?.team === agent.team
+      if (!hasValidAssignment) return { ...agent, assignedWorkItemId: undefined, state: 'blocked' as const }
+      if (agent.state === 'waiting_review' && !agent.lastEvidence) return { ...agent, state: 'blocked' as const }
+      return agent
+    })
+  return {
+    items,
+    agents,
     decisions: Array.isArray(value.decisions) ? value.decisions.map(normalizeDecision) : seedTeamWorkspace.decisions,
     release: value.release && Array.isArray(value.release.checks) ? value.release : seedTeamWorkspace.release,
   }
@@ -292,12 +472,15 @@ function normalizeWorkspace(value: Partial<TeamWorkspaceState>): TeamWorkspaceSt
 
 export function useTeamWorkspace() {
   const [state, setState] = useState<TeamWorkspaceState>(() => {
-    try {
-      const stored = window.localStorage.getItem(TEAM_WORK_KEY)
-      return stored ? normalizeWorkspace(JSON.parse(stored) as Partial<TeamWorkspaceState>) : seedTeamWorkspace
-    } catch {
-      return seedTeamWorkspace
+    for (const storageKey of [TEAM_WORK_KEY, ...LEGACY_TEAM_WORK_KEYS]) {
+      try {
+        const stored = window.localStorage.getItem(storageKey)
+        if (stored) return normalizeWorkspace(JSON.parse(stored) as Partial<TeamWorkspaceState>)
+      } catch {
+        // Continue to a valid legacy record before falling back to the seed.
+      }
     }
+    return seedTeamWorkspace
   })
 
   useEffect(() => {

--- a/showroom/src/products/ecommerce/CommerceWorkspaces.tsx
+++ b/showroom/src/products/ecommerce/CommerceWorkspaces.tsx
@@ -29,7 +29,6 @@ type CommerceWorkspacesProps = {
   onRequestWebsiteIntake: () => void
   onSelectOrder: (orderId: string) => void
   websiteHandoff: WebsiteEcommerceHandoffContext | null
-  websiteDraftCreated: boolean
 }
 
 type OrderFilter = 'attention' | 'all'
@@ -211,7 +210,6 @@ function OrdersWorkspace({
   onRequestWebsiteIntake,
   onSelectOrder,
   websiteHandoff,
-  websiteDraftCreated,
 }: {
   filter: OrderFilter
   orders: CommerceOrder[]
@@ -222,26 +220,32 @@ function OrdersWorkspace({
   onRequestWebsiteIntake: () => void
   onSelectOrder: (orderId: string) => void
   websiteHandoff: WebsiteEcommerceHandoffContext | null
-  websiteDraftCreated: boolean
 }) {
   const websiteDraft = websiteHandoff?.draft ?? null
+  const websiteOrder = websiteHandoff?.order ?? null
   const draftLine = websiteDraft?.lines[0]
+  const fulfilmentLabel = websiteOrder?.fulfilmentMethod === 'local_delivery' ? 'Local delivery' : 'Customer pickup'
+  const paymentLabel = websiteOrder?.paymentMethod === 'manual_qr'
+    ? 'Manual QR review'
+    : websiteOrder?.paymentMethod === 'manual_bank_transfer'
+      ? 'Manual bank transfer review'
+      : 'Cash on delivery'
 
   return (
     <div className="eco-orders-stack">
       {websiteHandoff ? (
         <section className="eco-website-intake" aria-labelledby="eco-website-intake-title">
-          <span className="eco-mode-badge"><i />{websiteDraft ? 'Order draft' : 'Website handoff'}</span>
+          <span className="eco-mode-badge"><i />{websiteOrder ? 'Ready record' : websiteDraft ? 'Order draft' : 'Website handoff'}</span>
           <div>
-            <strong id="eco-website-intake-title">{websiteDraft ? `${websiteDraft.id} · Needs completion` : websiteHandoff.display ? `${websiteHandoff.display.siteName} · ${websiteHandoff.display.pagePath}` : 'Accepted Website revision'}</strong>
+            <strong id="eco-website-intake-title">{websiteOrder ? `${websiteOrder.id} · Ready for confirmation` : websiteDraft ? `${websiteDraft.id} · Needs completion` : websiteHandoff.display ? `${websiteHandoff.display.siteName} · ${websiteHandoff.display.pagePath}` : 'Accepted Website revision'}</strong>
             <small>{websiteHandoff.display ? `${websiteHandoff.display.pageHeadline} · approved by ${websiteHandoff.display.approvedBy}` : 'The source workspace changed after acceptance; only the audit references remain.'}</small>
           </div>
           <div>
-            <strong>{draftLine ? `${draftLine.quantity} × ${draftLine.itemName} · ${formatMmk(websiteDraft?.totalMmk ?? 0)}` : `${websiteHandoff.handoff.intake.quantity} × ${websiteHandoff.handoff.intake.sku}`}</strong>
-            <small>{draftLine ? `${draftLine.sku} · price snapshot ${formatMmk(draftLine.unitPriceMmk)} · missing customer, fulfilment, payment` : 'Non-PII intake · no order, reservation, payment, or customer contact'}</small>
+            <strong>{websiteOrder ? `${websiteOrder.customerReference} · ${fulfilmentLabel} · ${paymentLabel}` : draftLine ? `${draftLine.quantity} × ${draftLine.itemName} · ${formatMmk(websiteDraft?.totalMmk ?? 0)}` : `${websiteHandoff.handoff.intake.quantity} × ${websiteHandoff.handoff.intake.sku}`}</strong>
+            <small>{websiteOrder ? `${websiteOrder.lines[0].sku} · immutable ${formatMmk(websiteOrder.totalMmk)} · no confirmation, reservation, payment, or send` : draftLine ? `${draftLine.sku} · price snapshot ${formatMmk(draftLine.unitPriceMmk)} · missing customer, fulfilment, payment` : 'Non-PII intake · no order, reservation, payment, or customer contact'}</small>
           </div>
-          <button className="eco-button eco-button-primary" disabled={websiteDraftCreated} onClick={onRequestWebsiteIntake} type="button">
-            {websiteDraftCreated ? 'Draft created' : websiteHandoff.handoff.state === 'accepted' ? 'Create local draft' : 'Review intake'}
+          <button className="eco-button eco-button-primary" disabled={Boolean(websiteOrder)} onClick={onRequestWebsiteIntake} type="button">
+            {websiteOrder ? 'Ready for confirmation' : websiteDraft ? 'Complete draft' : websiteHandoff.handoff.state === 'accepted' ? 'Create local draft' : 'Review intake'}
           </button>
         </section>
       ) : null}
@@ -426,7 +430,6 @@ export function CommerceWorkspaces({
   onRequestWebsiteIntake,
   onSelectOrder,
   websiteHandoff,
-  websiteDraftCreated,
 }: CommerceWorkspacesProps) {
   const [orderFilter, setOrderFilter] = useState<OrderFilter>('attention')
   const [paymentFilter, setPaymentFilter] = useState<PaymentFilter>('review')
@@ -438,5 +441,5 @@ export function CommerceWorkspaces({
   if (view === 'fulfillment') return <FulfillmentWorkspace orders={orders} selectedOrder={selectedOrder} onOpenOrder={onOpenOrder} onRequestFulfillment={onRequestFulfillment} onSelectOrder={onSelectOrder} />
   if (view === 'payments') return <PaymentsWorkspace filter={paymentFilter} orders={orders} selectedOrder={selectedOrder} onFilterChange={setPaymentFilter} onOpenOrder={onOpenOrder} onRequestPayment={onRequestPayment} onSelectOrder={onSelectOrder} />
 
-  return <OrdersWorkspace filter={orderFilter} orders={orders} selectedOrder={selectedOrder} onFilterChange={setOrderFilter} onRequestFulfillment={onRequestFulfillment} onRequestPayment={onRequestPayment} onRequestWebsiteIntake={onRequestWebsiteIntake} onSelectOrder={onSelectOrder} websiteDraftCreated={websiteDraftCreated} websiteHandoff={websiteHandoff} />
+  return <OrdersWorkspace filter={orderFilter} orders={orders} selectedOrder={selectedOrder} onFilterChange={setOrderFilter} onRequestFulfillment={onRequestFulfillment} onRequestPayment={onRequestPayment} onRequestWebsiteIntake={onRequestWebsiteIntake} onSelectOrder={onSelectOrder} websiteHandoff={websiteHandoff} />
 }

--- a/showroom/src/products/ecommerce/EcommerceOrdersProduct.tsx
+++ b/showroom/src/products/ecommerce/EcommerceOrdersProduct.tsx
@@ -4,8 +4,13 @@ import { ApprovalGate } from './ApprovalGate'
 import { CommerceWorkspaces } from './CommerceWorkspaces'
 import {
   acceptWebsiteEcommerceHandoff,
+  completeWebsiteOrderDraft,
   createWebsiteOrderDraft,
+  getWebsiteOrderCustomerReference,
   readWebsiteEcommerceHandoff,
+  type WebsiteOrderCompletionInput,
+  type WebsiteOrderFulfilmentMethod,
+  type WebsiteOrderPaymentMethod,
   type WebsiteEcommerceHandoffContext,
 } from '../product-handoff'
 import {
@@ -152,7 +157,7 @@ function AuditDrawer({ events, onClose }: { events: AuditEvent[]; onClose: () =>
             </article>
           ))}
         </div>
-        <p className="eco-drawer-boundary">History is held in component memory for this standalone prototype and resets on reload. It is not a production audit store.</p>
+        <p className="eco-drawer-boundary">Scenario history resets on reload; Website handoff and completion evidence persists only in this browser. Neither is a production audit store.</p>
       </aside>
     </div>
   )
@@ -233,6 +238,128 @@ function WebsiteIntakeApproval({
   )
 }
 
+function WebsiteOrderCompletion({
+  context,
+  onComplete,
+  onCancel,
+}: {
+  context: WebsiteEcommerceHandoffContext
+  onComplete: (input: WebsiteOrderCompletionInput) => Promise<void>
+  onCancel: () => void
+}) {
+  const [fulfilmentMethod, setFulfilmentMethod] = useState<WebsiteOrderFulfilmentMethod | ''>('')
+  const [paymentMethod, setPaymentMethod] = useState<WebsiteOrderPaymentMethod | ''>('')
+  const [operatorId, setOperatorId] = useState('')
+  const [evidenceReference, setEvidenceReference] = useState('')
+  const [confirmed, setConfirmed] = useState(false)
+  const [submitting, setSubmitting] = useState(false)
+  const fulfilmentRef = useRef<HTMLSelectElement>(null)
+  const draft = context.draft
+  const customerReference = getWebsiteOrderCustomerReference(context.handoff.id)
+  const canComplete = Boolean(customerReference)
+    && Boolean(fulfilmentMethod)
+    && Boolean(paymentMethod)
+    && /^OP-[A-Z0-9][A-Z0-9_-]{2,31}$/.test(operatorId)
+    && /^EV-[A-HJ-NP-Z2-9]{8,24}$/.test(evidenceReference)
+    && confirmed
+    && !submitting
+
+  useEffect(() => {
+    fulfilmentRef.current?.focus()
+    function closeOnEscape(event: KeyboardEvent) {
+      if (event.key === 'Escape') onCancel()
+    }
+    document.addEventListener('keydown', closeOnEscape)
+    return () => document.removeEventListener('keydown', closeOnEscape)
+  }, [onCancel])
+
+  async function submit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    if (!canComplete || !fulfilmentMethod || !paymentMethod) return
+    setSubmitting(true)
+    await onComplete({ fulfilmentMethod, paymentMethod, operatorId, evidenceReference })
+    setSubmitting(false)
+  }
+
+  if (!draft || !customerReference) return null
+
+  return (
+    <div className="eco-modal-backdrop">
+      <section aria-labelledby="eco-order-completion-title" aria-modal="true" className="eco-approval-dialog" role="dialog">
+        <header className="eco-dialog-head">
+          <div><span className="eco-eyebrow">Required fields</span><h2 id="eco-order-completion-title">Complete local order · {draft.id}</h2></div>
+          <button aria-label="Cancel order completion" className="eco-icon-button" onClick={onCancel} type="button">×</button>
+        </header>
+        <div className="eco-change-preview" aria-label="Proposed order change">
+          <span><small>Before</small><strong>Draft incomplete</strong></span>
+          <i aria-hidden="true">→</i>
+          <span><small>After approval</small><strong>Ready for confirmation</strong></span>
+        </div>
+        <p className="eco-boundary-note">Completion creates one browser-local record and one audit event. It does not insert into the scenario queue, reserve stock, confirm a customer, collect payment, send a message, or write externally.</p>
+        <form className="eco-approval-form" onSubmit={submit}>
+          <div className="eco-handoff-evidence">
+            <span>Generated non-PII customer reference</span>
+            <code>{customerReference}</code>
+            <small>This opaque reference is derived by the system. The form cannot accept a name, phone number, address, or message.</small>
+          </div>
+          <div className="eco-completion-grid">
+            <label>
+              Fulfilment method
+              <select onChange={(event) => setFulfilmentMethod(event.target.value as WebsiteOrderFulfilmentMethod | '')} ref={fulfilmentRef} required value={fulfilmentMethod}>
+                <option value="">Select method</option>
+                <option value="pickup">Customer pickup</option>
+                <option value="local_delivery">Local delivery</option>
+              </select>
+            </label>
+            <label>
+              Payment method
+              <select onChange={(event) => setPaymentMethod(event.target.value as WebsiteOrderPaymentMethod | '')} required value={paymentMethod}>
+                <option value="">Select method</option>
+                <option value="cash_on_delivery">Cash on delivery</option>
+                <option value="manual_qr">Manual QR review</option>
+                <option value="manual_bank_transfer">Manual bank transfer review</option>
+              </select>
+            </label>
+            <label>
+              Responsible operator ID
+              <input
+                autoComplete="off"
+                maxLength={35}
+                onChange={(event) => setOperatorId(event.target.value.toUpperCase())}
+                pattern="OP-[A-Z0-9][A-Z0-9_-]{2,31}"
+                placeholder="OP-OWNER"
+                required
+                value={operatorId}
+              />
+            </label>
+          </div>
+          <label>
+            Opaque evidence reference
+            <input
+              autoComplete="off"
+              maxLength={27}
+              onChange={(event) => setEvidenceReference(event.target.value.toUpperCase())}
+              pattern="EV-[A-HJ-NP-Z2-9]{8,24}"
+              placeholder="EV-TESTAB23"
+              required
+              value={evidenceReference}
+            />
+          </label>
+          <label className="eco-handoff-confirmation">
+            <input checked={confirmed} onChange={(event) => setConfirmed(event.target.checked)} type="checkbox" />
+            <span>I verified the immutable line and MMK total, and confirm these three local fields are ready for the next human-controlled step.</span>
+          </label>
+          <div className="eco-dialog-actions">
+            <span />
+            <button className="eco-button eco-button-quiet" onClick={onCancel} type="button">Cancel</button>
+            <button className="eco-button eco-button-primary" disabled={!canComplete} type="submit">{submitting ? 'Creating…' : 'Create ready record'}</button>
+          </div>
+        </form>
+      </section>
+    </div>
+  )
+}
+
 export function EcommerceOrdersProduct() {
   const [workspace, dispatch] = useReducer(commerceReducer, 0, () => createDemoWorkspace())
   const [activeView, setActiveView] = useState<CommerceView>('orders')
@@ -243,9 +370,11 @@ export function EcommerceOrdersProduct() {
   const [guideStep, setGuideStep] = useState(0)
   const [websiteHandoff, setWebsiteHandoff] = useState(() => readWebsiteEcommerceHandoff())
   const [handoffApprovalOpen, setHandoffApprovalOpen] = useState(false)
+  const [orderCompletionOpen, setOrderCompletionOpen] = useState(false)
   const [announcement, setAnnouncement] = useState(() => {
     if (!websiteHandoff) return 'Scenario records loaded locally. No integrations are connected.'
     if (websiteHandoff.handoff.state !== 'accepted') return 'Approved Website fixture is ready for human intake review. No order has been created.'
+    if (websiteHandoff.order) return `${websiteHandoff.order.id} is ready for confirmation in this browser. No customer confirmation, stock reservation, payment, or send occurred.`
     return websiteHandoff.draft
       ? `${websiteHandoff.draft.id} is a local order draft with customer, fulfilment, and payment fields still missing. No order was confirmed.`
       : `${websiteHandoff.handoff.id} is an accepted local intake; no order draft has been created yet.`
@@ -253,7 +382,7 @@ export function EcommerceOrdersProduct() {
   const activeCopy = viewCopy[activeView]
   const handoffAudit: AuditEvent[] = (websiteHandoff?.audit ?? []).map((event) => ({
     ...event,
-    summary: 'Accepted Website-to-Ecommerce handoff',
+    summary: event.action === 'complete_website_order' ? 'Completed required local order fields' : 'Accepted Website-to-Ecommerce handoff',
   }))
   const combinedAudit = [...handoffAudit, ...workspace.audit]
     .sort((left, right) => Date.parse(right.createdAt) - Date.parse(left.createdAt))
@@ -316,18 +445,25 @@ export function EcommerceOrdersProduct() {
       setAnnouncement('No valid Website handoff is available in this browser.')
       return
     }
+    setWebsiteHandoff(current)
+    if (current.handoff.state === 'accepted') {
+      if (current.order) {
+        setAnnouncement(`${current.order.id} already exists for ${current.draft?.id}; idempotency prevented a duplicate ready record.`)
+        return
+      }
+      if (current.draft) {
+        setOrderCompletionOpen(true)
+        setAnnouncement(`${current.draft.id} is waiting for its three required fields and attributable human completion.`)
+        return
+      }
+    }
     const matchingItems = workspace.catalog.filter((candidate) => candidate.sku === current.handoff.intake.sku && candidate.active)
     if (matchingItems.length !== 1) {
       setAnnouncement('The Website fixture does not match exactly one active local catalog item, so intake failed closed.')
       return
     }
     const [item] = matchingItems
-    setWebsiteHandoff(current)
     if (current.handoff.state === 'accepted') {
-      if (current.draft) {
-        setAnnouncement(`${current.draft.id} already exists for ${current.handoff.id}; idempotency prevented a duplicate draft.`)
-        return
-      }
       const drafted = createWebsiteOrderDraft(current.handoff.id, {
         sku: item.sku,
         itemName: item.name,
@@ -364,6 +500,20 @@ export function EcommerceOrdersProduct() {
     setWebsiteHandoff(accepted)
     setHandoffApprovalOpen(false)
     setAnnouncement(`${accepted.handoff.id} accepted locally by ${accepted.handoff.acceptance.operatorId}; create the idempotent local draft when ready.`)
+  }
+
+  async function completeWebsiteDraft(input: WebsiteOrderCompletionInput) {
+    const draft = websiteHandoff?.draft
+    if (!draft || websiteHandoff.order) return
+    const completed = await completeWebsiteOrderDraft(draft.id, input)
+    if (!completed?.order) {
+      setOrderCompletionOpen(false)
+      setAnnouncement('Order completion failed closed. The accepted Website source, draft, operator, or opaque references could not be verified; nothing changed.')
+      return
+    }
+    setWebsiteHandoff(completed)
+    setOrderCompletionOpen(false)
+    setAnnouncement(`${completed.order.id} is ready for confirmation with its immutable MMK price and one completion audit. No stock, payment, customer confirmation, send, or external write occurred.`)
   }
 
   function approveAction(details: ApprovalDetails) {
@@ -468,7 +618,6 @@ export function EcommerceOrdersProduct() {
               selectedOrderId={selectedOrderId}
               view={activeView}
               websiteHandoff={websiteHandoff}
-              websiteDraftCreated={Boolean(websiteHandoff?.draft)}
             />
           </div>
         </main>
@@ -478,6 +627,7 @@ export function EcommerceOrdersProduct() {
       {auditOpen ? <AuditDrawer events={combinedAudit} onClose={() => setAuditOpen(false)} /> : null}
       {pendingAction ? <ApprovalGate action={pendingAction} guidedDemo={guideOpen} onApprove={approveAction} onCancel={() => setPendingAction(null)} /> : null}
       {handoffApprovalOpen && websiteHandoff ? <WebsiteIntakeApproval context={websiteHandoff} onApprove={approveWebsiteIntake} onCancel={() => setHandoffApprovalOpen(false)} /> : null}
+      {orderCompletionOpen && websiteHandoff?.draft && !websiteHandoff.order ? <WebsiteOrderCompletion context={websiteHandoff} onComplete={completeWebsiteDraft} onCancel={() => setOrderCompletionOpen(false)} /> : null}
     </div>
   )
 }

--- a/showroom/src/products/ecommerce/ecommerce-model.ts
+++ b/showroom/src/products/ecommerce/ecommerce-model.ts
@@ -63,13 +63,14 @@ export type CommerceOrder = {
 }
 
 export type AuditActorKind = 'human' | 'demo_fixture'
+export type AuditEventAction = ProposedActionKind | 'scenario_loaded' | 'accept_website_handoff' | 'complete_website_order'
 
 export type AuditEvent = {
   id: string
   createdAt: string
   actorKind: AuditActorKind
   actor: string
-  action: ProposedActionKind | 'scenario_loaded'
+  action: AuditEventAction
   subjectId: string
   summary: string
   before: string
@@ -86,7 +87,6 @@ export type CommerceWorkspace = {
 }
 
 export type ProposedActionKind =
-  | 'accept_website_handoff'
   | 'confirm_order'
   | 'complete_pick'
   | 'approve_dispatch'

--- a/showroom/src/products/ecommerce/ecommerce-orders.css
+++ b/showroom/src/products/ecommerce/ecommerce-orders.css
@@ -1383,6 +1383,12 @@
   gap: 9px;
 }
 
+.eco-completion-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 9px;
+}
+
 .eco-approval-form label {
   display: grid;
   gap: 5px;
@@ -1392,6 +1398,7 @@
 }
 
 .eco-approval-form input,
+.eco-approval-form select,
 .eco-approval-form textarea {
   width: 100%;
   min-width: 0;
@@ -1404,6 +1411,7 @@
 }
 
 .eco-approval-form input:focus,
+.eco-approval-form select:focus,
 .eco-approval-form textarea:focus {
   border-color: var(--eco-green);
   box-shadow: 0 0 0 2px rgba(124, 245, 180, 0.08);
@@ -1809,6 +1817,10 @@
 }
 
 @media (max-width: 560px) {
+  .eco-completion-grid {
+    grid-template-columns: 1fr;
+  }
+
   .eco-topbar {
     padding: 0 10px;
   }

--- a/showroom/src/products/product-handoff.ts
+++ b/showroom/src/products/product-handoff.ts
@@ -4,7 +4,7 @@ import {
   restoreWorkspace,
   workspaceFingerprint,
   type WebsiteWorkspace,
-} from './website/website-model'
+} from './website/website-model.ts'
 
 export const WEBSITE_ECOMMERCE_HANDOFF_KEY = 'supermega.website-ecommerce-handoff.v1'
 
@@ -64,6 +64,45 @@ export type WebsiteOrderDraft = {
   missingFields: ['customer_reference', 'fulfilment_method', 'payment_method']
 }
 
+export const websiteOrderFulfilmentMethods = ['pickup', 'local_delivery'] as const
+export const websiteOrderPaymentMethods = ['cash_on_delivery', 'manual_qr', 'manual_bank_transfer'] as const
+
+export type WebsiteOrderFulfilmentMethod = (typeof websiteOrderFulfilmentMethods)[number]
+export type WebsiteOrderPaymentMethod = (typeof websiteOrderPaymentMethods)[number]
+
+export type WebsiteOrderRecord = {
+  schema: 'ecommerce_order_record.v1'
+  mode: 'browser-local'
+  id: string
+  idempotencyKey: string
+  createdAt: string
+  state: 'ready_for_confirmation'
+  source: {
+    kind: 'website_order_draft'
+    handoffId: string
+    draftId: string
+    websiteEvidenceReference: string
+  }
+  currency: 'MMK'
+  lines: WebsiteOrderDraft['lines']
+  totalMmk: number
+  customerReference: string
+  fulfilmentMethod: WebsiteOrderFulfilmentMethod
+  paymentMethod: WebsiteOrderPaymentMethod
+  completion: {
+    operatorId: string
+    evidenceReference: string
+    auditEventId: string
+  }
+}
+
+export type WebsiteOrderCompletionInput = {
+  fulfilmentMethod: WebsiteOrderFulfilmentMethod
+  paymentMethod: WebsiteOrderPaymentMethod
+  operatorId: string
+  evidenceReference: string
+}
+
 export type WebsiteOrderDraftCatalogItem = {
   sku: string
   itemName: string
@@ -85,15 +124,32 @@ export type WebsiteHandoffAuditEvent = {
   after: 'Accepted local intake'
 }
 
-type HandoffStore = {
-  schema: 'website_ecommerce_handoff_store.v1' | 'website_ecommerce_handoff_store.v2'
-  handoff: WebsiteEcommerceHandoff
-  audit: WebsiteHandoffAuditEvent[]
-  draft?: WebsiteOrderDraft
+export type WebsiteOrderCompletionAuditEvent = {
+  id: string
+  createdAt: string
+  actorKind: 'human'
+  actor: string
+  action: 'complete_website_order'
+  subjectId: string
+  reason: 'Required local order fields verified'
+  evidenceReference: string
+  before: 'Draft incomplete'
+  after: 'Ready for confirmation'
 }
 
-export type WebsiteEcommerceHandoffContext = Omit<HandoffStore, 'draft'> & {
+export type WebsiteEcommerceAuditEvent = WebsiteHandoffAuditEvent | WebsiteOrderCompletionAuditEvent
+
+type HandoffStore = {
+  schema: 'website_ecommerce_handoff_store.v1' | 'website_ecommerce_handoff_store.v2' | 'website_ecommerce_handoff_store.v3'
+  handoff: WebsiteEcommerceHandoff
+  audit: WebsiteEcommerceAuditEvent[]
+  draft?: WebsiteOrderDraft
+  order?: WebsiteOrderRecord
+}
+
+export type WebsiteEcommerceHandoffContext = Omit<HandoffStore, 'draft' | 'order'> & {
   draft: WebsiteOrderDraft | null
+  order: WebsiteOrderRecord | null
   display: {
     siteName: string
     pagePath: string
@@ -105,9 +161,14 @@ export type WebsiteEcommerceHandoffContext = Omit<HandoffStore, 'draft'> & {
 const operatorIdPattern = /^OP-[A-Z0-9][A-Z0-9_-]{2,31}$/
 const handoffIdPattern = /^WEH-[A-Z0-9]{6,32}$/
 const auditIdPattern = /^WHA-[A-Z0-9]{6,32}$/
+const completionAuditIdPattern = /^EOA-[A-Z0-9]{6,32}$/
 const draftIdPattern = /^EOD-[A-Z0-9]{6,32}$/
+const orderIdPattern = /^EOR-[A-Z0-9]{6,32}$/
 const fingerprintPattern = /^web-[a-f0-9]{8}$/
 const skuPattern = /^[A-Z0-9][A-Z0-9_-]{2,31}$/
+const customerReferencePattern = /^CREF-[A-HJ-NP-Z2-9]{12}$/
+const evidenceReferencePattern = /^EV-[A-HJ-NP-Z2-9]{8,24}$/
+const handoffMutationLock = 'supermega.website-ecommerce-handoff.mutation.v1'
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
@@ -135,11 +196,26 @@ function sameStringSet(left: string[], right: string[]) {
   return sortedLeft.every((value, index) => value === sortedRight[index])
 }
 
-function createId(prefix: 'WEH' | 'WHA') {
+function createId(prefix: 'WEH' | 'WHA' | 'EOA') {
   const suffix = typeof globalThis.crypto?.randomUUID === 'function'
     ? globalThis.crypto.randomUUID().replaceAll('-', '').slice(0, 12)
     : Date.now().toString(36)
   return `${prefix}-${suffix.toUpperCase()}`
+}
+
+function customerReferenceFor(handoffId: string) {
+  const alphabet = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789'
+  const source = handoffId.slice(4)
+  let suffix = ''
+  for (let index = 0; index < 12; index += 1) {
+    const character = source[index % source.length]
+    suffix += alphabet[(character.charCodeAt(0) + (index * 11)) % alphabet.length]
+  }
+  return `CREF-${suffix}`
+}
+
+export function getWebsiteOrderCustomerReference(handoffId: string) {
+  return handoffIdPattern.test(handoffId) ? customerReferenceFor(handoffId) : null
 }
 
 function isHandoffSource(value: unknown): value is HandoffSource {
@@ -185,6 +261,21 @@ export function isWebsiteEcommerceHandoff(value: unknown): value is WebsiteEcomm
     && auditIdPattern.test(acceptance.auditEventId)
 }
 
+function isWebsiteOrderLine(value: unknown): value is WebsiteOrderDraft['lines'][number] {
+  if (!isRecord(value) || !hasExactKeys(value, ['sku', 'itemName', 'variant', 'quantity', 'unitPriceMmk'])) return false
+  return typeof value.sku === 'string'
+    && skuPattern.test(value.sku)
+    && isTrimmedText(value.itemName, 120)
+    && isTrimmedText(value.variant, 120)
+    && typeof value.quantity === 'number'
+    && Number.isInteger(value.quantity)
+    && value.quantity >= 1
+    && value.quantity <= 99
+    && typeof value.unitPriceMmk === 'number'
+    && Number.isSafeInteger(value.unitPriceMmk)
+    && value.unitPriceMmk > 0
+}
+
 function isWebsiteOrderDraft(value: unknown): value is WebsiteOrderDraft {
   if (!isRecord(value) || !hasExactKeys(value, ['schema', 'mode', 'id', 'idempotencyKey', 'createdAt', 'state', 'source', 'currency', 'lines', 'totalMmk', 'missingFields'])) return false
   if (value.schema !== 'ecommerce_order_draft.v1' || value.mode !== 'browser-local' || value.state !== 'draft' || value.currency !== 'MMK') return false
@@ -196,16 +287,41 @@ function isWebsiteOrderDraft(value: unknown): value is WebsiteOrderDraft {
     || !handoffIdPattern.test(value.source.handoffId)) return false
   if (!Array.isArray(value.lines) || value.lines.length !== 1) return false
   const line = value.lines[0]
-  if (!isRecord(line) || !hasExactKeys(line, ['sku', 'itemName', 'variant', 'quantity', 'unitPriceMmk'])) return false
-  if (typeof line.sku !== 'string' || !skuPattern.test(line.sku) || !isTrimmedText(line.itemName, 120) || !isTrimmedText(line.variant, 120)) return false
-  if (typeof line.quantity !== 'number' || !Number.isInteger(line.quantity) || line.quantity < 1 || line.quantity > 99) return false
-  if (typeof line.unitPriceMmk !== 'number' || !Number.isSafeInteger(line.unitPriceMmk) || line.unitPriceMmk <= 0) return false
+  if (!isWebsiteOrderLine(line)) return false
   if (typeof value.totalMmk !== 'number' || !Number.isSafeInteger(value.totalMmk) || value.totalMmk !== line.quantity * line.unitPriceMmk) return false
   return Array.isArray(value.missingFields)
     && value.missingFields.length === 3
     && value.missingFields[0] === 'customer_reference'
     && value.missingFields[1] === 'fulfilment_method'
     && value.missingFields[2] === 'payment_method'
+}
+
+function isWebsiteOrderRecord(value: unknown): value is WebsiteOrderRecord {
+  if (!isRecord(value) || !hasExactKeys(value, ['schema', 'mode', 'id', 'idempotencyKey', 'createdAt', 'state', 'source', 'currency', 'lines', 'totalMmk', 'customerReference', 'fulfilmentMethod', 'paymentMethod', 'completion'])) return false
+  if (value.schema !== 'ecommerce_order_record.v1' || value.mode !== 'browser-local' || value.state !== 'ready_for_confirmation' || value.currency !== 'MMK') return false
+  if (typeof value.id !== 'string' || !orderIdPattern.test(value.id)) return false
+  if (typeof value.idempotencyKey !== 'string' || !draftIdPattern.test(value.idempotencyKey) || !isIsoTimestamp(value.createdAt)) return false
+  if (!isRecord(value.source) || !hasExactKeys(value.source, ['kind', 'handoffId', 'draftId', 'websiteEvidenceReference'])) return false
+  if (value.source.kind !== 'website_order_draft'
+    || typeof value.source.handoffId !== 'string'
+    || !handoffIdPattern.test(value.source.handoffId)
+    || typeof value.source.draftId !== 'string'
+    || !draftIdPattern.test(value.source.draftId)
+    || !isTrimmedText(value.source.websiteEvidenceReference, 80)
+    || value.idempotencyKey !== value.source.draftId) return false
+  if (!Array.isArray(value.lines) || value.lines.length !== 1 || !isWebsiteOrderLine(value.lines[0])) return false
+  const line = value.lines[0]
+  if (typeof value.totalMmk !== 'number' || !Number.isSafeInteger(value.totalMmk) || value.totalMmk !== line.quantity * line.unitPriceMmk) return false
+  if (typeof value.customerReference !== 'string' || !customerReferencePattern.test(value.customerReference)) return false
+  if (typeof value.fulfilmentMethod !== 'string' || !websiteOrderFulfilmentMethods.includes(value.fulfilmentMethod as WebsiteOrderFulfilmentMethod)) return false
+  if (typeof value.paymentMethod !== 'string' || !websiteOrderPaymentMethods.includes(value.paymentMethod as WebsiteOrderPaymentMethod)) return false
+  if (!isRecord(value.completion) || !hasExactKeys(value.completion, ['operatorId', 'evidenceReference', 'auditEventId'])) return false
+  return typeof value.completion.operatorId === 'string'
+    && operatorIdPattern.test(value.completion.operatorId)
+    && typeof value.completion.evidenceReference === 'string'
+    && evidenceReferencePattern.test(value.completion.evidenceReference)
+    && typeof value.completion.auditEventId === 'string'
+    && completionAuditIdPattern.test(value.completion.auditEventId)
 }
 
 function isWebsiteHandoffAuditEvent(value: unknown): value is WebsiteHandoffAuditEvent {
@@ -225,32 +341,85 @@ function isWebsiteHandoffAuditEvent(value: unknown): value is WebsiteHandoffAudi
     && value.after === 'Accepted local intake'
 }
 
+function isWebsiteOrderCompletionAuditEvent(value: unknown): value is WebsiteOrderCompletionAuditEvent {
+  if (!isRecord(value) || !hasExactKeys(value, ['id', 'createdAt', 'actorKind', 'actor', 'action', 'subjectId', 'reason', 'evidenceReference', 'before', 'after'])) return false
+  return typeof value.id === 'string'
+    && completionAuditIdPattern.test(value.id)
+    && isIsoTimestamp(value.createdAt)
+    && value.actorKind === 'human'
+    && typeof value.actor === 'string'
+    && operatorIdPattern.test(value.actor)
+    && value.action === 'complete_website_order'
+    && typeof value.subjectId === 'string'
+    && orderIdPattern.test(value.subjectId)
+    && value.reason === 'Required local order fields verified'
+    && typeof value.evidenceReference === 'string'
+    && evidenceReferencePattern.test(value.evidenceReference)
+    && value.before === 'Draft incomplete'
+    && value.after === 'Ready for confirmation'
+}
+
+function isWebsiteEcommerceAuditEvent(value: unknown): value is WebsiteEcommerceAuditEvent {
+  return isWebsiteHandoffAuditEvent(value) || isWebsiteOrderCompletionAuditEvent(value)
+}
+
+function sameOrderLine(left: WebsiteOrderDraft['lines'][number], right: WebsiteOrderDraft['lines'][number]) {
+  return left.sku === right.sku
+    && left.itemName === right.itemName
+    && left.variant === right.variant
+    && left.quantity === right.quantity
+    && left.unitPriceMmk === right.unitPriceMmk
+}
+
 function isHandoffStore(value: unknown): value is HandoffStore {
   if (!isRecord(value)) return false
-  const hasDraft = hasExactKeys(value, ['schema', 'handoff', 'audit', 'draft'])
-  if (!hasDraft && !hasExactKeys(value, ['schema', 'handoff', 'audit'])) return false
   const isV1 = value.schema === 'website_ecommerce_handoff_store.v1'
   const isV2 = value.schema === 'website_ecommerce_handoff_store.v2'
-  if ((!isV1 && !isV2) || (isV1 && hasDraft) || (isV2 && !hasDraft)) return false
+  const isV3 = value.schema === 'website_ecommerce_handoff_store.v3'
+  if (!(isV1 && hasExactKeys(value, ['schema', 'handoff', 'audit']))
+    && !(isV2 && hasExactKeys(value, ['schema', 'handoff', 'audit', 'draft']))
+    && !(isV3 && hasExactKeys(value, ['schema', 'handoff', 'audit', 'draft', 'order']))) return false
   if (!isWebsiteEcommerceHandoff(value.handoff) || !Array.isArray(value.audit)) return false
   const audit = value.audit
-  if (!audit.every(isWebsiteHandoffAuditEvent)) return false
+  if (!audit.every(isWebsiteEcommerceAuditEvent)) return false
   if (value.handoff.state === 'pending_acceptance') return isV1 && audit.length === 0
-  const auditMatches = audit.length === 1
-    && audit[0].id === value.handoff.acceptance.auditEventId
-    && audit[0].subjectId === value.handoff.id
-    && audit[0].actor === value.handoff.acceptance.operatorId
-    && audit[0].createdAt === value.handoff.acceptance.acceptedAt
-    && audit[0].evidenceReference === value.handoff.source.localPublishId
-  if (!auditMatches || isV1) return auditMatches
+  const acceptanceAudit = audit[0]
+  const acceptanceMatches = isWebsiteHandoffAuditEvent(acceptanceAudit)
+    && acceptanceAudit.id === value.handoff.acceptance.auditEventId
+    && acceptanceAudit.subjectId === value.handoff.id
+    && acceptanceAudit.actor === value.handoff.acceptance.operatorId
+    && acceptanceAudit.createdAt === value.handoff.acceptance.acceptedAt
+    && acceptanceAudit.evidenceReference === value.handoff.source.localPublishId
+  if (!acceptanceMatches) return false
+  if (isV1) return audit.length === 1
   if (!isWebsiteOrderDraft(value.draft)) return false
   const line = value.draft.lines[0]
-  return value.draft.id === `EOD-${value.handoff.id.slice(4)}`
+  const draftMatches = value.draft.id === `EOD-${value.handoff.id.slice(4)}`
     && value.draft.idempotencyKey === value.handoff.id
     && Date.parse(value.draft.createdAt) >= Date.parse(value.handoff.acceptance.acceptedAt)
     && value.draft.source.handoffId === value.handoff.id
     && line.sku === value.handoff.intake.sku
     && line.quantity === value.handoff.intake.quantity
+  if (!draftMatches || isV2) return draftMatches && audit.length === 1
+  if (!isWebsiteOrderRecord(value.order) || audit.length !== 2) return false
+  const completionAudit = audit[1]
+  const orderLine = value.order.lines[0]
+  return isWebsiteOrderCompletionAuditEvent(completionAudit)
+    && value.order.id === `EOR-${value.handoff.id.slice(4)}`
+    && value.order.idempotencyKey === value.draft.id
+    && value.order.source.handoffId === value.handoff.id
+    && value.order.source.draftId === value.draft.id
+    && value.order.source.websiteEvidenceReference === value.handoff.source.localPublishId
+    && value.order.customerReference === customerReferenceFor(value.handoff.id)
+    && Date.parse(value.order.createdAt) >= Date.parse(value.draft.createdAt)
+    && value.order.currency === value.draft.currency
+    && value.order.totalMmk === value.draft.totalMmk
+    && sameOrderLine(orderLine, line)
+    && completionAudit.id === value.order.completion.auditEventId
+    && completionAudit.createdAt === value.order.createdAt
+    && completionAudit.actor === value.order.completion.operatorId
+    && completionAudit.subjectId === value.order.id
+    && completionAudit.evidenceReference === value.order.completion.evidenceReference
 }
 
 function validateAgainstWorkspace(handoff: WebsiteEcommerceHandoff, workspace: WebsiteWorkspace) {
@@ -319,7 +488,7 @@ export function readWebsiteEcommerceHandoff(): WebsiteEcommerceHandoffContext | 
     if (!isHandoffStore(store)) return null
     const display = workspace ? validateAgainstWorkspace(store.handoff, workspace) : null
     if (store.handoff.state === 'pending_acceptance' && !display) return null
-    return { ...store, draft: store.draft ?? null, display }
+    return { ...store, draft: store.draft ?? null, order: store.order ?? null, display }
   } catch {
     return null
   }
@@ -444,6 +613,103 @@ export function createWebsiteOrderDraft(handoffId: string, catalogItem: WebsiteO
       && restored.draft.totalMmk === totalMmk
       ? restored
       : null
+  } catch {
+    return null
+  }
+}
+
+function isWebsiteOrderCompletionInput(value: unknown): value is WebsiteOrderCompletionInput {
+  if (!isRecord(value) || !hasExactKeys(value, ['fulfilmentMethod', 'paymentMethod', 'operatorId', 'evidenceReference'])) return false
+  return typeof value.fulfilmentMethod === 'string'
+    && websiteOrderFulfilmentMethods.includes(value.fulfilmentMethod as WebsiteOrderFulfilmentMethod)
+    && typeof value.paymentMethod === 'string'
+    && websiteOrderPaymentMethods.includes(value.paymentMethod as WebsiteOrderPaymentMethod)
+    && typeof value.operatorId === 'string'
+    && operatorIdPattern.test(value.operatorId)
+    && typeof value.evidenceReference === 'string'
+    && evidenceReferencePattern.test(value.evidenceReference)
+}
+
+function completionMatches(order: WebsiteOrderRecord, input: WebsiteOrderCompletionInput) {
+  return order.fulfilmentMethod === input.fulfilmentMethod
+    && order.paymentMethod === input.paymentMethod
+    && order.completion.operatorId === input.operatorId
+    && order.completion.evidenceReference === input.evidenceReference
+}
+
+function completeWebsiteOrderDraftWithLock(draftId: string, input: WebsiteOrderCompletionInput) {
+  try {
+    const current = readWebsiteEcommerceHandoff()
+    if (!current || current.handoff.state !== 'accepted' || current.draft?.id !== draftId) return null
+    if (current.order) return current.order.idempotencyKey === draftId && completionMatches(current.order, input) ? current : null
+    if (!current.display) return null
+
+    const createdAt = new Date().toISOString()
+    if (Date.parse(createdAt) < Date.parse(current.draft.createdAt)) return null
+    const auditEventId = createId('EOA')
+    const orderId = `EOR-${current.handoff.id.slice(4)}`
+    const order: WebsiteOrderRecord = {
+      schema: 'ecommerce_order_record.v1',
+      mode: 'browser-local',
+      id: orderId,
+      idempotencyKey: current.draft.id,
+      createdAt,
+      state: 'ready_for_confirmation',
+      source: {
+        kind: 'website_order_draft',
+        handoffId: current.handoff.id,
+        draftId: current.draft.id,
+        websiteEvidenceReference: current.handoff.source.localPublishId,
+      },
+      currency: current.draft.currency,
+      lines: current.draft.lines.map((line) => ({ ...line })),
+      totalMmk: current.draft.totalMmk,
+      customerReference: customerReferenceFor(current.handoff.id),
+      fulfilmentMethod: input.fulfilmentMethod,
+      paymentMethod: input.paymentMethod,
+      completion: {
+        operatorId: input.operatorId,
+        evidenceReference: input.evidenceReference,
+        auditEventId,
+      },
+    }
+    const audit: WebsiteOrderCompletionAuditEvent = {
+      id: auditEventId,
+      createdAt,
+      actorKind: 'human',
+      actor: input.operatorId,
+      action: 'complete_website_order',
+      subjectId: order.id,
+      reason: 'Required local order fields verified',
+      evidenceReference: input.evidenceReference,
+      before: 'Draft incomplete',
+      after: 'Ready for confirmation',
+    }
+    const store: HandoffStore = {
+      schema: 'website_ecommerce_handoff_store.v3',
+      handoff: current.handoff,
+      audit: [...current.audit, audit],
+      draft: current.draft,
+      order,
+    }
+    if (!isHandoffStore(store)) return null
+    globalThis.localStorage?.setItem(WEBSITE_ECOMMERCE_HANDOFF_KEY, JSON.stringify(store))
+    const restored = readWebsiteEcommerceHandoff()
+    return restored?.order?.id === orderId
+      && restored.order.idempotencyKey === draftId
+      && restored.order.completion.auditEventId === auditEventId
+      && restored.audit.length === current.audit.length + 1
+      ? restored
+      : null
+  } catch {
+    return null
+  }
+}
+
+export async function completeWebsiteOrderDraft(draftId: string, input: WebsiteOrderCompletionInput) {
+  try {
+    if (!draftIdPattern.test(draftId) || !isWebsiteOrderCompletionInput(input) || !globalThis.navigator?.locks) return null
+    return await globalThis.navigator.locks.request(handoffMutationLock, { mode: 'exclusive' }, () => completeWebsiteOrderDraftWithLock(draftId, input))
   } catch {
     return null
   }

--- a/showroom/src/products/website/WebsiteProduct.tsx
+++ b/showroom/src/products/website/WebsiteProduct.tsx
@@ -51,18 +51,34 @@ const viewCopy: Record<WorkspaceView, { eyebrow: string; title: string; copy: st
   },
 }
 
+function handoffSourceKey(context: ReturnType<typeof readWebsiteEcommerceHandoff>) {
+  if (!context?.display) return ''
+  const source = context.handoff.source
+  return [source.fingerprint, source.approvalId, source.localPublishId, source.pageId].join('|')
+}
+
 export function WebsiteProduct() {
   const { workspace, setWorkspace, storageMode } = useWebsiteWorkspace()
   const [view, setView] = useState<WorkspaceView>('content')
   const [device, setDevice] = useState<PreviewDevice>('desktop')
   const [notice, setNotice] = useState('Local demo loaded. No website has been deployed.')
   const [deleteCandidateId, setDeleteCandidateId] = useState('')
-  const [handoffFingerprint, setHandoffFingerprint] = useState(() => readWebsiteEcommerceHandoff()?.handoff.source.fingerprint ?? '')
+  const [preparedHandoffSource, setPreparedHandoffSource] = useState(() => handoffSourceKey(readWebsiteEcommerceHandoff()))
   const selectedPage = workspace.pages.find((page) => page.id === workspace.selectedPageId) ?? workspace.pages[0]
   const fingerprint = workspaceFingerprint(workspace)
   const checks = readinessChecks(workspace, fingerprint)
   const approvalIsCurrent = isCurrentApproval(workspace.approval, fingerprint)
   const publishIsCurrent = isCurrentPublish(workspace.localPublishes[0], fingerprint)
+  const handoffSourcePage = workspace.pages.find((page) => page.stage === 'ready' && page.slug === '/products')
+    ?? workspace.pages.find((page) => page.stage === 'ready')
+  const currentHandoffSource = workspace.approval && workspace.localPublishes[0] && handoffSourcePage
+    ? [fingerprint, workspace.approval.id, workspace.localPublishes[0].id, handoffSourcePage.id].join('|')
+    : ''
+  const handoffIsCurrent = Boolean(preparedHandoffSource
+    && preparedHandoffSource === currentHandoffSource
+    && approvalIsCurrent
+    && publishIsCurrent
+    && checks.every((check) => check.passed))
   const activeViewCopy = viewCopy[view]
 
   useEffect(() => {
@@ -207,11 +223,22 @@ export function WebsiteProduct() {
     const existingHandoff = readWebsiteEcommerceHandoff()
     const approval = workspace.approval
     const publish = workspace.localPublishes[0]
-    const sourcePage = workspace.pages.find((page) => page.stage === 'ready' && page.slug === '/products')
-      ?? workspace.pages.find((page) => page.stage === 'ready')
+    const sourcePage = handoffSourcePage
 
-    if (existingHandoff?.handoff.state === 'accepted' && existingHandoff.handoff.source.fingerprint !== fingerprint) {
-      setNotice('The prior accepted intake and audit record are retained. This bounded prototype will not overwrite them.')
+    if (existingHandoff?.handoff.state === 'accepted') {
+      const source = existingHandoff.handoff.source
+      const acceptedSourceIsCurrent = Boolean(existingHandoff.display
+        && approval
+        && publish
+        && sourcePage
+        && source.fingerprint === fingerprint
+        && source.approvalId === approval.id
+        && source.localPublishId === publish.id
+        && source.pageId === sourcePage.id)
+      setPreparedHandoffSource(acceptedSourceIsCurrent ? handoffSourceKey(existingHandoff) : '')
+      setNotice(acceptedSourceIsCurrent
+        ? 'This exact Website intake is already accepted and retained with its audit record.'
+        : 'The prior accepted intake and audit record are retained. This bounded prototype will not overwrite them.')
       return
     }
 
@@ -249,7 +276,7 @@ export function WebsiteProduct() {
       return
     }
 
-    setHandoffFingerprint(restored.handoff.source.fingerprint)
+    setPreparedHandoffSource(handoffSourceKey(restored))
     setNotice('Versioned Website intake fixture prepared locally. Review it in Ecommerce & Orders.')
   }
 
@@ -378,7 +405,7 @@ export function WebsiteProduct() {
                 checks={checks}
                 fingerprint={fingerprint}
                 handoffAvailable={storageMode === 'browser-local'}
-                handoffIsCurrent={handoffFingerprint === fingerprint}
+                handoffIsCurrent={handoffIsCurrent}
                 onAddEvidence={addEvidence}
                 onApprove={approveCurrentRevision}
                 onPrepareEcommerceHandoff={prepareEcommerceHandoff}

--- a/tools/verify_app_build.mjs
+++ b/tools/verify_app_build.mjs
@@ -7,12 +7,13 @@ const dist = resolve(root, 'showroom', 'dist')
 const failures = []
 let orderCompletionRuntimeChecks = 0
 const fail = (reason) => failures.push(reason)
-const [manifestText, appPackageText, appSource, coreSource, teamSource, teamModel, websiteSource, publishSource, ecommerceSource, ecommerceWorkspacesSource, ecommerceModel, handoffSource] = await Promise.all([
+const [manifestText, appPackageText, appSource, coreSource, teamSource, agentTeamsSource, teamModel, websiteSource, publishSource, ecommerceSource, ecommerceWorkspacesSource, ecommerceModel, handoffSource] = await Promise.all([
   readFile(resolve(root, 'site-manifest.json'), 'utf8'),
   readFile(resolve(root, 'showroom', 'package.json'), 'utf8'),
   readFile(resolve(root, 'showroom', 'src', 'App.tsx'), 'utf8'),
   readFile(resolve(root, 'showroom', 'src', 'core', 'CoreApp.tsx'), 'utf8'),
   readFile(resolve(root, 'showroom', 'src', 'core', 'TeamWorkspace.tsx'), 'utf8'),
+  readFile(resolve(root, 'showroom', 'src', 'core', 'AgentTeamsPanel.tsx'), 'utf8'),
   readFile(resolve(root, 'showroom', 'src', 'core', 'team-work.ts'), 'utf8'),
   readFile(resolve(root, 'showroom', 'src', 'products', 'website', 'WebsiteProduct.tsx'), 'utf8'),
   readFile(resolve(root, 'showroom', 'src', 'products', 'website', 'PublishWorkspace.tsx'), 'utf8'),
@@ -67,7 +68,7 @@ else {
 const files = await walk(dist)
 const textFiles = files.filter((path) => /\.(?:html|js|css|json|svg)$/.test(path))
 const corpus = (await Promise.all(textFiles.map((path) => readFile(path, 'utf8')))).join('\n')
-for (const required of ['SUPERMEGA', 'Teams', 'Product', 'Acceptance outcome', 'Prepare brief', 'Evidence register', 'Mark verified', 'Verified evidence', 'verifiedAt', 'Operations', 'Human confirmation', 'Confirm and record', 'Action history', 'actorKind', 'evidenceReference', 'accountableActions', 'decision_packet.v1', 'Claims and provenance', 'claimType', 'claim_type', 'source_reference', 'artifact_reference', 'managedApprovalRequests', 'packetFingerprint', 'uncertainty', 'visibility', 'artifactReference', 'Human reviewer', 'Decision note', 'Approve and record', 'Local trial', 'Pilot definition', 'Template profile', 'Workflow', 'workflowProfile', 'Current record', 'Baseline', 'Target outcome', 'Human authority boundary', 'Acceptance evidence', 'Operating mode', 'Write path', '#7cf5b4', '#f2f5f1']) {
+for (const required of ['SUPERMEGA', 'Teams', 'Product', 'Acceptance outcome', 'Prepare brief', 'Evidence register', 'Record evidence', 'Verified evidence', 'verifiedAt', 'Operations', 'Human confirmation', 'Confirm and record', 'Action history', 'actorKind', 'evidenceReference', 'accountableActions', 'decision_packet.v1', 'Claims and provenance', 'claimType', 'claim_type', 'source_reference', 'artifact_reference', 'managedApprovalRequests', 'packetFingerprint', 'uncertainty', 'visibility', 'artifactReference', 'Human reviewer', 'Decision note', 'Approve and record', 'Local trial', 'Delegation control', 'Pilot definition', 'Template profile', 'Workflow', 'workflowProfile', 'Current record', 'Baseline', 'Target outcome', 'Human authority boundary', 'Acceptance evidence', 'Operating mode', 'Write path', '#7cf5b4', '#f2f5f1']) {
   if (!corpus.includes(required)) fail(`missing_context:${required}`)
 }
 if (!coreSource.includes("import siteManifest from '../../../site-manifest.json'")) fail('workflow_contract_not_shared')
@@ -76,11 +77,14 @@ if (coreSource.includes('className="core-panel approval-panel"')) fail('approval
 if (!coreSource.includes("decidedActorKind: 'human'") || !coreSource.includes('decisionNote: note')) fail('approval_decision_not_human_attributed')
 if (!coreSource.includes('dialog.showModal()') || coreSource.includes('decision-dialog-backdrop')) fail('approval_review_not_native_modal')
 if (!coreSource.includes("body.operating_mode === 'managed_trial'") || !coreSource.includes('writesReady') || !coreSource.includes('requirements.length === 0')) fail('managed_readiness_not_fail_closed')
-if (!coreSource.includes('LEGACY_COMMERCE_KEYS') || !coreSource.includes('LEGACY_PRODUCTION_KEYS') || !coreSource.includes('LEGACY_APPROVAL_KEYS') || !coreSource.includes('LEGACY_SETUP_KEYS')) fail('legacy_local_workspace_not_migrated')
+if (!coreSource.includes('LEGACY_TEAM_WORK_KEYS') || !coreSource.includes('LEGACY_COMMERCE_KEYS') || !coreSource.includes('LEGACY_PRODUCTION_KEYS') || !coreSource.includes('LEGACY_APPROVAL_KEYS') || !coreSource.includes('LEGACY_SETUP_KEYS')) fail('legacy_local_workspace_not_migrated')
 if (!coreSource.includes('decisionPacketFingerprint') || !coreSource.includes("status: 'superseded' as const")) fail('stale_approval_packet_not_superseded')
 if (!coreSource.includes('toManagedDecisionPacket') || !coreSource.includes('managedApprovalRequests')) fail('managed_decision_packet_serializer_missing')
 if (!teamSource.includes('Accept and record') || !teamSource.includes("acceptedActorKind: 'human'") || !teamModel.includes('acceptanceEvidenceReference')) fail('product_decision_not_human_attributed')
 if (!teamModel.includes("status: 'proposed'") || !teamModel.includes('isAttributedHumanAcceptance')) fail('legacy_product_acceptance_not_reopened')
+if (!teamSource.includes("verifiedActorKind: 'human'") || !teamModel.includes("candidate.verifiedActorKind === 'human'") || !teamModel.includes('verifiedBy')) fail('team_evidence_not_human_attributed')
+if (!teamModel.includes("supermega.team.workspace.v3") || !teamModel.includes("supermega.team.workspace.v2") || !teamModel.includes('hasValidAssignment')) fail('agent_team_migration_or_integrity_missing')
+if (!agentTeamsSource.includes('No agent can send, pay, publish, merge, deploy, or write to production') || !agentTeamsSource.includes('humanOwner') || !agentTeamsSource.includes('approvalBoundary') || agentTeamsSource.includes('>Run<')) fail('agent_authority_boundary_missing')
 if (!appSource.includes("lazy(() => import('./products/website/WebsiteProduct')") || !appSource.includes("lazy(() => import('./products/ecommerce/EcommerceOrdersProduct')") || !appSource.includes('Suspense')) fail('prototype_routes_not_lazy_loaded')
 if (!appPackage.scripts?.lint?.includes('src/products')) fail('prototype_sources_not_linted')
 if (!websiteSource.includes('No website has been deployed.') || !websiteSource.includes('No deployment or external write occurred.')) fail('website_prototype_boundary_missing')

--- a/tools/verify_app_build.mjs
+++ b/tools/verify_app_build.mjs
@@ -1,11 +1,13 @@
 import { readdir, readFile, stat } from 'node:fs/promises'
 import { resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
 
 const root = resolve(import.meta.dirname, '..')
 const dist = resolve(root, 'showroom', 'dist')
 const failures = []
+let orderCompletionRuntimeChecks = 0
 const fail = (reason) => failures.push(reason)
-const [manifestText, appPackageText, appSource, coreSource, teamSource, teamModel, websiteSource, publishSource, ecommerceSource, ecommerceModel, handoffSource] = await Promise.all([
+const [manifestText, appPackageText, appSource, coreSource, teamSource, teamModel, websiteSource, publishSource, ecommerceSource, ecommerceWorkspacesSource, ecommerceModel, handoffSource] = await Promise.all([
   readFile(resolve(root, 'site-manifest.json'), 'utf8'),
   readFile(resolve(root, 'showroom', 'package.json'), 'utf8'),
   readFile(resolve(root, 'showroom', 'src', 'App.tsx'), 'utf8'),
@@ -15,6 +17,7 @@ const [manifestText, appPackageText, appSource, coreSource, teamSource, teamMode
   readFile(resolve(root, 'showroom', 'src', 'products', 'website', 'WebsiteProduct.tsx'), 'utf8'),
   readFile(resolve(root, 'showroom', 'src', 'products', 'website', 'PublishWorkspace.tsx'), 'utf8'),
   readFile(resolve(root, 'showroom', 'src', 'products', 'ecommerce', 'EcommerceOrdersProduct.tsx'), 'utf8'),
+  readFile(resolve(root, 'showroom', 'src', 'products', 'ecommerce', 'CommerceWorkspaces.tsx'), 'utf8'),
   readFile(resolve(root, 'showroom', 'src', 'products', 'ecommerce', 'ecommerce-model.ts'), 'utf8'),
   readFile(resolve(root, 'showroom', 'src', 'products', 'product-handoff.ts'), 'utf8'),
 ])
@@ -83,11 +86,18 @@ if (!appPackage.scripts?.lint?.includes('src/products')) fail('prototype_sources
 if (!websiteSource.includes('No website has been deployed.') || !websiteSource.includes('No deployment or external write occurred.')) fail('website_prototype_boundary_missing')
 if (!ecommerceSource.includes('No integrations are connected.') || !ecommerceSource.includes('Customer sends, checkout, payments, delivery, and production writes are not connected.')) fail('ecommerce_prototype_boundary_missing')
 if (!handoffSource.includes("schema: 'website_ecommerce_handoff.v1'") || !handoffSource.includes("state: 'pending_acceptance'") || !handoffSource.includes('hasExactKeys') || !handoffSource.includes('validateAgainstWorkspace') || !handoffSource.includes('readinessChecks(workspace, fingerprint).every') || !handoffSource.includes('acceptWebsiteEcommerceHandoff')) fail('website_ecommerce_handoff_contract_missing')
-if (['customerLabel', 'phoneSuffix', 'township', 'paymentMethod', 'deliveryMethod'].some((field) => handoffSource.includes(field))) fail('website_handoff_contains_pii_shaped_fields')
+const handoffIntakeSource = handoffSource.slice(handoffSource.indexOf('type HandoffIntake'), handoffSource.indexOf('type PendingHandoff'))
+if (!handoffIntakeSource.includes('sku: string') || !handoffIntakeSource.includes('quantity: number') || ['customer', 'phone', 'township', 'payment', 'delivery', 'fulfilment'].some((field) => handoffIntakeSource.toLowerCase().includes(field))) fail('website_handoff_contains_pii_shaped_fields')
 if (!handoffSource.includes("actorKind: 'human'") || !handoffSource.includes("action: 'accept_website_handoff'") || !handoffSource.includes('audit: [audit]') || !handoffSource.includes("existing.handoff.state === 'accepted'") || !handoffSource.includes('setItem(WEBSITE_ECOMMERCE_HANDOFF_KEY, JSON.stringify(store))')) fail('website_handoff_atomic_audit_missing')
 if (!handoffSource.includes("schema: 'ecommerce_order_draft.v1'") || !handoffSource.includes("mode: 'browser-local'") || !handoffSource.includes("schema: 'website_ecommerce_handoff_store.v2'") || !handoffSource.includes('createWebsiteOrderDraft') || !handoffSource.includes('idempotencyKey: current.handoff.id') || !handoffSource.includes("missingFields: ['customer_reference', 'fulfilment_method', 'payment_method']") || !handoffSource.includes('current.draft.idempotencyKey === handoffId') || !handoffSource.includes('if (!current.display) return null')) fail('ecommerce_order_draft_contract_missing')
+if (!handoffSource.includes("schema: 'ecommerce_order_record.v1'") || !handoffSource.includes("schema: 'website_ecommerce_handoff_store.v3'") || !handoffSource.includes("state: 'ready_for_confirmation'") || !handoffSource.includes("action: 'complete_website_order'") || !handoffSource.includes('customerReferenceFor(current.handoff.id)') || !handoffSource.includes('websiteEvidenceReference: current.handoff.source.localPublishId') || !handoffSource.includes('completionMatches(current.order, input)') || !handoffSource.includes('globalThis.navigator.locks.request') || !handoffSource.includes('if (!isHandoffStore(store)) return null')) fail('ecommerce_order_completion_contract_missing')
 if (!websiteSource.includes('approvalIsCurrent || !publishIsCurrent') || !websiteSource.includes('checks.every((check) => check.passed)') || !websiteSource.includes('writeWebsiteEcommerceHandoff(handoff, workspace)') || !publishSource.includes('fingerprint is a revision marker, not a signature')) fail('website_handoff_gate_missing')
 if (!ecommerceModel.includes("'accept_website_handoff'") || !ecommerceModel.includes('isValidApprovalDetails(action.approval)') || !ecommerceSource.includes('waiting for attributable human approval') || !ecommerceSource.includes('Responsible operator ID') || !ecommerceSource.includes('matchingItems.length !== 1') || !ecommerceSource.includes('createWebsiteOrderDraft(current.handoff.id') || !ecommerceSource.includes('It does not create an order, contact a customer, reserve stock, collect payment, or write to Commerce.')) fail('ecommerce_intake_approval_contract_missing')
+if (!ecommerceModel.includes("'complete_website_order'") || !ecommerceSource.includes('Generated non-PII customer reference') || !ecommerceSource.includes('await completeWebsiteOrderDraft') || !ecommerceSource.includes('It does not insert into the scenario queue, reserve stock, confirm a customer, collect payment, send a message, or write externally.') || !ecommerceSource.includes('Website handoff and completion evidence persists only in this browser') || !ecommerceWorkspacesSource.includes('Ready for confirmation') || !ecommerceWorkspacesSource.includes('no confirmation, reservation, payment, or send')) fail('ecommerce_order_completion_ui_missing')
+const requestWebsiteIntakeSource = ecommerceSource.slice(ecommerceSource.indexOf('function requestWebsiteIntake'), ecommerceSource.indexOf('function approveWebsiteIntake'))
+if (requestWebsiteIntakeSource.indexOf('if (current.draft)') < 0 || requestWebsiteIntakeSource.indexOf('if (current.draft)') > requestWebsiteIntakeSource.indexOf('const matchingItems = workspace.catalog.filter')) fail('immutable_draft_blocked_by_current_catalog')
+const proposalKindSource = ecommerceModel.slice(ecommerceModel.indexOf('export type ProposedActionKind'), ecommerceModel.indexOf('type FulfillmentChange'))
+if (proposalKindSource.includes('accept_website_handoff') || proposalKindSource.includes('complete_website_order')) fail('audit_action_leaked_into_proposal_kind')
 let workflowProfiles = 0
 for (const product of manifest.products || []) {
   if (product.templates?.length !== 3) fail(`wrong_template_count:${product.id}`)
@@ -109,6 +119,128 @@ for (const marker of ['\uFFFD', '\u00e2\u20ac\u201d', '\u00e2\u20ac\u201c', '\u0
   if (corpus.includes(marker)) fail('app_copy_encoding_corrupt')
 }
 
+async function verifyWebsiteOrderCompletionRuntime() {
+  const originalNavigator = Object.getOwnPropertyDescriptor(globalThis, 'navigator')
+  const originalLocalStorage = Object.getOwnPropertyDescriptor(globalThis, 'localStorage')
+  const values = new Map()
+  let lockRequests = 0
+  const localStorage = {
+    getItem: (key) => values.get(key) ?? null,
+    setItem: (key, value) => values.set(key, String(value)),
+    removeItem: (key) => values.delete(key),
+    clear: () => values.clear(),
+    key: (index) => [...values.keys()][index] ?? null,
+    get length() { return values.size },
+  }
+  const assert = (condition, reason) => {
+    if (!condition) throw new Error(reason)
+    orderCompletionRuntimeChecks += 1
+  }
+
+  try {
+    Object.defineProperty(globalThis, 'localStorage', { configurable: true, value: localStorage })
+    Object.defineProperty(globalThis, 'navigator', {
+      configurable: true,
+      value: {
+        locks: {
+          request: async (_name, _options, callback) => {
+            lockRequests += 1
+            return await callback()
+          },
+        },
+      },
+    })
+
+    const websiteModel = await import(`${pathToFileURL(resolve(root, 'showroom', 'src', 'products', 'website', 'website-model.ts')).href}?verify=${Date.now()}`)
+    const handoffContract = await import(`${pathToFileURL(resolve(root, 'showroom', 'src', 'products', 'product-handoff.ts')).href}?verify=${Date.now()}`)
+    const workspace = websiteModel.createInitialWorkspace()
+    const fingerprint = websiteModel.workspaceFingerprint(workspace)
+    const at = (offset) => new Date(Date.now() + offset).toISOString()
+    workspace.evidence = ['content', 'responsive', 'links'].map((kind, index) => ({
+      id: `evidence-${kind}`,
+      kind,
+      finding: `${kind} verified`,
+      reference: `REF-${kind.toUpperCase()}`,
+      verifiedBy: 'OP-OWNER',
+      verifiedAt: at(-5_000 + index),
+      fingerprint,
+    }))
+    workspace.approval = {
+      id: 'approval-runtime',
+      reviewer: 'OP-OWNER',
+      note: 'Approved for runtime contract verification',
+      approvedAt: at(-4_000),
+      fingerprint,
+    }
+    workspace.localPublishes = [{
+      id: 'local-publish-runtime',
+      recordedAt: at(-3_000),
+      recordedBy: 'OP-OWNER',
+      fingerprint,
+      readyPageIds: workspace.pages.filter((page) => page.stage === 'ready').map((page) => page.id),
+    }]
+    localStorage.setItem(websiteModel.WEBSITE_STORAGE_KEY, JSON.stringify(workspace))
+
+    const pendingHandoff = handoffContract.createWebsiteEcommerceHandoff({
+      fingerprint,
+      approvalId: workspace.approval.id,
+      localPublishId: workspace.localPublishes[0].id,
+      pageId: 'page-products',
+      sku: 'SM-CARE-01',
+      quantity: 1,
+    })
+    const pending = handoffContract.writeWebsiteEcommerceHandoff(pendingHandoff, workspace)
+    assert(pending?.schema === 'website_ecommerce_handoff_store.v1' && pending.audit.length === 0 && !pending.draft && !pending.order, 'runtime_v1_pending_invalid')
+    const accepted = handoffContract.acceptWebsiteEcommerceHandoff(pendingHandoff.id, 'OP-OWNER')
+    assert(accepted?.schema === 'website_ecommerce_handoff_store.v1' && accepted.audit.length === 1 && !accepted.draft && !accepted.order, 'runtime_v1_acceptance_invalid')
+    const drafted = handoffContract.createWebsiteOrderDraft(pendingHandoff.id, {
+      sku: 'SM-CARE-01',
+      itemName: 'Family care set',
+      variant: 'Standard bundle',
+      active: true,
+      unitPriceMmk: 31_000,
+    })
+    assert(drafted?.schema === 'website_ecommerce_handoff_store.v2' && drafted.draft?.totalMmk === 31_000 && !drafted.order && drafted.audit.length === 1, 'runtime_v2_draft_invalid')
+    const v2Raw = localStorage.getItem(handoffContract.WEBSITE_ECOMMERCE_HANDOFF_KEY)
+    const input = {
+      fulfilmentMethod: 'local_delivery',
+      paymentMethod: 'manual_qr',
+      operatorId: 'OP-OWNER',
+      evidenceReference: 'EV-TESTAB23',
+    }
+    const completed = await handoffContract.completeWebsiteOrderDraft(drafted.draft.id, input)
+    assert(completed?.schema === 'website_ecommerce_handoff_store.v3' && completed.order?.state === 'ready_for_confirmation' && completed.audit.length === 2, 'runtime_v3_completion_invalid')
+    assert(/^CREF-[A-HJ-NP-Z2-9]{12}$/.test(completed.order.customerReference), 'runtime_customer_reference_not_opaque')
+    assert(completed.order.idempotencyKey === drafted.draft.id && completed.order.source.websiteEvidenceReference === workspace.localPublishes[0].id, 'runtime_source_identity_invalid')
+    assert(JSON.stringify(completed.order.lines) === JSON.stringify(drafted.draft.lines) && completed.order.totalMmk === drafted.draft.totalMmk, 'runtime_price_snapshot_changed')
+    const v3Raw = localStorage.getItem(handoffContract.WEBSITE_ECOMMERCE_HANDOFF_KEY)
+    const exactRetry = await handoffContract.completeWebsiteOrderDraft(drafted.draft.id, input)
+    assert(exactRetry?.order?.id === completed.order.id && localStorage.getItem(handoffContract.WEBSITE_ECOMMERCE_HANDOFF_KEY) === v3Raw && exactRetry.audit.length === 2, 'runtime_exact_retry_not_idempotent')
+    const conflictingRetry = await handoffContract.completeWebsiteOrderDraft(drafted.draft.id, { ...input, paymentMethod: 'manual_bank_transfer' })
+    assert(conflictingRetry === null && localStorage.getItem(handoffContract.WEBSITE_ECOMMERCE_HANDOFF_KEY) === v3Raw, 'runtime_conflicting_retry_overwrote_record')
+    assert(lockRequests === 3, 'runtime_completion_lock_missing')
+
+    localStorage.setItem(handoffContract.WEBSITE_ECOMMERCE_HANDOFF_KEY, v2Raw)
+    localStorage.setItem(websiteModel.WEBSITE_STORAGE_KEY, JSON.stringify({ ...workspace, siteName: 'Changed Website source' }))
+    const staleAttempt = await handoffContract.completeWebsiteOrderDraft(drafted.draft.id, input)
+    assert(staleAttempt === null && localStorage.getItem(handoffContract.WEBSITE_ECOMMERCE_HANDOFF_KEY) === v2Raw, 'runtime_stale_source_did_not_fail_closed')
+
+    const malformed = '{broken'
+    localStorage.setItem(handoffContract.WEBSITE_ECOMMERCE_HANDOFF_KEY, malformed)
+    const malformedAttempt = await handoffContract.completeWebsiteOrderDraft(drafted.draft.id, input)
+    assert(malformedAttempt === null && localStorage.getItem(handoffContract.WEBSITE_ECOMMERCE_HANDOFF_KEY) === malformed, 'runtime_malformed_store_was_replaced')
+  } catch (error) {
+    fail(`ecommerce_order_completion_runtime:${error instanceof Error ? error.message : 'unknown'}`)
+  } finally {
+    if (originalLocalStorage) Object.defineProperty(globalThis, 'localStorage', originalLocalStorage)
+    else delete globalThis.localStorage
+    if (originalNavigator) Object.defineProperty(globalThis, 'navigator', originalNavigator)
+    else delete globalThis.navigator
+  }
+}
+
+await verifyWebsiteOrderCompletionRuntime()
+
 const bytes = (await Promise.all(files.map(async (path) => (await stat(path)).size))).reduce((total, size) => total + size, 0)
 if (bytes > 2_500_000) fail(`artifact_budget:${bytes}`)
 
@@ -116,4 +248,4 @@ if (failures.length) {
   console.error(JSON.stringify({ ok: false, contract: 'supermega_app_build', failures }, null, 2))
   process.exit(1)
 }
-console.log(JSON.stringify({ ok: true, contract: 'supermega_app_build', primaryRoutes: 4, operatingModules: 2, prototypeRoutes: 2, workflowProfiles, bytes }, null, 2))
+console.log(JSON.stringify({ ok: true, contract: 'supermega_app_build', primaryRoutes: 4, operatingModules: 2, prototypeRoutes: 2, workflowProfiles, orderCompletionRuntimeChecks, bytes }, null, 2))

--- a/tools/verify_hq_contract.mjs
+++ b/tools/verify_hq_contract.mjs
@@ -16,7 +16,7 @@ const failures = []
 const requireContract = (name, condition) => { if (!condition) failures.push(name) }
 
 requireContract('portfolio schema', portfolio.schemaVersion === 'supermega.hq.portfolio.v1')
-requireContract('portfolio is current', portfolio.updatedAt === '2026-07-22' && now.includes('Updated: 2026-07-22'))
+requireContract('portfolio is current', portfolio.updatedAt === '2026-07-23' && now.includes('Updated: 2026-07-23'))
 requireContract('portfolio is narrow', portfolio.portfolio?.map((entry) => entry.id).join(',') === 'company-system,website,ecommerce,commerce,production')
 requireContract('portfolio paths are canonical', portfolio.portfolio?.map((entry) => entry.path).join(',') === '/,/products/website/,/products/ecommerce/,/operations/commerce/,/operations/production/')
 requireContract('new products remain truthful prototypes', portfolio.portfolio?.filter((entry) => ['website', 'ecommerce'].includes(entry.id)).every((entry) => entry.status === 'prototype-local' && entry.nextGate?.trim()))


### PR DESCRIPTION
## What
- completes the controlled Website -> Ecommerce order handoff as an idempotent `ready_for_confirmation` record
- simplifies the operating shell to Today, Teams, and Operations while keeping Website and Ecommerce as product launches
- adds bounded internal Agent Teams with explicit human owners, evidence, and approval boundaries
- tightens HQ, release, security, and product-contract evidence

## Why
The current product needed a real order-state transition, fewer competing controls, and a practical internal delegation model without pretending that agents can send, pay, publish, merge, deploy, or write to production autonomously.

## Impact
- no increase in public route count
- no customer confirmation, stock mutation, payment, external send, deployment, or production database write
- local workspace data advances to v3 while retaining v2 reads and failing closed on malformed or cross-team agent data
- Commerce and Production remain operating modes; Website and Ecommerce remain distinct products

## Root cause addressed
The previous shell mixed product launches with daily operating modes, showed too many simultaneous controls, and left Ecommerce at a draft-only state. This change separates those concepts and introduces a bounded, auditable completion step.

## Verification
- showroom lint and strict TypeScript
- app build: 12 order-completion runtime checks, 47 coordinated release checks, and 36 security checks
- RLS validator self-test: 6 checks
- Vercel environment/domain contracts: 11 checks
- HQ contract and public prebuilt contract: 73 contact-behavior checks
- desktop and 390px browser verification for Today, Teams, Operations, Product apps, query navigation, overflow, and console errors

## Release safety
This PR does not directly deploy production. Production remains behind the repository's coordinated main release workflow.