### PR TITLE
Add Production job and equipment planning

### DIFF
--- a/showroom/src/core/CoreApp.tsx
+++ b/showroom/src/core/CoreApp.tsx
@@ -48,17 +48,20 @@ import {
   PRODUCTION_KEY,
   advanceProductionMachineState,
   createEmptyProduction,
+  createProductionJob,
   loadProductionWorkspace,
   mutateProductionWorkspace,
   openProductionIssue,
   productionMachineTransitions,
   recordProductionOutput,
+  registerProductionMachine,
   resolveProductionIssue,
   validateProductionState,
   type ProductionActionProof,
   type ProductionEvent,
   type ProductionIssue,
   type ProductionJob,
+  type ProductionMachine,
   type ProductionMachineState,
   type ProductionState,
 } from './production-workspace'
@@ -135,9 +138,11 @@ type ActionKind =
   | 'payment_reconcile'
   | 'inventory_receipt'
   | 'daily_close'
+  | 'job_create'
   | 'production_output'
   | 'issue_create'
   | 'issue_resolution'
+  | 'machine_register'
   | 'machine_state'
 
 type AccountableAction = {
@@ -1632,9 +1637,11 @@ function StockMovementHistory({ movements }: { movements: CommerceStockMovement[
 }
 
 const productionEventLabels: Record<ProductionEvent['kind'], string> = {
+  job_created: 'Job created',
   output_recorded: 'Output recorded',
   issue_opened: 'Issue opened',
   issue_resolved: 'Issue resolved',
+  machine_registered: 'Equipment registered',
   machine_state_changed: 'Machine state changed',
 }
 
@@ -1665,6 +1672,8 @@ function ProductionPage({ managedIdentity, tab }: { managedIdentity: ManagedIden
   const [summary, setSummary] = useState('')
   const [notice, setNotice] = useState('')
   const [setupDraft, setSetupDraft] = useState({ jobId: '', line: '', product: '', target: '', machineId: '', machineName: '', machineState: 'stopped' as ProductionMachineState, reason: '', evidenceReference: '' })
+  const [jobDraft, setJobDraft] = useState({ id: '', line: '', product: '', target: '' })
+  const [machineDraft, setMachineDraft] = useState({ id: '', name: '', state: 'stopped' as ProductionMachineState })
   const [setupBusy, setSetupBusy] = useState(false)
   const [setupError, setSetupError] = useState('')
   const output = production.jobs.reduce((total, job) => total + job.output, 0)
@@ -1746,6 +1755,63 @@ function ProductionPage({ managedIdentity, tab }: { managedIdentity: ManagedIden
     }
     setPendingAction({ ...action, id: uid('ACT'), commandId: commandUuid(), domain: 'production' })
     setNotice('Review the change, accountable operator, and evidence before it is applied.')
+  }
+
+  function queueNewJob(event: FormEvent) {
+    event.preventDefault()
+    const id = jobDraft.id.trim().toUpperCase()
+    const line = jobDraft.line.trim()
+    const product = jobDraft.product.trim()
+    const jobTarget = Number(jobDraft.target)
+    if (!id || !line || !product || !Number.isSafeInteger(jobTarget) || jobTarget < 1) {
+      setNotice('Enter a job ID, line, product or batch, and a whole-unit target of at least 1.')
+      return
+    }
+    if (production.jobs.some((job) => job.id === id)) {
+      setNotice(`${id} already exists. No job was queued.`)
+      return
+    }
+    const job: ProductionJob = { id, line, product, target: jobTarget, output: 0 }
+    queueAction({
+      kind: 'job_create',
+      subjectId: job.id,
+      summary: `Create ${job.id} for ${job.line}`,
+      before: 'No job record',
+      after: `${job.product} · ${job.target.toLocaleString()} target units`,
+      apply: async (record) => {
+        const proof = productionActionProof(record)
+        await mutateProduction('production.job.created', record.commandId, proof, (current) => createProductionJob(current, job, proof))
+        setJobDraft({ id: '', line: '', product: '', target: '' })
+        setJobId(job.id)
+      },
+    })
+  }
+
+  function queueNewMachine(event: FormEvent) {
+    event.preventDefault()
+    const id = machineDraft.id.trim().toUpperCase()
+    const name = machineDraft.name.trim()
+    if (!id || !name) {
+      setNotice('Enter an equipment ID and name.')
+      return
+    }
+    if (production.machines.some((machine) => machine.id === id)) {
+      setNotice(`${id} already exists. No equipment record was queued.`)
+      return
+    }
+    const machine: ProductionMachine = { id, name, state: machineDraft.state }
+    queueAction({
+      kind: 'machine_register',
+      subjectId: machine.id,
+      summary: `Register ${machine.name}`,
+      before: 'No equipment record',
+      after: `${machine.id} · recorded as ${machine.state}`,
+      apply: async (record) => {
+        const proof = productionActionProof(record)
+        await mutateProduction('production.machine.registered', record.commandId, proof, (current) => registerProductionMachine(current, machine, proof))
+        setMachineDraft({ id: '', name: '', state: 'stopped' })
+      },
+    })
   }
 
   async function confirmAction(details: ActionDetails) {
@@ -1839,6 +1905,15 @@ function ProductionPage({ managedIdentity, tab }: { managedIdentity: ManagedIden
       <section className="core-panel job-panel">
         <div className="panel-head"><div><span className="core-eyebrow">Production plan</span><h2>Active jobs</h2></div><span className="panel-note">Target is a hard limit</span></div>
         <JobList jobs={production.jobs} />
+        <details className="compact-disclosure planning-disclosure">
+          <summary>Add a job</summary>
+          <form className="core-form compact-form planning-form" onSubmit={queueNewJob}>
+            <div className="form-row"><label>Job ID<input maxLength={80} onChange={(event) => setJobDraft((current) => ({ ...current, id: event.target.value }))} placeholder="JOB-002" required value={jobDraft.id} /></label><label>Line or area<input maxLength={160} onChange={(event) => setJobDraft((current) => ({ ...current, line: event.target.value }))} placeholder="Line 02" required value={jobDraft.line} /></label></div>
+            <div className="form-row"><label>Product or batch<input maxLength={180} onChange={(event) => setJobDraft((current) => ({ ...current, product: event.target.value }))} placeholder="Product name" required value={jobDraft.product} /></label><label>Target units<input min="1" onChange={(event) => setJobDraft((current) => ({ ...current, target: event.target.value }))} required step="1" type="number" value={jobDraft.target} /></label></div>
+            <div className="form-actions"><button className="core-button primary compact" disabled={Boolean(pendingAction)} type="submit">Review new job</button></div>
+            <p className="panel-copy">The job starts at zero output. A named operator, reason, and evidence are required before it is recorded.</p>
+          </form>
+        </details>
       </section>
       <section className="core-panel output-panel">
         <span className="core-eyebrow">Good output</span><h2>Confirm production</h2>
@@ -1857,10 +1932,19 @@ function ProductionPage({ managedIdentity, tab }: { managedIdentity: ManagedIden
     {sourceBanner}
     <div className="control-workspace">
       <div className="split-workspace">
-        <section className="core-panel">
+        <section className="core-panel equipment-panel">
           <div className="panel-head"><div><span className="core-eyebrow">Equipment</span><h2>Machine state</h2></div></div>
           <div className="machine-list">{production.machines.map((machine) => <button aria-label={`${productionMachineActionLabels[machine.state]} for ${machine.name}; current state ${machine.state}`} key={machine.id} type="button" onClick={() => cycleMachine(machine.id)}><span className={`machine-dot ${machine.state}`} /><span><strong>{machine.name}</strong><small>{machine.id} - Current: {machine.state}</small></span><b>{productionMachineActionLabels[machine.state]}</b></button>)}</div>
           <p className="panel-copy">{managedIdentity ? 'Managed operating record.' : 'Browser-local operating record.'} No telemetry or machine control is connected.</p>
+          <details className="compact-disclosure planning-disclosure">
+            <summary>Register equipment</summary>
+            <form className="core-form compact-form planning-form" onSubmit={queueNewMachine}>
+              <div className="form-row"><label>Equipment ID<input maxLength={80} onChange={(event) => setMachineDraft((current) => ({ ...current, id: event.target.value }))} placeholder="MC-02" required value={machineDraft.id} /></label><label>Equipment name<input maxLength={180} onChange={(event) => setMachineDraft((current) => ({ ...current, name: event.target.value }))} placeholder="Equipment name" required value={machineDraft.name} /></label></div>
+              <label>Current recorded state<select onChange={(event) => setMachineDraft((current) => ({ ...current, state: event.target.value as ProductionMachineState }))} value={machineDraft.state}><option value="stopped">Stopped</option><option value="running">Running</option><option value="attention">Needs attention</option></select></label>
+              <div className="form-actions"><button className="core-button primary compact" disabled={Boolean(pendingAction)} type="submit">Review equipment</button></div>
+              <p className="panel-copy">This adds an attributed operating record only. It does not connect to or control equipment.</p>
+            </form>
+          </details>
         </section>
         <section className="core-panel">
           <span className="core-eyebrow">Exception</span><h2>Open an issue</h2>

--- a/showroom/src/core/core-app.css
+++ b/showroom/src/core/core-app.css
@@ -389,6 +389,10 @@ textarea { min-height: 72px; resize: vertical; }
 .compact-disclosure { position: relative; }
 .compact-disclosure > summary { min-height: 34px; display: inline-flex; align-items: center; border: 1px solid var(--core-line-strong); border-radius: 5px; padding: 0 10px; color: var(--core-muted); font-size: 10px; font-weight: 760; cursor: pointer; list-style: none; }
 .compact-disclosure[open] > summary { border-color: var(--core-green); color: var(--core-ink); }
+.planning-disclosure { flex: 0 0 auto; margin-top: 10px; border-top: 1px solid var(--core-line); padding-top: 10px; }
+.planning-form { max-width: none; margin-top: 10px; }
+.planning-form .form-actions { justify-content: flex-start; }
+.equipment-panel { overflow: auto; }
 .agent-create-form { position: absolute; z-index: 8; top: 42px; right: 0; width: 300px; border: 1px solid var(--core-line-strong); border-radius: 12px; padding: 12px; background: #fff; box-shadow: 0 18px 50px rgba(25,54,42,.16); }
 .evidence-disclosure .compact-disclosure { margin-top: 2px; }
 .evidence-disclosure .inline-evidence { margin-bottom: 3px; }

--- a/showroom/src/core/managed-trial.ts
+++ b/showroom/src/core/managed-trial.ts
@@ -50,9 +50,11 @@ export type ManagedCommerceEvent =
 
 export type ManagedProductionEvent =
   | 'production.workspace.initialized'
+  | 'production.job.created'
   | 'production.output.recorded'
   | 'production.issue.opened'
   | 'production.issue.resolved'
+  | 'production.machine.registered'
   | 'production.machine.state_changed'
 
 type ManagedCommandResult<Surface extends 'commerce' | 'production', Event extends string> = {

--- a/showroom/src/core/production-workspace.ts
+++ b/showroom/src/core/production-workspace.ts
@@ -38,7 +38,7 @@ export type ProductionMachine = {
   state: ProductionMachineState
 }
 
-export type ProductionEventKind = 'output_recorded' | 'issue_opened' | 'issue_resolved' | 'machine_state_changed'
+export type ProductionEventKind = 'job_created' | 'output_recorded' | 'issue_opened' | 'issue_resolved' | 'machine_registered' | 'machine_state_changed'
 
 export type ProductionEvent = {
   id: string
@@ -93,7 +93,7 @@ export type ProductionMutationResult =
 
 const issueKinds: ProductionIssueKind[] = ['quality', 'maintenance', 'materials', 'operations']
 const machineStates: ProductionMachineState[] = ['running', 'attention', 'stopped']
-const eventKinds: ProductionEventKind[] = ['output_recorded', 'issue_opened', 'issue_resolved', 'machine_state_changed']
+const eventKinds: ProductionEventKind[] = ['job_created', 'output_recorded', 'issue_opened', 'issue_resolved', 'machine_registered', 'machine_state_changed']
 const deterministicSeedNow = Date.parse('2026-07-23T08:00:00.000Z')
 
 export const productionMachineTransitions: Record<ProductionMachineState, ProductionMachineState> = {
@@ -251,10 +251,16 @@ export function validateProductionState(value: unknown): ProductionState {
     if (!validTimestamp(candidate.createdAt)) throw new Error(`events[${index}].createdAt is invalid.`)
     for (const field of ['actor', 'reason', 'evidenceReference', 'subjectId', 'summary'] as const) requiredText(candidate[field], `events[${index}].${field}`)
     if (!eventKinds.includes(candidate.kind as ProductionEventKind)) throw new Error(`events[${index}].kind is invalid.`)
-    if (candidate.kind === 'output_recorded') {
+    if (candidate.kind === 'job_created') {
+      if (!jobIds.includes(candidate.subjectId as string)) throw new Error(`events[${index}] references an unknown job.`)
+      if (candidate.quantity !== undefined || candidate.fromState !== undefined || candidate.toState !== undefined) throw new Error(`events[${index}] job event has unrelated fields.`)
+    } else if (candidate.kind === 'output_recorded') {
       if (!jobIds.includes(candidate.subjectId as string)) throw new Error(`events[${index}] references an unknown job.`)
       assertSafeInteger(candidate.quantity, `events[${index}].quantity`, 1)
       if (candidate.fromState !== undefined || candidate.toState !== undefined) throw new Error(`events[${index}] output event has machine state fields.`)
+    } else if (candidate.kind === 'machine_registered') {
+      if (!machineIds.includes(candidate.subjectId as string)) throw new Error(`events[${index}] references an unknown machine.`)
+      if (candidate.quantity !== undefined || candidate.fromState !== undefined || candidate.toState !== undefined) throw new Error(`events[${index}] equipment event has unrelated fields.`)
     } else if (candidate.kind === 'machine_state_changed') {
       if (!machineIds.includes(candidate.subjectId as string)) throw new Error(`events[${index}] references an unknown machine.`)
       if (!machineStates.includes(candidate.fromState as ProductionMachineState) || !machineStates.includes(candidate.toState as ProductionMachineState)) throw new Error(`events[${index}] has invalid machine states.`)
@@ -427,6 +433,29 @@ function actionIdIsUsed(state: ProductionState, actionId: string) {
   return state.events.some((event) => event.actionId === actionId)
 }
 
+export function createProductionJob(state: ProductionState, job: ProductionJob, proof: ProductionActionProof) {
+  const jobId = optionalText(job.id)
+  const line = optionalText(job.line)
+  const product = optionalText(job.product)
+  if (!validProof(proof)
+    || !jobId || jobId !== job.id
+    || !line || line !== job.line
+    || !product || product !== job.product
+    || !Number.isSafeInteger(job.target) || job.target < 1
+    || job.output !== 0) return null
+  const existing = state.events.find((event) => event.actionId === proof.actionId)
+  if (existing) {
+    const storedJob = state.jobs.find((candidate) => candidate.id === job.id)
+    return existing.kind === 'job_created'
+      && existing.subjectId === job.id
+      && sameProof(existing, proof)
+      && JSON.stringify(storedJob) === JSON.stringify(job) ? state : null
+  }
+  if (actionIdIsUsed(state, proof.actionId) || state.jobs.some((candidate) => candidate.id === job.id) || state.revision >= Number.MAX_SAFE_INTEGER) return null
+  const event = eventFor(proof, { kind: 'job_created', subjectId: job.id, summary: `Created ${job.id} for ${job.line}` })
+  return validateProductionState({ ...state, revision: state.revision + 1, jobs: [job, ...state.jobs], events: [event, ...state.events] })
+}
+
 export function recordProductionOutput(state: ProductionState, jobId: string, quantity: number, proof: ProductionActionProof) {
   if (!validProof(proof) || !Number.isSafeInteger(quantity) || quantity < 1) return null
   const existing = state.events.find((event) => event.actionId === proof.actionId)
@@ -521,4 +550,24 @@ export function advanceProductionMachineState(
     machines: state.machines.map((candidate) => candidate.id === machineId ? { ...candidate, state: toState } : candidate),
     events: [event, ...state.events],
   })
+}
+
+export function registerProductionMachine(state: ProductionState, machine: ProductionMachine, proof: ProductionActionProof) {
+  const machineId = optionalText(machine.id)
+  const name = optionalText(machine.name)
+  if (!validProof(proof)
+    || !machineId || machineId !== machine.id
+    || !name || name !== machine.name
+    || !machineStates.includes(machine.state)) return null
+  const existing = state.events.find((event) => event.actionId === proof.actionId)
+  if (existing) {
+    const storedMachine = state.machines.find((candidate) => candidate.id === machine.id)
+    return existing.kind === 'machine_registered'
+      && existing.subjectId === machine.id
+      && sameProof(existing, proof)
+      && JSON.stringify(storedMachine) === JSON.stringify(machine) ? state : null
+  }
+  if (actionIdIsUsed(state, proof.actionId) || state.machines.some((candidate) => candidate.id === machine.id) || state.revision >= Number.MAX_SAFE_INTEGER) return null
+  const event = eventFor(proof, { kind: 'machine_registered', subjectId: machine.id, summary: `Registered ${machine.name} in ${machine.state} state` })
+  return validateProductionState({ ...state, revision: state.revision + 1, machines: [machine, ...state.machines], events: [event, ...state.events] })
 }

--- a/supermega_runtime/production_runtime.py
+++ b/supermega_runtime/production_runtime.py
@@ -14,16 +14,25 @@ PRODUCTION_SCHEMA = "supermega.production.workspace.v2"
 PRODUCTION_EVENTS = frozenset(
     {
         "production.workspace.initialized",
+        "production.job.created",
         "production.output.recorded",
         "production.issue.opened",
         "production.issue.resolved",
+        "production.machine.registered",
         "production.machine.state_changed",
     }
 )
 _ISSUE_KINDS = ("quality", "maintenance", "materials", "operations")
 _MACHINE_STATES = ("running", "attention", "stopped")
 _MACHINE_TRANSITIONS = {"running": "attention", "attention": "stopped", "stopped": "running"}
-_EVENT_KINDS = ("output_recorded", "issue_opened", "issue_resolved", "machine_state_changed")
+_EVENT_KINDS = (
+    "job_created",
+    "output_recorded",
+    "issue_opened",
+    "issue_resolved",
+    "machine_registered",
+    "machine_state_changed",
+)
 _MAX_SAFE_INTEGER = 9_007_199_254_740_991
 
 _STATE_FIELDS = frozenset({"schema", "revision", "jobs", "issues", "machines", "events"})
@@ -192,12 +201,22 @@ def validate_production_state(value: object) -> dict[str, Any]:
         kind = event["kind"]
         if kind not in _EVENT_KINDS:
             raise TrialValidationError(f"events[{index}].kind is invalid.")
-        if kind == "output_recorded":
+        if kind == "job_created":
+            if event["subjectId"] not in job_by_id:
+                raise TrialValidationError(f"events[{index}] references an unknown job.")
+            if any(field in event for field in ("quantity", "fromState", "toState")):
+                raise TrialValidationError(f"events[{index}] job event has unrelated fields.")
+        elif kind == "output_recorded":
             if event["subjectId"] not in job_by_id:
                 raise TrialValidationError(f"events[{index}] references an unknown job.")
             _integer(event.get("quantity"), f"events[{index}].quantity", minimum=1)
             if "fromState" in event or "toState" in event:
                 raise TrialValidationError(f"events[{index}] output event has machine state fields.")
+        elif kind == "machine_registered":
+            if event["subjectId"] not in machine_by_id:
+                raise TrialValidationError(f"events[{index}] references an unknown machine.")
+            if any(field in event for field in ("quantity", "fromState", "toState")):
+                raise TrialValidationError(f"events[{index}] equipment event has unrelated fields.")
         elif kind == "machine_state_changed":
             if event["subjectId"] not in machine_by_id:
                 raise TrialValidationError(f"events[{index}] references an unknown machine.")
@@ -322,6 +341,18 @@ def _new_event(
     return event
 
 
+def _validate_job_created(current: Mapping[str, Any], next_state: Mapping[str, Any], evidence: Mapping[str, str]) -> None:
+    event = _new_event(current, next_state, evidence, "job_created")
+    _require_unchanged(current, next_state, "issues", "machines")
+    if len(next_state["jobs"]) != len(current["jobs"]) + 1 or next_state["jobs"][1:] != current["jobs"]:
+        raise TrialValidationError("production.job.created must prepend exactly one job.")
+    job = next_state["jobs"][0]
+    if job["output"] != 0:
+        raise TrialValidationError("a new Production job must start with zero output.")
+    if event["subjectId"] != job["id"] or event["summary"] != f"Created {job['id']} for {job['line']}":
+        raise TrialValidationError("job-created event must match the new Production job.")
+
+
 def _validate_output(current: Mapping[str, Any], next_state: Mapping[str, Any], evidence: Mapping[str, str]) -> None:
     event = _new_event(current, next_state, evidence, "output_recorded")
     _require_unchanged(current, next_state, "issues", "machines")
@@ -383,10 +414,22 @@ def _validate_machine(current: Mapping[str, Any], next_state: Mapping[str, Any],
         raise TrialValidationError("machine event must match the exact recorded state change.")
 
 
+def _validate_machine_registered(current: Mapping[str, Any], next_state: Mapping[str, Any], evidence: Mapping[str, str]) -> None:
+    event = _new_event(current, next_state, evidence, "machine_registered")
+    _require_unchanged(current, next_state, "jobs", "issues")
+    if len(next_state["machines"]) != len(current["machines"]) + 1 or next_state["machines"][1:] != current["machines"]:
+        raise TrialValidationError("production.machine.registered must prepend exactly one equipment record.")
+    machine = next_state["machines"][0]
+    if event["subjectId"] != machine["id"] or event["summary"] != f"Registered {machine['name']} in {machine['state']} state":
+        raise TrialValidationError("machine-registered event must match the new equipment record.")
+
+
 _TRANSITION_VALIDATORS = {
+    "production.job.created": _validate_job_created,
     "production.output.recorded": _validate_output,
     "production.issue.opened": _validate_issue_opened,
     "production.issue.resolved": _validate_issue_resolved,
+    "production.machine.registered": _validate_machine_registered,
     "production.machine.state_changed": _validate_machine,
 }
 

--- a/tests/test_production_runtime.py
+++ b/tests/test_production_runtime.py
@@ -100,6 +100,42 @@ class ProductionRuntimeTests(unittest.TestCase):
         with self.assertRaises(TrialValidationError):
             apply_event(current, "production.output.recorded", output_state(current), "ACT-WRONG")
 
+    def test_job_and_machine_registration_prepend_one_attributed_record(self) -> None:
+        current = production_state()
+        new_job = {"id": "JOB-2", "line": "Line 02", "product": "Product B", "target": 80, "output": 0}
+        with_job = deepcopy(current)
+        with_job["revision"] = 1
+        with_job["jobs"] = [new_job, *current["jobs"]]  # type: ignore[misc]
+        with_job["events"] = [production_event("ACT-JOB", "job_created", "JOB-2", "Created JOB-2 for Line 02")]
+        accepted_job = apply_event(current, "production.job.created", with_job, "ACT-JOB")
+        self.assertEqual(accepted_job["jobs"][0], new_job)  # type: ignore[index]
+
+        invented_output = deepcopy(with_job)
+        invented_output["jobs"][0]["output"] = 1  # type: ignore[index]
+        with self.assertRaises(TrialValidationError):
+            apply_event(current, "production.job.created", invented_output, "ACT-JOB")
+
+        new_machine = {"id": "MC-2", "name": "Machine 02", "state": "stopped"}
+        with_machine = deepcopy(accepted_job)
+        with_machine["revision"] = 2
+        with_machine["machines"] = [new_machine, *accepted_job["machines"]]  # type: ignore[misc]
+        with_machine["events"] = [
+            production_event("ACT-REGISTER", "machine_registered", "MC-2", "Registered Machine 02 in stopped state"),
+            *accepted_job["events"],  # type: ignore[misc]
+        ]
+        accepted_machine = apply_event(
+            accepted_job,
+            "production.machine.registered",
+            with_machine,
+            "ACT-REGISTER",
+        )
+        self.assertEqual(accepted_machine["machines"][0], new_machine)  # type: ignore[index]
+
+        changed_existing = deepcopy(with_machine)
+        changed_existing["machines"][1]["name"] = "Rewritten machine"  # type: ignore[index]
+        with self.assertRaises(TrialValidationError):
+            apply_event(accepted_job, "production.machine.registered", changed_existing, "ACT-REGISTER")
+
     def test_issue_open_and_resolution_preserve_attributed_terminal_evidence(self) -> None:
         current = output_state(production_state())
         issue = {

--- a/tools/verify_app_build.mjs
+++ b/tools/verify_app_build.mjs
@@ -118,14 +118,15 @@ if (!coreSource.includes("mode: 'managed-unprovisioned'") || !coreSource.include
 if (!managedCommerceRuntime.includes('commerce.workspace.initialized') || managedCommerceRuntime.includes('commerce.snapshot.saved') || !managedCommerceRuntime.includes('_one_changed') || !managedCommerceRuntime.includes('_validate_event_evidence') || !managedCommerceRuntime.includes('daily close totals must match completed, reconciled orders')) fail('managed_commerce_server_transition_contract_missing')
 if (!coreSource.includes("const commerceTabs") || !coreSource.includes("{ id: 'today', label: 'Today' }") || !coreSource.includes("{ id: 'orders', label: 'Orders' }") || !coreSource.includes("{ id: 'inventory', label: 'Inventory' }") || coreSource.includes("{ id: 'payments'")) fail('commerce_three_tab_contract_changed')
 if (!productionSource.includes("supermega.production.workspace.v2") || !productionSource.includes('mutateProductionWorkspace') || !productionSource.includes('lockManager.request') || !productionSource.includes('next.revision !== current.revision + 1')) fail('production_v2_locked_store_missing')
-if (!productionSource.includes("'output_recorded' | 'issue_opened' | 'issue_resolved' | 'machine_state_changed'") || !productionSource.includes('events: [event, ...state.events]') || !productionSource.includes('Production revision must equal the append-only event count.')) fail('production_append_only_record_missing')
+if (!productionSource.includes("'job_created' | 'output_recorded' | 'issue_opened' | 'issue_resolved' | 'machine_registered' | 'machine_state_changed'") || !productionSource.includes('events: [event, ...state.events]') || !productionSource.includes('Production revision must equal the append-only event count.')) fail('production_append_only_record_missing')
 if (!productionSource.includes('currentRaw !== null') || !productionSource.includes('Migration failed closed') || !productionSource.includes('events: []')) fail('production_migration_fail_closed_contract_missing')
 if (!managedTrialSource.includes('saveManagedProductionCommand') || !managedTrialSource.includes("surface: 'production'") || !managedTrialSource.includes("'production.workspace.initialized'") || !managedTrialSource.includes('ManagedProductionEvent')) fail('managed_production_command_client_missing')
-for (const eventType of ['production.workspace.initialized', 'production.output.recorded', 'production.issue.opened', 'production.issue.resolved', 'production.machine.state_changed']) {
+for (const eventType of ['production.workspace.initialized', 'production.job.created', 'production.output.recorded', 'production.issue.opened', 'production.issue.resolved', 'production.machine.registered', 'production.machine.state_changed']) {
   if (!coreSource.includes(eventType) || !managedProductionRuntime.includes(eventType)) fail(`managed_production_event_missing:${eventType}`)
 }
 if (!coreSource.includes('Create managed Production') || !coreSource.includes('No browser demo output, issues, or machine history is copied') || !coreSource.includes('This records state; it does not control equipment.') || !coreSource.includes("error.code === 'trial_version_conflict'") || !coreSource.includes("result.surface !== 'production'")) fail('managed_production_ui_not_fail_closed')
 if (managedProductionRuntime.includes('production.snapshot.saved') || !managedProductionRuntime.includes('_new_event') || !managedProductionRuntime.includes('command evidence must match the appended Production event.') || !managedProductionRuntime.includes('Production initialization requires jobs and machines with no output or operating history.')) fail('managed_production_server_transition_contract_missing')
+if (!productionSource.includes('createProductionJob') || !productionSource.includes('registerProductionMachine') || !coreSource.includes('Add a job') || !coreSource.includes('Register equipment') || !coreSource.includes('The job starts at zero output.') || !coreSource.includes('It does not connect to or control equipment.')) fail('production_planning_controls_missing')
 const productionTabsContract = coreSource.slice(coreSource.indexOf('const productionTabs'), coreSource.indexOf('function uid'))
 if (!productionTabsContract.includes("{ id: 'today', label: 'Today' }") || !productionTabsContract.includes("{ id: 'production', label: 'Production' }") || !productionTabsContract.includes("{ id: 'control', label: 'Issues & equipment' }") || (productionTabsContract.match(/^\s*\{ id:/gm) || []).length !== 3) fail('production_three_tab_contract_changed')
 const productionPageContract = coreSource.slice(coreSource.indexOf('function ProductionPage'), coreSource.indexOf('function JobList'))
@@ -522,6 +523,20 @@ async function verifyProductionRuntime() {
       jobs: [{ id: 'JOB-1', line: 'Line 01', product: 'Test batch', target: 100, output: 90 }],
       machines: [{ id: 'MC-1', name: 'Test machine', state: 'running' }],
     }
+    const newJob = { id: 'JOB-2', line: 'Line 02', product: 'Next batch', target: 80, output: 0 }
+    const jobProof = proof('ACT-JOB-CREATE')
+    const createdJob = model.createProductionJob(base, newJob, jobProof)
+    assert(createdJob?.jobs[0].id === newJob.id && createdJob.revision === 1 && createdJob.events[0].kind === 'job_created', 'production_job_not_created_once')
+    assert(model.createProductionJob(createdJob, newJob, jobProof) === createdJob, 'production_job_retry_not_idempotent')
+    assert(model.createProductionJob(createdJob, { ...newJob, target: 81 }, jobProof) === null, 'production_job_conflicting_retry_succeeded')
+    assert(model.createProductionJob(createdJob, newJob, proof('ACT-JOB-DUPLICATE')) === null, 'production_duplicate_job_id_succeeded')
+    const newMachine = { id: 'MC-2', name: 'Second machine', state: 'stopped' }
+    const registerProof = proof('ACT-MACHINE-REGISTER')
+    const registeredMachine = model.registerProductionMachine(createdJob, newMachine, registerProof)
+    assert(registeredMachine?.machines[0].id === newMachine.id && registeredMachine.revision === 2 && registeredMachine.events[0].kind === 'machine_registered', 'production_machine_not_registered_once')
+    assert(model.registerProductionMachine(registeredMachine, newMachine, registerProof) === registeredMachine, 'production_machine_registration_retry_not_idempotent')
+    assert(model.registerProductionMachine(registeredMachine, { ...newMachine, name: 'Changed' }, registerProof) === null, 'production_machine_registration_conflicting_retry_succeeded')
+    assert(model.registerProductionMachine(registeredMachine, newMachine, proof('ACT-MACHINE-DUPLICATE')) === null, 'production_duplicate_machine_id_succeeded')
     const outputProof = proof('ACT-OUTPUT')
     const outputState = model.recordProductionOutput(base, 'JOB-1', 10, outputProof)
     assert(outputState?.jobs[0].output === 100 && outputState.revision === 1 && outputState.events[0].quantity === 10 && outputState.events[0].actor === outputProof.actor, 'production_output_not_recorded_once')


### PR DESCRIPTION
## Summary

- add attributed `production.job.created` and `production.machine.registered` lifecycle commands
- validate exact one-record diffs, immutable evidence, zero opening output, duplicate IDs, and idempotent retries in local and managed modes
- add collapsed job and equipment forms inside the existing Production views instead of adding pages or navigation
- keep equipment registration explicitly record-only with no telemetry or control claim

## Stack

This draft is intentionally based on managed Production PR #244. Review and land #244 first.

## Verification

- `65` Python backend/security tests pass
- `npm.cmd run lint` passes
- `npm.cmd run build` passes
- `node tools\\verify_app_build.mjs` passes with `59` Production runtime checks
- local Production route returns HTTP `200`
- responsive contract keeps forms single-column at `560px`, panels auto-height below `840px`, and disclosure controls `44px` high on mobile

## Boundaries

- no new pages, schema migrations, telemetry, equipment control, scheduling automation, or Commerce/Website changes
- no merge, deployment, domain, Vercel, Supabase, or production environment changes
- no tenant credentials or managed production records were introduced for testing
