### PR TITLE
Connect Production to managed lifecycle API

### DIFF
--- a/showroom/src/core/CoreApp.tsx
+++ b/showroom/src/core/CoreApp.tsx
@@ -14,11 +14,13 @@ import {
   ManagedTrialError,
   managedTrialAuthConfigured,
   saveManagedCommerceCommand,
+  saveManagedProductionCommand,
   signInManagedTrial,
   signOutManagedTrial,
   type ManagedApprovalRecord,
   type ManagedCommerceEvent,
   type ManagedIdentity,
+  type ManagedProductionEvent,
   type ManagedStateRecord,
 } from './managed-trial'
 import { LEGACY_TEAM_WORK_KEYS, TEAM_WORK_KEY, formatTime, teamDefinitions, useTeamWorkspace } from './team-work'
@@ -45,12 +47,14 @@ import {
   LEGACY_PRODUCTION_KEYS,
   PRODUCTION_KEY,
   advanceProductionMachineState,
+  createEmptyProduction,
   loadProductionWorkspace,
   mutateProductionWorkspace,
   openProductionIssue,
   productionMachineTransitions,
   recordProductionOutput,
   resolveProductionIssue,
+  validateProductionState,
   type ProductionActionProof,
   type ProductionEvent,
   type ProductionIssue,
@@ -724,32 +728,153 @@ function useCommerceWorkspace(managedIdentity: ManagedIdentity | null = null) {
   return [visible.state, mutate, visible.error, visible.mode, visible.version, visible.workspaceId] as const
 }
 
-function useProductionWorkspace() {
-  const [snapshot, setSnapshot] = useState(() => loadProductionWorkspace())
+type ProductionWorkspaceMode = 'local' | 'managed-loading' | 'managed-ready' | 'managed-unprovisioned' | 'managed-error'
+
+type ProductionWorkspaceView = {
+  state: ProductionState
+  mode: ProductionWorkspaceMode
+  workspaceId: string
+  version: number | null
+  error: string
+}
+
+function managedProductionView(record: ManagedStateRecord, workspaceId: string): ProductionWorkspaceView {
+  if (record.surface !== 'production' || !Number.isSafeInteger(record.version) || record.version < 0) throw new Error('Managed Production returned an invalid state envelope.')
+  if (record.version === 0) {
+    if (Object.keys(record.state).length) throw new Error('Managed Production has state without a valid revision.')
+    return { state: createEmptyProduction(), mode: 'managed-unprovisioned', workspaceId, version: 0, error: 'This managed workspace has no Production plan yet.' }
+  }
+  return { state: validateProductionState(record.state), mode: 'managed-ready', workspaceId, version: record.version, error: '' }
+}
+
+function useProductionWorkspace(managedIdentity: ManagedIdentity | null = null) {
+  const [localSnapshot, setLocalSnapshot] = useState<ProductionWorkspaceView>(() => {
+    const local = loadProductionWorkspace()
+    return { state: local.state, mode: 'local', workspaceId: '', version: null, error: local.error }
+  })
+  const [managedSnapshot, setManagedSnapshot] = useState<ProductionWorkspaceView>(() => ({
+    state: createEmptyProduction(), mode: 'managed-loading', workspaceId: '', version: null, error: '',
+  }))
+  const snapshotRef = useRef(localSnapshot)
+  const identityRef = useRef(managedIdentity)
 
   useEffect(() => {
+    identityRef.current = managedIdentity
+    snapshotRef.current = managedIdentity ? managedSnapshot : localSnapshot
+  }, [localSnapshot, managedIdentity, managedSnapshot])
+
+  useEffect(() => {
+    if (!managedIdentity) return undefined
+    let active = true
+    loadManagedBootstrap()
+      .then((bootstrap) => {
+        if (!active || identityRef.current?.workspaceId !== managedIdentity.workspaceId) return
+        const next = managedProductionView(bootstrap.states.production, managedIdentity.workspaceId)
+        snapshotRef.current = next
+        setManagedSnapshot(next)
+      })
+      .catch((error) => {
+        if (!active || identityRef.current?.workspaceId !== managedIdentity.workspaceId) return
+        const next = { state: createEmptyProduction(), mode: 'managed-error' as const, workspaceId: managedIdentity.workspaceId, version: null, error: error instanceof Error ? error.message : 'Managed Production could not be loaded.' }
+        snapshotRef.current = next
+        setManagedSnapshot(next)
+      })
+    return () => { active = false }
+  }, [managedIdentity])
+
+  useEffect(() => {
+    if (managedIdentity) return undefined
     function refreshFromStorage(event: StorageEvent) {
-      if (event.key === PRODUCTION_KEY) setSnapshot(loadProductionWorkspace())
+      if (event.key !== PRODUCTION_KEY) return
+      const refreshed = loadProductionWorkspace()
+      const next = { state: refreshed.state, mode: 'local' as const, workspaceId: '', version: null, error: refreshed.error }
+      snapshotRef.current = next
+      setLocalSnapshot(next)
     }
     window.addEventListener('storage', refreshFromStorage)
     return () => window.removeEventListener('storage', refreshFromStorage)
-  }, [])
+  }, [managedIdentity])
 
-  async function mutate(transition: (state: ProductionState) => ProductionState | null) {
-    const result = await mutateProductionWorkspace(transition)
-    if (!result.ok) {
-      const refreshed = loadProductionWorkspace()
-      setSnapshot((current) => ({
-        state: refreshed.error ? current.state : refreshed.state,
-        source: refreshed.error ? current.source : refreshed.source,
-        error: result.error,
-      }))
-      throw new Error(result.error)
+  async function mutate(
+    eventType: ManagedProductionEvent,
+    commandId: string,
+    evidence: ProductionActionProof,
+    transition: (state: ProductionState) => ProductionState | null,
+  ) {
+    if (!managedIdentity) {
+      if (eventType === 'production.workspace.initialized') throw new Error('Browser demo Production is already initialized.')
+      const result = await mutateProductionWorkspace(transition)
+      if (!result.ok) {
+        const refreshed = loadProductionWorkspace()
+        const rejected = { state: refreshed.error ? snapshotRef.current.state : refreshed.state, mode: 'local' as const, workspaceId: '', version: null, error: result.error }
+        snapshotRef.current = rejected
+        setLocalSnapshot(rejected)
+        throw new Error(result.error)
+      }
+      const accepted = { state: result.state, mode: 'local' as const, workspaceId: '', version: null, error: '' }
+      snapshotRef.current = accepted
+      setLocalSnapshot(accepted)
+      return
     }
-    setSnapshot({ state: result.state, source: 'current', error: '' })
+
+    const workspaceId = managedIdentity.workspaceId
+    const current = snapshotRef.current
+    const initializing = eventType === 'production.workspace.initialized'
+    const modeReady = initializing ? current.mode === 'managed-unprovisioned' && current.version === 0 : current.mode === 'managed-ready' && current.version !== null
+    if (!modeReady || current.workspaceId !== workspaceId || current.version === null) {
+      throw new Error(current.error || 'Managed Production is not ready for writes.')
+    }
+    const next = transition(current.state)
+    if (!next) throw new Error('The Production state changed or this lifecycle step is no longer valid. Nothing was written.')
+    if (next === current.state) return
+    const candidate = validateProductionState(next)
+
+    try {
+      const result = await saveManagedProductionCommand({
+        commandId,
+        evidence,
+        eventType,
+        expectedVersion: current.version,
+        state: candidate as unknown as Record<string, unknown>,
+      })
+      if (identityRef.current?.workspaceId !== workspaceId) throw new Error('The managed workspace changed before the Production write was confirmed.')
+      if (result.surface !== 'production' || result.event_type !== eventType || result.version !== current.version + 1) {
+        throw new Error('Managed Production returned an invalid command result.')
+      }
+      const accepted = validateProductionState(result.state)
+      const nextSnapshot = { state: accepted, mode: 'managed-ready' as const, workspaceId, version: result.version, error: '' }
+      snapshotRef.current = nextSnapshot
+      setManagedSnapshot(nextSnapshot)
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'The managed Production write was not confirmed.'
+      if (error instanceof ManagedTrialError && error.code === 'trial_version_conflict') {
+        try {
+          const bootstrap = await loadManagedBootstrap()
+          if (identityRef.current?.workspaceId !== workspaceId) throw new Error('The managed workspace changed before Production could refresh.')
+          const refreshed = managedProductionView(bootstrap.states.production, workspaceId)
+          const conflict = { ...refreshed, error: 'Production changed in another session. The latest revision is loaded; review and confirm the action again.' }
+          snapshotRef.current = conflict
+          setManagedSnapshot(conflict)
+        } catch (refreshError) {
+          const refreshMessage = refreshError instanceof Error ? refreshError.message : 'Production changed and the latest revision could not be loaded.'
+          const rejected = { ...snapshotRef.current, error: refreshMessage }
+          snapshotRef.current = rejected
+          setManagedSnapshot(rejected)
+          throw refreshError
+        }
+        throw new Error('Production changed in another session. The latest revision is loaded; review and confirm the action again.')
+      }
+      if (identityRef.current?.workspaceId === workspaceId) {
+        const rejected = { ...snapshotRef.current, error: message }
+        snapshotRef.current = rejected
+        setManagedSnapshot(rejected)
+      }
+      throw error
+    }
   }
 
-  return [snapshot.state, mutate, snapshot.error] as const
+  const visible = managedIdentity ? managedSnapshot : localSnapshot
+  return [visible.state, mutate, visible.error, visible.mode, visible.version, visible.workspaceId] as const
 }
 
 function useApprovalWorkspace() {
@@ -990,7 +1115,7 @@ export function OverviewPage() {
   const runtime = useOutletContext<RuntimeHealth>()
   const [managedIdentity] = useManagedIdentity(runtime.status === 'enterprise')
   const [commerce] = useCommerceWorkspace(managedIdentity)
-  const [production] = useProductionWorkspace()
+  const [production] = useProductionWorkspace(managedIdentity)
   const [approvals, setApprovals] = useApprovalWorkspace()
   const [setup] = useSetupWorkspace()
   const [workspace] = useTeamWorkspace()
@@ -1199,7 +1324,7 @@ export function OperationsPage() {
         <div className="segmented-control" role="group" aria-label="Operating workspace"><button aria-pressed={view === 'commerce'} onClick={() => setMode('commerce')} type="button">Commerce</button><button aria-pressed={view === 'production'} onClick={() => setMode('production')} type="button">Production</button></div>
         <div className="operations-toolbar-actions"><nav className="view-tabs" aria-label="Module views">{tabs.map((tab) => <button aria-current={activeTab === tab.id ? 'page' : undefined} key={tab.id} onClick={() => setTab(tab.id)} type="button">{tab.label}</button>)}</nav></div>
       </div>
-      <div className="workspace-view">{view === 'commerce' ? <CommercePage managedIdentity={managedIdentity} tab={commerceTab} /> : <ProductionPage tab={productionTab} />}</div>
+      <div className="workspace-view">{view === 'commerce' ? <CommercePage managedIdentity={managedIdentity} tab={commerceTab} /> : <ProductionPage managedIdentity={managedIdentity} tab={productionTab} />}</div>
     </div>
   )
 }
@@ -1530,9 +1655,8 @@ function ProductionEventHistory({ events }: { events: ProductionEvent[] }) {
   </details>
 }
 
-function ProductionPage({ tab }: { tab: ProductionTab }) {
-  const [production, mutateProduction, productionStorageError] = useProductionWorkspace()
-  const [, setActions] = useStoredState<AccountableAction[]>(ACTION_KEY, [], normalizeActions)
+function ProductionPage({ managedIdentity, tab }: { managedIdentity: ManagedIdentity | null; tab: ProductionTab }) {
+  const [production, mutateProduction, productionStorageError, workspaceMode, managedVersion, managedWorkspaceId] = useProductionWorkspace(managedIdentity)
   const [pendingAction, setPendingAction] = useState<PendingAccountableAction | null>(null)
   const [jobId, setJobId] = useState(production.jobs[0]?.id ?? '')
   const [quantity, setQuantity] = useState(25)
@@ -1540,12 +1664,80 @@ function ProductionPage({ tab }: { tab: ProductionTab }) {
   const [kind, setKind] = useState<ProductionIssue['kind']>('quality')
   const [summary, setSummary] = useState('')
   const [notice, setNotice] = useState('')
+  const [setupDraft, setSetupDraft] = useState({ jobId: '', line: '', product: '', target: '', machineId: '', machineName: '', machineState: 'stopped' as ProductionMachineState, reason: '', evidenceReference: '' })
+  const [setupBusy, setSetupBusy] = useState(false)
+  const [setupError, setSetupError] = useState('')
   const output = production.jobs.reduce((total, job) => total + job.output, 0)
   const target = production.jobs.reduce((total, job) => total + job.target, 0)
   const openIssues = production.issues.filter((issue) => issue.status === 'open')
-  const selectedJob = production.jobs.find((job) => job.id === jobId)
+  const selectedJobId = production.jobs.some((job) => job.id === jobId) ? jobId : production.jobs[0]?.id ?? ''
+  const selectedJob = production.jobs.find((job) => job.id === selectedJobId)
   const selectedRemaining = selectedJob ? selectedJob.target - selectedJob.output : 0
   const completion = target > 0 ? Math.round((output / target) * 100) : 0
+
+  async function initializeManagedProduction(event: FormEvent) {
+    event.preventDefault()
+    if (!managedIdentity) return
+    const firstJobId = setupDraft.jobId.trim().toUpperCase()
+    const line = setupDraft.line.trim()
+    const product = setupDraft.product.trim()
+    const firstTarget = Number(setupDraft.target)
+    const machineId = setupDraft.machineId.trim().toUpperCase()
+    const machineName = setupDraft.machineName.trim()
+    const reason = setupDraft.reason.trim()
+    const evidenceReference = setupDraft.evidenceReference.trim()
+    if (!firstJobId || !line || !product || !machineId || !machineName || !reason || !evidenceReference || !Number.isSafeInteger(firstTarget) || firstTarget < 1) {
+      setSetupError('Enter a valid job, line, target, machine, reason, and evidence reference.')
+      return
+    }
+    const proof: ProductionActionProof = {
+      actionId: uid('ACT'),
+      capturedAt: new Date().toISOString(),
+      actor: managedIdentity.email,
+      reason,
+      evidenceReference,
+    }
+    setSetupBusy(true)
+    setSetupError('')
+    try {
+      await mutateProduction('production.workspace.initialized', commandUuid(), proof, (current) => current.jobs.length || current.issues.length || current.machines.length || current.events.length || current.revision ? null : validateProductionState({
+        ...current,
+        jobs: [{ id: firstJobId, line, product, target: firstTarget, output: 0 }],
+        machines: [{ id: machineId, name: machineName, state: setupDraft.machineState }],
+      }))
+      setNotice(`Managed Production initialized with ${firstJobId} and ${machineId}.`)
+      setArea(line)
+    } catch (error) {
+      setSetupError(error instanceof Error ? error.message : 'Managed Production was not initialized.')
+    } finally {
+      setSetupBusy(false)
+    }
+  }
+
+  const effectiveMode = managedIdentity && (workspaceMode === 'local' || managedWorkspaceId !== managedIdentity.workspaceId) ? 'managed-loading' : workspaceMode
+  if (managedIdentity && effectiveMode !== 'managed-ready') {
+    if (effectiveMode === 'managed-unprovisioned') return <section className="core-panel managed-production-boundary">
+      <div className="panel-head"><div><span className="core-eyebrow">Managed Production setup</span><h2>Create the first real plan</h2></div><span className="status-pill pending">Not provisioned</span></div>
+      <p className="panel-copy">Define one real job and one equipment record. No browser demo output, issues, or machine history is copied into this workspace.</p>
+      <form className="core-form compact-form" onSubmit={(formEvent) => void initializeManagedProduction(formEvent)}>
+        <div className="form-row"><label>Job ID<input maxLength={80} onChange={(inputEvent) => setSetupDraft((current) => ({ ...current, jobId: inputEvent.target.value }))} placeholder="JOB-001" required value={setupDraft.jobId} /></label><label>Line or area<input maxLength={160} onChange={(inputEvent) => setSetupDraft((current) => ({ ...current, line: inputEvent.target.value }))} placeholder="Line 01" required value={setupDraft.line} /></label></div>
+        <div className="form-row"><label>Product or batch<input maxLength={180} onChange={(inputEvent) => setSetupDraft((current) => ({ ...current, product: inputEvent.target.value }))} placeholder="Product name" required value={setupDraft.product} /></label><label>Target units<input min="1" onChange={(inputEvent) => setSetupDraft((current) => ({ ...current, target: inputEvent.target.value }))} required step="1" type="number" value={setupDraft.target} /></label></div>
+        <div className="form-row"><label>Machine ID<input maxLength={80} onChange={(inputEvent) => setSetupDraft((current) => ({ ...current, machineId: inputEvent.target.value }))} placeholder="MC-01" required value={setupDraft.machineId} /></label><label>Machine name<input maxLength={180} onChange={(inputEvent) => setSetupDraft((current) => ({ ...current, machineName: inputEvent.target.value }))} placeholder="Equipment name" required value={setupDraft.machineName} /></label></div>
+        <label>Current recorded state<select onChange={(inputEvent) => setSetupDraft((current) => ({ ...current, machineState: inputEvent.target.value as ProductionMachineState }))} value={setupDraft.machineState}><option value="stopped">Stopped</option><option value="running">Running</option><option value="attention">Needs attention</option></select></label>
+        <label>Setup reason<input maxLength={180} onChange={(inputEvent) => setSetupDraft((current) => ({ ...current, reason: inputEvent.target.value }))} placeholder="How this plan and equipment state were verified" required value={setupDraft.reason} /></label>
+        <label>Evidence reference<input maxLength={180} onChange={(inputEvent) => setSetupDraft((current) => ({ ...current, evidenceReference: inputEvent.target.value }))} placeholder="Plan, shift sheet, or observation" required value={setupDraft.evidenceReference} /></label>
+        <div className="form-actions"><Link className="text-link" to="/settings/">Workspace settings</Link><button className="core-button primary" disabled={setupBusy} type="submit">{setupBusy ? 'Creating…' : 'Create managed Production'}</button></div>
+        <p className="form-notice" role="status">{setupError || productionStorageError || `Authenticated as ${managedIdentity.email}. This records state; it does not control equipment.`}</p>
+      </form>
+    </section>
+    return <section className="core-panel managed-production-boundary">
+      <div className="panel-head"><div><span className="core-eyebrow">Managed Production</span><h2>{effectiveMode === 'managed-error' ? 'Managed workspace unavailable' : 'Loading authenticated workspace'}</h2></div><span className="status-pill bounded">{effectiveMode === 'managed-error' ? 'Blocked' : 'Checking'}</span></div>
+      <p className="panel-copy">{productionStorageError || 'Production remains read-only until the authenticated tenant state is confirmed.'}</p>
+      <div className="form-actions"><Link className="core-button" to="/settings/">Open workspace settings</Link></div>
+    </section>
+  }
+
+  const sourceNotice = managedIdentity ? `Managed workspace ${managedIdentity.workspaceId} · revision ${managedVersion ?? 0} · writes are confirmed by the tenant API.` : 'Browser demo · Production data stays on this device and is not a managed business record.'
 
   function queueAction(action: Omit<PendingAccountableAction, 'id' | 'commandId' | 'domain'>) {
     if (pendingAction) {
@@ -1561,8 +1753,7 @@ function ProductionPage({ tab }: { tab: ProductionTab }) {
     const action = pendingAction
     const record = confirmAccountableAction(action, details)
     await action.apply(record)
-    setActions((current) => [record, ...current])
-    setNotice(`${record.id} persisted with attributed Production evidence.`)
+    setNotice(managedIdentity ? `${record.id} confirmed by the managed Production API.` : `${record.id} persisted with attributed Production evidence.`)
     setPendingAction(null)
   }
 
@@ -1581,7 +1772,7 @@ function ProductionPage({ tab }: { tab: ProductionTab }) {
       before: `${selectedJob.output} / ${selectedJob.target}`,
       after: `${selectedJob.output + recordedQuantity} / ${selectedJob.target}`,
       apply: async (record) => {
-        await mutateProduction((current) => recordProductionOutput(current, recordedJobId, recordedQuantity, productionActionProof(record)))
+        await mutateProduction('production.output.recorded', record.commandId, productionActionProof(record), (current) => recordProductionOutput(current, recordedJobId, recordedQuantity, productionActionProof(record)))
       },
     })
   }
@@ -1597,7 +1788,7 @@ function ProductionPage({ tab }: { tab: ProductionTab }) {
       before: 'No issue record',
       after: `${issue.id} - open`,
       apply: async (record) => {
-        await mutateProduction((current) => openProductionIssue(current, issue, productionActionProof(record)))
+        await mutateProduction('production.issue.opened', record.commandId, productionActionProof(record), (current) => openProductionIssue(current, issue, productionActionProof(record)))
         setSummary('')
       },
     })
@@ -1613,7 +1804,7 @@ function ProductionPage({ tab }: { tab: ProductionTab }) {
       before: issue.status,
       after: 'resolved with operator evidence',
       apply: async (record) => {
-        await mutateProduction((current) => resolveProductionIssue(current, issueId, productionActionProof(record)))
+        await mutateProduction('production.issue.resolved', record.commandId, productionActionProof(record), (current) => resolveProductionIssue(current, issueId, productionActionProof(record)))
       },
     })
   }
@@ -1630,18 +1821,20 @@ function ProductionPage({ tab }: { tab: ProductionTab }) {
       before: expectedState,
       after: nextState,
       apply: async (record) => {
-        await mutateProduction((current) => advanceProductionMachineState(current, machineId, expectedState, productionActionProof(record)))
+        await mutateProduction('production.machine.state_changed', record.commandId, productionActionProof(record), (current) => advanceProductionMachineState(current, machineId, expectedState, productionActionProof(record)))
       },
     })
   }
 
   const actionControls = <>
-    <p className="form-notice" aria-live="polite">{productionStorageError || notice}</p>
+    {notice || productionStorageError ? <p className="form-notice" aria-live="polite">{notice || productionStorageError}</p> : null}
     <AccountableActionGate key={pendingAction?.id ?? 'production-idle'} action={pendingAction} onCancel={() => { setPendingAction(null); setNotice('Change cancelled. Production data was not modified.') }} onConfirm={confirmAction} />
     <ProductionEventHistory events={production.events} />
   </>
+  const sourceBanner = <p className="form-notice production-source-notice" role="status">{sourceNotice}</p>
 
   if (tab === 'production') return <div className="operation-module">
+    {sourceBanner}
     <div className="split-workspace production-view">
       <section className="core-panel job-panel">
         <div className="panel-head"><div><span className="core-eyebrow">Production plan</span><h2>Active jobs</h2></div><span className="panel-note">Target is a hard limit</span></div>
@@ -1650,7 +1843,7 @@ function ProductionPage({ tab }: { tab: ProductionTab }) {
       <section className="core-panel output-panel">
         <span className="core-eyebrow">Good output</span><h2>Confirm production</h2>
         <form className="core-form compact-form" onSubmit={recordOutput}>
-          <label>Job<select value={jobId} onChange={(event) => setJobId(event.target.value)}>{production.jobs.map((job) => <option key={job.id} value={job.id}>{job.id}</option>)}</select></label>
+          <label>Job<select value={selectedJobId} onChange={(event) => setJobId(event.target.value)}>{production.jobs.map((job) => <option key={job.id} value={job.id}>{job.id}</option>)}</select></label>
           <label>Quantity<input min="1" step="1" type="number" value={quantity} onChange={(event) => setQuantity(Number(event.target.value))} /></label>
           <button className="core-button primary" disabled={!selectedJob || selectedRemaining < 1} type="submit">Record output</button>
           <p className="panel-copy">{selectedJob ? `${selectedRemaining.toLocaleString()} units remain for ${selectedJob.id}.` : 'Choose an active job.'} Every change requires an operator, reason, and evidence.</p>
@@ -1661,17 +1854,18 @@ function ProductionPage({ tab }: { tab: ProductionTab }) {
   </div>
 
   if (tab === 'control') return <div className="operation-module">
+    {sourceBanner}
     <div className="control-workspace">
       <div className="split-workspace">
         <section className="core-panel">
           <div className="panel-head"><div><span className="core-eyebrow">Equipment</span><h2>Machine state</h2></div></div>
           <div className="machine-list">{production.machines.map((machine) => <button aria-label={`${productionMachineActionLabels[machine.state]} for ${machine.name}; current state ${machine.state}`} key={machine.id} type="button" onClick={() => cycleMachine(machine.id)}><span className={`machine-dot ${machine.state}`} /><span><strong>{machine.name}</strong><small>{machine.id} - Current: {machine.state}</small></span><b>{productionMachineActionLabels[machine.state]}</b></button>)}</div>
-          <p className="panel-copy">Local operating record only. No telemetry or machine control is connected.</p>
+          <p className="panel-copy">{managedIdentity ? 'Managed operating record.' : 'Browser-local operating record.'} No telemetry or machine control is connected.</p>
         </section>
         <section className="core-panel">
           <span className="core-eyebrow">Exception</span><h2>Open an issue</h2>
           <form className="core-form compact-form" onSubmit={createIssue}>
-            <div className="form-row"><label>Type<select value={kind} onChange={(event) => setKind(event.target.value as ProductionIssue['kind'])}><option value="quality">Quality</option><option value="maintenance">Maintenance</option><option value="materials">Materials</option><option value="operations">Operations</option></select></label><label>Area<select value={area} onChange={(event) => setArea(event.target.value)}><option>Line 01</option><option>Line 02</option><option>Line 03</option><option>Materials</option><option>Quality</option></select></label></div>
+            <div className="form-row"><label>Type<select value={kind} onChange={(event) => setKind(event.target.value as ProductionIssue['kind'])}><option value="quality">Quality</option><option value="maintenance">Maintenance</option><option value="materials">Materials</option><option value="operations">Operations</option></select></label><label>Area<input maxLength={160} onChange={(event) => setArea(event.target.value)} required value={area} /></label></div>
             <label>Observation<textarea maxLength={240} required value={summary} onChange={(event) => setSummary(event.target.value)} placeholder="Describe what happened, not the assumption." /></label>
             <button className="core-button primary" type="submit">Open issue</button>
           </form>
@@ -1683,6 +1877,7 @@ function ProductionPage({ tab }: { tab: ProductionTab }) {
   </div>
 
   return <div className="operation-module">
+    {sourceBanner}
     <div className="module-today">
       <section className="summary-strip"><span><small>Output</small><strong>{output.toLocaleString()}</strong></span><span><small>Target</small><strong>{target.toLocaleString()}</strong></span><span><small>Completion</small><strong>{completion}%</strong></span><span><small>Open issues</small><strong>{openIssues.length}</strong></span><span><small>Machines running</small><strong>{production.machines.filter((item) => item.state === 'running').length}/{production.machines.length}</strong></span></section>
       <div className="split-workspace ops-today-grid">

--- a/showroom/src/core/managed-trial.ts
+++ b/showroom/src/core/managed-trial.ts
@@ -48,10 +48,17 @@ export type ManagedCommerceEvent =
   | 'commerce.stock.received'
   | 'commerce.close.saved'
 
-export type ManagedCommandResult = {
+export type ManagedProductionEvent =
+  | 'production.workspace.initialized'
+  | 'production.output.recorded'
+  | 'production.issue.opened'
+  | 'production.issue.resolved'
+  | 'production.machine.state_changed'
+
+type ManagedCommandResult<Surface extends 'commerce' | 'production', Event extends string> = {
   command_id: string
-  surface: 'commerce'
-  event_type: ManagedCommerceEvent
+  surface: Surface
+  event_type: Event
   version: number
   state: Record<string, unknown>
   idempotent_replay: boolean
@@ -284,11 +291,31 @@ export async function saveManagedCommerceCommand(request: {
   expectedVersion: number
   state: Record<string, unknown>
 }) {
-  const response = await authorizedRequest<{ result: ManagedCommandResult }>('/api/trial/v1/commands', {
+  const response = await authorizedRequest<{ result: ManagedCommandResult<'commerce', ManagedCommerceEvent> }>('/api/trial/v1/commands', {
     method: 'POST',
     body: JSON.stringify({
       command_id: request.commandId,
       surface: 'commerce',
+      event_type: request.eventType,
+      expected_version: request.expectedVersion,
+      payload: { state: request.state, evidence: request.evidence },
+    }),
+  })
+  return response.result
+}
+
+export async function saveManagedProductionCommand(request: {
+  commandId: string
+  evidence: ManagedCommandEvidence
+  eventType: ManagedProductionEvent
+  expectedVersion: number
+  state: Record<string, unknown>
+}) {
+  const response = await authorizedRequest<{ result: ManagedCommandResult<'production', ManagedProductionEvent> }>('/api/trial/v1/commands', {
+    method: 'POST',
+    body: JSON.stringify({
+      command_id: request.commandId,
+      surface: 'production',
       event_type: request.eventType,
       expected_version: request.expectedVersion,
       payload: { state: request.state, evidence: request.evidence },

--- a/supermega_runtime/production_runtime.py
+++ b/supermega_runtime/production_runtime.py
@@ -1,0 +1,423 @@
+"""Fail-closed Production state and event validation for managed workspaces."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from copy import deepcopy
+from datetime import datetime
+from typing import Any
+
+from supermega_runtime.trial_store import TrialValidationError
+
+
+PRODUCTION_SCHEMA = "supermega.production.workspace.v2"
+PRODUCTION_EVENTS = frozenset(
+    {
+        "production.workspace.initialized",
+        "production.output.recorded",
+        "production.issue.opened",
+        "production.issue.resolved",
+        "production.machine.state_changed",
+    }
+)
+_ISSUE_KINDS = ("quality", "maintenance", "materials", "operations")
+_MACHINE_STATES = ("running", "attention", "stopped")
+_MACHINE_TRANSITIONS = {"running": "attention", "attention": "stopped", "stopped": "running"}
+_EVENT_KINDS = ("output_recorded", "issue_opened", "issue_resolved", "machine_state_changed")
+_MAX_SAFE_INTEGER = 9_007_199_254_740_991
+
+_STATE_FIELDS = frozenset({"schema", "revision", "jobs", "issues", "machines", "events"})
+_JOB_FIELDS = frozenset({"id", "line", "product", "target", "output"})
+_ISSUE_FIELDS = frozenset({"id", "createdAt", "area", "kind", "summary", "status", "resolution"})
+_RESOLUTION_FIELDS = frozenset({"actionId", "resolvedAt", "resolvedBy", "reason", "evidenceReference"})
+_MACHINE_FIELDS = frozenset({"id", "name", "state"})
+_EVENT_REQUIRED_FIELDS = frozenset(
+    {"id", "actionId", "createdAt", "actor", "reason", "evidenceReference", "kind", "subjectId", "summary"}
+)
+_EVENT_OPTIONAL_FIELDS = frozenset({"quantity", "fromState", "toState"})
+_EVIDENCE_FIELDS = frozenset({"actionId", "capturedAt", "actor", "reason", "evidenceReference"})
+
+
+def _object(value: object, field: str) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        raise TrialValidationError(f"{field} must be an object.")
+    if any(not isinstance(key, str) for key in value):
+        raise TrialValidationError(f"{field} keys must be strings.")
+    return dict(value)
+
+
+def _exact_fields(
+    value: Mapping[str, Any],
+    field: str,
+    *,
+    required: frozenset[str],
+    optional: frozenset[str] = frozenset(),
+) -> None:
+    fields = set(value)
+    missing = sorted(required - fields)
+    extra = sorted(fields - required - optional)
+    if missing:
+        raise TrialValidationError(f"{field} is missing fields: {', '.join(missing)}.")
+    if extra:
+        raise TrialValidationError(f"{field} has unsupported fields: {', '.join(extra)}.")
+
+
+def _text(value: object, field: str, *, maximum: int = 240) -> str:
+    if not isinstance(value, str) or not value.strip() or value != value.strip() or len(value) > maximum:
+        raise TrialValidationError(f"{field} must be canonical non-empty text of at most {maximum} characters.")
+    return value
+
+
+def _timestamp(value: object, field: str) -> str:
+    timestamp = _text(value, field, maximum=40)
+    try:
+        parsed = datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise TrialValidationError(f"{field} must be an ISO-8601 timestamp.") from exc
+    if parsed.tzinfo is None:
+        raise TrialValidationError(f"{field} must include a timezone.")
+    return timestamp
+
+
+def _integer(value: object, field: str, *, minimum: int = 0) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or not minimum <= value <= _MAX_SAFE_INTEGER:
+        raise TrialValidationError(f"{field} must be a safe integer of at least {minimum}.")
+    return value
+
+
+def _list(value: object, field: str) -> list[Any]:
+    if not isinstance(value, list):
+        raise TrialValidationError(f"{field} must be an array.")
+    return value
+
+
+def _unique(values: Sequence[str], field: str) -> None:
+    if len(set(values)) != len(values):
+        raise TrialValidationError(f"{field} values must be unique.")
+
+
+def validate_production_state(value: object) -> dict[str, Any]:
+    """Validate the complete managed Production snapshot without repairing it."""
+
+    state = _object(value, "production state")
+    _exact_fields(state, "production state", required=_STATE_FIELDS)
+    if state.get("schema") != PRODUCTION_SCHEMA:
+        raise TrialValidationError(f"production state schema must be {PRODUCTION_SCHEMA}.")
+    revision = _integer(state["revision"], "production state.revision")
+    jobs = _list(state["jobs"], "production state.jobs")
+    issues = _list(state["issues"], "production state.issues")
+    machines = _list(state["machines"], "production state.machines")
+    events = _list(state["events"], "production state.events")
+
+    job_ids: list[str] = []
+    job_by_id: dict[str, dict[str, Any]] = {}
+    for index, candidate in enumerate(jobs):
+        job = _object(candidate, f"jobs[{index}]")
+        _exact_fields(job, f"jobs[{index}]", required=_JOB_FIELDS)
+        job_id = _text(job["id"], f"jobs[{index}].id", maximum=160)
+        _text(job["line"], f"jobs[{index}].line", maximum=160)
+        _text(job["product"], f"jobs[{index}].product", maximum=180)
+        target = _integer(job["target"], f"jobs[{index}].target", minimum=1)
+        output = _integer(job["output"], f"jobs[{index}].output")
+        if output > target:
+            raise TrialValidationError(f"jobs[{index}].output exceeds target.")
+        job_ids.append(job_id)
+        job_by_id[job_id] = job
+    _unique(job_ids, "Production job ID")
+
+    issue_ids: list[str] = []
+    issue_by_id: dict[str, dict[str, Any]] = {}
+    for index, candidate in enumerate(issues):
+        issue = _object(candidate, f"issues[{index}]")
+        _exact_fields(
+            issue,
+            f"issues[{index}]",
+            required=_ISSUE_FIELDS - {"resolution"},
+            optional=frozenset({"resolution"}),
+        )
+        issue_id = _text(issue["id"], f"issues[{index}].id", maximum=160)
+        _timestamp(issue["createdAt"], f"issues[{index}].createdAt")
+        _text(issue["area"], f"issues[{index}].area", maximum=160)
+        _text(issue["summary"], f"issues[{index}].summary")
+        if issue["kind"] not in _ISSUE_KINDS:
+            raise TrialValidationError(f"issues[{index}].kind is invalid.")
+        if issue["status"] not in {"open", "resolved"}:
+            raise TrialValidationError(f"issues[{index}].status is invalid.")
+        if issue["status"] == "open" and "resolution" in issue:
+            raise TrialValidationError(f"issues[{index}] is open but has resolution evidence.")
+        if issue["status"] == "resolved" and "resolution" not in issue:
+            raise TrialValidationError(f"issues[{index}] is resolved without evidence.")
+        if "resolution" in issue:
+            resolution = _object(issue["resolution"], f"issues[{index}].resolution")
+            _exact_fields(resolution, f"issues[{index}].resolution", required=_RESOLUTION_FIELDS)
+            _text(resolution["actionId"], f"issues[{index}].resolution.actionId", maximum=160)
+            _timestamp(resolution["resolvedAt"], f"issues[{index}].resolution.resolvedAt")
+            _text(resolution["resolvedBy"], f"issues[{index}].resolution.resolvedBy")
+            _text(resolution["reason"], f"issues[{index}].resolution.reason")
+            _text(resolution["evidenceReference"], f"issues[{index}].resolution.evidenceReference")
+        issue_ids.append(issue_id)
+        issue_by_id[issue_id] = issue
+    _unique(issue_ids, "Production issue ID")
+
+    machine_ids: list[str] = []
+    machine_by_id: dict[str, dict[str, Any]] = {}
+    for index, candidate in enumerate(machines):
+        machine = _object(candidate, f"machines[{index}]")
+        _exact_fields(machine, f"machines[{index}]", required=_MACHINE_FIELDS)
+        machine_id = _text(machine["id"], f"machines[{index}].id", maximum=160)
+        _text(machine["name"], f"machines[{index}].name", maximum=180)
+        if machine["state"] not in _MACHINE_STATES:
+            raise TrialValidationError(f"machines[{index}].state is invalid.")
+        machine_ids.append(machine_id)
+        machine_by_id[machine_id] = machine
+    _unique(machine_ids, "Production machine ID")
+
+    event_ids: list[str] = []
+    action_ids: list[str] = []
+    for index, candidate in enumerate(events):
+        event = _object(candidate, f"events[{index}]")
+        _exact_fields(
+            event,
+            f"events[{index}]",
+            required=_EVENT_REQUIRED_FIELDS,
+            optional=_EVENT_OPTIONAL_FIELDS,
+        )
+        event_id = _text(event["id"], f"events[{index}].id", maximum=180)
+        action_id = _text(event["actionId"], f"events[{index}].actionId", maximum=160)
+        if event_id != f"EVT-{action_id}":
+            raise TrialValidationError(f"events[{index}].id does not match its action.")
+        _timestamp(event["createdAt"], f"events[{index}].createdAt")
+        for field in ("actor", "reason", "evidenceReference", "subjectId", "summary"):
+            _text(event[field], f"events[{index}].{field}")
+        kind = event["kind"]
+        if kind not in _EVENT_KINDS:
+            raise TrialValidationError(f"events[{index}].kind is invalid.")
+        if kind == "output_recorded":
+            if event["subjectId"] not in job_by_id:
+                raise TrialValidationError(f"events[{index}] references an unknown job.")
+            _integer(event.get("quantity"), f"events[{index}].quantity", minimum=1)
+            if "fromState" in event or "toState" in event:
+                raise TrialValidationError(f"events[{index}] output event has machine state fields.")
+        elif kind == "machine_state_changed":
+            if event["subjectId"] not in machine_by_id:
+                raise TrialValidationError(f"events[{index}] references an unknown machine.")
+            if event.get("fromState") not in _MACHINE_STATES or event.get("toState") not in _MACHINE_STATES:
+                raise TrialValidationError(f"events[{index}] has invalid machine states.")
+            if _MACHINE_TRANSITIONS[event["fromState"]] != event["toState"]:
+                raise TrialValidationError(f"events[{index}] has an invalid machine transition.")
+            if "quantity" in event:
+                raise TrialValidationError(f"events[{index}] machine event has a quantity.")
+        else:
+            if event["subjectId"] not in issue_by_id:
+                raise TrialValidationError(f"events[{index}] references an unknown issue.")
+            if any(field in event for field in ("quantity", "fromState", "toState")):
+                raise TrialValidationError(f"events[{index}] issue event has unrelated fields.")
+        event_ids.append(event_id)
+        action_ids.append(action_id)
+    _unique(event_ids, "Production event ID")
+    _unique(action_ids, "Production action ID")
+    if revision != len(events):
+        raise TrialValidationError("Production revision must equal the append-only event count.")
+
+    for issue_id, issue in issue_by_id.items():
+        if issue["status"] != "resolved":
+            continue
+        resolution = issue["resolution"]
+        matching = [
+            event
+            for event in events
+            if event["kind"] == "issue_resolved"
+            and event["subjectId"] == issue_id
+            and event["actionId"] == resolution["actionId"]
+        ]
+        if len(matching) != 1:
+            raise TrialValidationError(f"{issue_id} resolution is not backed by exactly one event.")
+    for event in events:
+        if event["kind"] != "issue_resolved":
+            continue
+        issue = issue_by_id[event["subjectId"]]
+        if issue["status"] != "resolved" or issue["resolution"]["actionId"] != event["actionId"]:
+            raise TrialValidationError(f"{event['id']} is not backed by matching issue resolution evidence.")
+    for job_id, job in job_by_id.items():
+        recorded = sum(
+            event["quantity"]
+            for event in events
+            if event["kind"] == "output_recorded" and event["subjectId"] == job_id
+        )
+        if recorded > job["output"]:
+            raise TrialValidationError(f"Output events exceed the stored output for {job_id}.")
+    for machine_id, machine in machine_by_id.items():
+        latest = next(
+            (event for event in events if event["kind"] == "machine_state_changed" and event["subjectId"] == machine_id),
+            None,
+        )
+        if latest and latest["toState"] != machine["state"]:
+            raise TrialValidationError(f"Latest machine event does not match {machine_id}.")
+    return deepcopy(state)
+
+
+def _payload(payload: Mapping[str, Any]) -> tuple[dict[str, Any], dict[str, str]]:
+    if set(payload) != {"state", "evidence"}:
+        raise TrialValidationError("Production payload must contain exactly state and evidence objects.")
+    evidence = _object(payload.get("evidence"), "evidence")
+    _exact_fields(evidence, "evidence", required=_EVIDENCE_FIELDS)
+    validated_evidence = {
+        "actionId": _text(evidence["actionId"], "evidence.actionId", maximum=160),
+        "capturedAt": _timestamp(evidence["capturedAt"], "evidence.capturedAt"),
+        "actor": _text(evidence["actor"], "evidence.actor"),
+        "reason": _text(evidence["reason"], "evidence.reason"),
+        "evidenceReference": _text(evidence["evidenceReference"], "evidence.evidenceReference"),
+    }
+    return validate_production_state(payload.get("state")), validated_evidence
+
+
+def _one_changed(current: list[Any], next_values: list[Any], field: str) -> tuple[dict[str, Any], dict[str, Any]]:
+    if len(current) != len(next_values):
+        raise TrialValidationError(f"{field} must preserve its record count for this event.")
+    changes = [index for index, pair in enumerate(zip(current, next_values, strict=True)) if pair[0] != pair[1]]
+    if len(changes) != 1:
+        raise TrialValidationError(f"{field} must change exactly one existing record.")
+    index = changes[0]
+    before = _object(current[index], f"current {field}[{index}]")
+    after = _object(next_values[index], f"next {field}[{index}]")
+    if before.get("id") != after.get("id"):
+        raise TrialValidationError(f"{field} record identity cannot change.")
+    return before, after
+
+
+def _without(value: Mapping[str, Any], fields: frozenset[str]) -> dict[str, Any]:
+    return {key: nested for key, nested in value.items() if key not in fields}
+
+
+def _require_unchanged(current: Mapping[str, Any], next_state: Mapping[str, Any], *fields: str) -> None:
+    changed = [field for field in fields if current[field] != next_state[field]]
+    if changed:
+        raise TrialValidationError(f"event cannot change: {', '.join(changed)}.")
+
+
+def _new_event(
+    current: Mapping[str, Any],
+    next_state: Mapping[str, Any],
+    evidence: Mapping[str, str],
+    kind: str,
+) -> dict[str, Any]:
+    if next_state["revision"] != current["revision"] + 1:
+        raise TrialValidationError("Production revision must increase exactly once per event.")
+    if len(next_state["events"]) != len(current["events"]) + 1 or next_state["events"][1:] != current["events"]:
+        raise TrialValidationError("Production commands must prepend exactly one immutable event.")
+    event = next_state["events"][0]
+    if event["kind"] != kind or event["id"] != f"EVT-{event['actionId']}":
+        raise TrialValidationError(f"Production command requires one {kind} event.")
+    if any(
+        event[event_field] != evidence[evidence_field]
+        for event_field, evidence_field in (
+            ("actionId", "actionId"),
+            ("createdAt", "capturedAt"),
+            ("actor", "actor"),
+            ("reason", "reason"),
+            ("evidenceReference", "evidenceReference"),
+        )
+    ):
+        raise TrialValidationError("command evidence must match the appended Production event.")
+    return event
+
+
+def _validate_output(current: Mapping[str, Any], next_state: Mapping[str, Any], evidence: Mapping[str, str]) -> None:
+    event = _new_event(current, next_state, evidence, "output_recorded")
+    _require_unchanged(current, next_state, "issues", "machines")
+    before, after = _one_changed(current["jobs"], next_state["jobs"], "jobs")
+    if _without(before, frozenset({"output"})) != _without(after, frozenset({"output"})):
+        raise TrialValidationError("output recording may change only job output.")
+    quantity = after["output"] - before["output"]
+    if quantity < 1 or after["output"] > before["target"]:
+        raise TrialValidationError("output must increase by a positive quantity within the job target.")
+    if event.get("subjectId") != before["id"] or event.get("quantity") != quantity or event.get("summary") != f"Recorded {quantity} good units":
+        raise TrialValidationError("output event must match the changed job and exact quantity.")
+
+
+def _validate_issue_opened(current: Mapping[str, Any], next_state: Mapping[str, Any], evidence: Mapping[str, str]) -> None:
+    event = _new_event(current, next_state, evidence, "issue_opened")
+    _require_unchanged(current, next_state, "jobs", "machines")
+    if len(next_state["issues"]) != len(current["issues"]) + 1 or next_state["issues"][1:] != current["issues"]:
+        raise TrialValidationError("production.issue.opened must prepend exactly one issue.")
+    issue = next_state["issues"][0]
+    if issue["status"] != "open" or "resolution" in issue:
+        raise TrialValidationError("a new Production issue must start open without resolution evidence.")
+    if event["subjectId"] != issue["id"] or event["summary"] != f"Opened {issue['kind']} issue for {issue['area']}":
+        raise TrialValidationError("issue-opened event must match the new issue.")
+
+
+def _validate_issue_resolved(current: Mapping[str, Any], next_state: Mapping[str, Any], evidence: Mapping[str, str]) -> None:
+    event = _new_event(current, next_state, evidence, "issue_resolved")
+    _require_unchanged(current, next_state, "jobs", "machines")
+    before, after = _one_changed(current["issues"], next_state["issues"], "issues")
+    if before["status"] != "open" or "resolution" in before:
+        raise TrialValidationError("only an open issue can be resolved.")
+    expected_resolution = {
+        "actionId": evidence["actionId"],
+        "resolvedAt": evidence["capturedAt"],
+        "resolvedBy": evidence["actor"],
+        "reason": evidence["reason"],
+        "evidenceReference": evidence["evidenceReference"],
+    }
+    if after != {**before, "status": "resolved", "resolution": expected_resolution}:
+        raise TrialValidationError("issue resolution may add only the attributed terminal evidence.")
+    if event["subjectId"] != before["id"] or event["summary"] != f"Resolved {before['kind']} issue for {before['area']}":
+        raise TrialValidationError("issue-resolved event must match the resolved issue.")
+
+
+def _validate_machine(current: Mapping[str, Any], next_state: Mapping[str, Any], evidence: Mapping[str, str]) -> None:
+    event = _new_event(current, next_state, evidence, "machine_state_changed")
+    _require_unchanged(current, next_state, "jobs", "issues")
+    before, after = _one_changed(current["machines"], next_state["machines"], "machines")
+    if _without(before, frozenset({"state"})) != _without(after, frozenset({"state"})):
+        raise TrialValidationError("machine transition may change only recorded state.")
+    if _MACHINE_TRANSITIONS[before["state"]] != after["state"]:
+        raise TrialValidationError("machine state must advance exactly one recorded lifecycle step.")
+    if (
+        event["subjectId"] != before["id"]
+        or event.get("fromState") != before["state"]
+        or event.get("toState") != after["state"]
+        or event["summary"] != f"{before['name']}: {before['state']} to {after['state']}"
+    ):
+        raise TrialValidationError("machine event must match the exact recorded state change.")
+
+
+_TRANSITION_VALIDATORS = {
+    "production.output.recorded": _validate_output,
+    "production.issue.opened": _validate_issue_opened,
+    "production.issue.resolved": _validate_issue_resolved,
+    "production.machine.state_changed": _validate_machine,
+}
+
+
+def reduce_production_state(
+    event_type: str,
+    current: Mapping[str, Any],
+    payload: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Accept only one declared Production lifecycle transition per command."""
+
+    if event_type not in PRODUCTION_EVENTS:
+        raise TrialValidationError("event_type must be a supported Production lifecycle event.")
+    next_state, evidence = _payload(payload)
+    if event_type == "production.workspace.initialized":
+        if dict(current):
+            raise TrialValidationError("managed Production is already initialized.")
+        if (
+            next_state["revision"] != 0
+            or not next_state["jobs"]
+            or not next_state["machines"]
+            or next_state["issues"]
+            or next_state["events"]
+            or any(job["output"] != 0 for job in next_state["jobs"])
+        ):
+            raise TrialValidationError("Production initialization requires jobs and machines with no output or operating history.")
+        return next_state
+
+    current_state = validate_production_state(current)
+    _TRANSITION_VALIDATORS[event_type](current_state, next_state, evidence)
+    return next_state
+
+
+__all__ = ["PRODUCTION_EVENTS", "PRODUCTION_SCHEMA", "reduce_production_state", "validate_production_state"]

--- a/supermega_runtime/runtime.py
+++ b/supermega_runtime/runtime.py
@@ -21,6 +21,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from supermega_runtime.cloud_runtime import router as cloud_runtime_router
 from supermega_runtime.commerce_runtime import reduce_commerce_state
+from supermega_runtime.production_runtime import reduce_production_state
 from supermega_runtime.supabase_auth import SupabaseAuthConfig, verify_supabase_user_token
 from supermega_runtime.trial_runtime import create_trial_router
 from supermega_runtime.trial_store import (
@@ -34,7 +35,6 @@ SERVICE_NAME = "supermega-service"
 SERVICE_VERSION = "1.1.0"
 TRIAL_EVENT_BY_SURFACE = {
     "company": "company.snapshot.saved",
-    "production": "production.snapshot.saved",
     "setup": "setup.snapshot.saved",
 }
 _IDENTIFIER = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
@@ -106,10 +106,12 @@ def reduce_trial_state(
     current: Mapping[str, Any],
     payload: Mapping[str, Any],
 ) -> Mapping[str, Any]:
-    """Reduce one bounded command, with explicit lifecycle rules for Commerce."""
+    """Reduce one bounded command, with explicit lifecycle rules for Commerce and Production."""
 
     if surface == "commerce":
         state = reduce_commerce_state(event_type, current, payload)
+    elif surface == "production":
+        state = reduce_production_state(event_type, current, payload)
     else:
         expected_event = TRIAL_EVENT_BY_SURFACE.get(surface)
         if event_type != expected_event:

--- a/tests/test_production_runtime.py
+++ b/tests/test_production_runtime.py
@@ -1,0 +1,225 @@
+from __future__ import annotations
+
+from copy import deepcopy
+import unittest
+from uuid import uuid4
+
+from supermega_runtime.runtime import reduce_trial_state
+from supermega_runtime.trial_store import InMemoryTrialStore, TrialPrincipal, TrialValidationError
+
+
+NOW = "2026-07-23T10:00:00.000Z"
+
+
+def production_state() -> dict[str, object]:
+    return {
+        "schema": "supermega.production.workspace.v2",
+        "revision": 0,
+        "jobs": [{"id": "JOB-1", "line": "Line 01", "product": "Product A", "target": 100, "output": 0}],
+        "issues": [],
+        "machines": [{"id": "MC-1", "name": "Machine 01", "state": "stopped"}],
+        "events": [],
+    }
+
+
+def evidence(action_id: str) -> dict[str, str]:
+    return {
+        "actionId": action_id,
+        "capturedAt": NOW,
+        "actor": "Accountable operator",
+        "reason": "Verified against the shift record.",
+        "evidenceReference": f"EV-{action_id}",
+    }
+
+
+def production_event(action_id: str, kind: str, subject_id: str, summary: str, **details: object) -> dict[str, object]:
+    proof = evidence(action_id)
+    return {
+        "id": f"EVT-{action_id}",
+        "actionId": action_id,
+        "createdAt": proof["capturedAt"],
+        "actor": proof["actor"],
+        "reason": proof["reason"],
+        "evidenceReference": proof["evidenceReference"],
+        "kind": kind,
+        "subjectId": subject_id,
+        "summary": summary,
+        **details,
+    }
+
+
+def apply_event(
+    current: dict[str, object],
+    event_type: str,
+    next_state: dict[str, object],
+    action_id: str,
+) -> dict[str, object]:
+    return dict(
+        reduce_trial_state(
+            "production",
+            event_type,
+            current,
+            {"state": next_state, "evidence": evidence(action_id)},
+        )
+    )
+
+
+def output_state(current: dict[str, object], action_id: str = "ACT-OUTPUT", quantity: int = 10) -> dict[str, object]:
+    state = deepcopy(current)
+    state["revision"] = int(current["revision"]) + 1
+    state["jobs"][0]["output"] += quantity  # type: ignore[index,operator]
+    state["events"] = [
+        production_event(action_id, "output_recorded", "JOB-1", f"Recorded {quantity} good units", quantity=quantity),
+        *current["events"],  # type: ignore[misc]
+    ]
+    return state
+
+
+class ProductionRuntimeTests(unittest.TestCase):
+    def test_initialization_requires_real_jobs_and_machines_without_history(self) -> None:
+        initialized = apply_event({}, "production.workspace.initialized", production_state(), "ACT-INITIALIZE")
+        self.assertEqual(initialized, production_state())
+
+        missing_machine = production_state()
+        missing_machine["machines"] = []
+        with self.assertRaises(TrialValidationError):
+            apply_event({}, "production.workspace.initialized", missing_machine, "ACT-INITIALIZE")
+        invented_output = production_state()
+        invented_output["jobs"][0]["output"] = 1  # type: ignore[index]
+        with self.assertRaises(TrialValidationError):
+            apply_event({}, "production.workspace.initialized", invented_output, "ACT-INITIALIZE")
+
+    def test_output_changes_one_job_with_one_matching_event(self) -> None:
+        current = production_state()
+        accepted = apply_event(current, "production.output.recorded", output_state(current), "ACT-OUTPUT")
+        self.assertEqual(accepted["jobs"][0]["output"], 10)  # type: ignore[index]
+
+        over_target = output_state(current, quantity=101)
+        with self.assertRaises(TrialValidationError):
+            apply_event(current, "production.output.recorded", over_target, "ACT-OUTPUT")
+        with self.assertRaises(TrialValidationError):
+            apply_event(current, "production.output.recorded", output_state(current), "ACT-WRONG")
+
+    def test_issue_open_and_resolution_preserve_attributed_terminal_evidence(self) -> None:
+        current = output_state(production_state())
+        issue = {
+            "id": "ISS-1",
+            "createdAt": NOW,
+            "area": "Line 01",
+            "kind": "quality",
+            "summary": "Measured defect requires review",
+            "status": "open",
+        }
+        opened = deepcopy(current)
+        opened["revision"] = int(current["revision"]) + 1
+        opened["issues"] = [issue]
+        opened["events"] = [
+            production_event("ACT-OPEN", "issue_opened", "ISS-1", "Opened quality issue for Line 01"),
+            *current["events"],  # type: ignore[misc]
+        ]
+        current = apply_event(current, "production.issue.opened", opened, "ACT-OPEN")
+
+        resolved = deepcopy(current)
+        resolved["revision"] = int(current["revision"]) + 1
+        resolved["issues"][0].update(  # type: ignore[index]
+            {
+                "status": "resolved",
+                "resolution": {
+                    "actionId": "ACT-RESOLVE",
+                    "resolvedAt": NOW,
+                    "resolvedBy": "Accountable operator",
+                    "reason": "Verified against the shift record.",
+                    "evidenceReference": "EV-ACT-RESOLVE",
+                },
+            }
+        )
+        resolved["events"] = [
+            production_event("ACT-RESOLVE", "issue_resolved", "ISS-1", "Resolved quality issue for Line 01"),
+            *current["events"],  # type: ignore[misc]
+        ]
+        accepted = apply_event(current, "production.issue.resolved", resolved, "ACT-RESOLVE")
+        self.assertEqual(accepted["issues"][0]["status"], "resolved")  # type: ignore[index]
+
+        changed_summary = deepcopy(resolved)
+        changed_summary["issues"][0]["summary"] = "Rewritten history"  # type: ignore[index]
+        with self.assertRaises(TrialValidationError):
+            apply_event(current, "production.issue.resolved", changed_summary, "ACT-RESOLVE")
+
+    def test_machine_state_records_but_does_not_skip_lifecycle_steps(self) -> None:
+        current = production_state()
+        running = deepcopy(current)
+        running["revision"] = 1
+        running["machines"][0]["state"] = "running"  # type: ignore[index]
+        running["events"] = [
+            production_event(
+                "ACT-MACHINE",
+                "machine_state_changed",
+                "MC-1",
+                "Machine 01: stopped to running",
+                fromState="stopped",
+                toState="running",
+            )
+        ]
+        accepted = apply_event(current, "production.machine.state_changed", running, "ACT-MACHINE")
+        self.assertEqual(accepted["machines"][0]["state"], "running")  # type: ignore[index]
+
+        skipped = deepcopy(running)
+        skipped["machines"][0]["state"] = "attention"  # type: ignore[index]
+        skipped["events"][0]["toState"] = "attention"  # type: ignore[index]
+        skipped["events"][0]["summary"] = "Machine 01: stopped to attention"  # type: ignore[index]
+        with self.assertRaises(TrialValidationError):
+            apply_event(current, "production.machine.state_changed", skipped, "ACT-MACHINE")
+
+    def test_store_preserves_versions_replay_and_authenticated_actor(self) -> None:
+        store = InMemoryTrialStore(reducer=reduce_trial_state)
+        principal = TrialPrincipal("workspace-a", "user-a", "human")
+        store.provision_membership(
+            workspace_id=principal.workspace_id,
+            actor_id=principal.actor_id,
+            actor_kind=principal.actor_kind,
+            capabilities=("production.write",),
+        )
+        initialize_id = str(uuid4())
+        initialized = store.apply_command(
+            principal,
+            command_id=initialize_id,
+            surface="production",
+            event_type="production.workspace.initialized",
+            expected_version=0,
+            payload={"state": production_state(), "evidence": evidence("ACT-INITIALIZE")},
+        )
+        replay = store.apply_command(
+            principal,
+            command_id=initialize_id,
+            surface="production",
+            event_type="production.workspace.initialized",
+            expected_version=0,
+            payload={"state": production_state(), "evidence": evidence("ACT-INITIALIZE")},
+        )
+        recorded_state = output_state(production_state())
+        recorded = store.apply_command(
+            principal,
+            command_id=str(uuid4()),
+            surface="production",
+            event_type="production.output.recorded",
+            expected_version=initialized.version,
+            payload={"state": recorded_state, "evidence": evidence("ACT-OUTPUT")},
+        )
+        self.assertEqual(initialized.version, 1)
+        self.assertTrue(replay.idempotent_replay)
+        self.assertEqual(recorded.version, 2)
+        stored = store.get_state(principal, "production")
+        self.assertEqual(stored.updated_by, principal.actor_id)
+        self.assertEqual(stored.state, recorded_state)
+
+    def test_legacy_snapshot_and_unknown_fields_fail_closed(self) -> None:
+        invalid = production_state()
+        invalid["telemetry_controlled"] = True
+        with self.assertRaises(TrialValidationError):
+            apply_event({}, "production.workspace.initialized", invalid, "ACT-INITIALIZE")
+        with self.assertRaises(TrialValidationError):
+            apply_event({}, "production.snapshot.saved", production_state(), "ACT-INITIALIZE")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/verify_app_build.mjs
+++ b/tools/verify_app_build.mjs
@@ -9,7 +9,7 @@ let orderCompletionRuntimeChecks = 0
 let commerceRuntimeChecks = 0
 let productionRuntimeChecks = 0
 const fail = (reason) => failures.push(reason)
-const [manifestText, appPackageText, appSource, coreSource, commerceSource, managedTrialSource, managedCommerceRuntime, productionSource, teamSource, agentTeamsSource, teamModel, websiteSource, publishSource, commerceIntakeSource, handoffSource] = await Promise.all([
+const [manifestText, appPackageText, appSource, coreSource, commerceSource, managedTrialSource, managedCommerceRuntime, managedProductionRuntime, productionSource, teamSource, agentTeamsSource, teamModel, websiteSource, publishSource, commerceIntakeSource, handoffSource] = await Promise.all([
   readFile(resolve(root, 'site-manifest.json'), 'utf8'),
   readFile(resolve(root, 'showroom', 'package.json'), 'utf8'),
   readFile(resolve(root, 'showroom', 'src', 'App.tsx'), 'utf8'),
@@ -17,6 +17,7 @@ const [manifestText, appPackageText, appSource, coreSource, commerceSource, mana
   readFile(resolve(root, 'showroom', 'src', 'core', 'commerce-workspace.ts'), 'utf8'),
   readFile(resolve(root, 'showroom', 'src', 'core', 'managed-trial.ts'), 'utf8'),
   readFile(resolve(root, 'supermega_runtime', 'commerce_runtime.py'), 'utf8'),
+  readFile(resolve(root, 'supermega_runtime', 'production_runtime.py'), 'utf8'),
   readFile(resolve(root, 'showroom', 'src', 'core', 'production-workspace.ts'), 'utf8'),
   readFile(resolve(root, 'showroom', 'src', 'core', 'TeamWorkspace.tsx'), 'utf8'),
   readFile(resolve(root, 'showroom', 'src', 'core', 'AgentTeamsPanel.tsx'), 'utf8'),
@@ -119,6 +120,12 @@ if (!coreSource.includes("const commerceTabs") || !coreSource.includes("{ id: 't
 if (!productionSource.includes("supermega.production.workspace.v2") || !productionSource.includes('mutateProductionWorkspace') || !productionSource.includes('lockManager.request') || !productionSource.includes('next.revision !== current.revision + 1')) fail('production_v2_locked_store_missing')
 if (!productionSource.includes("'output_recorded' | 'issue_opened' | 'issue_resolved' | 'machine_state_changed'") || !productionSource.includes('events: [event, ...state.events]') || !productionSource.includes('Production revision must equal the append-only event count.')) fail('production_append_only_record_missing')
 if (!productionSource.includes('currentRaw !== null') || !productionSource.includes('Migration failed closed') || !productionSource.includes('events: []')) fail('production_migration_fail_closed_contract_missing')
+if (!managedTrialSource.includes('saveManagedProductionCommand') || !managedTrialSource.includes("surface: 'production'") || !managedTrialSource.includes("'production.workspace.initialized'") || !managedTrialSource.includes('ManagedProductionEvent')) fail('managed_production_command_client_missing')
+for (const eventType of ['production.workspace.initialized', 'production.output.recorded', 'production.issue.opened', 'production.issue.resolved', 'production.machine.state_changed']) {
+  if (!coreSource.includes(eventType) || !managedProductionRuntime.includes(eventType)) fail(`managed_production_event_missing:${eventType}`)
+}
+if (!coreSource.includes('Create managed Production') || !coreSource.includes('No browser demo output, issues, or machine history is copied') || !coreSource.includes('This records state; it does not control equipment.') || !coreSource.includes("error.code === 'trial_version_conflict'") || !coreSource.includes("result.surface !== 'production'")) fail('managed_production_ui_not_fail_closed')
+if (managedProductionRuntime.includes('production.snapshot.saved') || !managedProductionRuntime.includes('_new_event') || !managedProductionRuntime.includes('command evidence must match the appended Production event.') || !managedProductionRuntime.includes('Production initialization requires jobs and machines with no output or operating history.')) fail('managed_production_server_transition_contract_missing')
 const productionTabsContract = coreSource.slice(coreSource.indexOf('const productionTabs'), coreSource.indexOf('function uid'))
 if (!productionTabsContract.includes("{ id: 'today', label: 'Today' }") || !productionTabsContract.includes("{ id: 'production', label: 'Production' }") || !productionTabsContract.includes("{ id: 'control', label: 'Issues & equipment' }") || (productionTabsContract.match(/^\s*\{ id:/gm) || []).length !== 3) fail('production_three_tab_contract_changed')
 const productionPageContract = coreSource.slice(coreSource.indexOf('function ProductionPage'), coreSource.indexOf('function JobList'))


### PR DESCRIPTION
## Summary

- connect Production to authenticated, workspace-scoped managed state instead of browser storage
- enforce exact server-side lifecycle transitions for initialization, output, issues, resolution, and recorded machine state
- add first-real-plan onboarding with one job and one equipment record; no demo history is copied
- preserve the browser demo as a clearly labeled, device-local mode with no cross-workspace fallback

## Stack

This draft is intentionally based on the managed Commerce branch from #243. Review and land #243 first.

## Verification

- `64` Python backend/security tests pass
- `npm.cmd run lint` passes
- `npm.cmd run build` passes
- `node tools\\verify_app_build.mjs` passes with `51` Production runtime checks
- local `/operations/production/?tab=control` route returns HTTP `200`
- responsive CSS audit confirms single-column forms at `560px`, auto-height workspaces below `840px`, and `44px` mobile controls

## Boundaries

- no merge, deployment, domain, Vercel, Supabase, or production environment changes
- no telemetry or equipment control; machine changes are attributed operating records only
- managed onboarding was not browser-rendered because no provisioned tenant credentials were introduced or fabricated
