### PR TITLE
feat: ship Jade mobile-first SuperMega brand system

### DIFF
--- a/showroom/src/core/core-app.css
+++ b/showroom/src/core/core-app.css
@@ -1,18 +1,18 @@
 :root {
-  color-scheme: dark;
-  --core-bg: #080a09;
-  --core-panel: #101411;
-  --core-panel-raised: #151a16;
-  --core-ink: #f2f5f1;
-  --core-muted: #a3ada6;
-  --core-quiet: #707b73;
-  --core-line: rgba(225, 238, 229, .12);
-  --core-line-strong: rgba(225, 238, 229, .22);
-  --core-green: #7cf5b4;
-  --core-green-soft: rgba(124, 245, 180, .1);
-  --core-warn: #ffb86b;
-  --core-danger: #ff7b8d;
-  --core-radius: 10px;
+  color-scheme: light;
+  --core-bg: #f6f4ee;
+  --core-panel: #ffffff;
+  --core-panel-raised: #eef4ef;
+  --core-ink: #17231d;
+  --core-muted: #56665d;
+  --core-quiet: #7b8980;
+  --core-line: rgba(31, 68, 51, .12);
+  --core-line-strong: rgba(31, 68, 51, .2);
+  --core-green: #0b745e;
+  --core-green-soft: rgba(11, 116, 94, .1);
+  --core-warn: #946200;
+  --core-danger: #b42336;
+  --core-radius: 14px;
   --core-mono: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
 }
 
@@ -20,14 +20,14 @@
 html, body, #root { width: 100%; height: 100%; }
 html { min-width: 320px; background: var(--core-bg); }
 body { min-width: 320px; margin: 0; overflow: hidden; background: var(--core-bg); color: var(--core-ink); font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; text-rendering: optimizeLegibility; }
