### PR TITLE
Add human-reviewed agent evidence handoffs

### DIFF
--- a/showroom/src/core/AgentTeamsPanel.tsx
+++ b/showroom/src/core/AgentTeamsPanel.tsx
@@ -7,6 +7,9 @@ import {
   createTeamId,
   defaultAgentCapabilities,
   formatTime,
+  reviewAgentHandoff,
+  submitAgentHandoff,
+  type AgentHandoffDecision,
   type AgentApprovalBoundary,
   type AgentCapability,
   type AgentState,
@@ -19,6 +22,7 @@ type AgentTeamsPanelProps = {
   activeTeam: TeamId
   selectedAgentId: string
   onSelectAgent: (agentId: string) => void
+  onSelectWork: (workItemId: string) => void
   workspace: TeamWorkspaceState
   setWorkspace: Dispatch<SetStateAction<TeamWorkspaceState>>
 }
@@ -27,7 +31,7 @@ function agentStateLabel(state: AgentState) {
   return agentStates.find((entry) => entry.id === state)?.label ?? state
 }
 
-export function AgentTeamsPanel({ activeTeam, selectedAgentId, onSelectAgent, workspace, setWorkspace }: AgentTeamsPanelProps) {
+export function AgentTeamsPanel({ activeTeam, selectedAgentId, onSelectAgent, onSelectWork, workspace, setWorkspace }: AgentTeamsPanelProps) {
   const teamAgents = workspace.agents.filter((agent) => agent.team === activeTeam)
   const teamItems = workspace.items.filter((item) => item.team === activeTeam && item.status !== 'done')
   const [name, setName] = useState('')
@@ -35,8 +39,12 @@ export function AgentTeamsPanel({ activeTeam, selectedAgentId, onSelectAgent, wo
   const [humanOwner, setHumanOwner] = useState('')
   const [evidenceSummary, setEvidenceSummary] = useState('')
   const [evidenceReference, setEvidenceReference] = useState('')
+  const [handoffReviewer, setHandoffReviewer] = useState('')
+  const [handoffNote, setHandoffNote] = useState('')
   const [notice, setNotice] = useState('')
   const selectedAgent = selectedAgentId ? teamAgents.find((agent) => agent.id === selectedAgentId) : teamAgents[0]
+  const pendingHandoff = selectedAgent ? workspace.handoffs.find((handoff) => handoff.agentId === selectedAgent.id && handoff.status === 'pending_review') : undefined
+  const latestHandoff = selectedAgent ? workspace.handoffs.find((handoff) => handoff.agentId === selectedAgent.id) : undefined
 
   function updateAgent(agentId: string, patch: Partial<DelegatedAgent>) {
     const updatedAt = new Date().toISOString()
@@ -72,6 +80,10 @@ export function AgentTeamsPanel({ activeTeam, selectedAgentId, onSelectAgent, wo
 
   function assignWork(workItemId: string) {
     if (!selectedAgent) return
+    if (pendingHandoff) {
+      setNotice('Accept or return the pending handoff before changing its assignment.')
+      return
+    }
     updateAgent(selectedAgent.id, {
       assignedWorkItemId: workItemId || undefined,
       state: workItemId ? selectedAgent.state === 'available' ? 'assigned' : selectedAgent.state : 'available',
@@ -81,15 +93,15 @@ export function AgentTeamsPanel({ activeTeam, selectedAgentId, onSelectAgent, wo
 
   function changeState(state: AgentState) {
     if (!selectedAgent) return
+    if (pendingHandoff) {
+      setNotice('Human review must accept or return the pending handoff before its state changes.')
+      return
+    }
     if (state !== 'available' && !selectedAgent.assignedWorkItemId) {
       setNotice('Assign accountable work before changing this role state.')
       return
     }
-    if (state === 'waiting_review' && !selectedAgent.lastEvidence) {
-      setNotice('Record evidence before requesting human review.')
-      return
-    }
-    updateAgent(selectedAgent.id, { state })
+    updateAgent(selectedAgent.id, { state, assignedWorkItemId: state === 'available' ? undefined : selectedAgent.assignedWorkItemId })
     setNotice(`${selectedAgent.name} moved to ${agentStateLabel(state)}.`)
   }
 
@@ -110,16 +122,46 @@ export function AgentTeamsPanel({ activeTeam, selectedAgentId, onSelectAgent, wo
   function recordEvidence(event: FormEvent) {
     event.preventDefault()
     if (!selectedAgent || !evidenceSummary.trim() || !evidenceReference.trim()) return
-    updateAgent(selectedAgent.id, {
-      lastEvidence: {
-        capturedAt: new Date().toISOString(),
-        summary: evidenceSummary.trim(),
-        reference: evidenceReference.trim(),
-      },
+    if (!selectedAgent.assignedWorkItemId || selectedAgent.state !== 'assigned') {
+      setNotice('Assign open accountable work before submitting evidence for review.')
+      return
+    }
+    const next = submitAgentHandoff(workspace, {
+      agentId: selectedAgent.id,
+      summary: evidenceSummary,
+      reference: evidenceReference,
     })
+    if (!next) {
+      setNotice('The handoff could not be submitted. Confirm the assignment is open and no review is pending.')
+      return
+    }
+    const submitted = next.handoffs.find((handoff) => handoff.agentId === selectedAgent.id && handoff.status === 'pending_review')
+    setWorkspace(next)
     setEvidenceSummary('')
     setEvidenceReference('')
-    setNotice(`Evidence recorded for ${selectedAgent.name}; human review is still required.`)
+    setHandoffReviewer('')
+    setHandoffNote('')
+    setNotice(`${submitted?.id ?? 'Handoff'} submitted for human review.`)
+  }
+
+  function completeHandoff(decision: AgentHandoffDecision) {
+    if (!pendingHandoff || !handoffReviewer.trim() || !handoffNote.trim()) return
+    const next = reviewAgentHandoff(workspace, {
+      handoffId: pendingHandoff.id,
+      decision,
+      reviewer: handoffReviewer,
+      note: handoffNote,
+    })
+    if (!next) {
+      setNotice('The handoff review failed closed because its assignment or evidence changed.')
+      return
+    }
+    setWorkspace(next)
+    setHandoffReviewer('')
+    setHandoffNote('')
+    setNotice(decision === 'accepted'
+      ? `${pendingHandoff.id} accepted into ${pendingHandoff.workItemId} as verified evidence.`
+      : `${pendingHandoff.id} returned to the assigned role for revision.`)
   }
 
   const assignedCount = teamAgents.filter((agent) => agent.state === 'assigned').length
@@ -170,28 +212,42 @@ export function AgentTeamsPanel({ activeTeam, selectedAgentId, onSelectAgent, wo
               <span className={`status-pill ${selectedAgent.state === 'waiting_review' ? 'pending' : selectedAgent.state === 'blocked' ? 'pending' : 'bounded'}`}>{agentStateLabel(selectedAgent.state)}</span>
             </div>
             <div className="agent-control-grid">
-              <label>Human owner<input maxLength={80} value={selectedAgent.humanOwner} onChange={(event) => updateAgent(selectedAgent.id, { humanOwner: event.target.value })} /></label>
-              <label>Assignment<select value={selectedAgent.assignedWorkItemId ?? ''} onChange={(event) => assignWork(event.target.value)}><option value="">Available</option>{teamItems.map((item) => <option key={item.id} value={item.id}>{item.id} · {item.title}</option>)}</select></label>
-              <label>State<select value={selectedAgent.state} onChange={(event) => changeState(event.target.value as AgentState)}>{agentStates.map((state) => <option key={state.id} value={state.id}>{state.label}</option>)}</select></label>
-              <label>Approval boundary<select value={selectedAgent.approvalBoundary} onChange={(event) => updateAgent(selectedAgent.id, { approvalBoundary: event.target.value as AgentApprovalBoundary })}>{agentApprovalBoundaries.map((boundary) => <option key={boundary.id} value={boundary.id}>{boundary.label}</option>)}</select></label>
+              <label>Human owner<input disabled={Boolean(pendingHandoff)} maxLength={80} value={selectedAgent.humanOwner} onChange={(event) => updateAgent(selectedAgent.id, { humanOwner: event.target.value })} /></label>
+              <label>Assignment<select disabled={Boolean(pendingHandoff)} value={selectedAgent.assignedWorkItemId ?? ''} onChange={(event) => assignWork(event.target.value)}><option value="">Available</option>{teamItems.map((item) => <option key={item.id} value={item.id}>{item.id} · {item.title}</option>)}</select></label>
+              {pendingHandoff ? <label>State<input readOnly value="Needs review" /></label> : <label>State<select value={selectedAgent.state} onChange={(event) => changeState(event.target.value as AgentState)}>{agentStates.filter((state) => state.id !== 'waiting_review').map((state) => <option key={state.id} value={state.id}>{state.label}</option>)}</select></label>}
+              <label>Approval boundary<select disabled={Boolean(pendingHandoff)} value={selectedAgent.approvalBoundary} onChange={(event) => updateAgent(selectedAgent.id, { approvalBoundary: event.target.value as AgentApprovalBoundary })}>{agentApprovalBoundaries.map((boundary) => <option key={boundary.id} value={boundary.id}>{boundary.label}</option>)}</select></label>
             </div>
             <p className="agent-boundary-copy">{agentApprovalBoundaries.find((boundary) => boundary.id === selectedAgent.approvalBoundary)?.description}</p>
             <fieldset className="capability-fieldset">
               <legend>Bounded capabilities</legend>
-              <div>{agentCapabilities.map((capability) => <label key={capability.id}><input checked={selectedAgent.capabilities.includes(capability.id)} onChange={() => toggleCapability(capability.id)} type="checkbox" /><span>{capability.label}</span></label>)}</div>
+              <div>{agentCapabilities.map((capability) => <label key={capability.id}><input checked={selectedAgent.capabilities.includes(capability.id)} disabled={Boolean(pendingHandoff)} onChange={() => toggleCapability(capability.id)} type="checkbox" /><span>{capability.label}</span></label>)}</div>
             </fieldset>
             <section className="agent-evidence-card">
               <div><span>Latest evidence</span>{selectedAgent.lastEvidence ? <small>{formatTime(selectedAgent.lastEvidence.capturedAt)}</small> : null}</div>
               {selectedAgent.lastEvidence ? <><strong>{selectedAgent.lastEvidence.summary}</strong><small>{selectedAgent.lastEvidence.reference}</small></> : <p>No evidence has been attributed to this role.</p>}
-              <details className="compact-disclosure evidence-disclosure">
+              {!pendingHandoff && selectedAgent.assignedWorkItemId && selectedAgent.state === 'assigned' ? <details className="compact-disclosure evidence-disclosure">
                 <summary>Record evidence</summary>
                 <form className="core-form agent-evidence-form" onSubmit={recordEvidence}>
                   <label>Finding<input maxLength={240} required value={evidenceSummary} onChange={(event) => setEvidenceSummary(event.target.value)} placeholder="What was completed or learned?" /></label>
                   <label>Reference<input maxLength={180} required value={evidenceReference} onChange={(event) => setEvidenceReference(event.target.value)} placeholder="Test, file, task, or source reference" /></label>
-                  <button className="core-button compact" type="submit">Record</button>
+                  <button className="core-button compact" type="submit">Submit for review</button>
                 </form>
-              </details>
+              </details> : <p>{pendingHandoff ? 'Evidence is locked while a named human reviews this handoff.' : 'Assign open work and use Assigned state before submitting evidence.'}</p>}
             </section>
+            {pendingHandoff ? <section className="agent-handoff-card" aria-labelledby={`handoff-${pendingHandoff.id}`}>
+              <div className="agent-handoff-head"><div><span className="core-eyebrow">Human handoff review</span><h3 id={`handoff-${pendingHandoff.id}`}>{pendingHandoff.id}</h3></div><span className="status-pill pending">Pending</span></div>
+              <div className="agent-handoff-evidence"><strong>{pendingHandoff.evidence.summary}</strong><small>{pendingHandoff.evidence.reference}</small><small>{pendingHandoff.agentName} / {pendingHandoff.humanOwner} / {pendingHandoff.workItemId}</small></div>
+              <form className="core-form agent-handoff-form" onSubmit={(event) => { event.preventDefault(); completeHandoff('accepted') }}>
+                <label>Human reviewer<input maxLength={80} required value={handoffReviewer} onChange={(event) => setHandoffReviewer(event.target.value)} /></label>
+                <label>Review note<textarea maxLength={360} required value={handoffNote} onChange={(event) => setHandoffNote(event.target.value)} /></label>
+                <div className="form-actions"><button className="core-button" disabled={!handoffReviewer.trim() || !handoffNote.trim()} onClick={() => completeHandoff('returned')} type="button">Return for revision</button><button className="core-button primary" type="submit">Accept into work</button></div>
+              </form>
+              <p>Acceptance creates one human-verified evidence record and moves the assigned item to Review. It performs no external action.</p>
+            </section> : latestHandoff ? <section className="agent-handoff-card compact" aria-label="Latest handoff result">
+              <div className="agent-handoff-head"><div><span className="core-eyebrow">Latest handoff</span><h3>{latestHandoff.id}</h3></div><span className={`status-pill ${latestHandoff.status === 'accepted' ? 'approved' : 'pending'}`}>{latestHandoff.status}</span></div>
+              <div className="agent-handoff-evidence"><strong>{latestHandoff.evidence.summary}</strong><small>{latestHandoff.reviewedBy} / {latestHandoff.reviewNote}</small>{latestHandoff.workEvidenceId ? <small>Verified evidence {latestHandoff.workEvidenceId}</small> : null}</div>
+              <button className="text-link" onClick={() => onSelectWork(latestHandoff.workItemId)} type="button">Open work record</button>
+            </section> : null}
             <p className="form-notice" aria-live="polite">{notice || `Updated ${formatTime(selectedAgent.updatedAt)} · local record only.`}</p>
           </> : <p className="panel-copy">{teamAgents.length ? 'Select a delegated role.' : 'Add a bounded role to begin delegating work for this team.'}</p>}
         </section>

--- a/showroom/src/core/TeamWorkspace.tsx
+++ b/showroom/src/core/TeamWorkspace.tsx
@@ -7,6 +7,7 @@ import {
   createTeamId,
   evidenceKinds,
   formatTime,
+  productWorkflowExercised,
   productStages,
   teamDefinitions,
   type EvidenceKind,
@@ -98,7 +99,8 @@ export function TeamsPage() {
   const blockedItems = teamItems.filter((item) => item.status === 'blocked')
   const evidenceCount = teamItems.reduce((total, item) => total + item.evidence.length, 0)
   const verifiedEvidenceCount = teamItems.reduce((total, item) => total + item.evidence.filter((entry) => entry.status === 'verified').length, 0)
-  const releaseComplete = workspace.release.checks.filter((check) => check.complete).length
+  const workflowExercised = productWorkflowExercised(workspace)
+  const releaseComplete = workspace.release.checks.filter((check) => check.id === 'workflow' ? workflowExercised : check.complete).length
   const releasePercent = Math.round((releaseComplete / workspace.release.checks.length) * 100)
   const reviewDecision = workspace.decisions.find((decision) => decision.id === reviewDecisionId && decision.status === 'proposed')
 
@@ -260,6 +262,12 @@ export function TeamsPage() {
   }
 
   function toggleReleaseCheck(checkId: string) {
+    if (checkId === 'workflow') {
+      setNotice(workflowExercised
+        ? 'Product workflow evidence is complete and stays linked to the accepted handoff.'
+        : 'Complete one Product item with an accepted agent handoff to satisfy this check.')
+      return
+    }
     const check = workspace.release.checks.find((candidate) => candidate.id === checkId)
     if (check && !check.complete && verifiedEvidenceCount === 0) {
       setNotice('Verify at least one Product evidence record before completing a release check.')
@@ -339,13 +347,16 @@ export function TeamsPage() {
           </section>
         </div> : null}
 
-        {activeView === 'agents' ? <AgentTeamsPanel activeTeam={activeTeam} onSelectAgent={(agentId) => navigate(activeTeam, 'agents', agentId)} selectedAgentId={requestedAgentId ?? ''} setWorkspace={setWorkspace} workspace={workspace} /> : null}
+        {activeView === 'agents' ? <AgentTeamsPanel activeTeam={activeTeam} onSelectAgent={(agentId) => navigate(activeTeam, 'agents', agentId)} onSelectWork={(workItemId) => navigate(activeTeam, 'work', workItemId)} selectedAgentId={requestedAgentId ?? ''} setWorkspace={setWorkspace} workspace={workspace} /> : null}
 
         {activeView === 'review' ? <div className="review-workspace simplified-review">
           <div className="split-workspace review-grid">
             <section className="core-panel release-panel">
               <div className="panel-head"><div><span className="core-eyebrow">{activeTeam === 'product' ? 'Release control' : 'Evidence review'}</span><h2>{activeTeam === 'product' ? workspace.release.name : activeDefinition.label}</h2></div>{activeTeam === 'product' ? <span className="status-pill bounded">{releasePercent}% ready</span> : null}</div>
-              {activeTeam === 'product' ? <div className="release-checks">{workspace.release.checks.map((check) => <label key={check.id}><input checked={check.complete} onChange={() => toggleReleaseCheck(check.id)} type="checkbox" /><span>{check.label}</span></label>)}</div> : <div className="evidence-summary"><strong>{verifiedEvidenceCount}/{evidenceCount}</strong><p>Verified evidence across {teamItems.length} work records.</p></div>}
+              {activeTeam === 'product' ? <div className="release-checks">{workspace.release.checks.map((check) => {
+                const isWorkflowCheck = check.id === 'workflow'
+                return <label key={check.id} title={isWorkflowCheck ? 'Completed automatically after an accepted agent handoff is linked to a done Product item.' : undefined}><input checked={isWorkflowCheck ? workflowExercised : check.complete} disabled={isWorkflowCheck} onChange={() => toggleReleaseCheck(check.id)} type="checkbox" /><span>{check.label}{isWorkflowCheck ? ' (automatic)' : ''}</span></label>
+              })}</div> : <div className="evidence-summary"><strong>{verifiedEvidenceCount}/{evidenceCount}</strong><p>Verified evidence across {teamItems.length} work records.</p></div>}
             </section>
             <section className="core-panel brief-panel">
               <div className="panel-head"><div><span className="core-eyebrow">Team brief</span><h2>Review recorded facts.</h2></div><button className="core-button compact" onClick={prepareBrief} type="button">Prepare</button></div>

--- a/showroom/src/core/core-app.css
+++ b/showroom/src/core/core-app.css
@@ -386,6 +386,17 @@ textarea { min-height: 72px; resize: vertical; }
 .agent-evidence-card > div { display: flex; align-items: center; justify-content: space-between; color: var(--core-muted); font-size: 10px; }
 .agent-evidence-card > strong { font-size: 11px; }
 .agent-evidence-card > small, .agent-evidence-card > p { margin: 0; color: var(--core-quiet); font-size: 9px; }
+.agent-handoff-card { display: grid; gap: 10px; margin-top: 12px; border: 1px solid rgba(11,116,94,.24); border-radius: var(--core-radius); padding: 12px; background: rgba(11,116,94,.055); }
+.agent-handoff-card.compact { border-color: var(--core-line); background: var(--core-panel-soft); }
+.agent-handoff-head { display: flex; align-items: flex-start; justify-content: space-between; gap: 12px; }
+.agent-handoff-head > div { min-width: 0; display: grid; gap: 3px; }
+.agent-handoff-head h3 { overflow: hidden; margin: 0; font-family: var(--core-mono); font-size: 11px; text-overflow: ellipsis; }
+.agent-handoff-evidence { min-width: 0; display: grid; gap: 4px; border-left: 2px solid var(--core-green); padding-left: 10px; }
+.agent-handoff-evidence strong { font-size: 11px; }
+.agent-handoff-evidence small { overflow: hidden; color: var(--core-quiet); font-size: 9px; text-overflow: ellipsis; white-space: nowrap; }
+.agent-handoff-form { display: grid; grid-template-columns: minmax(0,.7fr) minmax(0,1.3fr); gap: 8px; }
+.agent-handoff-form .form-actions { grid-column: 1/-1; }
+.agent-handoff-card > p { margin: 0; color: var(--core-muted); font-size: 9px; line-height: 1.45; }
 .compact-disclosure { position: relative; }
 .compact-disclosure > summary { min-height: 34px; display: inline-flex; align-items: center; border: 1px solid var(--core-line-strong); border-radius: 5px; padding: 0 10px; color: var(--core-muted); font-size: 10px; font-weight: 760; cursor: pointer; list-style: none; }
 .compact-disclosure[open] > summary { border-color: var(--core-green); color: var(--core-ink); }
@@ -560,6 +571,8 @@ textarea { min-height: 72px; resize: vertical; }
   .agent-summary span:nth-child(2n) { border-right: 0; }
   .agent-summary span:nth-last-child(-n+2) { border-bottom: 0; }
   .agent-control-grid { grid-template-columns: 1fr; }
+  .agent-handoff-form { grid-template-columns: 1fr; }
+  .agent-handoff-form .form-actions { grid-column: auto; }
   .agent-create-form { position: static; width: min(100%,300px); margin-top: 8px; }
   .agent-roster-panel .panel-head { align-items: flex-start; }
   .compact-disclosure > summary { min-height: 44px; }

--- a/showroom/src/core/team-work.ts
+++ b/showroom/src/core/team-work.ts
@@ -1,14 +1,16 @@
-import { useEffect, useState } from 'react'
+import { type Dispatch, type SetStateAction, useEffect, useState } from 'react'
 
 export type TeamId = 'product' | 'engineering' | 'growth' | 'finance'
 export type WorkPriority = 'P0' | 'P1' | 'P2'
 export type WorkStatus = 'backlog' | 'in_progress' | 'blocked' | 'review' | 'done'
 export type ProductStage = 'discover' | 'define' | 'build' | 'release' | 'learn'
-export type EvidenceKind = 'customer' | 'metric' | 'test' | 'release' | 'decision' | 'source'
+export type EvidenceKind = 'customer' | 'metric' | 'test' | 'release' | 'decision' | 'source' | 'handoff'
 export type EvidenceStatus = 'observed' | 'verified'
 export type AgentState = 'available' | 'assigned' | 'waiting_review' | 'blocked'
 export type AgentCapability = 'research' | 'planning' | 'implementation' | 'verification' | 'analysis' | 'drafting'
 export type AgentApprovalBoundary = 'prepare_only' | 'local_change_review'
+export type AgentHandoffDecision = 'accepted' | 'returned'
+export type AgentHandoffStatus = 'pending_review' | AgentHandoffDecision
 
 export type EvidenceRecord = {
   id: string
@@ -77,15 +79,35 @@ export type DelegatedAgent = {
   lastEvidence?: AgentEvidence
 }
 
+export type AgentHandoffRecord = {
+  id: string
+  createdAt: string
+  agentId: string
+  workItemId: string
+  team: TeamId
+  agentName: string
+  humanOwner: string
+  approvalBoundary: AgentApprovalBoundary
+  capabilities: AgentCapability[]
+  evidence: AgentEvidence
+  status: AgentHandoffStatus
+  reviewedAt?: string
+  reviewedBy?: string
+  reviewedActorKind?: 'human'
+  reviewNote?: string
+  workEvidenceId?: string
+}
+
 export type TeamWorkspaceState = {
   items: TeamWorkItem[]
   agents: DelegatedAgent[]
+  handoffs: AgentHandoffRecord[]
   decisions: ProductDecision[]
   release: ProductRelease
 }
 
-export const TEAM_WORK_KEY = 'supermega.team.workspace.v3'
-export const LEGACY_TEAM_WORK_KEYS = ['supermega.team.workspace.v2'] as const
+export const TEAM_WORK_KEY = 'supermega.team.workspace.v4'
+export const LEGACY_TEAM_WORK_KEYS = ['supermega.team.workspace.v3', 'supermega.team.workspace.v2'] as const
 
 export const teamDefinitions = [
   { id: 'product', label: 'Product', purpose: 'Outcomes, backlog, acceptance, decisions, and release readiness.' },
@@ -109,6 +131,7 @@ export const evidenceKinds = [
   { id: 'release', label: 'Release' },
   { id: 'decision', label: 'Decision' },
   { id: 'source', label: 'Source' },
+  { id: 'handoff', label: 'Agent handoff' },
 ] as const satisfies ReadonlyArray<{ id: EvidenceKind; label: string }>
 
 export const agentStates = [
@@ -152,6 +175,12 @@ const minutesAgo = (minutes: number) => new Date(Date.now() - minutes * 60 * 100
 function seedEvidence(id: string, minutes: number, kind: EvidenceKind, finding: string, reference: string): EvidenceRecord {
   const timestamp = minutesAgo(minutes)
   return { id, createdAt: timestamp, kind, finding, reference, status: 'verified', verifiedAt: timestamp, verifiedBy: 'Workspace owner', verifiedActorKind: 'human' }
+}
+
+const seedEngineeringAgentEvidence: AgentEvidence = {
+  capturedAt: minutesAgo(27),
+  summary: 'Canonical application build and release checks passed locally.',
+  reference: 'local://verification/app-build-contract',
 }
 
 export const seedTeamWorkspace: TeamWorkspaceState = {
@@ -267,11 +296,7 @@ export const seedTeamWorkspace: TeamWorkspaceState = {
       capabilities: [...defaultAgentCapabilities.engineering],
       approvalBoundary: 'local_change_review',
       assignedWorkItemId: 'ENG-201',
-      lastEvidence: {
-        capturedAt: minutesAgo(27),
-        summary: 'Canonical application build and release checks passed locally.',
-        reference: 'local://verification/app-build-contract',
-      },
+      lastEvidence: { ...seedEngineeringAgentEvidence },
     },
     {
       id: 'AGT-GROW-01',
@@ -298,6 +323,21 @@ export const seedTeamWorkspace: TeamWorkspaceState = {
       capabilities: [...defaultAgentCapabilities.finance],
       approvalBoundary: 'prepare_only',
       assignedWorkItemId: 'FIN-401',
+    },
+  ],
+  handoffs: [
+    {
+      id: 'HND-ENG-201',
+      createdAt: seedEngineeringAgentEvidence.capturedAt,
+      agentId: 'AGT-ENG-01',
+      workItemId: 'ENG-201',
+      team: 'engineering',
+      agentName: 'Build engineer',
+      humanOwner: 'Engineering lead',
+      approvalBoundary: 'local_change_review',
+      capabilities: [...defaultAgentCapabilities.engineering],
+      evidence: { ...seedEngineeringAgentEvidence },
+      status: 'pending_review',
     },
   ],
   decisions: [
@@ -452,21 +492,263 @@ function normalizeAgent(value: DelegatedAgent, index: number): DelegatedAgent | 
   }
 }
 
-function normalizeWorkspace(value: Partial<TeamWorkspaceState>): TeamWorkspaceState {
+function sameAgentEvidence(left: AgentEvidence | undefined, right: AgentEvidence | undefined) {
+  return Boolean(left && right
+    && left.capturedAt === right.capturedAt
+    && left.summary === right.summary
+    && left.reference === right.reference)
+}
+
+const handoffIdPattern = /^HND-[A-Z0-9-]{4,80}$/i
+const evidenceIdPattern = /^EVD-[A-Z0-9-]{4,80}$/i
+
+function normalizeHandoff(value: AgentHandoffRecord, index: number, items: TeamWorkItem[], agents: DelegatedAgent[]): AgentHandoffRecord | null {
+  if (!value || typeof value !== 'object') return null
+  const candidate = value as Partial<AgentHandoffRecord>
+  const agent = agents.find((entry) => entry.id === candidate.agentId)
+  const item = items.find((entry) => entry.id === candidate.workItemId)
+  if (!agent || !item || agent.team !== item.team || candidate.team !== item.team) return null
+
+  const summary = String(candidate.evidence?.summary || '').trim()
+  const reference = String(candidate.evidence?.reference || '').trim()
+  const capturedAt = String(candidate.evidence?.capturedAt || candidate.createdAt || '')
+  if (!summary || !reference || !Number.isFinite(Date.parse(capturedAt))) return null
+  const evidence = { capturedAt, summary, reference }
+  const agentName = String(candidate.agentName || agent.name).trim()
+  const humanOwner = String(candidate.humanOwner || agent.humanOwner).trim()
+  const approvalBoundary = agentApprovalBoundaries.some((entry) => entry.id === candidate.approvalBoundary)
+    ? candidate.approvalBoundary as AgentApprovalBoundary
+    : agent.approvalBoundary
+  const capabilities = Array.isArray(candidate.capabilities)
+    ? candidate.capabilities.filter((capability): capability is AgentCapability => agentCapabilities.some((entry) => entry.id === capability))
+    : [...agent.capabilities]
+  if (!agentName || !humanOwner || capabilities.length === 0) return null
+  const status = candidate.status
+  if (status !== 'pending_review' && status !== 'accepted' && status !== 'returned') return null
+
+  const id = String(candidate.id || `HND-MIGRATED-${index + 1}`)
+  if (!handoffIdPattern.test(id)) return null
+  const base: AgentHandoffRecord = {
+    id,
+    createdAt: Number.isFinite(Date.parse(String(candidate.createdAt))) ? String(candidate.createdAt) : capturedAt,
+    agentId: agent.id,
+    workItemId: item.id,
+    team: item.team,
+    agentName,
+    humanOwner,
+    approvalBoundary,
+    capabilities: [...new Set(capabilities)],
+    evidence,
+    status,
+  }
+  if (status === 'pending_review') {
+    if (agent.state !== 'waiting_review' || agent.assignedWorkItemId !== item.id || !sameAgentEvidence(agent.lastEvidence, evidence)) return null
+    return base
+  }
+
+  const reviewedBy = String(candidate.reviewedBy || '').trim()
+  const reviewNote = String(candidate.reviewNote || '').trim()
+  const reviewedAt = String(candidate.reviewedAt || '')
+  if (candidate.reviewedActorKind !== 'human' || !reviewedBy || !reviewNote || !Number.isFinite(Date.parse(reviewedAt))) return null
+  if (status === 'returned') return { ...base, reviewedAt, reviewedBy, reviewedActorKind: 'human', reviewNote }
+
+  const workEvidenceId = String(candidate.workEvidenceId || '').trim()
+  const linkedEvidence = item.evidence.find((entry) => entry.id === workEvidenceId)
+  if (!evidenceIdPattern.test(workEvidenceId)
+    || linkedEvidence?.kind !== 'handoff'
+    || linkedEvidence.status !== 'verified'
+    || linkedEvidence.verifiedActorKind !== 'human'
+    || linkedEvidence.verifiedBy !== reviewedBy
+    || linkedEvidence.finding !== evidence.summary
+    || linkedEvidence.reference !== evidence.reference
+    || linkedEvidence.verifiedAt !== reviewedAt) return null
+  return { ...base, reviewedAt, reviewedBy, reviewedActorKind: 'human', reviewNote, workEvidenceId }
+}
+
+export function normalizeTeamWorkspace(value: Partial<TeamWorkspaceState>): TeamWorkspaceState {
   const items = Array.isArray(value.items) ? value.items.map(normalizeWorkItem) : seedTeamWorkspace.items
   const agents = (Array.isArray(value.agents) ? value.agents.map(normalizeAgent).filter((agent): agent is DelegatedAgent => Boolean(agent)) : [])
     .map((agent) => {
       const assignedItem = items.find((item) => item.id === agent.assignedWorkItemId)
-      const hasValidAssignment = !agent.assignedWorkItemId || assignedItem?.team === agent.team
+      const hasValidAssignment = !agent.assignedWorkItemId || (assignedItem?.team === agent.team && assignedItem.status !== 'done')
       if (!hasValidAssignment) return { ...agent, assignedWorkItemId: undefined, state: 'blocked' as const }
       if (agent.state === 'waiting_review' && !agent.lastEvidence) return { ...agent, state: 'blocked' as const }
       return agent
     })
-  return {
+  const handoffs: AgentHandoffRecord[] = []
+  const handoffIds = new Set<string>()
+  const pendingAgents = new Set<string>()
+  for (const [index, valueHandoff] of (Array.isArray(value.handoffs) ? value.handoffs : []).entries()) {
+    const handoff = normalizeHandoff(valueHandoff, index, items, agents)
+    if (!handoff || handoffIds.has(handoff.id) || (handoff.status === 'pending_review' && pendingAgents.has(handoff.agentId))) continue
+    handoffs.push(handoff)
+    handoffIds.add(handoff.id)
+    if (handoff.status === 'pending_review') pendingAgents.add(handoff.agentId)
+  }
+  for (const agent of agents) {
+    if (agent.state !== 'waiting_review' || !agent.assignedWorkItemId || !agent.lastEvidence || pendingAgents.has(agent.id)) continue
+    const item = items.find((entry) => entry.id === agent.assignedWorkItemId && entry.team === agent.team && entry.status !== 'done')
+    if (!item) continue
+    const baseId = `HND-MIGRATED-${agent.id}`
+    const id = handoffIds.has(baseId) ? `${baseId}-${handoffs.length + 1}` : baseId
+    handoffs.push({
+      id,
+      createdAt: agent.lastEvidence.capturedAt,
+      agentId: agent.id,
+      workItemId: item.id,
+      team: item.team,
+      agentName: agent.name,
+      humanOwner: agent.humanOwner,
+      approvalBoundary: agent.approvalBoundary,
+      capabilities: [...agent.capabilities],
+      evidence: { ...agent.lastEvidence },
+      status: 'pending_review',
+    })
+    handoffIds.add(id)
+    pendingAgents.add(agent.id)
+  }
+  return syncProductWorkflowCheck({
     items,
     agents,
+    handoffs,
     decisions: Array.isArray(value.decisions) ? value.decisions.map(normalizeDecision) : seedTeamWorkspace.decisions,
     release: value.release && Array.isArray(value.release.checks) ? value.release : seedTeamWorkspace.release,
+  })
+}
+
+type SubmitAgentHandoffInput = {
+  agentId: string
+  summary: string
+  reference: string
+  submittedAt?: string
+  handoffId?: string
+}
+
+type ReviewAgentHandoffInput = {
+  handoffId: string
+  decision: AgentHandoffDecision
+  reviewer: string
+  note: string
+  reviewedAt?: string
+  evidenceId?: string
+}
+
+export function submitAgentHandoff(state: TeamWorkspaceState, input: SubmitAgentHandoffInput): TeamWorkspaceState | null {
+  const agent = state.agents.find((entry) => entry.id === input.agentId)
+  const item = state.items.find((entry) => entry.id === agent?.assignedWorkItemId)
+  const summary = input.summary.trim()
+  const reference = input.reference.trim()
+  const submittedAt = input.submittedAt ?? new Date().toISOString()
+  const handoffId = input.handoffId?.trim() || createTeamId('HND')
+  if (!agent || agent.state !== 'assigned' || !item || item.team !== agent.team || item.status === 'done') return null
+  if (!summary || !reference || !Number.isFinite(Date.parse(submittedAt)) || !handoffIdPattern.test(handoffId)) return null
+  if (state.handoffs.some((handoff) => handoff.id === handoffId || (handoff.agentId === agent.id && handoff.status === 'pending_review'))) return null
+
+  const evidence: AgentEvidence = { capturedAt: submittedAt, summary, reference }
+  const handoff: AgentHandoffRecord = {
+    id: handoffId,
+    createdAt: submittedAt,
+    agentId: agent.id,
+    workItemId: item.id,
+    team: item.team,
+    agentName: agent.name,
+    humanOwner: agent.humanOwner,
+    approvalBoundary: agent.approvalBoundary,
+    capabilities: [...agent.capabilities],
+    evidence,
+    status: 'pending_review',
+  }
+  return {
+    ...state,
+    agents: state.agents.map((entry) => entry.id === agent.id
+      ? { ...entry, state: 'waiting_review', updatedAt: submittedAt, lastEvidence: { ...evidence } }
+      : entry),
+    handoffs: [handoff, ...state.handoffs],
+  }
+}
+
+export function reviewAgentHandoff(state: TeamWorkspaceState, input: ReviewAgentHandoffInput): TeamWorkspaceState | null {
+  const handoff = state.handoffs.find((entry) => entry.id === input.handoffId)
+  const reviewer = input.reviewer.trim()
+  const note = input.note.trim()
+  if (!handoff || !reviewer || !note || (input.decision !== 'accepted' && input.decision !== 'returned')) return null
+  if (handoff.status !== 'pending_review') {
+    const sameDecision = handoff.status === input.decision
+      && handoff.reviewedBy === reviewer
+      && handoff.reviewNote === note
+      && (!input.evidenceId || handoff.workEvidenceId === input.evidenceId)
+    return sameDecision ? state : null
+  }
+
+  const agent = state.agents.find((entry) => entry.id === handoff.agentId)
+  const item = state.items.find((entry) => entry.id === handoff.workItemId)
+  const reviewedAt = input.reviewedAt ?? new Date().toISOString()
+  if (!agent || agent.state !== 'waiting_review' || agent.assignedWorkItemId !== handoff.workItemId || !sameAgentEvidence(agent.lastEvidence, handoff.evidence)) return null
+  if (!item || item.team !== agent.team || item.status === 'done' || !Number.isFinite(Date.parse(reviewedAt)) || Date.parse(reviewedAt) < Date.parse(handoff.createdAt)) return null
+
+  const reviewedHandoff = {
+    ...handoff,
+    status: input.decision,
+    reviewedAt,
+    reviewedBy: reviewer,
+    reviewedActorKind: 'human' as const,
+    reviewNote: note,
+  }
+  if (input.decision === 'returned') {
+    return {
+      ...state,
+      agents: state.agents.map((entry) => entry.id === agent.id ? { ...entry, state: 'assigned', updatedAt: reviewedAt } : entry),
+      handoffs: state.handoffs.map((entry) => entry.id === handoff.id ? reviewedHandoff : entry),
+    }
+  }
+
+  const evidenceId = input.evidenceId?.trim() || createTeamId('EVD')
+  if (!evidenceIdPattern.test(evidenceId) || state.items.some((entry) => entry.evidence.some((evidence) => evidence.id === evidenceId))) return null
+  const workEvidence: EvidenceRecord = {
+    id: evidenceId,
+    createdAt: reviewedAt,
+    kind: 'handoff',
+    finding: handoff.evidence.summary,
+    reference: handoff.evidence.reference,
+    status: 'verified',
+    verifiedAt: reviewedAt,
+    verifiedBy: reviewer,
+    verifiedActorKind: 'human',
+  }
+  return {
+    ...state,
+    items: state.items.map((entry) => entry.id === item.id ? { ...entry, status: 'review', evidence: [...entry.evidence, workEvidence] } : entry),
+    agents: state.agents.map((entry) => entry.id === agent.id
+      ? { ...entry, state: 'available', assignedWorkItemId: undefined, updatedAt: reviewedAt }
+      : entry),
+    handoffs: state.handoffs.map((entry) => entry.id === handoff.id ? { ...reviewedHandoff, workEvidenceId: evidenceId } : entry),
+  }
+}
+
+export function productWorkflowExercised(state: TeamWorkspaceState) {
+  return state.handoffs.some((handoff) => {
+    if (handoff.team !== 'product' || handoff.status !== 'accepted' || !handoff.workEvidenceId) return false
+    const item = state.items.find((entry) => entry.id === handoff.workItemId && entry.team === 'product' && entry.status === 'done')
+    const evidence = item?.evidence.find((entry) => entry.id === handoff.workEvidenceId)
+    return evidence?.kind === 'handoff'
+      && evidence.status === 'verified'
+      && evidence.verifiedActorKind === 'human'
+      && evidence.verifiedBy === handoff.reviewedBy
+      && evidence.finding === handoff.evidence.summary
+      && evidence.reference === handoff.evidence.reference
+  })
+}
+
+export function syncProductWorkflowCheck(state: TeamWorkspaceState) {
+  const complete = productWorkflowExercised(state)
+  const workflowCheck = state.release.checks.find((check) => check.id === 'workflow')
+  if (!workflowCheck || workflowCheck.complete === complete) return state
+  return {
+    ...state,
+    release: {
+      ...state.release,
+      checks: state.release.checks.map((check) => check.id === 'workflow' ? { ...check, complete } : check),
+    },
   }
 }
 
@@ -475,13 +757,17 @@ export function useTeamWorkspace() {
     for (const storageKey of [TEAM_WORK_KEY, ...LEGACY_TEAM_WORK_KEYS]) {
       try {
         const stored = window.localStorage.getItem(storageKey)
-        if (stored) return normalizeWorkspace(JSON.parse(stored) as Partial<TeamWorkspaceState>)
+        if (stored) return normalizeTeamWorkspace(JSON.parse(stored) as Partial<TeamWorkspaceState>)
       } catch {
         // Continue to a valid legacy record before falling back to the seed.
       }
     }
-    return seedTeamWorkspace
+    return syncProductWorkflowCheck(seedTeamWorkspace)
   })
+
+  const setWorkspace: Dispatch<SetStateAction<TeamWorkspaceState>> = (next) => {
+    setState((current) => syncProductWorkflowCheck(typeof next === 'function' ? next(current) : next))
+  }
 
   useEffect(() => {
     try {
@@ -491,7 +777,7 @@ export function useTeamWorkspace() {
     }
   }, [state])
 
-  return [state, setState] as const
+  return [state, setWorkspace] as const
 }
 
 export function createTeamId(prefix: string) {

--- a/tools/verify_app_build.mjs
+++ b/tools/verify_app_build.mjs
@@ -9,6 +9,7 @@ let orderCompletionRuntimeChecks = 0
 let websiteRuntimeChecks = 0
 let commerceRuntimeChecks = 0
 let productionRuntimeChecks = 0
+let agentHandoffRuntimeChecks = 0
 const fail = (reason) => failures.push(reason)
 const [manifestText, appPackageText, appSource, coreSource, commerceSource, managedTrialSource, managedCommerceRuntime, productionSource, teamSource, agentTeamsSource, teamModel, websiteSource, publishSource, sitePreviewSource, websiteModelSource, websiteWorkspaceSource, websiteCssSource, commerceIntakeSource, handoffSource] = await Promise.all([
   readFile(resolve(root, 'site-manifest.json'), 'utf8'),
@@ -77,7 +78,7 @@ else {
 const files = await walk(dist)
 const textFiles = files.filter((path) => /\.(?:html|js|css|json|svg)$/.test(path))
 const corpus = (await Promise.all(textFiles.map((path) => readFile(path, 'utf8')))).join('\n')
-for (const required of ['SUPERMEGA', 'Teams', 'Product', 'Acceptance outcome', 'Prepare brief', 'Evidence register', 'Record evidence', 'Verified evidence', 'verifiedAt', 'Operations', 'Human confirmation', 'Confirm and record', 'Action history', 'actorKind', 'evidenceReference', 'accountableActions', 'decision_packet.v1', 'Claims and provenance', 'claimType', 'claim_type', 'source_reference', 'artifact_reference', 'managedApprovalRequests', 'packetFingerprint', 'uncertainty', 'visibility', 'artifactReference', 'Human reviewer', 'Decision note', 'Approve and record', 'Local trial', 'Delegation control', 'Pilot definition', 'Template profile', 'Workflow', 'workflowProfile', 'Current record', 'Baseline', 'Target outcome', 'Human authority boundary', 'Acceptance evidence', 'Operating mode', 'Write path', manifest.brand.colors.accent, manifest.brand.colors.ink]) {
+for (const required of ['SUPERMEGA', 'Teams', 'Product', 'Acceptance outcome', 'Prepare brief', 'Evidence register', 'Record evidence', 'Verified evidence', 'verifiedAt', 'Submit for review', 'Return for revision', 'Accept into work', 'Operations', 'Human confirmation', 'Confirm and record', 'Action history', 'actorKind', 'evidenceReference', 'accountableActions', 'decision_packet.v1', 'Claims and provenance', 'claimType', 'claim_type', 'source_reference', 'artifact_reference', 'managedApprovalRequests', 'packetFingerprint', 'uncertainty', 'visibility', 'artifactReference', 'Human reviewer', 'Decision note', 'Approve and record', 'Local trial', 'Delegation control', 'Pilot definition', 'Template profile', 'Workflow', 'workflowProfile', 'Current record', 'Baseline', 'Target outcome', 'Human authority boundary', 'Acceptance evidence', 'Operating mode', 'Write path', manifest.brand.colors.accent, manifest.brand.colors.ink]) {
   if (!corpus.includes(required)) fail(`missing_context:${required}`)
 }
 if (!coreSource.includes("import siteManifest from '../../../site-manifest.json'")) fail('workflow_contract_not_shared')
@@ -92,8 +93,11 @@ if (!coreSource.includes('toManagedDecisionPacket') || !coreSource.includes('man
 if (!teamSource.includes('Accept and record') || !teamSource.includes("acceptedActorKind: 'human'") || !teamModel.includes('acceptanceEvidenceReference')) fail('product_decision_not_human_attributed')
 if (!teamModel.includes("status: 'proposed'") || !teamModel.includes('isAttributedHumanAcceptance')) fail('legacy_product_acceptance_not_reopened')
 if (!teamSource.includes("verifiedActorKind: 'human'") || !teamModel.includes("candidate.verifiedActorKind === 'human'") || !teamModel.includes('verifiedBy')) fail('team_evidence_not_human_attributed')
-if (!teamModel.includes("supermega.team.workspace.v3") || !teamModel.includes("supermega.team.workspace.v2") || !teamModel.includes('hasValidAssignment')) fail('agent_team_migration_or_integrity_missing')
+if (!teamModel.includes("supermega.team.workspace.v4") || !teamModel.includes("supermega.team.workspace.v3") || !teamModel.includes("supermega.team.workspace.v2") || !teamModel.includes('hasValidAssignment') || !teamModel.includes('normalizeTeamWorkspace')) fail('agent_team_migration_or_integrity_missing')
 if (!agentTeamsSource.includes('No agent can send, pay, publish, merge, deploy, or write to production') || !agentTeamsSource.includes('humanOwner') || !agentTeamsSource.includes('approvalBoundary') || agentTeamsSource.includes('>Run<')) fail('agent_authority_boundary_missing')
+if (!teamModel.includes('submitAgentHandoff') || !teamModel.includes('reviewAgentHandoff') || !teamModel.includes("kind: 'handoff'") || !teamModel.includes("verifiedActorKind: 'human'") || !teamModel.includes('productWorkflowExercised') || !teamModel.includes('syncProductWorkflowCheck')) fail('agent_handoff_model_missing')
+if (!agentTeamsSource.includes('Submit for review') || !agentTeamsSource.includes('Return for revision') || !agentTeamsSource.includes('Accept into work') || !agentTeamsSource.includes('The handoff review failed closed') || !agentTeamsSource.includes('onSelectWork(latestHandoff.workItemId)')) fail('agent_handoff_review_ui_missing')
+if (!teamSource.includes("check.id === 'workflow' ? workflowExercised : check.complete") || !teamSource.includes('disabled={isWorkflowCheck}') || !teamSource.includes("' (automatic)'") || !teamSource.includes('Complete one Product item with an accepted agent handoff')) fail('product_workflow_gate_not_derived')
 if (!coreSource.includes('view=work&item=${item.id}') || !coreSource.includes('view=agents&agent=${agent.id}') || !teamSource.includes("const requestedItemId = searchParams.get('item')") || !teamSource.includes("const requestedAgentId = searchParams.get('agent')") || !teamSource.includes("if (view === 'work' && selectedId) next.item = selectedId") || !teamSource.includes("if (view === 'agents' && selectedId) next.agent = selectedId") || !agentTeamsSource.includes('onSelectAgent: (agentId: string) => void') || agentTeamsSource.includes('const [selectedAgentId')) fail('team_record_deep_links_missing')
 if (!appSource.includes("lazy(() => import('./products/website/WebsiteProduct')") || !appSource.includes('Suspense') || appSource.includes("import('./products/ecommerce/EcommerceOrdersProduct')")) fail('website_prototype_route_not_isolated')
 if (!appSource.includes('<Navigate replace to="/operations/commerce/?tab=orders" />') || !appSource.includes('path="products/ecommerce/*"')) fail('legacy_ecommerce_route_not_redirected')
@@ -173,6 +177,106 @@ for (const forbidden of ['pos.supermega.dev', 'ytf.supermega.dev', 'Yangon Tyre'
 }
 for (const marker of ['\uFFFD', '\u00e2\u20ac\u201d', '\u00e2\u20ac\u201c', '\u00c2', '\u00f0\u0178']) {
   if (corpus.includes(marker)) fail('app_copy_encoding_corrupt')
+}
+
+async function verifyAgentHandoffRuntime() {
+  const assert = (condition, reason) => {
+    if (!condition) throw new Error(reason)
+    agentHandoffRuntimeChecks += 1
+  }
+  try {
+    const model = await import(`${pathToFileURL(resolve(root, 'showroom', 'src', 'core', 'team-work.ts')).href}?agent-handoff-verify=${Date.now()}`)
+    const seed = structuredClone(model.seedTeamWorkspace)
+    const { handoffs: _legacyHandoffs, ...legacySeed } = seed
+    const migrated = model.normalizeTeamWorkspace(legacySeed)
+    assert(migrated.handoffs.some((handoff) => handoff.agentId === 'AGT-ENG-01' && handoff.status === 'pending_review'), 'agent_v3_pending_handoff_not_migrated')
+
+    const firstSubmitted = model.submitAgentHandoff(seed, {
+      agentId: 'AGT-PROD-01',
+      summary: 'One Product workflow fixture passed its local acceptance checks.',
+      reference: 'local://verification/product-workflow-1',
+      submittedAt: '2026-07-23T08:00:00.000Z',
+      handoffId: 'HND-RUNTIME-1',
+    })
+    assert(firstSubmitted?.agents.find((agent) => agent.id === 'AGT-PROD-01')?.state === 'waiting_review', 'agent_handoff_did_not_enter_review')
+    assert(firstSubmitted?.handoffs[0].workItemId === 'PROD-102' && firstSubmitted.handoffs[0].humanOwner === 'Product lead', 'agent_handoff_provenance_missing')
+    assert(seed.agents.find((agent) => agent.id === 'AGT-PROD-01')?.lastEvidence === undefined, 'agent_handoff_mutated_source_state')
+    assert(model.submitAgentHandoff(firstSubmitted, {
+      agentId: 'AGT-PROD-01',
+      summary: 'Duplicate',
+      reference: 'local://duplicate',
+      handoffId: 'HND-RUNTIME-DUPLICATE',
+    }) === null, 'agent_parallel_pending_handoff_succeeded')
+
+    const returned = model.reviewAgentHandoff(firstSubmitted, {
+      handoffId: 'HND-RUNTIME-1',
+      decision: 'returned',
+      reviewer: 'Product lead',
+      note: 'Add the source fixture identity.',
+      reviewedAt: '2026-07-23T08:05:00.000Z',
+    })
+    const returnedItem = returned?.items.find((item) => item.id === 'PROD-102')
+    assert(returned?.handoffs[0].status === 'returned' && returned.agents.find((agent) => agent.id === 'AGT-PROD-01')?.state === 'assigned', 'agent_return_transition_invalid')
+    assert(returnedItem?.evidence.length === 0, 'agent_return_created_verified_evidence')
+
+    const resubmitted = model.submitAgentHandoff(returned, {
+      agentId: 'AGT-PROD-01',
+      summary: 'Fixture SM-PRODUCT-01 passed with source identity retained.',
+      reference: 'local://verification/product-workflow-1/source-fixture',
+      submittedAt: '2026-07-23T08:10:00.000Z',
+      handoffId: 'HND-RUNTIME-2',
+    })
+    assert(resubmitted?.handoffs.filter((handoff) => handoff.agentId === 'AGT-PROD-01').length === 2, 'agent_resubmission_lost_audit_history')
+    const accepted = model.reviewAgentHandoff(resubmitted, {
+      handoffId: 'HND-RUNTIME-2',
+      decision: 'accepted',
+      reviewer: 'Product lead',
+      note: 'Accepted against the named fixture and outcome.',
+      reviewedAt: '2026-07-23T08:15:00.000Z',
+      evidenceId: 'EVD-HANDOFF-RUNTIME',
+    })
+    const acceptedAgent = accepted?.agents.find((agent) => agent.id === 'AGT-PROD-01')
+    const acceptedItem = accepted?.items.find((item) => item.id === 'PROD-102')
+    const acceptedEvidence = acceptedItem?.evidence.find((evidence) => evidence.id === 'EVD-HANDOFF-RUNTIME')
+    assert(acceptedAgent?.state === 'available' && !acceptedAgent.assignedWorkItemId, 'agent_acceptance_did_not_close_assignment')
+    assert(acceptedItem?.status === 'review' && acceptedEvidence?.kind === 'handoff', 'agent_acceptance_did_not_move_work_to_review')
+    assert(acceptedEvidence?.status === 'verified' && acceptedEvidence.verifiedBy === 'Product lead' && acceptedEvidence.verifiedActorKind === 'human', 'agent_acceptance_not_human_attributed')
+    assert(accepted?.handoffs[0].workEvidenceId === acceptedEvidence.id && accepted.handoffs[0].status === 'accepted', 'agent_acceptance_not_linked_to_work_evidence')
+    const exactRetry = model.reviewAgentHandoff(accepted, {
+      handoffId: 'HND-RUNTIME-2',
+      decision: 'accepted',
+      reviewer: 'Product lead',
+      note: 'Accepted against the named fixture and outcome.',
+      evidenceId: 'EVD-HANDOFF-RUNTIME',
+    })
+    assert(exactRetry === accepted && acceptedItem?.evidence.length === 1, 'agent_acceptance_retry_duplicated_evidence')
+    assert(model.reviewAgentHandoff(accepted, {
+      handoffId: 'HND-RUNTIME-2',
+      decision: 'returned',
+      reviewer: 'Product lead',
+      note: 'Conflicting retry.',
+    }) === null, 'agent_conflicting_review_retry_succeeded')
+    assert(!model.productWorkflowExercised(accepted), 'product_workflow_gate_completed_before_done')
+    const completed = {
+      ...accepted,
+      items: accepted.items.map((item) => item.id === 'PROD-102' ? { ...item, status: 'done' } : item),
+    }
+    assert(model.productWorkflowExercised(completed), 'product_workflow_gate_not_linked_to_completed_handoff')
+    const synchronized = model.syncProductWorkflowCheck(completed)
+    assert(synchronized.release.checks.find((check) => check.id === 'workflow')?.complete === true, 'product_workflow_gate_not_synchronized_for_other_routes')
+    assert(model.normalizeTeamWorkspace(completed).release.checks.find((check) => check.id === 'workflow')?.complete === true, 'product_workflow_gate_not_synchronized_after_reload')
+    const tampered = {
+      ...synchronized,
+      items: synchronized.items.map((item) => item.id === 'PROD-102'
+        ? { ...item, evidence: item.evidence.map((evidence) => evidence.id === 'EVD-HANDOFF-RUNTIME' ? { ...evidence, finding: 'Changed finding' } : evidence) }
+        : item),
+    }
+    assert(!model.productWorkflowExercised(tampered), 'product_workflow_gate_accepted_tampered_evidence')
+    assert(model.syncProductWorkflowCheck(tampered).release.checks.find((check) => check.id === 'workflow')?.complete === false, 'product_workflow_gate_did_not_fail_closed_after_tamper')
+    assert(!model.normalizeTeamWorkspace(tampered).handoffs.some((handoff) => handoff.id === 'HND-RUNTIME-2'), 'agent_handoff_normalizer_retained_tampered_acceptance')
+  } catch (error) {
+    fail(`agent_handoff_runtime:${error instanceof Error ? error.message : 'unknown'}`)
+  }
 }
 
 async function verifyWebsiteRuntime() {
@@ -1013,6 +1117,7 @@ async function verifyProductionRuntime() {
   }
 }
 
+await verifyAgentHandoffRuntime()
 await verifyWebsiteRuntime()
 await verifyWebsiteOrderCompletionRuntime()
 await verifyCommerceRuntime()
@@ -1025,4 +1130,4 @@ if (failures.length) {
   console.error(JSON.stringify({ ok: false, contract: 'supermega_app_build', failures }, null, 2))
   process.exit(1)
 }
-console.log(JSON.stringify({ ok: true, contract: 'supermega_app_build', primaryRoutes: 4, operatingModules: 2, prototypeRoutes: 1, compatibilityRedirects: 1, workflowProfiles, websiteRuntimeChecks, orderCompletionRuntimeChecks, commerceRuntimeChecks, productionRuntimeChecks, bytes }, null, 2))
+console.log(JSON.stringify({ ok: true, contract: 'supermega_app_build', primaryRoutes: 4, operatingModules: 2, prototypeRoutes: 1, compatibilityRedirects: 1, workflowProfiles, agentHandoffRuntimeChecks, websiteRuntimeChecks, orderCompletionRuntimeChecks, commerceRuntimeChecks, productionRuntimeChecks, bytes }, null, 2))


### PR DESCRIPTION
## What changed

- completes the existing Product work → delegated agent → human review → verified work-evidence lifecycle
- records immutable handoff provenance: agent, assignment, human owner, approval boundary, capabilities, finding, and reference
- supports explicit Return for revision and Accept into work decisions with named-human attribution
- links accepted evidence to the existing work record, closes the agent assignment, and moves work to Review
- derives the Product workflow release check only from an accepted handoff linked to a Done Product item
- surfaces pending handoffs through the existing Today owner-attention link; no new route or navigation item was added
- migrates legacy waiting-review agent records and rejects duplicate, stale, conflicting, or tampered transitions

## Why

The prior agent roster could record a result but did not provide a complete, auditable transition from delegated work into human-accepted product evidence. Release readiness was also a manual checkbox, so it could disagree with the underlying work. This change makes the handoff practical and fail-closed while keeping consequential authority with a named human.

## User impact

A team lead can now submit evidence, return it with a review note, accept a corrected handoff, open the linked work record, and complete the release gate without leaving the compact Team workspace. Pending review freezes assignment and authority metadata. No send, payment, publish, merge, deployment, or production-write capability is introduced.

## Validation

- `npm.cmd --prefix showroom run lint`
- `npm.cmd run app:build`
- 21 agent-handoff runtime checks, including v3 migration, provenance, idempotency, return/resubmit/accept, reload synchronization, and tamper failure
- coordinated release workflow: 48 checks
- app security contract: 43 checks
- database RLS validator self-test: 6 checks, 0 mutations, no secrets exposed
- Vercel environment/domain contracts: 11 checks
- HQ contract verification passed
- browser flow exercised at 1280×720, 390×844, and 320×700 with no document overflow or console errors
- Today → Engineering pending handoff route verified; Product accepted evidence and automatic 75% release readiness persisted after reload

## Safety

Draft only. No production deployment, database mutation, environment change, external send, or branch merge was performed.