### PR TITLE
Harden Mark1 ChatGPT app review surface

### DIFF
--- a/chatgpt-app-submission.json
+++ b/chatgpt-app-submission.json
@@ -1,0 +1,140 @@
+{
+  "$schema": "https://developers.openai.com/apps-sdk/schemas/chatgpt-app-submission.v1.json",
+  "schema_version": 1,
+  "app_info": {
+    "display_name": "SuperMega Mark 1",
+    "subtitle": "Review private operations",
+    "description": "SuperMega Mark 1 helps authorized operators review a private workspace, inspect exceptions and a contact-redacted lead pipeline, read the current operating brief, and create a pending approval item for human review.",
+    "category": "BUSINESS"
+  },
+  "tools": {
+    "mark1_status": {
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": false,
+        "destructiveHint": false
+      },
+      "justifications": {
+        "read_only_justification": "Retrieves health and operating-summary data without creating or changing workspace records.",
+        "open_world_justification": "Reads only the configured private SuperMega workspace and does not change public or third-party state.",
+        "destructive_justification": "Does not delete, overwrite, revoke, send, or perform an irreversible action."
+      }
+    },
+    "mark1_insights": {
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": false,
+        "destructiveHint": false
+      },
+      "justifications": {
+        "read_only_justification": "Retrieves the current operating brief and recommended actions without modifying workspace data.",
+        "open_world_justification": "Reads only private SuperMega operating data and does not publish or write to an external system.",
+        "destructive_justification": "Cannot delete, overwrite, revoke, send, or commit an irreversible operation."
+      }
+    },
+    "mark1_exceptions": {
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": false,
+        "destructiveHint": false
+      },
+      "justifications": {
+        "read_only_justification": "Retrieves a bounded list of private exception records and does not update their state.",
+        "open_world_justification": "Reads from the configured private workspace without changing public internet or third-party state.",
+        "destructive_justification": "Does not resolve, delete, overwrite, or otherwise irreversibly change an exception."
+      }
+    },
+    "mark1_approvals": {
+      "annotations": {
+        "readOnlyHint": false,
+        "openWorldHint": false,
+        "destructiveHint": false
+      },
+      "justifications": {
+        "read_only_justification": "Can create one pending approval item in the configured private SuperMega workspace when action is create.",
+        "open_world_justification": "Changes only a private workspace record and does not publish, message, submit, or write to a third-party system.",
+        "destructive_justification": "Creates a reviewable pending item and does not delete, overwrite, revoke, or execute an irreversible approval decision."
+      }
+    },
+    "mark1_leads": {
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": false,
+        "destructiveHint": false
+      },
+      "justifications": {
+        "read_only_justification": "Retrieves a contact-redacted private lead pipeline without creating, updating, or contacting a lead.",
+        "open_world_justification": "Reads only private workspace data and cannot contact leads or change an external service.",
+        "destructive_justification": "Does not delete, overwrite, send, revoke, or perform another irreversible action."
+      }
+    }
+  },
+  "test_cases": [
+    {
+      "description": "Review current workspace health and summary.",
+      "user_prompt": "Show me the current SuperMega workspace status and operating summary.",
+      "file_attachment_urls": null,
+      "tools_triggered": "mark1_status",
+      "expected_output": "Returns the private workspace health and current operating summary with no state change.",
+      "expected_output_url": null
+    },
+    {
+      "description": "Read the current operating brief.",
+      "user_prompt": "What does the current SuperMega operating brief recommend next?",
+      "file_attachment_urls": null,
+      "tools_triggered": "mark1_insights",
+      "expected_output": "Summarizes the current private operating brief and recommended actions.",
+      "expected_output_url": null
+    },
+    {
+      "description": "Return a bounded exception queue.",
+      "user_prompt": "Show the five most relevant current SuperMega exceptions.",
+      "file_attachment_urls": null,
+      "tools_triggered": "mark1_exceptions",
+      "expected_output": "Returns no more than five current private exception records with enough context for review.",
+      "expected_output_url": null
+    },
+    {
+      "description": "Create a pending private approval item.",
+      "user_prompt": "Create a pending approval titled Release evidence review, owned by Product, for a human to review this week.",
+      "file_attachment_urls": null,
+      "tools_triggered": "mark1_approvals",
+      "expected_output": "Creates one pending private approval item and returns the resulting review record without making the final decision.",
+      "expected_output_url": null
+    },
+    {
+      "description": "Review the saved lead pipeline without outreach.",
+      "user_prompt": "List the leads currently saved in the SuperMega workspace; do not contact anyone.",
+      "file_attachment_urls": null,
+      "tools_triggered": "mark1_leads",
+      "expected_output": "Returns saved private lead records without contact details, outreach drafts, free-form notes, messages, or state changes.",
+      "expected_output_url": null
+    }
+  ],
+  "negative_test_cases": [
+    {
+      "description": "Do not trigger for email delivery.",
+      "user_prompt": "Send a marketing email to my customer list.",
+      "file_attachment_urls": null,
+      "tools_triggered": null,
+      "expected_output": "The app should not be invoked because its default tool surface cannot send email or contact customers.",
+      "expected_output_url": null
+    },
+    {
+      "description": "Do not trigger for public deployment.",
+      "user_prompt": "Deploy my website to production and change its domain.",
+      "file_attachment_urls": null,
+      "tools_triggered": null,
+      "expected_output": "The app should not be invoked because it cannot deploy, publish, or change domains.",
+      "expected_output_url": null
+    },
+    {
+      "description": "Do not trigger for calendar scheduling.",
+      "user_prompt": "Schedule a meeting with my team tomorrow afternoon.",
+      "file_attachment_urls": null,
+      "tools_triggered": null,
+      "expected_output": "The app should not be invoked because calendar scheduling is outside its supported workflows.",
+      "expected_output_url": null
+    }
+  ]
+}