-body::before { position: fixed; inset: 0; z-index: -2; background: radial-gradient(circle at 78% -12%, rgba(124,245,180,.08), transparent 32%), linear-gradient(180deg, #090c0a, #080a09 60%); content: ""; }
+body::before { position: fixed; inset: 0; z-index: -2; background: radial-gradient(circle at 78% -12%, rgba(11,116,94,.1), transparent 32%), linear-gradient(180deg, #fbfaf6, var(--core-bg) 60%); content: ""; }
 button, input, select, textarea { font: inherit; }
 button, a { -webkit-tap-highlight-color: transparent; }
 a { color: inherit; }
 .sr-only { position: absolute; width: 1px; height: 1px; overflow: hidden; clip: rect(0,0,0,0); white-space: nowrap; }
 
 .core-shell { height: 100svh; display: grid; grid-template-columns: 184px minmax(0, 1fr); }
-.core-sidebar { position: fixed; inset: 0 auto 0 0; z-index: 30; width: 184px; display: flex; flex-direction: column; border-right: 1px solid var(--core-line); padding: 20px 16px 16px; background: rgba(8,10,9,.94); backdrop-filter: blur(20px); }
+.core-sidebar { position: fixed; inset: 0 auto 0 0; z-index: 30; width: 184px; display: flex; flex-direction: column; border-right: 1px solid var(--core-line); padding: 20px 16px 16px; background: rgba(238,244,239,.96); backdrop-filter: blur(20px); }
 .core-stage { min-width: 0; min-height: 0; grid-column: 2; display: grid; grid-template-rows: 56px minmax(0,1fr); }
 .core-main { width: min(calc(100% - 40px), 1420px); height: 100%; min-width: 0; min-height: 0; margin: 0 auto; padding: 20px 0; overflow: hidden; }
 .core-skip { position: fixed; z-index: 100; top: -60px; left: 230px; border: 1px solid var(--core-green); border-radius: 5px; padding: 9px 12px; background: var(--core-panel); text-decoration: none; }
@@ -42,14 +42,14 @@ a { color: inherit; }
 .core-nav { display: grid; gap: 5px; margin-top: 26px; }
 .core-nav a { min-height: 44px; display: flex; align-items: center; border: 1px solid transparent; border-radius: 6px; padding: 0 12px; color: var(--core-muted); font-size: 13px; font-weight: 720; text-decoration: none; }
 .core-nav a span { width: 20px; color: var(--core-quiet); font-family: var(--core-mono); font-size: 8px; }
-.core-nav a:hover { background: rgba(255,255,255,.035); color: var(--core-ink); }
-.core-nav a.active { border-color: rgba(124,245,180,.2); background: var(--core-green-soft); color: var(--core-ink); }
+.core-nav a:hover { background: rgba(11,116,94,.07); color: var(--core-ink); }
+.core-nav a.active { border-color: rgba(11,116,94,.2); background: var(--core-green-soft); color: var(--core-ink); }
 .core-nav a.active span { color: var(--core-green); }
 .sidebar-foot { display: grid; gap: 8px; margin-top: auto; border-top: 1px solid var(--core-line); padding: 14px 4px 0; }
 .sidebar-foot p { margin: 0; color: var(--core-quiet); font-size: 8px; line-height: 1.55; }
 .sidebar-foot a { min-height: 36px; display: inline-flex; align-items: center; color: var(--core-muted); font-size: 12px; text-decoration: none; }
 
-.core-topbar { position: relative; z-index: 20; display: flex; align-items: center; justify-content: space-between; gap: 14px; border-bottom: 1px solid var(--core-line); padding: 0 20px; background: rgba(8,10,9,.84); backdrop-filter: blur(18px); }
+.core-topbar { position: relative; z-index: 20; display: flex; align-items: center; justify-content: space-between; gap: 14px; border-bottom: 1px solid var(--core-line); padding: 0 20px; background: rgba(246,244,238,.9); backdrop-filter: blur(18px); }
 .core-topbar > div { display: flex; align-items: center; gap: 9px; }
 .mobile-brand { display: none !important; }
 .terminal-prompt { color: var(--core-green); font-family: var(--core-mono); font-size: 14px; font-weight: 850; }
@@ -64,7 +64,7 @@ a { color: inherit; }
 .mobile-nav { display: none; }
 .runtime-badge { min-height: 28px; display: inline-flex; align-items: center; gap: 6px; border: 1px solid var(--core-line); border-radius: 5px; padding: 0 9px; color: var(--core-muted); font-family: var(--core-mono); font-size: 9px; font-weight: 740; text-transform: uppercase; }
 .runtime-badge i { width: 5px; height: 5px; border-radius: 50%; background: var(--core-quiet); }
-.runtime-badge.demo, .runtime-badge.enterprise { border-color: rgba(124,245,180,.22); background: var(--core-green-soft); color: var(--core-green); }
+.runtime-badge.demo, .runtime-badge.enterprise { border-color: rgba(11,116,94,.2); background: var(--core-green-soft); color: var(--core-green); }
 .runtime-badge.demo i, .runtime-badge.enterprise i { background: var(--core-green); }
 
 .workspace-screen { height: 100%; min-height: 0; display: flex; flex-direction: column; gap: 14px; }
@@ -80,9 +80,9 @@ a { color: inherit; }
 .operations-profile > strong { grid-column: 1; overflow: hidden; font-size: 11px; text-overflow: ellipsis; white-space: nowrap; }
 .operations-profile .text-link { grid-column: 2; grid-row: 1/3; min-height: 32px; }
 
-.core-button { min-height: 40px; display: inline-flex; align-items: center; justify-content: center; gap: 7px; border: 1px solid var(--core-line-strong); border-radius: 6px; padding: 0 14px; background: rgba(255,255,255,.025); color: var(--core-ink); font-size: 12px; font-weight: 760; text-decoration: none; cursor: pointer; }
-.core-button:hover { border-color: rgba(255,255,255,.34); background: rgba(255,255,255,.06); }
-.core-button.primary { border-color: var(--core-green); background: var(--core-green); color: #07100a; }
+.core-button { min-height: 44px; display: inline-flex; align-items: center; justify-content: center; gap: 7px; border: 1px solid var(--core-line-strong); border-radius: 10px; padding: 0 14px; background: #fff; color: var(--core-ink); font-size: 12px; font-weight: 760; text-decoration: none; cursor: pointer; }
+.core-button:hover { border-color: var(--core-green); background: var(--core-green-soft); }
+.core-button.primary { border-color: var(--core-green); background: var(--core-green); color: #fff; }
 .core-button.compact { min-height: 36px; padding-inline: 11px; font-size: 11px; }
 .core-button.danger { border-color: rgba(255,123,141,.4); color: var(--core-danger); }
 .text-link { min-height: 34px; display: inline-flex; align-items: center; border: 0; padding: 0; background: transparent; color: var(--core-green); font-family: var(--core-mono); font-size: 10px; font-weight: 760; text-decoration: none; text-transform: uppercase; cursor: pointer; }
@@ -93,11 +93,11 @@ a { color: inherit; }
 .segmented-control, .view-tabs { display: flex; min-width: 0; align-items: center; gap: 3px; }
 .segmented-control button, .segmented-control a, .view-tabs button { min-height: 38px; border: 1px solid transparent; border-radius: 5px; padding: 0 12px; display: inline-flex; align-items: center; background: transparent; color: var(--core-quiet); font-size: 11px; font-weight: 720; text-decoration: none; cursor: pointer; white-space: nowrap; }
 .segmented-control button:hover, .segmented-control a:hover, .view-tabs button:hover { color: var(--core-ink); }
-.segmented-control button[aria-pressed="true"] { border-color: rgba(124,245,180,.22); background: var(--core-green-soft); color: var(--core-green); }
+.segmented-control button[aria-pressed="true"] { border-color: rgba(11,116,94,.2); background: var(--core-green-soft); color: var(--core-green); }
 .view-tabs button[aria-selected="true"], .view-tabs button[aria-current="page"] { border-bottom-color: var(--core-green); border-radius: 0; color: var(--core-ink); }
 .segmented-control.wide { display: grid; grid-template-columns: repeat(2,minmax(0,1fr)); }
 
-.summary-strip { min-height: 62px; display: grid; grid-template-columns: repeat(auto-fit,minmax(120px,1fr)); overflow: hidden; border: 1px solid var(--core-line); border-radius: var(--core-radius); background: rgba(255,255,255,.018); }
+.summary-strip { min-height: 62px; display: grid; grid-template-columns: repeat(auto-fit,minmax(120px,1fr)); overflow: hidden; border: 1px solid var(--core-line); border-radius: var(--core-radius); background: var(--core-panel); }
 .summary-strip.compact-summary { grid-template-columns: repeat(3,minmax(0,1fr)); }
 .summary-strip > span { min-width: 0; display: flex; align-items: center; justify-content: space-between; gap: 10px; border-right: 1px solid var(--core-line); padding: 0 14px; }
 .summary-strip > span:last-child { border-right: 0; }
@@ -108,7 +108,7 @@ a { color: inherit; }
 .operation-module { height: 100%; min-height: 0; display: flex; flex-direction: column; gap: 11px; }
 .operation-module > .split-workspace, .operation-module > .module-today, .operation-module > .control-workspace, .operation-module > .inventory-panel { height: auto; min-height: 0; flex: 1; }
 .split-workspace { height: 100%; min-height: 0; display: grid; grid-template-columns: minmax(300px,.85fr) minmax(0,1.15fr); gap: 11px; }
-.core-panel { min-width: 0; min-height: 0; overflow: hidden; border: 1px solid var(--core-line); border-radius: var(--core-radius); padding: 18px; background: rgba(16,20,17,.88); box-shadow: inset 0 1px rgba(255,255,255,.025); }
+.core-panel { min-width: 0; min-height: 0; overflow: hidden; border: 1px solid var(--core-line); border-radius: var(--core-radius); padding: 18px; background: var(--core-panel); box-shadow: 0 10px 28px rgba(25,54,42,.055); }
 .panel-head { min-height: 35px; display: flex; align-items: flex-start; justify-content: space-between; gap: 14px; margin-bottom: 10px; }
 .panel-head h2, .core-panel > h2 { margin: 4px 0 0; font-size: 18px; line-height: 1.15; letter-spacing: -.025em; }
 .panel-head p { margin: 4px 0 0; color: var(--core-muted); font-size: 11px; }
@@ -117,14 +117,14 @@ a { color: inherit; }
 .authority-note { border-left: 2px solid var(--core-green); padding-left: 10px; }
 .status-pill { min-height: 26px; display: inline-flex; align-items: center; gap: 5px; border: 1px solid var(--core-line); border-radius: 999px; padding: 0 8px; color: var(--core-muted); font-family: var(--core-mono); font-size: 9px; font-weight: 740; text-transform: uppercase; white-space: nowrap; }
 .status-pill::before { width: 4px; height: 4px; border-radius: 50%; background: currentColor; content: ""; }
-.status-pill.ready, .status-pill.approved, .status-pill.bounded { border-color: rgba(124,245,180,.22); background: var(--core-green-soft); color: var(--core-green); }
+.status-pill.ready, .status-pill.approved, .status-pill.bounded { border-color: rgba(11,116,94,.2); background: var(--core-green-soft); color: var(--core-green); }
 .status-pill.pending { border-color: rgba(255,184,107,.28); color: var(--core-warn); }
 
-.record-list, .order-list, .issue-list, .decision-list, .attention-list, .approval-list, .job-list { min-height: 0; overflow: auto; scrollbar-color: rgba(124,245,180,.25) transparent; }
+.record-list, .order-list, .issue-list, .decision-list, .attention-list, .approval-list, .job-list { min-height: 0; overflow: auto; scrollbar-color: rgba(11,116,94,.26) transparent; }
 .record-row { width: 100%; min-height: 60px; display: grid; grid-template-columns: 8px minmax(0,1fr) auto; gap: 10px; align-items: center; border: 0; border-bottom: 1px solid var(--core-line); padding: 8px 6px; background: transparent; color: var(--core-ink); text-align: left; text-decoration: none; cursor: pointer; }
-.record-row:hover, .record-row[aria-current="true"] { background: rgba(124,245,180,.045); }
+.record-row:hover, .record-row[aria-current="true"] { background: rgba(11,116,94,.07); }
 .record-status { width: 5px; height: 5px; border-radius: 50%; background: var(--core-quiet); }
-.record-status.in_progress, .record-status.review { background: var(--core-green); box-shadow: 0 0 8px rgba(124,245,180,.4); }
+.record-status.in_progress, .record-status.review { background: var(--core-green); }
 .record-status.blocked { background: var(--core-warn); }
 .record-status.done { background: var(--core-muted); }
 .record-row > span { min-width: 0; display: grid; gap: 3px; }
@@ -142,14 +142,14 @@ a { color: inherit; }
 .record-detail-head p { margin: 0; color: var(--core-muted); font-size: 12px; line-height: 1.5; }
 .record-controls { display: grid; grid-template-columns: repeat(4,minmax(0,1fr)); gap: 8px; margin-top: 12px; }
 label { display: grid; gap: 6px; color: var(--core-muted); font-size: 11px; font-weight: 700; }
-input, select, textarea { width: 100%; min-width: 0; min-height: 40px; border: 1px solid var(--core-line); border-radius: 5px; padding: 9px 10px; background: #0a0d0b; color: var(--core-ink); font-size: 12px; outline: none; }
-input:focus, select:focus, textarea:focus { border-color: var(--core-green); box-shadow: 0 0 0 2px rgba(124,245,180,.08); }
+input, select, textarea { width: 100%; min-width: 0; min-height: 44px; border: 1px solid var(--core-line); border-radius: 9px; padding: 9px 10px; background: #fff; color: var(--core-ink); font-size: 12px; outline: none; }
+input:focus, select:focus, textarea:focus { border-color: var(--core-green); box-shadow: 0 0 0 3px rgba(11,116,94,.1); }
 textarea { min-height: 72px; resize: vertical; }
 .evidence-register { margin-top: 12px; border-top: 1px solid var(--core-line); padding-top: 10px; }
 .evidence-register > div { display: flex; align-items: center; justify-content: space-between; color: var(--core-muted); font-size: 9px; }
 .evidence-register p { margin: 8px 0 0; color: var(--core-quiet); font-size: 8px; }
 .evidence-record-list { max-height: 175px; display: grid !important; gap: 6px; overflow: auto; margin-top: 8px; }
-.evidence-record-list article { display: grid; grid-template-columns: minmax(0,1fr) auto; gap: 4px 10px; border: 1px solid var(--core-line); border-radius: 4px; padding: 7px 8px; background: rgba(124,245,180,.02); }
+.evidence-record-list article { display: grid; grid-template-columns: minmax(0,1fr) auto; gap: 4px 10px; border: 1px solid var(--core-line); border-radius: 8px; padding: 7px 8px; background: rgba(11,116,94,.04); }
 .evidence-record-list article > div { display: flex; align-items: center; gap: 6px; }
 .evidence-record-list article > div b { color: var(--core-muted); font-family: var(--core-mono); font-size: 9px; text-transform: uppercase; }
 .evidence-record-list article > strong { grid-column: 1/-1; color: var(--core-ink); font-size: 11px; }
@@ -159,13 +159,13 @@ textarea { min-height: 72px; resize: vertical; }
 .core-form { display: grid; gap: 10px; }
 .compact-form { max-width: 680px; }
 .form-row { display: grid; grid-template-columns: repeat(2,minmax(0,1fr)); gap: 8px; }
-.template-contract { display: grid; grid-template-columns: auto minmax(0,1fr); gap: 3px 8px; border: 1px solid var(--core-line); border-radius: 4px; padding: 7px 8px; background: rgba(124,245,180,.025); }
+.template-contract { display: grid; grid-template-columns: auto minmax(0,1fr); gap: 3px 8px; border: 1px solid var(--core-line); border-radius: 8px; padding: 7px 8px; background: rgba(11,116,94,.05); }
 .template-contract span { color: var(--core-green); font-family: var(--core-mono); font-size: 7px; font-weight: 760; letter-spacing: .06em; text-transform: uppercase; }
 .template-contract strong { overflow: hidden; font-size: 8px; font-weight: 680; text-overflow: ellipsis; white-space: nowrap; }
 .template-contract small { grid-column: 2; color: var(--core-quiet); font-size: 7px; }
 .form-actions { display: flex; justify-content: flex-end; gap: 8px; }
 .form-notice { min-height: 16px; margin: 7px 0 0; color: var(--core-quiet); font-size: 10px; line-height: 1.45; }
-.accountable-action-gate { flex: 0 0 auto; display: grid; grid-template-columns: minmax(200px,.55fr) minmax(0,1.45fr); gap: 18px; align-items: end; border-color: rgba(124,245,180,.3); background: linear-gradient(110deg, rgba(124,245,180,.07), rgba(16,20,17,.96) 42%); }
+.accountable-action-gate { flex: 0 0 auto; display: grid; grid-template-columns: minmax(200px,.55fr) minmax(0,1.45fr); gap: 18px; align-items: end; border-color: rgba(11,116,94,.24); background: linear-gradient(110deg, rgba(11,116,94,.09), #fff 42%); }
 .action-change h2 { margin: 4px 0 8px; font-size: 15px; }
 .action-change p { display: flex; flex-wrap: wrap; align-items: center; gap: 7px; margin: 0; color: var(--core-quiet); font-family: var(--core-mono); font-size: 8px; }
 .action-change p strong { color: var(--core-muted); font-weight: 700; }
@@ -222,7 +222,7 @@ textarea { min-height: 72px; resize: vertical; }
 .attention-list { flex: 1; }
 .attention-list > a, .attention-list > button { width: 100%; min-height: 49px; display: grid; grid-template-columns: 54px minmax(0,1fr); gap: 2px 9px; align-items: center; border: 0; border-bottom: 1px solid var(--core-line); padding: 5px 2px; background: transparent; color: var(--core-ink); text-align: left; text-decoration: none; }
 .attention-list > button { grid-template-columns: 54px minmax(0,1fr) auto; cursor: pointer; }
-.attention-list > a:hover, .attention-list > button:hover { background: rgba(124,245,180,.04); }
+.attention-list > a:hover, .attention-list > button:hover { background: rgba(11,116,94,.07); }
 .attention-list span { grid-row: 1 / 3; color: var(--core-warn); font-family: var(--core-mono); font-size: 7px; text-transform: uppercase; }
 .attention-list strong { overflow: hidden; font-size: 10px; text-overflow: ellipsis; white-space: nowrap; }
 .attention-list small { color: var(--core-quiet); font-size: 9px; }
@@ -238,7 +238,7 @@ textarea { min-height: 72px; resize: vertical; }
 .brief-divider { display: flex; align-items: center; justify-content: space-between; margin-top: 8px; border-top: 1px solid var(--core-line); color: var(--core-muted); font-size: 8px; }
 .brief-output.compact { gap: 3px; }
 .brief-output.compact p { font-size: 8px; }
-.decision-dialog { position: fixed; inset: 0; width: min(820px,calc(100% - 36px)); max-height: calc(100svh - 36px); margin: auto; overflow: auto; border: 1px solid rgba(124,245,180,.34); border-radius: var(--core-radius); padding: 18px; color: var(--core-ink); background: #0d120f; box-shadow: 0 26px 80px rgba(0,0,0,.55); }
+.decision-dialog { position: fixed; inset: 0; width: min(820px,calc(100% - 36px)); max-height: calc(100svh - 36px); margin: auto; overflow: auto; border: 1px solid rgba(11,116,94,.24); border-radius: var(--core-radius); padding: 18px; color: var(--core-ink); background: #fff; box-shadow: 0 26px 80px rgba(25,54,42,.2); }
 .decision-dialog::backdrop { background: rgba(2,4,3,.82); backdrop-filter: blur(8px); }
 .decision-packet-meta, .decision-outcomes { display: grid; grid-template-columns: repeat(4,minmax(0,1fr)); border: 1px solid var(--core-line); border-radius: 5px; }
 .decision-packet-meta span, .decision-outcomes span { min-width: 0; display: grid; gap: 4px; border-right: 1px solid var(--core-line); padding: 9px 10px; }
@@ -312,7 +312,7 @@ textarea { min-height: 72px; resize: vertical; }
 .issue-list strong { font-size: 11px; }
 .issue-list small { color: var(--core-quiet); font-size: 9px; }
 .issue-mark { width: 20px; height: 20px; display: grid; place-items: center; border: 1px solid rgba(255,184,107,.3); border-radius: 50%; color: var(--core-warn); font-family: var(--core-mono); font-size: 8px; }
-.issue-mark.resolved { border-color: rgba(124,245,180,.3); color: var(--core-green); }
+.issue-mark.resolved { border-color: rgba(11,116,94,.24); color: var(--core-green); }
 
 .settings-grid { min-height: 0; flex: 1; display: grid; grid-template-columns: minmax(430px,1.2fr) minmax(260px,.8fr); gap: 11px; }
 .setup-form { display: grid; align-content: start; gap: 10px; }
@@ -348,7 +348,7 @@ textarea { min-height: 72px; resize: vertical; }
 .evidence-disclosure[open] > summary, .decision-workspace-disclosure[open] > summary { border-bottom: 1px solid var(--core-line); }
 
 .agent-team-workspace { height: 100%; min-height: 0; display: flex; flex-direction: column; gap: 11px; }
-.agent-boundary-banner { flex: 0 0 auto; display: flex; align-items: center; justify-content: space-between; gap: 18px; border: 1px solid rgba(124,245,180,.24); border-radius: var(--core-radius); padding: 11px 14px; background: rgba(124,245,180,.045); }
+.agent-boundary-banner { flex: 0 0 auto; display: flex; align-items: center; justify-content: space-between; gap: 18px; border: 1px solid rgba(11,116,94,.2); border-radius: var(--core-radius); padding: 11px 14px; background: rgba(11,116,94,.07); }
 .agent-boundary-banner > div { min-width: 0; display: grid; gap: 3px; }
 .agent-boundary-banner strong { font-size: 12px; }
 .agent-boundary-banner p { max-width: 560px; margin: 0; color: var(--core-muted); font-size: 10px; line-height: 1.45; text-align: right; }
@@ -362,7 +362,7 @@ textarea { min-height: 72px; resize: vertical; }
 .agent-roster-panel { position: relative; }
 .agent-roster { min-height: 0; flex: 1; overflow: auto; }
 .agent-roster > button { width: 100%; min-height: 62px; display: grid; grid-template-columns: 8px minmax(0,1fr) auto; gap: 10px; align-items: center; border: 0; border-bottom: 1px solid var(--core-line); padding: 8px 5px; background: transparent; color: var(--core-ink); text-align: left; cursor: pointer; }
-.agent-roster > button:hover, .agent-roster > button[aria-current="true"] { background: rgba(124,245,180,.045); }
+.agent-roster > button:hover, .agent-roster > button[aria-current="true"] { background: rgba(11,116,94,.07); }
 .agent-roster > button > span { min-width: 0; display: grid; gap: 3px; }
 .agent-roster > button > span:last-child { justify-items: end; }
 .agent-roster strong, .agent-roster small, .agent-roster b { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
@@ -384,7 +384,7 @@ textarea { min-height: 72px; resize: vertical; }
 .compact-disclosure { position: relative; }
 .compact-disclosure > summary { min-height: 34px; display: inline-flex; align-items: center; border: 1px solid var(--core-line-strong); border-radius: 5px; padding: 0 10px; color: var(--core-muted); font-size: 10px; font-weight: 760; cursor: pointer; list-style: none; }
 .compact-disclosure[open] > summary { border-color: var(--core-green); color: var(--core-ink); }
-.agent-create-form { position: absolute; z-index: 8; top: 42px; right: 0; width: 300px; border: 1px solid var(--core-line-strong); border-radius: 7px; padding: 12px; background: #0d120f; box-shadow: 0 18px 50px rgba(0,0,0,.45); }
+.agent-create-form { position: absolute; z-index: 8; top: 42px; right: 0; width: 300px; border: 1px solid var(--core-line-strong); border-radius: 12px; padding: 12px; background: #fff; box-shadow: 0 18px 50px rgba(25,54,42,.16); }
 .evidence-disclosure .compact-disclosure { margin-top: 2px; }
 .evidence-disclosure .inline-evidence { margin-bottom: 3px; }
 .evidence-disclosure .evidence-record-list { max-height: 190px; }
@@ -412,12 +412,12 @@ textarea { min-height: 72px; resize: vertical; }
 .operations-toolbar-actions { display: flex; align-items: center; gap: 10px; }
 .product-app-launcher { position: relative; }
 .product-app-launcher > summary { min-height: 36px; display: inline-flex; align-items: center; border: 1px solid var(--core-line); border-radius: 5px; padding: 0 10px; color: var(--core-muted); font-size: 10px; font-weight: 720; cursor: pointer; list-style: none; }
-.product-app-launcher[open] > summary { border-color: rgba(124,245,180,.3); color: var(--core-ink); }
-.product-app-launcher > div { position: absolute; z-index: 10; top: 42px; right: 0; width: 170px; display: grid; border: 1px solid var(--core-line-strong); border-radius: 7px; padding: 6px; background: #0d120f; box-shadow: 0 16px 45px rgba(0,0,0,.45); }
+.product-app-launcher[open] > summary { border-color: rgba(11,116,94,.24); color: var(--core-ink); }
+.product-app-launcher > div { position: absolute; z-index: 10; top: 42px; right: 0; width: 170px; display: grid; border: 1px solid var(--core-line-strong); border-radius: 12px; padding: 6px; background: #fff; box-shadow: 0 16px 45px rgba(25,54,42,.16); }
 .product-app-launcher a { min-height: 40px; display: flex; align-items: center; border-radius: 5px; padding: 0 10px; color: var(--core-muted); font-size: 11px; text-decoration: none; }
 .product-app-launcher a:hover { background: var(--core-green-soft); color: var(--core-ink); }
 
-:focus-visible { outline: 2px solid rgba(124,245,180,.5); outline-offset: 2px; }
+:focus-visible { outline: 3px solid rgba(11,116,94,.32); outline-offset: 2px; }
 
 @media (max-width: 1120px) {
   .core-shell { grid-template-columns: 184px minmax(0,1fr); }
@@ -441,7 +441,7 @@ textarea { min-height: 72px; resize: vertical; }
   .mobile-brand { display: flex !important; }
   .topbar-title, .topbar-meta > span { display: none !important; }
   .topbar-meta > a { min-height: 38px; display: inline-flex; align-items: center; color: var(--core-muted); font-size: 10px; text-decoration: none; }
-  .mobile-nav { position: sticky; top: 54px; z-index: 19; min-height: 42px; display: grid; grid-template-columns: repeat(3,1fr); border-bottom: 1px solid var(--core-line); background: rgba(8,10,9,.94); }
+  .mobile-nav { position: sticky; top: 54px; z-index: 19; min-height: 48px; display: grid; grid-template-columns: repeat(3,1fr); border-bottom: 1px solid var(--core-line); background: rgba(255,255,255,.96); }
   .mobile-nav a { display: grid; place-items: center; color: var(--core-quiet); font-size: 9px; font-weight: 720; text-decoration: none; }
   .mobile-nav a.active { border-bottom: 2px solid var(--core-green); color: var(--core-ink); }
   .core-main { width: min(calc(100% - 24px),760px); height: auto; min-height: 0; padding: 16px 0 32px; overflow: visible; }

--- a/showroom/src/products/ecommerce/ecommerce-orders.css
+++ b/showroom/src/products/ecommerce/ecommerce-orders.css
@@ -1,17 +1,17 @@
 .eco-product {
-  --eco-bg: #080a09;
-  --eco-panel: #101411;
-  --eco-panel-raised: #151a16;
-  --eco-ink: #f2f5f1;
-  --eco-muted: #a3ada6;
-  --eco-quiet: #707b73;
-  --eco-line: rgba(225, 238, 229, 0.12);
-  --eco-line-strong: rgba(225, 238, 229, 0.22);
-  --eco-green: #7cf5b4;
-  --eco-green-soft: rgba(124, 245, 180, 0.1);
-  --eco-warn: #ffb86b;
-  --eco-danger: #ff7b8d;
-  --eco-radius: 8px;
+  --eco-bg: #f6f4ee;
+  --eco-panel: #ffffff;
+  --eco-panel-raised: #eef4ef;
+  --eco-ink: #17231d;
+  --eco-muted: #56665d;
+  --eco-quiet: #7b8980;
+  --eco-line: rgba(31, 68, 51, 0.12);
+  --eco-line-strong: rgba(31, 68, 51, 0.2);
+  --eco-green: #0b745e;
+  --eco-green-soft: rgba(11, 116, 94, 0.1);
+  --eco-warn: #946200;
+  --eco-danger: #b42336;
+  --eco-radius: 14px;
   --eco-mono: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
   width: 100%;
   height: 100svh;
@@ -21,9 +21,9 @@
   overflow: hidden;
   color: var(--eco-ink);
   background:
-    radial-gradient(circle at 82% -10%, rgba(124, 245, 180, 0.08), transparent 31%),
-    linear-gradient(180deg, #090c0a, var(--eco-bg) 65%);
-  color-scheme: dark;
+    radial-gradient(circle at 82% -10%, rgba(11, 116, 94, 0.1), transparent 31%),
+    linear-gradient(180deg, #fbfaf6, var(--eco-bg) 65%);
+  color-scheme: light;
   font-family: Geist, Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   text-rendering: optimizeLegibility;
 }
@@ -85,7 +85,7 @@
   flex-direction: column;
   border-right: 1px solid var(--eco-line);
   padding: 19px 14px 15px;
-  background: rgba(8, 10, 9, 0.94);
+  background: rgba(238, 244, 239, 0.96);
   backdrop-filter: blur(20px);
 }
 
@@ -161,11 +161,11 @@
 
 .eco-primary-nav button:hover {
   color: var(--eco-ink);
-  background: rgba(255, 255, 255, 0.035);
+  background: rgba(11, 116, 94, 0.07);
 }
 
 .eco-primary-nav button[aria-current="page"] {
-  border-color: rgba(124, 245, 180, 0.2);
+  border-color: rgba(11, 116, 94, 0.2);
   color: var(--eco-ink);
   background: var(--eco-green-soft);
 }
@@ -195,7 +195,7 @@
   align-items: center;
   gap: 6px;
   width: max-content;
-  border: 1px solid rgba(124, 245, 180, 0.22);
+  border: 1px solid rgba(11, 116, 94, 0.2);
   border-radius: 4px;
   padding: 0 8px;
   color: var(--eco-green);
@@ -230,7 +230,7 @@
   gap: 14px;
   border-bottom: 1px solid var(--eco-line);
   padding: 0 20px;
-  background: rgba(8, 10, 9, 0.84);
+  background: rgba(246, 244, 238, 0.92);
   backdrop-filter: blur(18px);
 }
 
@@ -269,7 +269,7 @@
 }
 
 .eco-button {
-  min-height: 32px;
+  min-height: 40px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -278,25 +278,25 @@
   border-radius: 5px;
   padding: 0 11px;
   color: var(--eco-ink);
-  background: rgba(255, 255, 255, 0.025);
+  background: #ffffff;
   font-size: 9px;
   font-weight: 760;
 }
 
 .eco-button:hover:not(:disabled) {
-  border-color: rgba(255, 255, 255, 0.34);
-  background: rgba(255, 255, 255, 0.06);
+  border-color: var(--eco-green);
+  background: var(--eco-green-soft);
 }
 
 .eco-button-primary {
   border-color: var(--eco-green);
-  color: #07100a;
+  color: #ffffff;
   background: var(--eco-green);
 }
 
 .eco-button-primary:hover:not(:disabled) {
-  border-color: #a6f8cb;
-  background: #a6f8cb;
+  border-color: #075c4b;
+  background: #075c4b;
 }
 
 .eco-button-quiet {
@@ -339,7 +339,7 @@
 
 .eco-icon-button:hover {
   color: var(--eco-ink);
-  background: rgba(255, 255, 255, 0.04);
+  background: var(--eco-green-soft);
 }
 
 .eco-main {
@@ -511,10 +511,10 @@
   grid-template-columns: auto minmax(0, 1.2fr) minmax(190px, .8fr) auto;
   align-items: center;
   gap: 12px;
-  border: 1px solid rgba(124, 245, 180, .24);
+  border: 1px solid rgba(11, 116, 94, .2);
   border-radius: var(--eco-radius);
   padding: 7px 9px;
-  background: linear-gradient(90deg, rgba(124, 245, 180, .07), rgba(16, 20, 17, .94) 44%);
+  background: linear-gradient(90deg, rgba(11, 116, 94, .09), #ffffff 44%);
 }
 
 .eco-website-intake > div {
@@ -547,8 +547,8 @@
   border: 1px solid var(--eco-line);
   border-radius: var(--eco-radius);
   padding: 14px;
-  background: rgba(16, 20, 17, 0.9);
-  box-shadow: inset 0 1px rgba(255, 255, 255, 0.025);
+  background: var(--eco-panel);
+  box-shadow: 0 10px 28px rgba(25, 54, 42, .055);
 }
 
 .eco-panel-head {
@@ -611,7 +611,7 @@
 }
 
 .eco-mini-tabs button[aria-pressed="true"] {
-  border-color: rgba(124, 245, 180, 0.22);
+  border-color: rgba(11, 116, 94, 0.2);
   color: var(--eco-green);
   background: var(--eco-green-soft);
 }
@@ -623,7 +623,7 @@
 .eco-audit-list {
   min-height: 0;
   overflow: auto;
-  scrollbar-color: rgba(124, 245, 180, 0.25) transparent;
+  scrollbar-color: rgba(11, 116, 94, 0.26) transparent;
   scrollbar-width: thin;
 }
 
@@ -650,7 +650,7 @@
 
 .eco-order-row:hover,
 .eco-order-row[aria-current="true"] {
-  background: rgba(124, 245, 180, 0.045);
+  background: rgba(11, 116, 94, 0.07);
 }
 
 .eco-record-dot {
@@ -747,7 +747,7 @@
 }
 
 .eco-status-pill[data-tone="success"] {
-  border-color: rgba(124, 245, 180, 0.22);
+  border-color: rgba(11, 116, 94, 0.2);
   color: var(--eco-green);
   background: var(--eco-green-soft);
 }
@@ -817,7 +817,7 @@
 .eco-timeline .is-complete i,
 .eco-timeline .is-current i {
   background: var(--eco-green);
-  box-shadow: 0 0 8px rgba(124, 245, 180, 0.4);
+  box-shadow: none;
 }
 
 .eco-hold-banner {
@@ -1040,7 +1040,7 @@
   gap: 7px;
   overflow: auto;
   padding-bottom: 3px;
-  scrollbar-color: rgba(124, 245, 180, 0.25) transparent;
+  scrollbar-color: rgba(11, 116, 94, 0.26) transparent;
 }
 
 .eco-lane {
@@ -1092,7 +1092,7 @@
 
 .eco-lane > div > button:hover,
 .eco-lane > div > button[aria-current="true"] {
-  border-color: rgba(124, 245, 180, 0.3);
+  border-color: rgba(11, 116, 94, 0.24);
   background: var(--eco-green-soft);
 }
 
@@ -1171,7 +1171,7 @@
 
 .eco-payment-list > button:hover,
 .eco-payment-list > button[aria-current="true"] {
-  background: rgba(124, 245, 180, 0.045);
+  background: rgba(11, 116, 94, 0.07);
 }
 
 .eco-payment-list > button > span {
@@ -1305,12 +1305,12 @@
   width: min(720px, 100%);
   max-height: calc(100svh - 36px);
   overflow: auto;
-  border: 1px solid rgba(124, 245, 180, 0.34);
+  border: 1px solid rgba(11, 116, 94, 0.24);
   border-radius: var(--eco-radius);
   padding: 17px;
   color: var(--eco-ink);
-  background: #0d120f;
-  box-shadow: 0 26px 80px rgba(0, 0, 0, 0.55);
+  background: #ffffff;
+  box-shadow: 0 26px 80px rgba(25, 54, 42, 0.2);
 }
 
 .eco-dialog-head,
@@ -1406,7 +1406,7 @@
   border-radius: 4px;
   padding: 8px 9px;
   color: var(--eco-ink);
-  background: #090c0a;
+  background: #ffffff;
   outline: none;
 }
 
@@ -1414,7 +1414,7 @@
 .eco-approval-form select:focus,
 .eco-approval-form textarea:focus {
   border-color: var(--eco-green);
-  box-shadow: 0 0 0 2px rgba(124, 245, 180, 0.08);
+  box-shadow: 0 0 0 3px rgba(11, 116, 94, 0.1);
 }
 
 .eco-approval-form textarea {
@@ -1458,7 +1458,7 @@
   border-radius: 4px;
   padding: 9px;
   color: var(--eco-muted);
-  background: rgba(124, 245, 180, .035);
+  background: rgba(11, 116, 94, .06);
 }
 
 .eco-approval-form .eco-handoff-confirmation input {
@@ -1500,11 +1500,11 @@
   bottom: 18px;
   width: min(350px, calc(100% - 36px));
   overflow: hidden;
-  border: 1px solid rgba(124, 245, 180, 0.34);
+  border: 1px solid rgba(11, 116, 94, 0.24);
   border-radius: var(--eco-radius);
   color: var(--eco-ink);
-  background: #0d120f;
-  box-shadow: 0 22px 70px rgba(0, 0, 0, 0.52);
+  background: #ffffff;
+  box-shadow: 0 22px 70px rgba(25, 54, 42, 0.18);
 }
 
 .eco-guide > header {
@@ -1585,11 +1585,11 @@
   min-height: 0;
   display: flex;
   flex-direction: column;
-  border-left: 1px solid rgba(124, 245, 180, 0.28);
+  border-left: 1px solid rgba(11, 116, 94, 0.22);
   padding: 17px;
   color: var(--eco-ink);
-  background: #0b0f0c;
-  box-shadow: -24px 0 70px rgba(0, 0, 0, 0.45);
+  background: #ffffff;
+  box-shadow: -24px 0 70px rgba(25, 54, 42, 0.16);
 }
 
 .eco-drawer-head {
@@ -1747,7 +1747,7 @@
     display: grid;
     grid-template-columns: repeat(4, minmax(0, 1fr));
     border-bottom: 1px solid var(--eco-line);
-    background: rgba(8, 10, 9, 0.92);
+    background: rgba(255, 255, 255, 0.96);
   }
 
   .eco-mobile-nav button {
@@ -1817,6 +1817,10 @@
 }
 
 @media (max-width: 560px) {
+  .eco-mobile-brand .eco-brand > strong {
+    display: block;
+  }
+
   .eco-completion-grid {
     grid-template-columns: 1fr;
   }
@@ -1834,9 +1838,19 @@
   }
 
   .eco-topbar-actions .eco-button {
-    min-height: 30px;
+    min-height: 44px;
     padding-inline: 8px;
     font-size: 7px;
+  }
+
+  .eco-topbar-actions .eco-button:first-of-type {
+    border-color: var(--eco-green);
+    background: var(--eco-green);
+    color: #fff;
+  }
+
+  .eco-topbar-actions .eco-button:nth-of-type(2) {
+    display: none;
   }
 
   .eco-main {

--- a/showroom/src/products/website/WebsiteProduct.tsx
+++ b/showroom/src/products/website/WebsiteProduct.tsx
@@ -36,8 +36,8 @@ const workspaceViews: Array<{ id: WorkspaceView; index: string; label: string }>
 const viewCopy: Record<WorkspaceView, { eyebrow: string; title: string; copy: string }> = {
   content: {
     eyebrow: 'Page workspace',
-    title: 'Write with the preview in view.',
-    copy: 'Edit a small, finite page set. Content changes return the page to draft.',
+    title: 'Edit one page at a time.',
+    copy: 'Change the content, then review the result before publishing.',
   },
   navigation: {
     eyebrow: 'Site structure',

--- a/showroom/src/products/website/website-product.css
+++ b/showroom/src/products/website/website-product.css
@@ -1,16 +1,16 @@
 .website-product {
-  --website-bg: #080a09;
-  --website-panel: #101411;
-  --website-panel-raised: #151a16;
-  --website-ink: #f2f5f1;
-  --website-muted: #a3ada6;
-  --website-quiet: #707b73;
-  --website-line: rgba(225, 238, 229, .12);
-  --website-line-strong: rgba(225, 238, 229, .22);
-  --website-green: #7cf5b4;
-  --website-green-soft: rgba(124, 245, 180, .1);
-  --website-warn: #ffb86b;
-  --website-danger: #ff7b8d;
+  --website-bg: #f6f4ee;
+  --website-panel: #ffffff;
+  --website-panel-raised: #eef4ef;
+  --website-ink: #17231d;
+  --website-muted: #56665d;
+  --website-quiet: #7b8980;
+  --website-line: rgba(31, 68, 51, .12);
+  --website-line-strong: rgba(31, 68, 51, .2);
+  --website-green: #0b745e;
+  --website-green-soft: rgba(11, 116, 94, .1);
+  --website-warn: #946200;
+  --website-danger: #b42336;
   --website-mono: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
   position: relative;
   width: 100%;
@@ -18,11 +18,11 @@
   min-width: 320px;
   overflow: hidden;
   background:
-    radial-gradient(circle at 82% -18%, rgba(124, 245, 180, .09), transparent 31%),
-    linear-gradient(180deg, #090c0a, var(--website-bg) 62%);
+    radial-gradient(circle at 82% -18%, rgba(11, 116, 94, .1), transparent 31%),
+    linear-gradient(180deg, #fbfaf6, var(--website-bg) 62%);
   color: var(--website-ink);
   font-family: Geist, Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-  color-scheme: dark;
+  color-scheme: light;
 }
 
 .website-product *,
@@ -53,7 +53,7 @@
 }
 
 .website-product ::selection {
-  background: rgba(124, 245, 180, .25);
+  background: rgba(11, 116, 94, .18);
 }
 
 .website-skip {
@@ -82,7 +82,7 @@
   gap: 18px;
   border-bottom: 1px solid var(--website-line);
   padding: 0 18px;
-  background: rgba(8, 10, 9, .9);
+  background: rgba(246, 244, 238, .92);
   backdrop-filter: blur(18px);
 }
 
@@ -159,7 +159,7 @@
 }
 
 .website-local-badge {
-  border-color: rgba(124, 245, 180, .23);
+  border-color: rgba(11, 116, 94, .2);
   background: var(--website-green-soft);
   color: var(--website-green);
 }
@@ -185,7 +185,7 @@
   flex-direction: column;
   border-right: 1px solid var(--website-line);
   padding: 17px 13px 14px;
-  background: rgba(8, 10, 9, .86);
+  background: rgba(238, 244, 239, .96);
 }
 
 .website-site-record {
@@ -251,7 +251,7 @@
 }
 
 .website-workspace-nav > button[aria-current="page"] {
-  border-color: rgba(124, 245, 180, .2);
+  border-color: rgba(11, 116, 94, .2);
   background: var(--website-green-soft);
   color: var(--website-ink);
 }
@@ -297,7 +297,7 @@
 .website-page-index > div {
   min-height: 0;
   overflow: auto;
-  scrollbar-color: rgba(124, 245, 180, .24) transparent;
+  scrollbar-color: rgba(11, 116, 94, .26) transparent;
 }
 
 .website-page-index > div > button {
@@ -317,7 +317,7 @@
 
 .website-page-index > div > button:hover,
 .website-page-index > div > button[aria-current="true"] {
-  background: rgba(124, 245, 180, .045);
+  background: rgba(11, 116, 94, .07);
 }
 
 .website-page-index > div > button > i {
@@ -329,7 +329,7 @@
 
 .website-page-index > div > button > i.is-ready {
   background: var(--website-green);
-  box-shadow: 0 0 8px rgba(124, 245, 180, .42);
+  box-shadow: none;
 }
 
 .website-page-index > div > button > span {
@@ -479,7 +479,7 @@
 }
 
 .website-preview-controls > button[aria-pressed="true"] {
-  border-color: rgba(124, 245, 180, .22);
+  border-color: rgba(11, 116, 94, .2);
   background: var(--website-green-soft);
   color: var(--website-green);
 }
@@ -503,8 +503,8 @@
   overflow: hidden;
   border: 1px solid var(--website-line);
   border-radius: 8px;
-  background: rgba(16, 20, 17, .9);
-  box-shadow: inset 0 1px rgba(255, 255, 255, .025);
+  background: var(--website-panel);
+  box-shadow: 0 10px 28px rgba(25, 54, 42, .055);
 }
 
 .website-editor-panel {
@@ -537,7 +537,7 @@
 }
 
 .website-status.is-ready {
-  border-color: rgba(124, 245, 180, .24);
+  border-color: rgba(11, 116, 94, .2);
   background: var(--website-green-soft);
   color: var(--website-green);
 }
@@ -557,7 +557,7 @@
   flex: 1;
   overflow: auto;
   padding: 14px;
-  scrollbar-color: rgba(124, 245, 180, .24) transparent;
+  scrollbar-color: rgba(11, 116, 94, .26) transparent;
 }
 
 .website-fieldset {
@@ -620,7 +620,7 @@
   border: 1px solid var(--website-line);
   border-radius: 4px;
   padding: 8px 9px;
-  background: #0a0d0b;
+  background: #ffffff;
   color: var(--website-ink);
   font-size: 10px;
   outline: none;
@@ -640,7 +640,7 @@
 .website-product select:focus,
 .website-product textarea:focus {
   border-color: var(--website-green);
-  box-shadow: 0 0 0 2px rgba(124, 245, 180, .08);
+  box-shadow: 0 0 0 3px rgba(11, 116, 94, .1);
 }
 
 .website-product input:disabled,
@@ -679,7 +679,7 @@
   border: 1px solid var(--website-line);
   border-radius: 5px;
   padding: 10px;
-  background: rgba(8, 10, 9, .46);
+  background: rgba(238, 244, 239, .7);
 }
 
 .website-section-editor > header {
@@ -786,7 +786,7 @@
 
 .website-page-check.is-complete {
   border-left-color: var(--website-green);
-  background: rgba(124, 245, 180, .035);
+  background: rgba(11, 116, 94, .06);
 }
 
 .website-page-check > div {
@@ -828,7 +828,7 @@
   gap: 10px;
   border-top: 1px solid var(--website-line);
   padding: 10px 14px;
-  background: rgba(8, 10, 9, .42);
+  background: rgba(246, 244, 238, .9);
 }
 
 .website-panel-actions > div {
@@ -837,7 +837,7 @@
 }
 
 .website-button {
-  min-height: 35px;
+  min-height: 40px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -845,7 +845,7 @@
   border: 1px solid var(--website-line-strong);
   border-radius: 5px;
   padding: 0 12px;
-  background: rgba(255, 255, 255, .025);
+  background: #ffffff;
   color: var(--website-ink);
   font-size: 9px;
   font-weight: 760;
@@ -853,19 +853,19 @@
 }
 
 .website-button:hover:not(:disabled) {
-  border-color: rgba(255, 255, 255, .34);
-  background: rgba(255, 255, 255, .06);
+  border-color: var(--website-green);
+  background: var(--website-green-soft);
 }
 
 .website-button.is-primary {
   border-color: var(--website-green);
   background: var(--website-green);
-  color: #07100a;
+  color: #ffffff;
 }
 
 .website-button.is-primary:hover:not(:disabled) {
-  border-color: #a1f9c8;
-  background: #a1f9c8;
+  border-color: #075c4b;
+  background: #075c4b;
 }
 
 .website-button.is-quiet {
@@ -1013,10 +1013,10 @@
   grid-template-columns: auto minmax(0, 1fr);
   gap: 10px;
   margin-top: 12px;
-  border: 1px solid rgba(124, 245, 180, .18);
+  border: 1px solid rgba(11, 116, 94, .18);
   border-radius: 5px;
   padding: 11px;
-  background: rgba(124, 245, 180, .035);
+  background: rgba(11, 116, 94, .06);
 }
 
 .website-boundary-note strong {
@@ -1059,7 +1059,7 @@
   min-height: 23px;
   display: grid;
   place-items: center;
-  border: 1px solid rgba(124, 245, 180, .24);
+  border: 1px solid rgba(11, 116, 94, .2);
   border-radius: 4px;
   color: var(--website-green);
   font-family: var(--website-mono);
@@ -1136,8 +1136,8 @@
 }
 
 .website-evidence-status > article.is-current {
-  border-color: rgba(124, 245, 180, .24);
-  background: rgba(124, 245, 180, .035);
+  border-color: rgba(11, 116, 94, .2);
+  background: rgba(11, 116, 94, .06);
 }
 
 .website-evidence-status > article > span {
@@ -1196,7 +1196,7 @@
   margin: 10px 10px 0;
   border-left: 2px solid var(--website-green);
   padding: 8px 10px;
-  background: rgba(124, 245, 180, .035);
+  background: rgba(11, 116, 94, .06);
 }
 
 .website-approval-record.is-stale {
@@ -1243,8 +1243,8 @@
 }
 
 .website-local-publish {
-  border-color: rgba(124, 245, 180, .22);
-  background: linear-gradient(120deg, rgba(124, 245, 180, .055), rgba(255, 255, 255, .014) 48%);
+  border-color: rgba(11, 116, 94, .2);
+  background: linear-gradient(120deg, rgba(11, 116, 94, .08), rgba(255, 255, 255, .82) 48%);
 }
 
 .website-local-publish-action {
@@ -1355,7 +1355,7 @@
   gap: 10px;
   border-bottom: 1px solid var(--website-line);
   padding: 0 12px;
-  background: rgba(8, 10, 9, .5);
+  background: rgba(246, 244, 238, .92);
 }
 
 .website-window-dots {
@@ -1379,7 +1379,7 @@
 }
 
 .website-window-dots > i:last-child {
-  background: rgba(124, 245, 180, .65);
+  background: rgba(11, 116, 94, .65);
 }
 
 .website-preview-toolbar > div:nth-child(2) {
@@ -1415,11 +1415,11 @@
   overflow: auto;
   padding: 14px;
   background:
-    linear-gradient(rgba(225, 238, 229, .025) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(225, 238, 229, .025) 1px, transparent 1px),
-    #0b0e0c;
+    linear-gradient(rgba(31, 68, 51, .035) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(31, 68, 51, .035) 1px, transparent 1px),
+    #edf2ed;
   background-size: 18px 18px;
-  scrollbar-color: rgba(124, 245, 180, .24) transparent;
+  scrollbar-color: rgba(11, 116, 94, .26) transparent;
 }
 
 .website-preview-frame {
@@ -1561,7 +1561,7 @@
 }
 
 .preview-hero > b > i {
-  color: #7cf5b4;
+  color: #72d1af;
   font-style: normal;
 }
 
@@ -1690,10 +1690,10 @@
   display: flex;
   align-items: center;
   gap: 9px;
-  border: 1px solid rgba(124, 245, 180, .2);
+  border: 1px solid rgba(11, 116, 94, .2);
   border-radius: 5px;
   padding: 9px 11px;
-  background: rgba(8, 10, 9, .94);
+  background: rgba(255, 255, 255, .96);
   color: var(--website-muted);
   font-size: 8px;
   line-height: 1.4;
@@ -1765,7 +1765,7 @@
   }
 
   .website-workspace-nav > button {
-    min-height: 43px;
+    min-height: 44px;
     justify-content: center;
     padding: 0 7px;
   }
@@ -1790,7 +1790,7 @@
   .website-page-index > div > button {
     width: 125px;
     min-width: 125px;
-    min-height: 43px;
+    min-height: 44px;
     border-right: 1px solid var(--website-line);
     border-bottom: 0;
   }
@@ -1865,11 +1865,11 @@
   }
 
   .website-heading {
-    min-height: 122px;
+    min-height: 92px;
     align-items: flex-start;
     flex-direction: column;
     justify-content: center;
-    gap: 10px;
+    gap: 6px;
   }
 
   .website-heading p {
@@ -1877,7 +1877,7 @@
   }
 
   .website-preview-controls {
-    width: 100%;
+    display: none;
   }
 
   .website-preview-controls > span {
@@ -1891,7 +1891,13 @@
 
   .website-editor-panel,
   .website-preview-panel {
-    min-height: 620px;
+    min-height: 560px;
+  }
+
+  .website-preview-frame.is-desktop,
+  .website-preview-frame.is-tablet,
+  .website-preview-frame.is-mobile {
+    width: min(100%, 390px);
   }
 
   .website-panel-head {
@@ -1959,6 +1965,7 @@
 
   .website-panel-actions .website-button {
     flex: 1;
+    min-height: 44px;
   }
 
   .website-notice {

--- a/site-manifest.json
+++ b/site-manifest.json
@@ -5,12 +5,12 @@
   "brand": {
     "name": "SuperMega",
     "domain": "supermega.dev",
-    "version": "terminal-v4-2026-07",
+    "version": "jade-v1-2026-07",
     "mark": "terminal",
     "colors": {
-      "background": "#080a09",
-      "accent": "#7cf5b4",
-      "ink": "#f2f5f1"
+      "background": "#f6f4ee",
+      "accent": "#0b745e",
+      "ink": "#17231d"
     }
   },
   "company": {

--- a/tools/create_public_vercel_output.mjs
+++ b/tools/create_public_vercel_output.mjs
@@ -64,50 +64,50 @@ const faviconSvg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" 
 
 const sharedStyle = `
   :root {
-    color-scheme: dark;
-    --bg: #080a09;
-    --bg-raised: #0d100e;
-    --panel: rgba(15, 19, 16, .9);
-    --panel-solid: #101411;
-    --panel-soft: #0c100d;
-    --ink: #f2f5f1;
-    --muted: #a3ada6;
-    --quiet: #707b73;
-    --line: rgba(225, 238, 229, .13);
-    --line-strong: rgba(225, 238, 229, .24);
-    --blue: #7cf5b4;
-    --blue-strong: #a0ffcb;
-    --green: #7cf5b4;
-    --green-soft: rgba(124, 245, 180, .1);
-    --blue-soft: rgba(124, 245, 180, .1);
-    --shadow: 0 30px 90px rgba(0, 0, 0, .44);
-    --radius: 10px;
+    color-scheme: light;
+    --bg: #f6f4ee;
+    --bg-raised: #eef2ec;
+    --panel: rgba(255, 255, 255, .92);
+    --panel-solid: #ffffff;
+    --panel-soft: #eef4ef;
+    --ink: #17231d;
+    --muted: #56665d;
+    --quiet: #7b8980;
+    --line: rgba(31, 68, 51, .12);
+    --line-strong: rgba(31, 68, 51, .2);
+    --blue: #0b745e;
+    --blue-strong: #075c4b;
+    --green: #0b745e;
+    --green-soft: rgba(11, 116, 94, .1);
+    --blue-soft: rgba(11, 116, 94, .1);
+    --shadow: 0 22px 65px rgba(25, 54, 42, .1);
+    --radius: 16px;
   }
   * { box-sizing: border-box; }
   html { min-width: 320px; scroll-behavior: smooth; background: var(--bg); }
   body { min-width: 320px; margin: 0; overflow-x: hidden; background: var(--bg); color: var(--ink); font-family: Geist, Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; line-height: 1.55; text-rendering: optimizeLegibility; }
-  body::before { position: fixed; inset: 0; z-index: -2; background: radial-gradient(circle at 74% -18%, rgba(124,245,180,.1), transparent 34%), linear-gradient(180deg, #0a0d0b 0, #080a09 48%, #090c0a 100%); content: ""; }
-  body::after { position: fixed; inset: 0; z-index: -1; opacity: .16; pointer-events: none; background-image: linear-gradient(rgba(255,255,255,.025) 1px, transparent 1px), linear-gradient(90deg, rgba(255,255,255,.025) 1px, transparent 1px); background-size: 56px 56px; mask-image: linear-gradient(to bottom, #000, transparent 76%); content: ""; }
+  body::before { position: fixed; inset: 0; z-index: -2; background: radial-gradient(circle at 76% -16%, rgba(11,116,94,.12), transparent 34%), linear-gradient(180deg, #fbfaf6 0, var(--bg) 54%, #f2f4ef 100%); content: ""; }
+  body::after { display: none; content: ""; }
   a { color: inherit; }
   button, input, select, textarea { font: inherit; }
   img, svg { display: block; max-width: 100%; }
   .shell { min-height: 100svh; }
   .frame { width: min(calc(100% - 48px), 1200px); margin-inline: auto; }
-  .site-header { position: sticky; top: 0; z-index: 40; border-bottom: 1px solid var(--line); background: rgba(8,10,9,.88); backdrop-filter: blur(18px); }
+  .site-header { position: sticky; top: 0; z-index: 40; border-bottom: 1px solid var(--line); background: rgba(246,244,238,.9); backdrop-filter: blur(18px); }
   .header-inner { min-height: 72px; display: flex; align-items: center; justify-content: space-between; gap: 18px; }
   .brand { display: inline-flex; min-height: 44px; align-items: center; gap: 12px; text-decoration: none; font-size: 13px; font-weight: 820; letter-spacing: .08em; }
   .brand-mark { color: var(--green); font-family: "SFMono-Regular", Consolas, monospace; font-size: 20px; letter-spacing: -.12em; }
   .brand-name { color: var(--ink); }
   .nav { display: flex; min-width: 0; align-items: center; justify-content: flex-end; gap: 4px; }
   .nav-link { min-height: 44px; display: inline-flex; align-items: center; border-radius: 10px; padding: 0 11px; color: var(--muted); font-size: 13px; font-weight: 720; text-decoration: none; }
-  .nav-link:hover, .nav-link[aria-current="page"] { background: rgba(255,255,255,.05); color: var(--ink); }
-  .button { min-height: 48px; display: inline-flex; align-items: center; justify-content: center; gap: 9px; border: 1px solid var(--line-strong); border-radius: 6px; padding: 0 18px; background: rgba(255,255,255,.025); color: var(--ink); font-size: 13px; font-weight: 780; text-decoration: none; transition: transform 160ms ease, border-color 160ms ease, background 160ms ease; }
-  .button:hover { transform: translateY(-1px); border-color: rgba(255,255,255,.34); background: rgba(255,255,255,.07); }
-  .button.primary { border-color: var(--green); background: var(--green); color: #07100a; box-shadow: 0 14px 34px rgba(124,245,180,.12); }
+  .nav-link:hover, .nav-link[aria-current="page"] { background: var(--green-soft); color: var(--ink); }
+  .button { min-height: 48px; display: inline-flex; align-items: center; justify-content: center; gap: 9px; border: 1px solid var(--line-strong); border-radius: 12px; padding: 0 18px; background: #fff; color: var(--ink); font-size: 13px; font-weight: 780; text-decoration: none; transition: transform 160ms ease, border-color 160ms ease, background 160ms ease; }
+  .button:hover { transform: translateY(-1px); border-color: var(--green); background: var(--green-soft); }
+  .button.primary { border-color: var(--green); background: var(--green); color: #fff; box-shadow: 0 12px 28px rgba(11,116,94,.18); }
   .button.primary:hover { background: var(--blue-strong); }
   .button.compact { min-height: 44px; padding-inline: 15px; }
   .eyebrow { display: inline-flex; align-items: center; gap: 9px; color: var(--green); font-family: "SFMono-Regular", Consolas, monospace; font-size: 12px; font-weight: 760; letter-spacing: .04em; text-transform: uppercase; }
-  .eyebrow::before { width: 7px; height: 7px; border-radius: 50%; background: currentColor; box-shadow: 0 0 18px currentColor; content: ""; }
+  .eyebrow::before { width: 7px; height: 7px; border-radius: 50%; background: currentColor; content: ""; }
   h1, h2, h3, p { margin-top: 0; }
   h1 { margin-bottom: 18px; font-size: clamp(42px, 5vw, 68px); line-height: .98; letter-spacing: -.058em; }
   h2 { margin-bottom: 12px; font-size: clamp(28px, 3.4vw, 44px); line-height: 1.04; letter-spacing: -.04em; }
@@ -120,7 +120,7 @@ const sharedStyle = `
   .hero-note { display: flex; flex-wrap: wrap; gap: 16px; margin-top: 34px; color: var(--quiet); font-size: 12px; font-weight: 720; }
   .hero-note span { display: inline-flex; align-items: center; gap: 7px; }
   .hero-note span::before { color: var(--green); content: "✓"; }
-  .workspace { overflow: hidden; border: 1px solid var(--line-strong); border-radius: var(--radius); background: rgba(12,17,24,.9); box-shadow: var(--shadow); transform: perspective(1200px) rotateY(-2deg) rotateX(1deg); }
+  .workspace { overflow: hidden; border: 1px solid var(--line-strong); border-radius: var(--radius); background: var(--panel-solid); box-shadow: var(--shadow); }
   .workspace-bar { min-height: 48px; display: flex; align-items: center; justify-content: space-between; gap: 14px; border-bottom: 1px solid var(--line); padding: 0 16px; color: var(--quiet); font-family: "SFMono-Regular", Consolas, monospace; font-size: 11px; }
   .workspace-dots { display: flex; gap: 6px; }
   .workspace-dots i { width: 7px; height: 7px; border-radius: 50%; background: var(--quiet); opacity: .55; }
@@ -133,29 +133,29 @@ const sharedStyle = `
   .workspace-title { display: flex; align-items: flex-start; justify-content: space-between; gap: 12px; margin-bottom: 22px; }
   .workspace-title strong { font-size: 18px; }
   .workspace-title small { display: block; margin-top: 4px; color: var(--quiet); }
-  .live-pill, .status-pill { display: inline-flex; min-height: 28px; align-items: center; gap: 7px; border: 1px solid rgba(124,245,180,.24); border-radius: 4px; padding: 0 10px; background: var(--green-soft); color: var(--green); font-size: 10px; font-weight: 760; text-transform: uppercase; }
+  .live-pill, .status-pill { display: inline-flex; min-height: 28px; align-items: center; gap: 7px; border: 1px solid rgba(11,116,94,.2); border-radius: 999px; padding: 0 10px; background: var(--green-soft); color: var(--green); font-size: 10px; font-weight: 760; text-transform: uppercase; }
   .live-pill::before, .status-pill::before { width: 6px; height: 6px; border-radius: 50%; background: currentColor; content: ""; }
   .metric-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 10px; }
-  .metric { min-height: 94px; border: 1px solid var(--line); border-radius: 13px; padding: 14px; background: rgba(255,255,255,.025); }
+  .metric { min-height: 94px; border: 1px solid var(--line); border-radius: 13px; padding: 14px; background: var(--panel-soft); }
   .metric span { color: var(--quiet); font-size: 10px; text-transform: uppercase; }
   .metric strong { display: block; margin-top: 14px; font-size: 15px; }
-  .work-list { margin-top: 12px; border: 1px solid var(--line); border-radius: 13px; padding: 8px 14px; background: rgba(255,255,255,.018); }
+  .work-list { margin-top: 12px; border: 1px solid var(--line); border-radius: 13px; padding: 8px 14px; background: #fff; }
   .work-row { display: grid; grid-template-columns: 1fr 84px; gap: 14px; align-items: center; min-height: 53px; border-bottom: 1px solid var(--line); color: var(--muted); font-size: 11px; }
   .work-row:last-child { border-bottom: 0; }
-  .progress { height: 6px; overflow: hidden; border-radius: 999px; background: rgba(255,255,255,.07); }
+  .progress { height: 6px; overflow: hidden; border-radius: 999px; background: var(--line); }
   .progress i { display: block; height: 100%; border-radius: inherit; background: linear-gradient(90deg, var(--blue), var(--green)); }
   .section { padding: 72px 0; border-top: 1px solid var(--line); }
   .section-head { max-width: 760px; margin-bottom: 30px; }
   .section-head h2 { margin-top: 17px; }
   .section-head p { color: var(--muted); font-size: 18px; }
   .surface-grid { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 14px; }
-  .surface-card { min-height: 260px; display: flex; flex-direction: column; border: 1px solid var(--line); border-radius: var(--radius); padding: 28px; background: linear-gradient(145deg, rgba(255,255,255,.05), rgba(255,255,255,.018)); }
+  .surface-card { min-height: 260px; display: flex; flex-direction: column; border: 1px solid var(--line); border-radius: var(--radius); padding: 28px; background: var(--panel-solid); box-shadow: 0 12px 34px rgba(25,54,42,.055); }
   .surface-card > span { color: var(--green); font-family: "SFMono-Regular", Consolas, monospace; font-size: 10px; }
   .surface-card h3 { margin-top: 46px; font-size: 31px; }
   .surface-card p { margin: 0; color: var(--muted); }
   .surface-card small { margin-top: auto; padding-top: 24px; color: var(--quiet); font-size: 11px; }
   .product-grid, .template-grid, .principle-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 18px; }
-  .product-card, .template-card, .principle-card, .module-card, .case-card { position: relative; overflow: hidden; border: 1px solid var(--line); border-radius: var(--radius); padding: 30px; background: linear-gradient(145deg, rgba(255,255,255,.05), rgba(255,255,255,.018)); box-shadow: inset 0 1px rgba(255,255,255,.04); }
+  .product-card, .template-card, .principle-card, .module-card, .case-card { position: relative; overflow: hidden; border: 1px solid var(--line); border-radius: var(--radius); padding: 30px; background: var(--panel-solid); box-shadow: 0 12px 34px rgba(25,54,42,.055); }
   .product-card::after { position: absolute; width: 220px; height: 220px; top: -130px; right: -80px; border-radius: 50%; background: var(--blue); opacity: .12; filter: blur(2px); content: ""; }
   .product-card.production::after { background: var(--green); }
   .card-index { color: var(--quiet); font-family: "SFMono-Regular", Consolas, monospace; font-size: 11px; }
@@ -173,7 +173,7 @@ const sharedStyle = `
   .template-card p { color: var(--muted); }
   .template-card .card-link { margin-top: auto; }
   .product-label { display: inline-flex; min-height: 30px; align-items: center; border: 1px solid var(--line); border-radius: 999px; padding: 0 10px; color: var(--muted); font-size: 11px; font-weight: 760; }
-  .callout { display: grid; grid-template-columns: 1fr auto; gap: 34px; align-items: center; border: 1px solid rgba(124,245,180,.25); border-radius: var(--radius); padding: 36px; background: linear-gradient(120deg, rgba(124,245,180,.09), rgba(124,245,180,.025)); }
+  .callout { display: grid; grid-template-columns: 1fr auto; gap: 34px; align-items: center; border: 1px solid rgba(11,116,94,.2); border-radius: var(--radius); padding: 36px; background: linear-gradient(120deg, rgba(11,116,94,.1), rgba(255,255,255,.76)); }
   .callout p { max-width: 700px; margin: 0; color: var(--muted); }
   .steps { counter-reset: step; display: grid; gap: 0; border-top: 1px solid var(--line); }
   .step { counter-increment: step; display: grid; grid-template-columns: 54px 1fr; gap: 22px; border-bottom: 1px solid var(--line); padding: 25px 0; }
@@ -199,8 +199,8 @@ const sharedStyle = `
   .field-grid { display: grid; grid-template-columns: repeat(2,minmax(0,1fr)); gap: 14px; }
   label { display: grid; gap: 7px; color: var(--muted); font-size: 12px; font-weight: 700; }
   label.wide { grid-column: 1/-1; }
-  input, select, textarea { width: 100%; min-width: 0; border: 1px solid var(--line); border-radius: 11px; padding: 13px 14px; background: #0c1118; color: var(--ink); outline: none; }
-  input:focus, select:focus, textarea:focus { border-color: var(--green); box-shadow: 0 0 0 3px rgba(124,245,180,.1); }
+  input, select, textarea { width: 100%; min-width: 0; border: 1px solid var(--line); border-radius: 11px; padding: 13px 14px; background: #fff; color: var(--ink); outline: none; }
+  input:focus, select:focus, textarea:focus { border-color: var(--green); box-shadow: 0 0 0 3px rgba(11,116,94,.1); }
   textarea { min-height: 150px; resize: vertical; }
   .form-note, .form-status { margin: 0; color: var(--quiet); font-size: 12px; }
   .form-status { min-height: 1.5em; color: var(--green); }
@@ -220,12 +220,12 @@ const sharedStyle = `
   .system-row > span { color: var(--green); font-family: "SFMono-Regular", Consolas, monospace; font-size: 10px; }
   .system-row strong { font-size: 13px; }
   .system-row small { color: var(--quiet); font-size: 10px; }
-  .system-row i { width: 7px; height: 7px; background: var(--green); box-shadow: 0 0 14px rgba(124,245,180,.55); }
+  .system-row i { width: 7px; height: 7px; border-radius: 50%; background: var(--green); }
   .system-boundary { display: grid; gap: 5px; margin-top: 22px; border-left: 2px solid var(--green); padding: 4px 0 4px 14px; }
   .system-boundary span { color: var(--green); font-family: "SFMono-Regular", Consolas, monospace; font-size: 9px; letter-spacing: .08em; }
   .system-boundary strong { color: var(--muted); font-size: 11px; font-weight: 650; }
   .solution-stack { display: grid; gap: 16px; }
-  .solution-block { display: grid; grid-template-columns: minmax(0, .9fr) minmax(340px, 1.1fr); gap: 56px; align-items: start; border: 1px solid var(--line); border-radius: var(--radius); padding: 40px; background: rgba(255,255,255,.018); }
+  .solution-block { display: grid; grid-template-columns: minmax(0, .9fr) minmax(340px, 1.1fr); gap: 56px; align-items: start; border: 1px solid var(--line); border-radius: var(--radius); padding: 40px; background: var(--panel-solid); }
   .solution-block h3 { margin-top: 24px; font-size: clamp(30px, 4vw, 48px); }
   .solution-block p { color: var(--muted); }
   .solution-modules { display: grid; border-top: 1px solid var(--line); }
@@ -237,7 +237,7 @@ const sharedStyle = `
   .trust-compact { grid-template-columns: repeat(4, minmax(0, 1fr)); }
   .trust-compact .principle-card { min-height: 210px; }
   .operating-map { display: grid; grid-template-columns: minmax(0,.84fr) minmax(0,1.16fr); gap: 14px; }
-  .operating-surface { min-height: 270px; border: 1px solid var(--line); border-radius: var(--radius); padding: 26px; background: rgba(255,255,255,.018); }
+  .operating-surface { min-height: 270px; border: 1px solid var(--line); border-radius: var(--radius); padding: 26px; background: var(--panel-solid); }
   .operating-surface.product-surface { display: grid; grid-template-columns: minmax(0,.72fr) minmax(300px,1.28fr); gap: 24px; }
   .operating-surface h3 { margin-top: 34px; font-size: 28px; }
   .operating-surface p { color: var(--muted); font-size: 13px; }
@@ -248,20 +248,20 @@ const sharedStyle = `
   .lifecycle-rail span { min-height: 40px; display: grid; grid-template-columns: 30px 86px 1fr; gap: 10px; align-items: center; border-bottom: 1px solid var(--line); color: var(--muted); font-size: 10px; }
   .lifecycle-rail i { color: var(--green); font-family: "SFMono-Regular", Consolas, monospace; font-size: 9px; font-style: normal; }
   .lifecycle-rail strong { color: var(--ink); font-size: 11px; }
-  .control-line { grid-column: 1/-1; display: flex; align-items: center; justify-content: space-between; gap: 22px; border: 1px solid rgba(124,245,180,.2); border-radius: var(--radius); padding: 18px 22px; background: var(--green-soft); }
+  .control-line { grid-column: 1/-1; display: flex; align-items: center; justify-content: space-between; gap: 22px; border: 1px solid rgba(11,116,94,.2); border-radius: var(--radius); padding: 18px 22px; background: var(--green-soft); }
   .control-line p { max-width: 760px; margin: 0; color: var(--muted); font-size: 12px; }
   .compact-solutions { display: grid; grid-template-columns: repeat(2,minmax(0,1fr)); gap: 14px; }
-  .compact-solution { min-width: 0; border: 1px solid var(--line); border-radius: var(--radius); padding: 28px; background: rgba(255,255,255,.018); }
+  .compact-solution { min-width: 0; border: 1px solid var(--line); border-radius: var(--radius); padding: 28px; background: var(--panel-solid); }
   .compact-solution h3 { margin: 20px 0 9px; font-size: 30px; }
   .compact-solution > p { min-height: 62px; color: var(--muted); font-size: 13px; }
   .module-tags { display: grid; grid-template-columns: repeat(2,minmax(0,1fr)); gap: 5px; margin-top: 18px; }
   .module-tags span { min-height: 34px; display: flex; align-items: center; border: 1px solid var(--line); border-radius: 4px; padding: 0 9px; color: var(--muted); font-size: 9px; }
   .template-line { display: flex; flex-wrap: wrap; gap: 7px; margin-top: 16px; border-top: 1px solid var(--line); padding-top: 14px; }
   .template-line span { color: var(--quiet); font-family: "SFMono-Regular", Consolas, monospace; font-size: 8px; }
-  .closing-strip { display: grid; grid-template-columns: 1fr auto; gap: 30px; align-items: center; margin-top: 14px; border: 1px solid rgba(124,245,180,.24); border-radius: var(--radius); padding: 24px 28px; background: linear-gradient(120deg, rgba(124,245,180,.08), rgba(124,245,180,.02)); }
+  .closing-strip { display: grid; grid-template-columns: 1fr auto; gap: 30px; align-items: center; margin-top: 14px; border: 1px solid rgba(11,116,94,.2); border-radius: var(--radius); padding: 24px 28px; background: linear-gradient(120deg, rgba(11,116,94,.1), rgba(255,255,255,.78)); }
   .closing-strip h2 { margin-bottom: 6px; font-size: 27px; }
   .closing-strip p { margin: 0; color: var(--muted); font-size: 12px; }
-  :focus-visible { outline: 3px solid rgba(124,245,180,.42); outline-offset: 3px; }
+  :focus-visible { outline: 3px solid rgba(11,116,94,.34); outline-offset: 3px; }
   @media (prefers-reduced-motion: reduce) { html { scroll-behavior: auto; } *, *::before, *::after { transition-duration: .01ms !important; } }
   @media (max-width: 980px) { .hero { grid-template-columns: 1fr; gap: 42px; padding-top: 60px; } .hero-copy { max-width: 820px; } .workspace { transform: none; } .split, .solution-block, .operating-map { grid-template-columns: 1fr; gap: 30px; } .sticky-copy { position: static; } .surface-grid { grid-template-columns: repeat(2,minmax(0,1fr)); } .surface-card:last-child { grid-column: 1/-1; min-height: 210px; } .principle-grid, .trust-compact { grid-template-columns: repeat(2,minmax(0,1fr)); } .contact-layout { grid-template-columns: 1fr; gap: 42px; } }
   @media (max-width: 760px) { .frame { width: min(calc(100% - 30px), 1200px); } .header-inner { min-height: 62px; gap: 10px; } .brand { gap: 8px; font-size: 11px; } .nav-link { padding-inline: 8px; } .nav-optional { display: none; } .header-cta { min-height: 42px; padding-inline: 13px; } .hero, .page-hero { padding-top: 46px; } .hero { padding-bottom: 52px; } .workspace-body { grid-template-columns: 1fr; min-height: 0; } .workspace-nav { display: none; } .workspace-main { padding: 16px; } .metric-grid { grid-template-columns: 1fr; } .metric { min-height: 76px; } .surface-grid, .product-grid, .template-grid, .module-grid, .principle-grid, .trust-compact, .case-grid, .compact-solutions { grid-template-columns: 1fr; } .surface-card, .surface-card:last-child { grid-column: auto; min-height: 220px; } .solution-block { padding: 24px; } .system-preview-body { padding: 18px; } .system-row { grid-template-columns: 28px 92px minmax(0, 1fr); } .system-row i { display: none; } .section { padding: 50px 0; } .operating-surface.product-surface { grid-template-columns: 1fr; } .control-line, .closing-strip { display: grid; grid-template-columns: 1fr; } .callout { grid-template-columns: 1fr; } .callout { padding: 26px; } .contact-form { padding: 20px; } .field-grid { grid-template-columns: 1fr; } label.wide { grid-column: auto; } .prose section { grid-template-columns: 1fr; gap: 6px; } .footer-inner { display: grid; } .footer-links { justify-content: flex-start; } }

--- a/tools/verify_app_build.mjs
+++ b/tools/verify_app_build.mjs
@@ -57,7 +57,7 @@ const manifestPath = resolve(dist, 'site.webmanifest')
 if (!await exists(faviconPath)) fail('missing_terminal_favicon')
 else {
   const favicon = await readFile(faviconPath, 'utf8')
-  if (!favicon.includes('SuperMega terminal mark') || !favicon.includes('#7cf5b4') || !favicon.includes('#f2f5f1')) fail('wrong_terminal_favicon')
+  if (!favicon.includes('SuperMega terminal mark') || !favicon.includes(manifest.brand.colors.accent) || !favicon.includes(manifest.brand.colors.ink)) fail('wrong_terminal_favicon')
 }
 if (!await exists(manifestPath)) fail('missing_app_webmanifest')
 else {
@@ -68,7 +68,7 @@ else {
 const files = await walk(dist)
 const textFiles = files.filter((path) => /\.(?:html|js|css|json|svg)$/.test(path))
 const corpus = (await Promise.all(textFiles.map((path) => readFile(path, 'utf8')))).join('\n')
-for (const required of ['SUPERMEGA', 'Teams', 'Product', 'Acceptance outcome', 'Prepare brief', 'Evidence register', 'Record evidence', 'Verified evidence', 'verifiedAt', 'Operations', 'Human confirmation', 'Confirm and record', 'Action history', 'actorKind', 'evidenceReference', 'accountableActions', 'decision_packet.v1', 'Claims and provenance', 'claimType', 'claim_type', 'source_reference', 'artifact_reference', 'managedApprovalRequests', 'packetFingerprint', 'uncertainty', 'visibility', 'artifactReference', 'Human reviewer', 'Decision note', 'Approve and record', 'Local trial', 'Delegation control', 'Pilot definition', 'Template profile', 'Workflow', 'workflowProfile', 'Current record', 'Baseline', 'Target outcome', 'Human authority boundary', 'Acceptance evidence', 'Operating mode', 'Write path', '#7cf5b4', '#f2f5f1']) {
+for (const required of ['SUPERMEGA', 'Teams', 'Product', 'Acceptance outcome', 'Prepare brief', 'Evidence register', 'Record evidence', 'Verified evidence', 'verifiedAt', 'Operations', 'Human confirmation', 'Confirm and record', 'Action history', 'actorKind', 'evidenceReference', 'accountableActions', 'decision_packet.v1', 'Claims and provenance', 'claimType', 'claim_type', 'source_reference', 'artifact_reference', 'managedApprovalRequests', 'packetFingerprint', 'uncertainty', 'visibility', 'artifactReference', 'Human reviewer', 'Decision note', 'Approve and record', 'Local trial', 'Delegation control', 'Pilot definition', 'Template profile', 'Workflow', 'workflowProfile', 'Current record', 'Baseline', 'Target outcome', 'Human authority boundary', 'Acceptance evidence', 'Operating mode', 'Write path', manifest.brand.colors.accent, manifest.brand.colors.ink]) {
   if (!corpus.includes(required)) fail(`missing_context:${required}`)
 }
 if (!coreSource.includes("import siteManifest from '../../../site-manifest.json'")) fail('workflow_contract_not_shared')


### PR DESCRIPTION
## Outcome
- replaces the black/neon system with a warm-neutral and accessible Jade brand contract
- applies the same visual hierarchy to the public site, core workspace, Website, and Ecommerce
- simplifies phone layouts: 44px actions, one guided Ecommerce CTA, fewer Website preview controls, and clearer editing copy
- makes favicon and app build verification derive colors from the shared brand manifest

## Verification
- `npm.cmd run public:prebuilt`
- `npm.cmd --prefix showroom run lint`
- `npm.cmd run app:build`
- desktop browser audit: public, Today, Website, Ecommerce; no overflow or console errors
- 390x844 browser audit: Today, Website, Ecommerce; no overflow, no page errors, interactive content present

## Release note
This changes presentation only. Existing browser-local/demo and human-approval boundaries remain unchanged.