### PR TITLE
Add managed Commerce catalog items

### DIFF
--- a/showroom/src/core/CoreApp.tsx
+++ b/showroom/src/core/CoreApp.tsx
@@ -33,9 +33,11 @@ import {
   mutateCommerceWorkspace,
   receiveCommerceStock,
   reconcileCommercePayment,
+  registerCommerceItem,
   reserveCommerceOrder,
   validateCommerceState,
   type CommerceActionProof,
+  type CommerceItem,
   type CommerceOrder,
   type CommerceOrderStatus,
   type CommerceState,
@@ -129,6 +131,7 @@ type ActionKind =
   | 'order_status'
   | 'order_cancel'
   | 'payment_reconcile'
+  | 'catalog_item_create'
   | 'inventory_receipt'
   | 'daily_close'
   | 'production_output'
@@ -1215,6 +1218,7 @@ function CommercePage({ managedIdentity, tab }: { managedIdentity: ManagedIdenti
   const [payment, setPayment] = useState('KBZPay')
   const [notice, setNotice] = useState('')
   const [catalogDraft, setCatalogDraft] = useState({ sku: '', name: '', onHand: '', reorderAt: '', price: '', reason: '', evidenceReference: '' })
+  const [itemDraft, setItemDraft] = useState({ sku: '', name: '', onHand: '', reorderAt: '', price: '' })
   const [catalogBusy, setCatalogBusy] = useState(false)
   const [catalogError, setCatalogError] = useState('')
   const selectedSku = commerce.items.some((item) => item.sku === sku) ? sku : commerce.items[0]?.sku ?? ''
@@ -1295,6 +1299,40 @@ function CommercePage({ managedIdentity, tab }: { managedIdentity: ManagedIdenti
     }
     setPendingAction({ ...action, id: uid('ACT'), commandId: commandUuid(), domain: 'commerce' })
     setNotice('Review the change, accountable operator, and evidence before it is applied.')
+  }
+
+  function queueCatalogItem(event: FormEvent) {
+    event.preventDefault()
+    const itemSku = itemDraft.sku.trim().toUpperCase()
+    const name = itemDraft.name.trim()
+    const onHand = Number(itemDraft.onHand)
+    const reorderAt = Number(itemDraft.reorderAt)
+    const price = Number(itemDraft.price)
+    if (!itemSku || !name
+      || !Number.isSafeInteger(onHand) || onHand < 0
+      || !Number.isSafeInteger(reorderAt) || reorderAt < 0
+      || !Number.isSafeInteger(price) || price < 1) {
+      setNotice('Enter a SKU, item name, non-negative opening and reorder quantities, and a whole-MMK price.')
+      return
+    }
+    if (commerce.items.some((item) => item.sku === itemSku)) {
+      setNotice(`${itemSku} already exists. No catalog item was queued.`)
+      return
+    }
+    const item: CommerceItem = { sku: itemSku, name, onHand, reorderAt, price }
+    queueAction({
+      kind: 'catalog_item_create',
+      subjectId: item.sku,
+      summary: `Add ${item.sku} to the catalog`,
+      before: 'No catalog item',
+      after: `${item.name} · ${item.onHand.toLocaleString()} opening units`,
+      apply: async (action) => {
+        const proof = commerceActionProof(action)
+        await mutateCommerce('commerce.item.created', action.commandId, proof, (current) => registerCommerceItem(current, item, proof))
+        setItemDraft({ sku: '', name: '', onHand: '', reorderAt: '', price: '' })
+        setSku(item.sku)
+      },
+    })
   }
 
   async function confirmAction(details: ActionDetails) {
@@ -1447,7 +1485,26 @@ function CommercePage({ managedIdentity, tab }: { managedIdentity: ManagedIdenti
     <section className="core-panel order-queue-panel"><div className="panel-head"><div><span className="core-eyebrow">Fulfilment</span><h2>{openOrders.length} open orders</h2></div><span className="panel-note">{paymentReview.length} payment review</span></div><OrderList canCancel={(orderId) => commerceOrderHasReleasableReservation(commerce, orderId)} onAdvance={advanceOrder} onCancel={cancelOrder} onReconcilePayment={reconcilePayment} orders={commerce.orders} /></section>
   </div>{actionControls}</div>
 
-  if (tab === 'inventory') return <div className="operation-module">{sourceNotice}<section className="core-panel inventory-panel"><div className="panel-head"><div><span className="core-eyebrow">Stock control</span><h2>Inventory and reorder boundaries</h2></div><span className="panel-note">{lowStock.length} at boundary</span></div><div className="data-table" role="table" aria-label="Commerce inventory"><div className="data-row table-head" role="row"><span>Item</span><span>On hand</span><span>Reorder</span><span>Price</span><span>Action</span></div>{commerce.items.map((item) => <div className="data-row" role="row" key={item.sku}><span><strong>{item.name}</strong><small>{item.sku}</small></span><span className={item.onHand <= item.reorderAt ? 'warning-text' : ''}>{item.onHand}</span><span>{item.reorderAt}</span><span>{formatMoney(item.price)}</span><span><button className="text-link" type="button" onClick={() => restock(item.sku)}>Receive +10</button></span></div>)}</div><p className="form-notice" aria-live="polite">{notice || commerceStorageError || 'Receipts require attributable confirmation and append one stock movement.'}</p></section><StockMovementHistory movements={commerce.movements} />{actionControls}</div>
+  if (tab === 'inventory') return <div className="operation-module">
+    {sourceNotice}
+    <section className="core-panel inventory-panel">
+      <div className="panel-head"><div><span className="core-eyebrow">Stock control</span><h2>Inventory and reorder boundaries</h2></div><span className="panel-note">{lowStock.length} at boundary</span></div>
+      <div className="data-table" role="table" aria-label="Commerce inventory"><div className="data-row table-head" role="row"><span>Item</span><span>On hand</span><span>Reorder</span><span>Price</span><span>Action</span></div>{commerce.items.map((item) => <div className="data-row" role="row" key={item.sku}><span><strong>{item.name}</strong><small>{item.sku}</small></span><span className={item.onHand <= item.reorderAt ? 'warning-text' : ''}>{item.onHand}</span><span>{item.reorderAt}</span><span>{formatMoney(item.price)}</span><span><button className="text-link" type="button" onClick={() => restock(item.sku)}>Receive +10</button></span></div>)}</div>
+      <details className="compact-disclosure catalog-disclosure">
+        <summary>Add catalog item</summary>
+        <form className="core-form compact-form catalog-create-form" onSubmit={queueCatalogItem}>
+          <div className="form-row"><label>SKU<input maxLength={80} onChange={(event) => setItemDraft((current) => ({ ...current, sku: event.target.value }))} placeholder="SKU-002" required value={itemDraft.sku} /></label><label>Item name<input maxLength={180} onChange={(event) => setItemDraft((current) => ({ ...current, name: event.target.value }))} placeholder="Real item name" required value={itemDraft.name} /></label></div>
+          <div className="form-row"><label>Opening stock<input min="0" onChange={(event) => setItemDraft((current) => ({ ...current, onHand: event.target.value }))} required step="1" type="number" value={itemDraft.onHand} /></label><label>Reorder at<input min="0" onChange={(event) => setItemDraft((current) => ({ ...current, reorderAt: event.target.value }))} required step="1" type="number" value={itemDraft.reorderAt} /></label></div>
+          <label>Price (MMK)<input min="1" onChange={(event) => setItemDraft((current) => ({ ...current, price: event.target.value }))} required step="1" type="number" value={itemDraft.price} /></label>
+          <div className="form-actions"><button className="core-button primary compact" disabled={Boolean(pendingAction)} type="submit">Review catalog item</button></div>
+          <p className="panel-copy">The opening balance may be zero. A named operator, reason, and evidence are required before the SKU is recorded.</p>
+        </form>
+      </details>
+      <p className="form-notice" aria-live="polite">{notice || commerceStorageError || 'Catalog openings and receipts require attributable confirmation and append one stock movement.'}</p>
+    </section>
+    <StockMovementHistory movements={commerce.movements} />
+    {actionControls}
+  </div>
 
   return <div className="operation-module">{sourceNotice}<div className="module-today"><section className="summary-strip"><span><small>Order value</small><strong>{formatMoney(orderValue)}</strong></span><span><small>Open orders</small><strong>{openOrders.length}</strong></span><span><small>Payment review</small><strong>{paymentReview.length}</strong></span><span><small>Low stock</small><strong>{lowStock.length}</strong></span></section><div className="split-workspace ops-today-grid"><section className="core-panel"><div className="panel-head"><div><span className="core-eyebrow">Order flow</span><h2>Latest channel orders</h2></div><Link className="text-link" to="/operations/commerce/?tab=orders">Open orders</Link></div><OrderList canCancel={(orderId) => commerceOrderHasReleasableReservation(commerce, orderId)} onAdvance={advanceOrder} onCancel={cancelOrder} onReconcilePayment={reconcilePayment} orders={commerce.orders.slice(0, 5)} /></section><section className="core-panel"><div className="panel-head"><div><span className="core-eyebrow">Daily control</span><h2>Exceptions and close</h2></div><span className="panel-note">{commerce.closes.length} snapshots</span></div><div className="exception-summary"><span><strong>{paymentReview.length}</strong><small>payment review</small></span><span><strong>{lowStock.length}</strong><small>reorder boundaries</small></span></div><div className="boundary-list">{lowStock.map((item) => <Link key={item.sku} to="/operations/commerce/?tab=inventory"><strong>{item.name}</strong><small>{item.onHand} on hand</small></Link>)}</div><button className="core-button" onClick={closeDay} type="button">Save daily close</button><p className="form-notice" aria-live="polite">{notice || commerceStorageError || `${closableOrders.length} completed, reconciled orders · ${formatMoney(reconciledValue)} ready to close.`}</p></section></div></div>{actionControls}</div>
 }

--- a/showroom/src/core/commerce-workspace.ts
+++ b/showroom/src/core/commerce-workspace.ts
@@ -39,7 +39,7 @@ export type CommerceOrder = {
   status: CommerceOrderStatus
 }
 
-export type CommerceStockMovementKind = 'reserve' | 'release' | 'receipt'
+export type CommerceStockMovementKind = 'opening' | 'reserve' | 'release' | 'receipt'
 
 export type CommerceStockMovement = {
   id: string
@@ -92,7 +92,7 @@ export type CommerceMutationResult =
 const orderStatuses: CommerceOrderStatus[] = ['confirmed', 'preparing', 'ready', 'completed', 'cancelled']
 const paymentStatuses: CommercePaymentStatus[] = ['pending', 'reconciled']
 const refundStatuses: CommerceRefundStatus[] = ['none', 'due']
-const movementKinds: CommerceStockMovementKind[] = ['reserve', 'release', 'receipt']
+const movementKinds: CommerceStockMovementKind[] = ['opening', 'reserve', 'release', 'receipt']
 const deterministicSeedNow = Date.parse('2026-07-23T08:00:00.000Z')
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -235,6 +235,11 @@ export function validateCommerceState(value: unknown): CommerceState {
     for (const field of ['actor', 'reason', 'evidenceReference', 'sku'] as const) requiredText(candidate[field], `movements[${index}].${field}`)
     if (!itemSkus.includes(candidate.sku as string)) throw new Error(`movements[${index}].sku is unknown.`)
     if (!movementKinds.includes(candidate.kind as CommerceStockMovementKind)) throw new Error(`movements[${index}].kind is invalid.`)
+    if (candidate.kind === 'opening') {
+      assertSafeInteger(candidate.quantityDelta, `movements[${index}].quantityDelta`)
+      if (candidate.orderId !== undefined) throw new Error(`movements[${index}] opening balance cannot reference an order.`)
+      continue
+    }
     if (!Number.isSafeInteger(candidate.quantityDelta) || candidate.quantityDelta === 0) throw new Error(`movements[${index}].quantityDelta is invalid.`)
     if (candidate.kind === 'reserve' && Number(candidate.quantityDelta) >= 0) throw new Error(`movements[${index}] reserve must be negative.`)
     if (candidate.kind !== 'reserve' && Number(candidate.quantityDelta) <= 0) throw new Error(`movements[${index}] release or receipt must be positive.`)
@@ -428,6 +433,31 @@ function movementFor(proof: CommerceActionProof, input: Omit<CommerceStockMoveme
 function actionIdIsUsed(state: CommerceState, actionId: string) {
   return state.movements.some((movement) => movement.actionId === actionId)
     || state.orders.some((order) => order.paymentReconciliationActionId === actionId)
+}
+
+export function registerCommerceItem(state: CommerceState, item: CommerceItem, proof: CommerceActionProof) {
+  const sku = optionalText(item.sku)
+  const name = optionalText(item.name)
+  const variant = item.variant === undefined ? undefined : optionalText(item.variant)
+  if (!validProof(proof)
+    || !sku || sku !== item.sku
+    || !name || name !== item.name
+    || (item.variant !== undefined && variant !== item.variant)
+    || !Number.isSafeInteger(item.onHand) || item.onHand < 0
+    || !Number.isSafeInteger(item.reorderAt) || item.reorderAt < 0
+    || !Number.isSafeInteger(item.price) || item.price < 1) return null
+  const proofMovement = state.movements.find((movement) => movement.actionId === proof.actionId)
+  if (proofMovement) {
+    const storedItem = state.items.find((candidate) => candidate.sku === item.sku)
+    return proofMovement.kind === 'opening'
+      && proofMovement.sku === item.sku
+      && proofMovement.quantityDelta === item.onHand
+      && sameProof(proofMovement, proof)
+      && JSON.stringify(storedItem) === JSON.stringify(item) ? state : null
+  }
+  if (actionIdIsUsed(state, proof.actionId) || state.items.some((candidate) => candidate.sku === item.sku)) return null
+  const opening = movementFor(proof, { kind: 'opening', sku: item.sku, quantityDelta: item.onHand })
+  return validateCommerceState({ ...state, items: [item, ...state.items], movements: [opening, ...state.movements] })
 }
 
 export function reserveCommerceOrder(state: CommerceState, order: CommerceOrder, proof: CommerceActionProof) {

--- a/showroom/src/core/core-app.css
+++ b/showroom/src/core/core-app.css
@@ -389,6 +389,9 @@ textarea { min-height: 72px; resize: vertical; }
 .compact-disclosure { position: relative; }
 .compact-disclosure > summary { min-height: 34px; display: inline-flex; align-items: center; border: 1px solid var(--core-line-strong); border-radius: 5px; padding: 0 10px; color: var(--core-muted); font-size: 10px; font-weight: 760; cursor: pointer; list-style: none; }
 .compact-disclosure[open] > summary { border-color: var(--core-green); color: var(--core-ink); }
+.catalog-disclosure { margin-top: 12px; border-top: 1px solid var(--core-line); padding-top: 10px; }
+.catalog-create-form { max-width: none; margin-top: 10px; }
+.catalog-create-form .form-actions { justify-content: flex-start; }
 .agent-create-form { position: absolute; z-index: 8; top: 42px; right: 0; width: 300px; border: 1px solid var(--core-line-strong); border-radius: 12px; padding: 12px; background: #fff; box-shadow: 0 18px 50px rgba(25,54,42,.16); }
 .evidence-disclosure .compact-disclosure { margin-top: 2px; }
 .evidence-disclosure .inline-evidence { margin-bottom: 3px; }

--- a/showroom/src/core/managed-trial.ts
+++ b/showroom/src/core/managed-trial.ts
@@ -41,6 +41,7 @@ export type ManagedStateRecord = {
 
 export type ManagedCommerceEvent =
   | 'commerce.workspace.initialized'
+  | 'commerce.item.created'
   | 'commerce.order.created'
   | 'commerce.order.advanced'
   | 'commerce.order.cancelled'

--- a/supermega_runtime/commerce_runtime.py
+++ b/supermega_runtime/commerce_runtime.py
@@ -14,6 +14,7 @@ COMMERCE_SCHEMA = "supermega.commerce.workspace.v2"
 COMMERCE_EVENTS = frozenset(
     {
         "commerce.workspace.initialized",
+        "commerce.item.created",
         "commerce.order.created",
         "commerce.order.advanced",
         "commerce.order.cancelled",
@@ -26,7 +27,7 @@ _ORDER_STATUSES = ("confirmed", "preparing", "ready", "completed", "cancelled")
 _NEXT_ORDER_STATUS = {"confirmed": "preparing", "preparing": "ready", "ready": "completed"}
 _PAYMENT_STATUSES = ("pending", "reconciled")
 _REFUND_STATUSES = ("none", "due")
-_MOVEMENT_KINDS = ("reserve", "release", "receipt")
+_MOVEMENT_KINDS = ("opening", "reserve", "release", "receipt")
 _MAX_SAFE_INTEGER = 9_007_199_254_740_991
 
 _STATE_FIELDS = frozenset({"schema", "items", "orders", "movements", "closes"})
@@ -245,15 +246,18 @@ def validate_commerce_state(value: object) -> dict[str, Any]:
         kind = movement["kind"]
         if kind not in _MOVEMENT_KINDS:
             raise TrialValidationError(f"movements[{index}].kind is invalid.")
-        quantity_delta = _integer(abs(movement["quantityDelta"]) if isinstance(movement["quantityDelta"], int) and not isinstance(movement["quantityDelta"], bool) else movement["quantityDelta"], f"movements[{index}].quantityDelta", minimum=1)
-        signed_delta = movement["quantityDelta"]
-        if kind == "reserve" and signed_delta >= 0:
-            raise TrialValidationError(f"movements[{index}] reserve must be negative.")
-        if kind != "reserve" and signed_delta <= 0:
-            raise TrialValidationError(f"movements[{index}] release or receipt must be positive.")
-        if kind == "receipt":
+        if kind == "opening":
+            quantity_delta = _integer(movement["quantityDelta"], f"movements[{index}].quantityDelta")
+        else:
+            quantity_delta = _integer(abs(movement["quantityDelta"]) if isinstance(movement["quantityDelta"], int) and not isinstance(movement["quantityDelta"], bool) else movement["quantityDelta"], f"movements[{index}].quantityDelta", minimum=1)
+            signed_delta = movement["quantityDelta"]
+            if kind == "reserve" and signed_delta >= 0:
+                raise TrialValidationError(f"movements[{index}] reserve must be negative.")
+            if kind != "reserve" and signed_delta <= 0:
+                raise TrialValidationError(f"movements[{index}] release or receipt must be positive.")
+        if kind in {"opening", "receipt"}:
             if "orderId" in movement:
-                raise TrialValidationError(f"movements[{index}] receipt cannot reference an order.")
+                raise TrialValidationError(f"movements[{index}] {kind} cannot reference an order.")
         else:
             order_id = _text(movement.get("orderId"), f"movements[{index}].orderId", maximum=160)
             order = order_by_id.get(order_id)
@@ -304,6 +308,7 @@ def _payload(payload: Mapping[str, Any]) -> tuple[dict[str, Any], dict[str, str]
 
 def _validate_event_evidence(event_type: str, next_state: Mapping[str, Any], evidence: Mapping[str, str]) -> None:
     movement_kind = {
+        "commerce.item.created": "opening",
         "commerce.order.created": "reserve",
         "commerce.order.cancelled": "release",
         "commerce.stock.received": "receipt",
@@ -391,6 +396,24 @@ def _validate_created(current: Mapping[str, Any], next_state: Mapping[str, Any])
         raise TrialValidationError("a new order requires one attributable stock reservation.")
 
 
+def _validate_item_created(current: Mapping[str, Any], next_state: Mapping[str, Any]) -> None:
+    _require_unchanged(current, next_state, "orders", "closes")
+    if len(next_state["items"]) != len(current["items"]) + 1 or next_state["items"][1:] != current["items"]:
+        raise TrialValidationError("commerce.item.created must prepend exactly one catalog item.")
+    if len(next_state["movements"]) != len(current["movements"]) + 1 or next_state["movements"][1:] != current["movements"]:
+        raise TrialValidationError("commerce.item.created must prepend exactly one opening balance.")
+    item = next_state["items"][0]
+    movement = next_state["movements"][0]
+    if (
+        movement.get("kind") != "opening"
+        or movement.get("sku") != item["sku"]
+        or movement.get("quantityDelta") != item["onHand"]
+        or "orderId" in movement
+        or movement.get("id") != f"MOV-{movement.get('actionId')}"
+    ):
+        raise TrialValidationError("a new catalog item requires one exact attributable opening balance.")
+
+
 def _validate_advanced(current: Mapping[str, Any], next_state: Mapping[str, Any]) -> None:
     _require_unchanged(current, next_state, "items", "movements", "closes")
     before, after = _one_changed(current["orders"], next_state["orders"], "orders")
@@ -464,6 +487,7 @@ def _validate_close(current: Mapping[str, Any], next_state: Mapping[str, Any]) -
 
 
 _TRANSITION_VALIDATORS = {
+    "commerce.item.created": _validate_item_created,
     "commerce.order.created": _validate_created,
     "commerce.order.advanced": _validate_advanced,
     "commerce.order.cancelled": _validate_cancelled,

--- a/tests/test_commerce_runtime.py
+++ b/tests/test_commerce_runtime.py
@@ -47,7 +47,7 @@ def order_record(order_id: str = "ORD-1") -> dict[str, object]:
     }
 
 
-def movement(kind: str, action_id: str, quantity: int, *, order_id: str | None = None) -> dict[str, object]:
+def movement(kind: str, action_id: str, quantity: int, *, order_id: str | None = None, sku: str = "SKU-1") -> dict[str, object]:
     record: dict[str, object] = {
         "id": f"MOV-{action_id}",
         "actionId": action_id,
@@ -56,7 +56,7 @@ def movement(kind: str, action_id: str, quantity: int, *, order_id: str | None =
         "reason": "Verified against the source record.",
         "evidenceReference": f"EV-{action_id}",
         "kind": kind,
-        "sku": "SKU-1",
+        "sku": sku,
         "quantityDelta": quantity,
     }
     if order_id:
@@ -83,7 +83,7 @@ def created_state(order_id: str = "ORD-1") -> dict[str, object]:
 
 
 def evidence_for(event_type: str, next_state: dict[str, object]) -> dict[str, str]:
-    if event_type in {"commerce.order.created", "commerce.order.cancelled", "commerce.stock.received"}:
+    if event_type in {"commerce.item.created", "commerce.order.created", "commerce.order.cancelled", "commerce.stock.received"}:
         movement_record = next_state["movements"][0]  # type: ignore[index]
         return {
             "actionId": movement_record["actionId"],
@@ -122,6 +122,26 @@ class CommerceRuntimeTests(unittest.TestCase):
             apply_event({}, "commerce.workspace.initialized", created_state())
         with self.assertRaises(TrialValidationError):
             apply_event(catalog_state(), "commerce.workspace.initialized", catalog_state())
+
+    def test_item_creation_records_an_exact_attributed_opening_balance(self) -> None:
+        current = catalog_state()
+        new_item = {"sku": "SKU-2", "name": "Second item", "onHand": 0, "reorderAt": 3, "price": 250}
+        created = deepcopy(current)
+        created["items"] = [new_item, *current["items"]]  # type: ignore[misc]
+        created["movements"] = [movement("opening", "ACT-ITEM", 0, sku="SKU-2")]
+        accepted = apply_event(current, "commerce.item.created", created)
+        self.assertEqual(accepted["items"][0], new_item)  # type: ignore[index]
+        self.assertEqual(accepted["movements"][0]["kind"], "opening")  # type: ignore[index]
+
+        wrong_balance = deepcopy(created)
+        wrong_balance["movements"][0]["quantityDelta"] = 1  # type: ignore[index]
+        with self.assertRaises(TrialValidationError):
+            apply_event(current, "commerce.item.created", wrong_balance)
+
+        changed_existing = deepcopy(created)
+        changed_existing["items"][1]["name"] = "Rewritten item"  # type: ignore[index]
+        with self.assertRaises(TrialValidationError):
+            apply_event(current, "commerce.item.created", changed_existing)
 
     def test_order_create_and_stock_receipt_allow_only_the_declared_diff(self) -> None:
         current = catalog_state()

--- a/tools/verify_app_build.mjs
+++ b/tools/verify_app_build.mjs
@@ -107,14 +107,15 @@ if (!commerceIntakeSource.includes('await completeWebsiteOrderDraft') || !commer
 if (!coreSource.includes('function queueWebsiteOrder') || !coreSource.includes('sourceRecordId') || !coreSource.includes('item.price !== line.unitPriceMmk') || !coreSource.includes('Website order confirmation failed closed') || !coreSource.includes('Confirm ${record.id} from Website')) fail('website_order_not_integrated_with_commerce')
 if (!commerceSource.includes("supermega.commerce.workspace.v2") || !commerceSource.includes('loadCommerceWorkspace') || !commerceSource.includes('mutateCommerceWorkspace') || !commerceSource.includes('lockManager.request')) fail('commerce_v2_locked_store_missing')
 if (!commerceSource.includes("CommercePaymentStatus = 'pending' | 'reconciled'") || !commerceSource.includes("CommerceRefundStatus = 'none' | 'due'") || commerceSource.includes("'unrecorded'") || commerceSource.includes("'refund_due'")) fail('commerce_payment_or_refund_contract_invalid')
-if (!commerceSource.includes('commerceOrderHasReleasableReservation') || !commerceSource.includes("movement.kind === 'reserve'") || !commerceSource.includes("movement.kind === 'release'") || !commerceSource.includes("kind: 'receipt'")) fail('commerce_stock_ledger_contract_missing')
+if (!commerceSource.includes('commerceOrderHasReleasableReservation') || !commerceSource.includes("movement.kind === 'reserve'") || !commerceSource.includes("movement.kind === 'release'") || !commerceSource.includes("kind: 'receipt'") || !commerceSource.includes("kind: 'opening'")) fail('commerce_stock_ledger_contract_missing')
 if (!commerceSource.includes('Recovery failed closed') || !commerceSource.includes('currentRaw !== null') || !commerceSource.includes("movements: []")) fail('commerce_migration_fail_closed_contract_missing')
 if (!managedTrialSource.includes('saveManagedCommerceCommand') || !managedTrialSource.includes('expected_version: request.expectedVersion') || !managedTrialSource.includes("surface: 'commerce'") || !managedTrialSource.includes('payload: { state: request.state, evidence: request.evidence }')) fail('managed_commerce_command_client_missing')
-for (const eventType of ['commerce.workspace.initialized', 'commerce.order.created', 'commerce.order.advanced', 'commerce.order.cancelled', 'commerce.payment.reconciled', 'commerce.stock.received', 'commerce.close.saved']) {
+for (const eventType of ['commerce.workspace.initialized', 'commerce.item.created', 'commerce.order.created', 'commerce.order.advanced', 'commerce.order.cancelled', 'commerce.payment.reconciled', 'commerce.stock.received', 'commerce.close.saved']) {
   if (!coreSource.includes(eventType) || !managedCommerceRuntime.includes(eventType)) fail(`managed_commerce_event_missing:${eventType}`)
 }
 if (!coreSource.includes("mode: 'managed-unprovisioned'") || !coreSource.includes('No browser demo orders, customers, or stock records are copied') || !coreSource.includes('Create managed catalog') || !coreSource.includes('Opening balance reason') || !coreSource.includes('result.version !== current.version + 1') || !coreSource.includes('validateCommerceState(result.state)') || !coreSource.includes("error.code === 'trial_version_conflict'") || !coreSource.includes('managedIdentity ? null : <ActionHistory')) fail('managed_commerce_ui_not_fail_closed')
 if (!managedCommerceRuntime.includes('commerce.workspace.initialized') || managedCommerceRuntime.includes('commerce.snapshot.saved') || !managedCommerceRuntime.includes('_one_changed') || !managedCommerceRuntime.includes('_validate_event_evidence') || !managedCommerceRuntime.includes('daily close totals must match completed, reconciled orders')) fail('managed_commerce_server_transition_contract_missing')
+if (!commerceSource.includes('registerCommerceItem') || !coreSource.includes('Add catalog item') || !coreSource.includes('Review catalog item') || !coreSource.includes('The opening balance may be zero.') || !managedCommerceRuntime.includes('one exact attributable opening balance')) fail('commerce_catalog_creation_contract_missing')
 if (!coreSource.includes("const commerceTabs") || !coreSource.includes("{ id: 'today', label: 'Today' }") || !coreSource.includes("{ id: 'orders', label: 'Orders' }") || !coreSource.includes("{ id: 'inventory', label: 'Inventory' }") || coreSource.includes("{ id: 'payments'")) fail('commerce_three_tab_contract_changed')
 if (!productionSource.includes("supermega.production.workspace.v2") || !productionSource.includes('mutateProductionWorkspace') || !productionSource.includes('lockManager.request') || !productionSource.includes('next.revision !== current.revision + 1')) fail('production_v2_locked_store_missing')
 if (!productionSource.includes("'output_recorded' | 'issue_opened' | 'issue_resolved' | 'machine_state_changed'") || !productionSource.includes('events: [event, ...state.events]') || !productionSource.includes('Production revision must equal the append-only event count.')) fail('production_append_only_record_missing')
@@ -337,6 +338,13 @@ async function verifyCommerceRuntime() {
       ...model.createEmptyCommerce(),
       items: [{ sku: 'SKU-1', name: 'Test item', onHand: 10, reorderAt: 2, price: 100 }],
     }
+    const newItem = { sku: 'SKU-2', name: 'Second item', onHand: 0, reorderAt: 3, price: 250 }
+    const openingProof = proof('ACT-ITEM-CREATE')
+    const withItem = model.registerCommerceItem(base, newItem, openingProof)
+    assert(withItem?.items[0].sku === newItem.sku && withItem.movements[0].kind === 'opening' && withItem.movements[0].quantityDelta === 0, 'catalog_item_opening_not_recorded')
+    assert(model.registerCommerceItem(withItem, newItem, openingProof) === withItem, 'catalog_item_retry_not_idempotent')
+    assert(model.registerCommerceItem(withItem, { ...newItem, price: 251 }, openingProof) === null, 'catalog_item_conflicting_retry_succeeded')
+    assert(model.registerCommerceItem(withItem, newItem, proof('ACT-ITEM-DUPLICATE')) === null, 'duplicate_catalog_sku_succeeded')
     const order = {
       id: 'ORD-1',
       createdAt: '2026-07-23T09:00:00.000Z',


### PR DESCRIPTION
## Summary

- add attributed `commerce.item.created` lifecycle commands for initialized workspaces
- record each new SKU with an exact `opening` stock movement, including valid zero opening balances
- reject duplicate SKUs, conflicting retries, mismatched balances, and unrelated state changes in local and managed modes
- add one collapsed catalog form inside Inventory; no page or navigation expansion

## Stack

This draft is intentionally based on managed Commerce PR #243 and is independent of the Production PR stack. Review and land #243 first.

## Verification

- `59` Python backend/security tests pass
- `npm.cmd run lint` passes
- `npm.cmd run build` passes
- `node tools\\verify_app_build.mjs` passes with `38` Commerce runtime checks
- local Inventory route returns HTTP `200`
- responsive contract keeps forms single-column at `560px`, prevents mobile inventory overflow, and uses `44px` disclosure controls

## Boundaries

- no extra pages, price editing, deletion, storefront, payment, or schema migration work
- no merge, deployment, domain, Vercel, Supabase, or production environment changes
- no tenant credentials or managed catalog records were introduced for testing