--- a/chatgpt-app-submission.json
+++ b/chatgpt-app-submission.json
@@ -4,35 +4,23 @@
   "app_info": {
     "display_name": "SuperMega Mark 1",
     "subtitle": "Review private operations",
-    "description": "SuperMega Mark 1 helps authorized operators review a private workspace, inspect exceptions and a contact-redacted lead pipeline, read the current operating brief, and create a pending approval item for human review.",
+    "description": "SuperMega Mark 1 helps authorized operators review one private operating brief, inspect exceptions, pending approvals, and a contact-redacted lead pipeline, and create a pending approval item for human review.",
     "category": "BUSINESS"
   },
   "tools": {
-    "mark1_status": {
+    "mark1_get_operating_brief": {
       "annotations": {
         "readOnlyHint": true,
         "openWorldHint": false,
         "destructiveHint": false
       },
       "justifications": {
-        "read_only_justification": "Retrieves health and operating-summary data without creating or changing workspace records.",
+        "read_only_justification": "Retrieves health, operating-summary, and recommended-action data without creating or changing workspace records.",
         "open_world_justification": "Reads only the configured private SuperMega workspace and does not change public or third-party state.",
         "destructive_justification": "Does not delete, overwrite, revoke, send, or perform an irreversible action."
       }
     },
-    "mark1_insights": {
-      "annotations": {
-        "readOnlyHint": true,
-        "openWorldHint": false,
-        "destructiveHint": false
-      },
-      "justifications": {
-        "read_only_justification": "Retrieves the current operating brief and recommended actions without modifying workspace data.",
-        "open_world_justification": "Reads only private SuperMega operating data and does not publish or write to an external system.",
-        "destructive_justification": "Cannot delete, overwrite, revoke, send, or commit an irreversible operation."
-      }
-    },
-    "mark1_exceptions": {
+    "mark1_list_exceptions": {
       "annotations": {
         "readOnlyHint": true,
         "openWorldHint": false,
@@ -44,7 +32,19 @@
         "destructive_justification": "Does not resolve, delete, overwrite, or otherwise irreversibly change an exception."
       }
     },
-    "mark1_approvals": {
+    "mark1_list_approvals": {
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": false,
+        "destructiveHint": false
+      },
+      "justifications": {
+        "read_only_justification": "Retrieves a bounded list of private approval items without creating, deciding, or changing them.",
+        "open_world_justification": "Reads only configured private workspace records and does not publish, message, submit, or write to a third-party system.",
+        "destructive_justification": "Does not delete, overwrite, revoke, decide, or execute an irreversible approval action."
+      }
+    },
+    "mark1_create_approval": {
       "annotations": {
         "readOnlyHint": false,
         "openWorldHint": false,
@@ -56,7 +56,7 @@
         "destructive_justification": "Creates a reviewable pending item and does not delete, overwrite, revoke, or execute an irreversible approval decision."
       }
     },
-    "mark1_leads": {
+    "mark1_list_leads": {
       "annotations": {
         "readOnlyHint": true,
         "openWorldHint": false,
@@ -71,26 +71,26 @@
   },
   "test_cases": [
     {
-      "description": "Review current workspace health and summary.",
-      "user_prompt": "Show me the current SuperMega workspace status and operating summary.",
+      "description": "Review one current private operating brief.",
+      "user_prompt": "Show me the current SuperMega operating brief, including health, summary, and recommended actions.",
       "file_attachment_urls": null,
-      "tools_triggered": "mark1_status",
-      "expected_output": "Returns the private workspace health and current operating summary with no state change.",
+      "tools_triggered": "mark1_get_operating_brief",
+      "expected_output": "Returns the private workspace health, operating summary, and recommended actions with no state change.",
       "expected_output_url": null
     },
     {
-      "description": "Read the current operating brief.",
-      "user_prompt": "What does the current SuperMega operating brief recommend next?",
+      "description": "List pending private approvals.",
+      "user_prompt": "Show the pending approval items in my SuperMega workspace without changing them.",
       "file_attachment_urls": null,
-      "tools_triggered": "mark1_insights",
-      "expected_output": "Summarizes the current private operating brief and recommended actions.",
+      "tools_triggered": "mark1_list_approvals",
+      "expected_output": "Returns a bounded list of private approval items without creating, deciding, or changing one.",
       "expected_output_url": null
     },
     {
       "description": "Return a bounded exception queue.",
       "user_prompt": "Show the five most relevant current SuperMega exceptions.",
       "file_attachment_urls": null,
-      "tools_triggered": "mark1_exceptions",
+      "tools_triggered": "mark1_list_exceptions",
       "expected_output": "Returns no more than five current private exception records with enough context for review.",
       "expected_output_url": null
     },
@@ -98,7 +98,7 @@
       "description": "Create a pending private approval item.",
       "user_prompt": "Create a pending approval titled Release evidence review, owned by Product, for a human to review this week.",
       "file_attachment_urls": null,
-      "tools_triggered": "mark1_approvals",
+      "tools_triggered": "mark1_create_approval",
       "expected_output": "Creates one pending private approval item and returns the resulting review record without making the final decision.",
       "expected_output_url": null
     },
@@ -106,7 +106,7 @@
       "description": "Review the saved lead pipeline without outreach.",
       "user_prompt": "List the leads currently saved in the SuperMega workspace; do not contact anyone.",
       "file_attachment_urls": null,
-      "tools_triggered": "mark1_leads",
+      "tools_triggered": "mark1_list_leads",
       "expected_output": "Returns saved private lead records without contact details, outreach drafts, free-form notes, messages, or state changes.",
       "expected_output_url": null
     }

--- a/mark1-mcp/package.json
+++ b/mark1-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@supermega/mark1-mcp",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Private SuperMega operations MCP server with a review-safe default tool surface",
   "type": "module",
   "bin": {

--- a/mark1-mcp/package.json
+++ b/mark1-mcp/package.json
@@ -1,15 +1,16 @@
 {
   "name": "@supermega/mark1-mcp",
-  "version": "1.0.0",
-  "description": "Mark 1 MCP Server — Expose SuperMega workspace as tools for Claude Code, Cline, Cursor, Windsurf",
+  "version": "2.1.0",
+  "description": "Private SuperMega operations MCP server with a review-safe default tool surface",
   "type": "module",
   "bin": {
     "mark1-mcp": "./server.mjs"
   },
   "scripts": {
-    "start": "node server.mjs"
+    "start": "node server.mjs",
+    "submission:verify": "node ../tools/verify_mark1_mcp_submission.mjs"
   },
-  "keywords": ["mcp", "ai", "workspace", "claude", "cursor", "cline"],
+  "keywords": ["mcp", "chatgpt", "ai", "private-operations", "workspace"],
   "author": "Swan Htet <swanhtet@supermega.dev>",
   "license": "MIT",
   "dependencies": {}

--- a/mark1-mcp/server.mjs
+++ b/mark1-mcp/server.mjs
@@ -151,32 +151,54 @@ function redactLeadPipeline(payload) {
   return { ...payload, rows };
 }
 
-const TOOL_OUTPUT_SCHEMA = {
+function dataOutputSchema(data) {
+  return {
+    type: 'object',
+    properties: { data },
+    required: ['data'],
+    additionalProperties: false,
+  };
+}
+
+const OBJECT_DATA_OUTPUT_SCHEMA = dataOutputSchema({ type: 'object' });
+const OPERATING_BRIEF_OUTPUT_SCHEMA = dataOutputSchema({
   type: 'object',
-  properties: { data: {} },
-  required: ['data'],
+  properties: {
+    health: { type: 'object' },
+    summary: { type: 'object' },
+    insights: { type: 'object' },
+  },
+  required: ['health', 'summary', 'insights'],
   additionalProperties: false,
-};
+});
+const LOCAL_FILES_OUTPUT_SCHEMA = dataOutputSchema({
+  type: 'array',
+  items: {
+    type: 'object',
+    properties: {
+      name: { type: 'string' },
+      type: { type: 'string', enum: ['dir', 'file'] },
+    },
+    required: ['name', 'type'],
+    additionalProperties: false,
+  },
+});
+const TEXT_OUTPUT_SCHEMA = dataOutputSchema({ type: 'string' });
 
 function buildTools() {
   const tools = [
     {
-      name: 'mark1_status',
-      description: 'Read health and operating-summary data from the configured private SuperMega workspace.',
+      name: 'mark1_get_operating_brief',
+      title: 'Get operating brief',
+      description: 'Use this when you need one current operating brief for the authorized private SuperMega workspace; it reads health, summary, and recommended actions without changing state.',
       inputSchema: { type: 'object', properties: {}, required: [], additionalProperties: false },
-      outputSchema: TOOL_OUTPUT_SCHEMA,
+      outputSchema: OPERATING_BRIEF_OUTPUT_SCHEMA,
       annotations: { readOnlyHint: true, openWorldHint: false, destructiveHint: false },
     },
     {
-      name: 'mark1_insights',
-      description: 'Read the current private operating brief and its recommended actions without changing workspace state.',
-      inputSchema: { type: 'object', properties: {}, required: [], additionalProperties: false },
-      outputSchema: TOOL_OUTPUT_SCHEMA,
-      annotations: { readOnlyHint: true, openWorldHint: false, destructiveHint: false },
-    },
-    {
-      name: 'mark1_exceptions',
-      description: 'Read a bounded page of current exceptions from the configured private SuperMega workspace.',
+      name: 'mark1_list_exceptions',
+      title: 'List current exceptions',
+      description: 'Use this when you need a bounded list of current exceptions from the authorized private SuperMega workspace without resolving or changing them.',
       inputSchema: {
         type: 'object',
         properties: {
@@ -185,50 +207,67 @@ function buildTools() {
         required: [],
         additionalProperties: false,
       },
-      outputSchema: TOOL_OUTPUT_SCHEMA,
+      outputSchema: OBJECT_DATA_OUTPUT_SCHEMA,
       annotations: { readOnlyHint: true, openWorldHint: false, destructiveHint: false },
     },
     {
-      name: 'mark1_approvals',
-      description: 'List private approval items, or create one pending private approval when action is create.',
+      name: 'mark1_list_approvals',
+      title: 'List pending approvals',
+      description: 'Use this when you need a bounded list of private approval items without creating, deciding, or changing an approval.',
       inputSchema: {
         type: 'object',
         properties: {
-          action: { type: 'string', enum: ['list', 'create'], description: 'Approval action' },
-          limit: { type: 'integer', minimum: 1, maximum: 50, description: 'Maximum approval records to return for list' },
-          title: { type: 'string', maxLength: 120 },
+          limit: { type: 'integer', minimum: 1, maximum: 50, description: 'Maximum approval records to return' },
+        },
+        required: [],
+        additionalProperties: false,
+      },
+      outputSchema: OBJECT_DATA_OUTPUT_SCHEMA,
+      annotations: { readOnlyHint: true, openWorldHint: false, destructiveHint: false },
+    },
+    {
+      name: 'mark1_create_approval',
+      title: 'Create pending approval',
+      description: 'Use this when an authorized operator explicitly asks to create one pending private approval for later human review; it never makes the final decision.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          title: { type: 'string', minLength: 1, maxLength: 120 },
           summary: { type: 'string', maxLength: 1000 },
           approval_gate: { type: 'string', maxLength: 80 },
           requested_by: { type: 'string', maxLength: 80 },
-          owner: { type: 'string', maxLength: 80 },
+          owner: { type: 'string', minLength: 1, maxLength: 80 },
           due: { type: 'string', maxLength: 40 },
           related_route: { type: 'string', maxLength: 200 },
           related_entity: { type: 'string', maxLength: 120 },
         },
-        required: ['action'],
+        required: ['title', 'owner'],
         additionalProperties: false,
       },
-      outputSchema: TOOL_OUTPUT_SCHEMA,
+      outputSchema: OBJECT_DATA_OUTPUT_SCHEMA,
       annotations: { readOnlyHint: false, openWorldHint: false, destructiveHint: false },
     },
     {
-      name: 'mark1_leads',
-      description: 'Read a redacted private lead pipeline without contact details, outreach messages, discovery notes, or free-form notes.',
+      name: 'mark1_list_leads',
+      title: 'List saved leads',
+      description: 'Use this when you need the saved private lead pipeline without contact details, outreach messages, discovery questions, free-form notes, or any state change.',
       inputSchema: { type: 'object', properties: {}, required: [], additionalProperties: false },
-      outputSchema: TOOL_OUTPUT_SCHEMA,
+      outputSchema: OBJECT_DATA_OUTPUT_SCHEMA,
       annotations: { readOnlyHint: true, openWorldHint: false, destructiveHint: false },
     },
   ];
 
   if (ENABLE_LOCAL_TOOLS) tools.push({
       name: 'mark1_files',
-      description: 'List top-level names and types in the configured local SuperMega repository; available only in explicit internal-local mode.',
+      title: 'List local repository files',
+      description: 'Use this when operating in an approved internal-local environment to list top-level names and types in the configured SuperMega repository.',
       inputSchema: { type: 'object', properties: {}, required: [], additionalProperties: false },
-      outputSchema: TOOL_OUTPUT_SCHEMA,
+      outputSchema: LOCAL_FILES_OUTPUT_SCHEMA,
       annotations: { readOnlyHint: true, openWorldHint: false, destructiveHint: false },
     }, {
       name: 'mark1_execute',
-      description: 'Run an arbitrary local shell command in the configured SuperMega repository; may change files, external systems, or public state and is available only in explicit internal-local mode.',
+      title: 'Run local repository command',
+      description: 'Use this when operating in an approved internal-local environment to run an arbitrary shell command that may change files, external systems, or public state.',
       inputSchema: {
         type: 'object',
         properties: {
@@ -238,7 +277,7 @@ function buildTools() {
         required: ['command'],
         additionalProperties: false,
       },
-      outputSchema: TOOL_OUTPUT_SCHEMA,
+      outputSchema: TEXT_OUTPUT_SCHEMA,
       annotations: { readOnlyHint: false, openWorldHint: true, destructiveHint: true },
     });
 
@@ -272,47 +311,46 @@ async function callTool(name, args = {}) {
     throw new Error('This local-only tool is disabled. Set SUPERMEGA_ENABLE_LOCAL_TOOLS=true only in an approved internal environment.');
   }
   switch (name) {
-    case 'mark1_status': {
-      const [health, summary] = await Promise.all([
+    case 'mark1_get_operating_brief': {
+      const [health, summary, insights] = await Promise.all([
         apiRequest('/api/health'),
         apiRequest('/api/summary'),
+        apiRequest('/api/insights'),
       ]);
-      return toolData({ health, summary });
+      return toolData({ health, summary, insights });
     }
-    case 'mark1_insights': {
-      const payload = await apiRequest('/api/insights');
-      return toolData(payload);
-    }
-    case 'mark1_exceptions': {
+    case 'mark1_list_exceptions': {
       const limit = boundedInteger(args.limit, 10, 1, 50);
       const payload = await apiRequest(`/api/exceptions?limit=${limit}`);
       return toolData(payload);
     }
-    case 'mark1_approvals': {
-      if (args.action !== 'list' && args.action !== 'create') throw new Error('Approval action must be list or create.');
-      if (args.action === 'create') {
-        const payload = await apiRequest('/api/approvals', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            title: String(args.title || 'Untitled approval').trim(),
-            summary: String(args.summary || '').trim(),
-            approval_gate: String(args.approval_gate || 'general').trim(),
-            requested_by: String(args.requested_by || 'MCP client').trim(),
-            owner: String(args.owner || 'Management').trim(),
-            due: String(args.due || '').trim(),
-            related_route: String(args.related_route || '/app').trim(),
-            related_entity: String(args.related_entity || '').trim(),
-            status: 'pending',
-          }),
-        });
-        return toolData(payload);
-      }
+    case 'mark1_list_approvals': {
       const limit = boundedInteger(args.limit, 10, 1, 50);
       const payload = await apiRequest(`/api/approvals?limit=${limit}`);
       return toolData(payload);
     }
-    case 'mark1_leads': {
+    case 'mark1_create_approval': {
+      const title = String(args.title || '').trim();
+      const owner = String(args.owner || '').trim();
+      if (!title || !owner) throw new Error('Approval title and owner are required.');
+      const payload = await apiRequest('/api/approvals', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          title,
+          summary: String(args.summary || '').trim(),
+          approval_gate: String(args.approval_gate || 'general').trim(),
+          requested_by: String(args.requested_by || 'MCP client').trim(),
+          owner,
+          due: String(args.due || '').trim(),
+          related_route: String(args.related_route || '/app').trim(),
+          related_entity: String(args.related_entity || '').trim(),
+          status: 'pending',
+        }),
+      });
+      return toolData(payload);
+    }
+    case 'mark1_list_leads': {
       const payload = await apiRequest('/api/lead-pipeline');
       return toolData(redactLeadPipeline(payload));
     }
@@ -347,7 +385,7 @@ async function handleMessage(message) {
       result: {
         protocolVersion: '2024-11-05',
         capabilities: { tools: {} },
-          serverInfo: { name: 'supermega-mark1', version: '2.1.0' },
+          serverInfo: { name: 'supermega-mark1', version: '2.2.0' },
       },
     });
     return;

--- a/mark1-mcp/server.mjs
+++ b/mark1-mcp/server.mjs
@@ -2,16 +2,16 @@
 
 import { execSync } from 'child_process';
 import { readdirSync, statSync } from 'fs';
-import { resolve } from 'path';
+import { dirname, resolve } from 'path';
+import { fileURLToPath } from 'url';
 
 const BASE_URL = (process.env.SUPERMEGA_BASE_URL || 'http://127.0.0.1:8787').replace(/\/$/, '');
-const USERNAME = String(process.env.SUPERMEGA_APP_USERNAME || 'owner').trim();
-const PASSWORD = String(process.env.SUPERMEGA_APP_PASSWORD || 'supermega-demo').trim();
+const USERNAME = String(process.env.SUPERMEGA_APP_USERNAME || '').trim();
+const PASSWORD = String(process.env.SUPERMEGA_APP_PASSWORD || '').trim();
 const WORKSPACE = String(process.env.SUPERMEGA_WORKSPACE_SLUG || 'supermega-lab').trim();
-const REPO_ROOT = String(
-  process.env.SUPERMEGA_REPO_ROOT ||
-    'C:\\Users\\swann\\OneDrive - BDA\\swanhtet01.github.io.worktrees\\copilot-worktree-2026-03-04T08-10-33',
-).trim();
+const SERVER_ROOT = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = String(process.env.SUPERMEGA_REPO_ROOT || resolve(SERVER_ROOT, '..')).trim();
+const ENABLE_LOCAL_TOOLS = process.env.SUPERMEGA_ENABLE_LOCAL_TOOLS === 'true';
 
 let cookieHeader = '';
 let initialized = false;
@@ -23,13 +23,25 @@ function writeMessage(payload) {
   process.stdout.write(Buffer.concat([header, body]));
 }
 
-function toolText(text) {
-  return { content: [{ type: 'text', text }] };
+function toolData(data) {
+  return {
+    content: [{ type: 'text', text: typeof data === 'string' ? data : JSON.stringify(data, null, 2) }],
+    structuredContent: { data },
+  };
+}
+
+function boundedInteger(value, fallback, minimum, maximum) {
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed)) return fallback;
+  return Math.max(minimum, Math.min(parsed, maximum));
 }
 
 async function loginIfNeeded(force = false) {
   if (cookieHeader && !force) {
     return cookieHeader;
+  }
+  if (!USERNAME || !PASSWORD) {
+    throw new Error('SuperMega credentials are not configured for private API access.');
   }
 
   const response = await fetch(`${BASE_URL}/api/auth/login`, {
@@ -100,7 +112,6 @@ function listTopFiles(rootPath) {
       const stats = statSync(fullPath);
       return {
         name,
-        fullPath,
         type: stats.isDirectory() ? 'dir' : 'file',
       };
     })
@@ -108,93 +119,177 @@ function listTopFiles(rootPath) {
     .slice(0, 80);
 }
 
+const SAFE_LEAD_FIELDS = [
+  'lead_id',
+  'company_name',
+  'archetype',
+  'stage',
+  'status',
+  'owner',
+  'campaign_goal',
+  'service_pack',
+  'wedge_product',
+  'starter_modules',
+  'semi_products',
+  'website',
+  'source',
+  'source_url',
+  'provider',
+  'score',
+  'created_at',
+  'synced_at',
+];
+
+function redactLeadPipeline(payload) {
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) return payload;
+  const rows = Array.isArray(payload.rows)
+    ? payload.rows.map((row) => {
+        if (!row || typeof row !== 'object' || Array.isArray(row)) return {};
+        return Object.fromEntries(SAFE_LEAD_FIELDS.filter((field) => field in row).map((field) => [field, row[field]]));
+      })
+    : [];
+  return { ...payload, rows };
+}
+
+const TOOL_OUTPUT_SCHEMA = {
+  type: 'object',
+  properties: { data: {} },
+  required: ['data'],
+  additionalProperties: false,
+};
+
 function buildTools() {
-  return [
+  const tools = [
     {
       name: 'mark1_status',
-      description: 'Get health and summary from the live SuperMega app.',
-      inputSchema: { type: 'object', properties: {}, required: [] },
+      description: 'Read health and operating-summary data from the configured private SuperMega workspace.',
+      inputSchema: { type: 'object', properties: {}, required: [], additionalProperties: false },
+      outputSchema: TOOL_OUTPUT_SCHEMA,
+      annotations: { readOnlyHint: true, openWorldHint: false, destructiveHint: false },
     },
     {
       name: 'mark1_insights',
-      description: 'Get the current operating brief and recommended actions.',
-      inputSchema: { type: 'object', properties: {}, required: [] },
+      description: 'Read the current private operating brief and its recommended actions without changing workspace state.',
+      inputSchema: { type: 'object', properties: {}, required: [], additionalProperties: false },
+      outputSchema: TOOL_OUTPUT_SCHEMA,
+      annotations: { readOnlyHint: true, openWorldHint: false, destructiveHint: false },
     },
     {
       name: 'mark1_exceptions',
-      description: 'Get the live exception queue from the private app.',
+      description: 'Read a bounded page of current exceptions from the configured private SuperMega workspace.',
       inputSchema: {
         type: 'object',
         properties: {
-          limit: { type: 'number', description: 'Maximum rows to return' },
+          limit: { type: 'integer', minimum: 1, maximum: 50, description: 'Maximum exception records to return' },
         },
         required: [],
+        additionalProperties: false,
       },
+      outputSchema: TOOL_OUTPUT_SCHEMA,
+      annotations: { readOnlyHint: true, openWorldHint: false, destructiveHint: false },
     },
     {
       name: 'mark1_approvals',
-      description: 'List approvals or create a new approval item.',
+      description: 'List private approval items, or create one pending private approval when action is create.',
       inputSchema: {
         type: 'object',
         properties: {
           action: { type: 'string', enum: ['list', 'create'], description: 'Approval action' },
-          limit: { type: 'number', description: 'Maximum rows to return for list' },
-          title: { type: 'string' },
-          summary: { type: 'string' },
-          approval_gate: { type: 'string' },
-          requested_by: { type: 'string' },
-          owner: { type: 'string' },
-          due: { type: 'string' },
-          related_route: { type: 'string' },
-          related_entity: { type: 'string' },
+          limit: { type: 'integer', minimum: 1, maximum: 50, description: 'Maximum approval records to return for list' },
+          title: { type: 'string', maxLength: 120 },
+          summary: { type: 'string', maxLength: 1000 },
+          approval_gate: { type: 'string', maxLength: 80 },
+          requested_by: { type: 'string', maxLength: 80 },
+          owner: { type: 'string', maxLength: 80 },
+          due: { type: 'string', maxLength: 40 },
+          related_route: { type: 'string', maxLength: 200 },
+          related_entity: { type: 'string', maxLength: 120 },
         },
         required: ['action'],
+        additionalProperties: false,
       },
+      outputSchema: TOOL_OUTPUT_SCHEMA,
+      annotations: { readOnlyHint: false, openWorldHint: false, destructiveHint: false },
     },
     {
       name: 'mark1_leads',
-      description: 'List the saved lead pipeline from the live workspace.',
-      inputSchema: { type: 'object', properties: {}, required: [] },
+      description: 'Read a redacted private lead pipeline without contact details, outreach messages, discovery notes, or free-form notes.',
+      inputSchema: { type: 'object', properties: {}, required: [], additionalProperties: false },
+      outputSchema: TOOL_OUTPUT_SCHEMA,
+      annotations: { readOnlyHint: true, openWorldHint: false, destructiveHint: false },
     },
-    {
+  ];
+
+  if (ENABLE_LOCAL_TOOLS) tools.push({
       name: 'mark1_files',
-      description: 'List top-level files and folders in the SuperMega repo root.',
-      inputSchema: { type: 'object', properties: {}, required: [] },
-    },
-    {
+      description: 'List top-level names and types in the configured local SuperMega repository; available only in explicit internal-local mode.',
+      inputSchema: { type: 'object', properties: {}, required: [], additionalProperties: false },
+      outputSchema: TOOL_OUTPUT_SCHEMA,
+      annotations: { readOnlyHint: true, openWorldHint: false, destructiveHint: false },
+    }, {
       name: 'mark1_execute',
-      description: 'Execute a local shell command against the SuperMega workspace.',
+      description: 'Run an arbitrary local shell command in the configured SuperMega repository; may change files, external systems, or public state and is available only in explicit internal-local mode.',
       inputSchema: {
         type: 'object',
         properties: {
-          command: { type: 'string', description: 'Command to run' },
-          timeout: { type: 'number', description: 'Timeout seconds' },
+          command: { type: 'string', minLength: 1, maxLength: 2000, description: 'Command to run' },
+          timeout: { type: 'integer', minimum: 5, maximum: 300, description: 'Timeout in seconds' },
         },
         required: ['command'],
+        additionalProperties: false,
       },
-    },
-  ];
+      outputSchema: TOOL_OUTPUT_SCHEMA,
+      annotations: { readOnlyHint: false, openWorldHint: true, destructiveHint: true },
+    });
+
+  return tools;
+}
+
+if (process.argv.includes('--describe-tools')) {
+  process.stdout.write(`${JSON.stringify(buildTools(), null, 2)}\n`);
+  process.exit(0);
+}
+
+if (process.argv.includes('--redact-lead-fixture')) {
+  process.stdout.write(`${JSON.stringify(redactLeadPipeline({
+    status: 'ready',
+    rows: [{
+      lead_id: 'LEAD-1',
+      company_name: 'Example Company',
+      stage: 'qualified',
+      contact_email: 'private@example.com',
+      contact_phone: '+95 000000',
+      outreach_message: 'Private draft',
+      discovery_questions: ['Private question'],
+      notes: 'Private note',
+    }],
+  }))}\n`);
+  process.exit(0);
 }
 
 async function callTool(name, args = {}) {
+  if (!ENABLE_LOCAL_TOOLS && (name === 'mark1_files' || name === 'mark1_execute')) {
+    throw new Error('This local-only tool is disabled. Set SUPERMEGA_ENABLE_LOCAL_TOOLS=true only in an approved internal environment.');
+  }
   switch (name) {
     case 'mark1_status': {
       const [health, summary] = await Promise.all([
         apiRequest('/api/health'),
         apiRequest('/api/summary'),
       ]);
-      return toolText(JSON.stringify({ health, summary }, null, 2));
+      return toolData({ health, summary });
     }
     case 'mark1_insights': {
       const payload = await apiRequest('/api/insights');
-      return toolText(JSON.stringify(payload, null, 2));
+      return toolData(payload);
     }
     case 'mark1_exceptions': {
-      const limit = Math.max(1, Math.min(Number(args.limit || 10), 50));
+      const limit = boundedInteger(args.limit, 10, 1, 50);
       const payload = await apiRequest(`/api/exceptions?limit=${limit}`);
-      return toolText(JSON.stringify(payload, null, 2));
+      return toolData(payload);
     }
     case 'mark1_approvals': {
+      if (args.action !== 'list' && args.action !== 'create') throw new Error('Approval action must be list or create.');
       if (args.action === 'create') {
         const payload = await apiRequest('/api/approvals', {
           method: 'POST',
@@ -203,7 +298,7 @@ async function callTool(name, args = {}) {
             title: String(args.title || 'Untitled approval').trim(),
             summary: String(args.summary || '').trim(),
             approval_gate: String(args.approval_gate || 'general').trim(),
-            requested_by: String(args.requested_by || 'Codex MCP').trim(),
+            requested_by: String(args.requested_by || 'MCP client').trim(),
             owner: String(args.owner || 'Management').trim(),
             due: String(args.due || '').trim(),
             related_route: String(args.related_route || '/app').trim(),
@@ -211,28 +306,30 @@ async function callTool(name, args = {}) {
             status: 'pending',
           }),
         });
-        return toolText(JSON.stringify(payload, null, 2));
+        return toolData(payload);
       }
-      const limit = Math.max(1, Math.min(Number(args.limit || 10), 50));
+      const limit = boundedInteger(args.limit, 10, 1, 50);
       const payload = await apiRequest(`/api/approvals?limit=${limit}`);
-      return toolText(JSON.stringify(payload, null, 2));
+      return toolData(payload);
     }
     case 'mark1_leads': {
       const payload = await apiRequest('/api/lead-pipeline');
-      return toolText(JSON.stringify(payload, null, 2));
+      return toolData(redactLeadPipeline(payload));
     }
     case 'mark1_files': {
-      return toolText(JSON.stringify(listTopFiles(REPO_ROOT), null, 2));
+      return toolData(listTopFiles(REPO_ROOT));
     }
     case 'mark1_execute': {
-      const timeout = Math.max(5, Number(args.timeout || 30)) * 1000;
-      const output = execSync(String(args.command || ''), {
+      const timeout = boundedInteger(args.timeout, 30, 5, 300) * 1000;
+      const command = String(args.command || '').trim();
+      if (!command) throw new Error('A non-empty local command is required.');
+      const output = execSync(command, {
         cwd: REPO_ROOT,
         timeout,
         encoding: 'utf-8',
         maxBuffer: 1024 * 1024,
       });
-      return toolText(output);
+      return toolData(output);
     }
     default:
       throw new Error(`Unknown tool: ${name}`);
@@ -250,7 +347,7 @@ async function handleMessage(message) {
       result: {
         protocolVersion: '2024-11-05',
         capabilities: { tools: {} },
-        serverInfo: { name: 'supermega-mark1', version: '2.0.0' },
+          serverInfo: { name: 'supermega-mark1', version: '2.1.0' },
       },
     });
     return;

--- a/tools/start_supermega_mcp.ps1
+++ b/tools/start_supermega_mcp.ps1
@@ -1,11 +1,15 @@
 param(
     [string]$BaseUrl = "http://127.0.0.1:8787",
     [string]$Username = "owner",
-    [string]$Password = "supermega-demo",
+    [string]$Password = $env:SUPERMEGA_APP_PASSWORD,
     [string]$WorkspaceSlug = "supermega-lab"
 )
 
 $ErrorActionPreference = "Stop"
+
+if ([string]::IsNullOrWhiteSpace($Password)) {
+    throw "Set SUPERMEGA_APP_PASSWORD before starting the private SuperMega MCP server."
+}
 
 $scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 $repoRoot = Split-Path -Parent $scriptDir

--- a/tools/verify_mark1_mcp_submission.mjs
+++ b/tools/verify_mark1_mcp_submission.mjs
@@ -116,11 +116,11 @@ const internalTools = describeTools({ SUPERMEGA_ENABLE_LOCAL_TOOLS: 'true' });
 const redactedLeadFixture = redactLeadFixture();
 const protocol = await listToolsThroughProtocol();
 const expectedDefaultHints = {
-  mark1_status: [true, false, false],
-  mark1_insights: [true, false, false],
-  mark1_exceptions: [true, false, false],
-  mark1_approvals: [false, false, false],
-  mark1_leads: [true, false, false],
+  mark1_get_operating_brief: [true, false, false],
+  mark1_list_exceptions: [true, false, false],
+  mark1_list_approvals: [true, false, false],
+  mark1_create_approval: [false, false, false],
+  mark1_list_leads: [true, false, false],
 };
 const expectedInternalHints = {
   mark1_files: [true, false, false],
@@ -147,8 +147,16 @@ for (const tool of internalTools) {
       && tool.annotations.openWorldHint === expected[1]
       && tool.annotations.destructiveHint === expected[2], `wrong_hints:${tool.name}`);
   }
-  assert(typeof tool.description === 'string' && tool.description.trim().length > 20, `weak_description:${tool.name}`);
+  assert(typeof tool.title === 'string' && tool.title.trim().length > 4, `missing_title:${tool.name}`);
+  assert(typeof tool.description === 'string' && tool.description.startsWith('Use this when'), `weak_description:${tool.name}`);
+  assert(Boolean(tool.outputSchema?.properties?.data), `untyped_output_data:${tool.name}`);
 }
+
+const createApproval = defaultTools.find((tool) => tool.name === 'mark1_create_approval');
+const listApprovals = defaultTools.find((tool) => tool.name === 'mark1_list_approvals');
+assert(JSON.stringify(createApproval?.inputSchema?.required) === JSON.stringify(['title', 'owner']), 'create_approval_required_fields');
+assert(!Object.hasOwn(createApproval?.inputSchema?.properties || {}, 'action'), 'create_approval_mixed_action');
+assert(!Object.hasOwn(listApprovals?.inputSchema?.properties || {}, 'action'), 'list_approval_mixed_action');
 
 assert(submission.$schema === 'https://developers.openai.com/apps-sdk/schemas/chatgpt-app-submission.v1.json', 'wrong_submission_schema');
 assert(submission.schema_version === 1, 'wrong_submission_version');
@@ -166,6 +174,8 @@ for (const tool of defaultTools) {
 assert(submission.test_cases?.length === 5, 'positive_test_count');
 assert(submission.negative_test_cases?.length === 3, 'negative_test_count');
 assert(submission.test_cases.every((test) => Object.hasOwn(submission.tools, test.tools_triggered)), 'positive_test_unknown_tool');
+assert(JSON.stringify(submission.test_cases.map((test) => test.tools_triggered).sort())
+  === JSON.stringify(defaultTools.map((tool) => tool.name).sort()), 'positive_tests_do_not_cover_default_surface');
 assert(submission.negative_test_cases.every((test) => test.tools_triggered === null), 'negative_test_should_not_trigger');
 assert(!serverSource.includes('supermega-demo') && !serverSource.includes('C:\\Users\\swann'), 'stale_secret_or_machine_path');
 assert(serverSource.includes("SUPERMEGA_ENABLE_LOCAL_TOOLS === 'true'") && serverSource.includes('This local-only tool is disabled.'), 'local_tool_gate_missing');

--- a/tools/verify_mark1_mcp_submission.mjs
+++ b/tools/verify_mark1_mcp_submission.mjs
@@ -1,0 +1,190 @@
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { spawn, spawnSync } from 'node:child_process';
+
+const root = resolve(import.meta.dirname, '..');
+const serverPath = resolve(root, 'mark1-mcp', 'server.mjs');
+const submissionPath = resolve(root, 'chatgpt-app-submission.json');
+const serverSource = await readFile(serverPath, 'utf8');
+const submission = JSON.parse(await readFile(submissionPath, 'utf8'));
+const failures = [];
+let checks = 0;
+
+function assert(condition, reason) {
+  checks += 1;
+  if (!condition) failures.push(reason);
+}
+
+function describeTools(extraEnvironment = {}) {
+  const result = spawnSync(process.execPath, [serverPath, '--describe-tools'], {
+    cwd: root,
+    encoding: 'utf8',
+    env: { ...process.env, SUPERMEGA_ENABLE_LOCAL_TOOLS: '', ...extraEnvironment },
+  });
+  if (result.status !== 0) throw new Error(result.stderr || 'descriptor process failed');
+  return JSON.parse(result.stdout);
+}
+
+function redactLeadFixture() {
+  const result = spawnSync(process.execPath, [serverPath, '--redact-lead-fixture'], {
+    cwd: root,
+    encoding: 'utf8',
+    env: { ...process.env, SUPERMEGA_ENABLE_LOCAL_TOOLS: '' },
+  });
+  if (result.status !== 0) throw new Error(result.stderr || 'lead redaction process failed');
+  return JSON.parse(result.stdout);
+}
+
+function encodeMessage(payload) {
+  const body = Buffer.from(JSON.stringify(payload), 'utf8');
+  return Buffer.concat([Buffer.from(`Content-Length: ${body.length}\r\n\r\n`, 'ascii'), body]);
+}
+
+function createFrameReader(stream) {
+  let buffer = Buffer.alloc(0);
+  const queued = [];
+  const waiters = [];
+
+  function flush() {
+    while (true) {
+      const headerEnd = buffer.indexOf('\r\n\r\n');
+      if (headerEnd < 0) return;
+      const header = buffer.slice(0, headerEnd).toString('ascii');
+      const lengthLine = header.split('\r\n').find((line) => line.toLowerCase().startsWith('content-length:'));
+      const length = Number(lengthLine?.split(':')[1]?.trim() || 0);
+      const frameEnd = headerEnd + 4 + length;
+      if (!Number.isSafeInteger(length) || length <= 0 || buffer.length < frameEnd) return;
+      const payload = JSON.parse(buffer.slice(headerEnd + 4, frameEnd).toString('utf8'));
+      buffer = buffer.slice(frameEnd);
+      const waiter = waiters.shift();
+      if (waiter) waiter(payload);
+      else queued.push(payload);
+    }
+  }
+
+  stream.on('data', (chunk) => {
+    buffer = Buffer.concat([buffer, chunk]);
+    flush();
+  });
+
+  return () => {
+    if (queued.length) return Promise.resolve(queued.shift());
+    return new Promise((resolveFrame, reject) => {
+      const timeout = setTimeout(() => reject(new Error('MCP frame timeout')), 3_000);
+      waiters.push((payload) => {
+        clearTimeout(timeout);
+        resolveFrame(payload);
+      });
+    });
+  };
+}
+
+async function listToolsThroughProtocol() {
+  const child = spawn(process.execPath, [serverPath], {
+    cwd: root,
+    env: { ...process.env, SUPERMEGA_ENABLE_LOCAL_TOOLS: '' },
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  const readFrame = createFrameReader(child.stdout);
+  try {
+    child.stdin.write(encodeMessage({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: { protocolVersion: '2024-11-05', capabilities: {}, clientInfo: { name: 'submission-verifier', version: '1.0.0' } },
+    }));
+    const initialized = await readFrame();
+    if (initialized?.result?.serverInfo?.name !== 'supermega-mark1') throw new Error('MCP initialize failed');
+    child.stdin.write(encodeMessage({ jsonrpc: '2.0', method: 'notifications/initialized', params: {} }));
+    child.stdin.write(encodeMessage({ jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} }));
+    const listed = await readFrame();
+    child.stdin.write(encodeMessage({
+      jsonrpc: '2.0',
+      id: 3,
+      method: 'tools/call',
+      params: { name: 'mark1_execute', arguments: { command: 'node --version' } },
+    }));
+    const disabledCall = await readFrame();
+    return { tools: listed?.result?.tools || [], disabledCall };
+  } finally {
+    child.kill();
+  }
+}
+
+const defaultTools = describeTools();
+const internalTools = describeTools({ SUPERMEGA_ENABLE_LOCAL_TOOLS: 'true' });
+const redactedLeadFixture = redactLeadFixture();
+const protocol = await listToolsThroughProtocol();
+const expectedDefaultHints = {
+  mark1_status: [true, false, false],
+  mark1_insights: [true, false, false],
+  mark1_exceptions: [true, false, false],
+  mark1_approvals: [false, false, false],
+  mark1_leads: [true, false, false],
+};
+const expectedInternalHints = {
+  mark1_files: [true, false, false],
+  mark1_execute: [false, true, true],
+};
+
+assert(defaultTools.length === 5, 'default_tool_count');
+assert(internalTools.length === 7, 'internal_tool_count');
+assert(JSON.stringify(protocol.tools) === JSON.stringify(defaultTools), 'protocol_tool_descriptors_mismatch');
+assert(protocol.disabledCall?.error?.message?.includes('local-only tool is disabled'), 'disabled_local_tool_was_callable');
+assert(!defaultTools.some((tool) => tool.name === 'mark1_files' || tool.name === 'mark1_execute'), 'local_tools_exposed_by_default');
+assert(redactedLeadFixture.rows?.[0]?.company_name === 'Example Company', 'lead_redaction_removed_business_identity');
+assert(!['contact_email', 'contact_phone', 'outreach_message', 'discovery_questions', 'notes']
+  .some((field) => Object.hasOwn(redactedLeadFixture.rows?.[0] || {}, field)), 'lead_redaction_leaked_private_fields');
+
+for (const tool of internalTools) {
+  const expected = expectedDefaultHints[tool.name] || expectedInternalHints[tool.name];
+  assert(Boolean(expected), `unexpected_tool:${tool.name}`);
+  assert(typeof tool.annotations?.readOnlyHint === 'boolean'
+    && typeof tool.annotations?.openWorldHint === 'boolean'
+    && typeof tool.annotations?.destructiveHint === 'boolean', `missing_hints:${tool.name}`);
+  if (expected) {
+    assert(tool.annotations.readOnlyHint === expected[0]
+      && tool.annotations.openWorldHint === expected[1]
+      && tool.annotations.destructiveHint === expected[2], `wrong_hints:${tool.name}`);
+  }
+  assert(typeof tool.description === 'string' && tool.description.trim().length > 20, `weak_description:${tool.name}`);
+}
+
+assert(submission.$schema === 'https://developers.openai.com/apps-sdk/schemas/chatgpt-app-submission.v1.json', 'wrong_submission_schema');
+assert(submission.schema_version === 1, 'wrong_submission_version');
+assert(submission.app_info?.subtitle?.length <= 30, 'subtitle_too_long');
+assert(submission.app_info?.category === 'BUSINESS', 'wrong_category');
+assert(JSON.stringify(Object.keys(submission.tools).sort()) === JSON.stringify(defaultTools.map((tool) => tool.name).sort()), 'submission_tool_set_mismatch');
+
+for (const tool of defaultTools) {
+  const submitted = submission.tools[tool.name];
+  assert(Boolean(submitted), `submission_tool_missing:${tool.name}`);
+  assert(JSON.stringify(submitted?.annotations) === JSON.stringify(tool.annotations), `submission_hints_mismatch:${tool.name}`);
+  assert(Object.values(submitted?.justifications || {}).every((value) => typeof value === 'string' && value.trim().endsWith('.')), `weak_justification:${tool.name}`);
+}
+
+assert(submission.test_cases?.length === 5, 'positive_test_count');
+assert(submission.negative_test_cases?.length === 3, 'negative_test_count');
+assert(submission.test_cases.every((test) => Object.hasOwn(submission.tools, test.tools_triggered)), 'positive_test_unknown_tool');
+assert(submission.negative_test_cases.every((test) => test.tools_triggered === null), 'negative_test_should_not_trigger');
+assert(!serverSource.includes('supermega-demo') && !serverSource.includes('C:\\Users\\swann'), 'stale_secret_or_machine_path');
+assert(serverSource.includes("SUPERMEGA_ENABLE_LOCAL_TOOLS === 'true'") && serverSource.includes('This local-only tool is disabled.'), 'local_tool_gate_missing');
+
+const outputSchemaWarnings = internalTools.filter((tool) => !tool.outputSchema).map((tool) => tool.name);
+assert(outputSchemaWarnings.length === 0, 'missing_output_schema');
+
+if (failures.length) {
+  console.error(JSON.stringify({ ok: false, contract: 'supermega_chatgpt_app_submission', checks, failures }, null, 2));
+  process.exit(1);
+}
+
+console.log(JSON.stringify({
+  ok: true,
+  contract: 'supermega_chatgpt_app_submission',
+  checks,
+  defaultTools: defaultTools.map((tool) => tool.name),
+  conditionalInternalTools: internalTools.slice(defaultTools.length).map((tool) => tool.name),
+  positiveTests: submission.test_cases.length,
+  negativeTests: submission.negative_test_cases.length,
+  outputSchemaWarnings,
+}, null, 2));


### PR DESCRIPTION
## What changed

- classifies Mark1 as a private, tool-only app and narrows its default surface to five single-purpose tools: operating brief, exception list, approval list, pending-approval creation, and contact-redacted lead list
- separates approval reads from writes so ChatGPT can apply the correct confirmation behavior
- hides local file listing and arbitrary shell execution behind explicit internal-only opt-in
- adds action-oriented titles, `Use this when...` descriptions, truthful safety annotations, and typed output envelopes
- removes hard-coded demo credentials and machine-specific paths; startup now fails closed without a password
- redacts contact details, outreach drafts, discovery questions, and free-form notes from lead results
- adds the exact `chatgpt-app-submission.json` review artifact with five one-to-one positive cases and three negative cases
- adds protocol-level verification for descriptors, annotations, schemas, redaction, tool separation, test coverage, and disabled local execution

## Why

The previous server exposed a broad local execution surface and mixed approval reads and writes in one tool. Current Apps SDK guidance calls for one job per tool and separate read/write actions. This creates a truthful review surface without claiming that the local server is production-ready.

## Validation

- `node --check mark1-mcp/server.mjs`
- `node --check tools/verify_mark1_mcp_submission.mjs`
- `npm.cmd --prefix mark1-mcp run submission:verify`
- 80 checks passed; five default tools, two conditional internal tools, five positive cases, three negative cases, zero output-schema warnings
- launcher confirmed to fail closed when `SUPERMEGA_APP_PASSWORD` is missing
- GitGuardian security check passed
- manually dispatched read-only SuperMega App CI passed on this branch

## Review boundary

This is a draft readiness PR, not authorization to submit or deploy. Live ChatGPT app submission remains blocked until SuperMega has a stable HTTPS `/mcp` endpoint, OAuth 2.1 with per-tool scopes and end-user consent, privacy/support metadata, and credentialed end-to-end payload review. No production deployment, domain change, or app submission is included. Private/internal use should remain in ChatGPT Developer Mode until those requirements are satisfied.
