### PR TITLE
Core: task-first product workspaces and safe channel intake

### DIFF
--- a/showroom/src/core/CoreApp.tsx
+++ b/showroom/src/core/CoreApp.tsx
@@ -47,6 +47,18 @@ import {
   type CommerceWebsiteOrderInput,
 } from './commerce-workspace'
 import {
+  CHANNEL_ORDER_MESSAGE_MAX,
+  CHANNEL_ORDER_QUOTE_MAX,
+  buildChannelOrderDraft,
+  channelOrderChannels,
+  channelOrderDraftIsReady,
+  channelOrderFields,
+  channelOrderPayments,
+  type ChannelOrderAttributionInput,
+  type ChannelOrderDraft,
+  type ChannelOrderField,
+} from './channel-order-intake'
+import {
   LEGACY_PRODUCTION_KEYS,
   PRODUCTION_KEY,
   advanceProductionMachineState,
@@ -161,6 +173,8 @@ type AccountableAction = {
 type PendingAccountableAction = Omit<AccountableAction, 'capturedAt' | 'actorKind' | 'actor' | 'reason' | 'evidenceReference'> & {
   apply: (record: AccountableAction) => void | Promise<void>
   confirmation?: AccountableAction
+  evidenceReferenceLocked?: boolean
+  evidenceReferenceSuggestion?: string
 }
 
 type ActionDetails = Pick<AccountableAction, 'actor' | 'reason' | 'evidenceReference'>
@@ -300,13 +314,13 @@ const navigation = [
 const commerceTabs: Array<{ id: CommerceTab; label: string }> = [
   { id: 'today', label: 'Today' },
   { id: 'orders', label: 'Orders' },
-  { id: 'inventory', label: 'Inventory' },
+  { id: 'inventory', label: 'Stock' },
 ]
 
 const productionTabs: Array<{ id: ProductionTab; label: string }> = [
   { id: 'today', label: 'Today' },
-  { id: 'production', label: 'Production' },
-  { id: 'control', label: 'Issues & equipment' },
+  { id: 'production', label: 'Jobs' },
+  { id: 'control', label: 'Problems' },
 ]
 
 const productionMachineActionLabels: Record<ProductionMachineState, string> = {
@@ -800,28 +814,38 @@ function formatMoney(value: number) {
   return `${new Intl.NumberFormat('en-US').format(value)} MMK`
 }
 
-function AccountableActionGate({ action, authenticatedActor, onCancel, onConfirm }: {
+function AccountableActionGate({ action, authenticatedActor, onCancel, onConfirm, returnFocus }: {
   action: PendingAccountableAction | null
   authenticatedActor?: { id: string; label: string }
   onCancel: () => void
   onConfirm: (details: ActionDetails) => void | Promise<void>
+  returnFocus?: HTMLElement | null
 }) {
   const [actor, setActor] = useState('')
   const [reason, setReason] = useState('')
-  const [evidenceReference, setEvidenceReference] = useState('')
+  const [evidenceReference, setEvidenceReference] = useState(action?.evidenceReferenceSuggestion ?? '')
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState('')
+  const dialogRef = useRef<HTMLDialogElement>(null)
   const headingRef = useRef<HTMLHeadingElement>(null)
   const previousFocusRef = useRef<HTMLElement | null>(null)
 
   useEffect(() => {
     if (!action) return undefined
-    previousFocusRef.current = document.activeElement instanceof HTMLElement ? document.activeElement : null
+    const dialog = dialogRef.current
+    previousFocusRef.current = returnFocus?.isConnected
+      ? returnFocus
+      : document.activeElement instanceof HTMLElement ? document.activeElement : null
+    if (dialog && !dialog.open) dialog.showModal()
     headingRef.current?.focus()
     return () => {
-      if (previousFocusRef.current?.isConnected) previousFocusRef.current.focus()
+      if (dialog?.open) dialog.close()
+      const previousFocus = previousFocusRef.current
+      requestAnimationFrame(() => {
+        if (previousFocus?.isConnected) previousFocus.focus()
+      })
     }
-  }, [action])
+  }, [action, returnFocus])
 
   if (!action) return null
 
@@ -830,7 +854,8 @@ function AccountableActionGate({ action, authenticatedActor, onCancel, onConfirm
     if (!action) return
     const responsibleActor = action.confirmation?.actor ?? authenticatedActor?.id ?? actor.trim()
     const confirmedReason = action.confirmation?.reason ?? reason.trim()
-    const confirmedEvidence = action.confirmation?.evidenceReference ?? evidenceReference.trim()
+    const confirmedEvidence = action.confirmation?.evidenceReference
+      ?? (action.evidenceReferenceLocked ? action.evidenceReferenceSuggestion?.trim() ?? '' : evidenceReference.trim())
     if (!responsibleActor || !confirmedReason || !confirmedEvidence) return
     setBusy(true)
     setError('')
@@ -842,18 +867,18 @@ function AccountableActionGate({ action, authenticatedActor, onCancel, onConfirm
     }
   }
 
-  return <section className="core-panel accountable-action-gate" aria-label="Human action confirmation">
-    <div className="action-change"><span className="core-eyebrow">Human confirmation</span><h2 ref={headingRef} tabIndex={-1}>{action.summary}</h2><p><strong>{action.before}</strong><span>→</span><strong>{action.after}</strong></p></div>
+  return <dialog aria-labelledby="action-confirm-title" className="accountable-action-gate" onCancel={(event) => { event.preventDefault(); if (!busy && !action.confirmation) onCancel() }} ref={dialogRef}>
+    <div className="action-change"><span className="core-eyebrow">Confirm change</span><h2 id="action-confirm-title" ref={headingRef} tabIndex={-1}>{action.summary}</h2><p><strong>{action.before}</strong><span>→</span><strong>{action.after}</strong></p></div>
     <form className="core-form action-confirm-form" onSubmit={(event) => void submit(event)}>
       {authenticatedActor
-        ? <label>Authenticated operator<input readOnly value={authenticatedActor.label} /></label>
-        : <label>Responsible operator<input maxLength={80} readOnly={Boolean(action.confirmation)} required value={action.confirmation?.actor ?? actor} onChange={(event) => setActor(event.target.value)} placeholder="Name or accountable role" /></label>}
+        ? <label>Your account<input readOnly value={authenticatedActor.label} /></label>
+        : <label>Your name<input maxLength={80} readOnly={Boolean(action.confirmation)} required value={action.confirmation?.actor ?? actor} onChange={(event) => setActor(event.target.value)} placeholder="Name or responsible role" /></label>}
       <label>Reason<input maxLength={180} readOnly={Boolean(action.confirmation)} required value={action.confirmation?.reason ?? reason} onChange={(event) => setReason(event.target.value)} placeholder="Why this change is correct now" /></label>
-      <label>Evidence source or reference<input maxLength={180} readOnly={Boolean(action.confirmation)} required value={action.confirmation?.evidenceReference ?? evidenceReference} onChange={(event) => setEvidenceReference(event.target.value)} placeholder="Message ID, receipt, count sheet, or observation" /></label>
-      <div className="form-actions"><button className="text-link" disabled={busy || Boolean(action.confirmation)} onClick={onCancel} type="button">Cancel</button><button className="core-button primary compact" disabled={busy} type="submit">{busy ? 'Applying…' : action.confirmation ? 'Retry same confirmation' : 'Confirm and record'}</button></div>
+      <label>Reference<input maxLength={180} readOnly={Boolean(action.confirmation) || action.evidenceReferenceLocked} required value={action.confirmation?.evidenceReference ?? (action.evidenceReferenceLocked ? action.evidenceReferenceSuggestion ?? '' : evidenceReference)} onChange={(event) => setEvidenceReference(event.target.value)} placeholder="Message ID, receipt, count sheet, or observation" /></label>
+      <div className="form-actions"><button className="core-button" disabled={busy || Boolean(action.confirmation)} onClick={onCancel} type="button">Cancel</button><button className="core-button primary" disabled={busy} type="submit">{busy ? 'Applying…' : action.confirmation ? 'Retry same confirmation' : 'Confirm change'}</button></div>
       {error || action.confirmation ? <p className="form-notice" role="status">{error || 'This command proof is frozen. Any retry reuses the same command and evidence; reload can reconcile managed state.'}</p> : null}
     </form>
-  </section>
+  </dialog>
 }
 
 function ActionHistory({ actions, domain }: { actions: AccountableAction[]; domain: ActionDomain }) {
@@ -1038,6 +1063,19 @@ export function OverviewPage() {
   const operatingExceptions = lowStock.length + openProductionIssues.length
   const ownerAttention = blockedWork.length + pendingApprovals.length + agentHandoffs.length + operatingExceptions + (isPilotReady ? 0 : 1)
   const selectedApproval = pendingApprovals.find((approval) => approval.id === selectedApprovalId)
+  const nextPriority: { label: string; title: string; detail: string; action: string; href?: string; approvalId?: string } = pendingApprovals[0]
+    ? { label: 'Approval', title: pendingApprovals[0].title, detail: `${pendingApprovals[0].packet.claims.length} claims are ready for a human decision.`, action: 'Review now', approvalId: pendingApprovals[0].id }
+    : blockedWork[0]
+      ? { label: 'Blocked work', title: blockedWork[0].title, detail: `${blockedWork[0].owner} needs a decision to continue.`, action: 'Review work', href: `/work/?team=${blockedWork[0].team}&view=work&item=${blockedWork[0].id}` }
+      : agentHandoffs[0]
+        ? { label: 'Team handoff', title: `${agentHandoffs[0].name} needs review`, detail: `${agentHandoffs[0].humanOwner} owns the next decision.`, action: 'Review handoff', href: `/work/?team=${agentHandoffs[0].team}&view=agents&agent=${agentHandoffs[0].id}` }
+        : lowStock[0]
+          ? { label: 'Stock', title: `Reorder ${lowStock[0].name}`, detail: `${lowStock[0].onHand} on hand; boundary is ${lowStock[0].reorderAt}.`, action: 'Open stock', href: '/operations/commerce/?tab=inventory' }
+          : openProductionIssues[0]
+            ? { label: 'Production problem', title: openProductionIssues[0].summary, detail: `${openProductionIssues[0].area} needs review.`, action: 'Review problem', href: '/operations/production/?tab=control' }
+            : !isPilotReady
+              ? { label: 'Setup', title: 'Define the measurable workflow', detail: `${pilotProgress(setup)}% complete; add the baseline and acceptance evidence.`, action: 'Finish setup', href: '/settings/' }
+              : { label: 'Ready', title: openOrders[0] ? `Continue ${openOrders[0].id}` : 'Start with Commerce', detail: openOrders[0] ? 'Move the next open order forward.' : 'No owner decision is waiting.', action: openOrders[0] ? 'Open orders' : 'Open Commerce', href: '/operations/commerce/?tab=orders' }
 
   useEffect(() => {
     if (!managedIdentity) return undefined
@@ -1150,14 +1188,13 @@ export function OverviewPage() {
 
   return (
     <div className="workspace-screen command-screen">
-      <PageHeading
-        actions={ownerAttention
-          ? <a className="core-button primary" href="#owner-priorities">Review {ownerAttention} {ownerAttention === 1 ? 'priority' : 'priorities'}</a>
-          : <Link className="core-button primary" to="/operations/commerce/?tab=today">Open Commerce</Link>}
-        copy="Open a product to do the work, or review the few items that need your decision."
-        eyebrow="Home"
-        title="Run what matters today."
-      />
+      <PageHeading copy="One clear next action, then the rest when you need it." eyebrow="Home" title="Today" />
+      <section className="core-panel next-task-card">
+        <div><span className="core-eyebrow">{nextPriority.label}</span><h2>{nextPriority.title}</h2><p>{nextPriority.detail}</p></div>
+        {nextPriority.approvalId
+          ? <button className="core-button primary" onClick={() => setSelectedApprovalId(nextPriority.approvalId ?? '')} type="button">{nextPriority.action}</button>
+          : <Link className="core-button primary" to={nextPriority.href ?? '/'}>{nextPriority.action}</Link>}
+      </section>
       <nav aria-label="Products" className="product-launcher">
         <Link to="/operations/commerce/?tab=today">
           <span><strong>Commerce</strong><small>Orders, stock and payments</small></span>
@@ -1172,7 +1209,9 @@ export function OverviewPage() {
           <b>Open</b>
         </Link>
       </nav>
-      <div className="command-grid">
+      <details className="home-more">
+        <summary><span>More activity</span><small>{visibleWork.length} active work · {ownerAttention} priorities</small></summary>
+        <div className="command-grid">
         <section className="core-panel command-queue-panel">
           <div className="panel-head"><div><span className="core-eyebrow">Active work</span><h2>{visibleWork.length} items in motion</h2></div><Link className="text-link" to="/work/?team=product&view=work">View all work</Link></div>
           <div className="record-list">{homeWork.map((item) => { const team = teamDefinitions.find((definition) => definition.id === item.team); return <Link className="record-row" key={item.id} to={`/work/?team=${item.team}&view=work&item=${item.id}`}><span className={`record-status ${item.status}`} /><span><strong>{item.title}</strong><small>{team?.label ?? item.team} / {item.owner} / {item.evidence.length} evidence</small></span><span><b>{item.priority}</b><small>{item.status.replace('_', ' ')}</small></span></Link> })}</div>
@@ -1196,6 +1235,7 @@ export function OverviewPage() {
           <details className="company-brief-disclosure"><summary>Company brief</summary><button className="text-link" onClick={prepareCompanyBrief} type="button">Prepare brief</button>{brief.length ? <div className="brief-output compact">{brief.map((line) => <p key={line}>{line}</p>)}<button className="core-button compact" disabled={briefBusy} onClick={() => void requestBriefApproval()} type="button">{briefBusy ? 'Recording…' : 'Request owner review'}</button></div> : <p className="panel-copy">Prepared locally from visible work and operating records.</p>}{briefNotice ? <p className="form-notice" role="status">{briefNotice}</p> : null}</details>
         </section>
       </div>
+      </details>
       {selectedApproval ? <ApprovalReviewDialog approval={selectedApproval} onClose={() => setSelectedApprovalId('')} onDecision={(status, reviewer, note) => setApprovalStatus(selectedApproval.id, status, reviewer, note)} /> : null}
     </div>
   )
@@ -1206,47 +1246,199 @@ export function OperationsPage() {
   const location = useLocation()
   const navigate = useNavigate()
   const [searchParams] = useSearchParams()
-  const [setup] = useSetupWorkspace()
   const [managedIdentity] = useManagedIdentity(runtime.status === 'enterprise')
   const routeModule = location.pathname.split('/').filter(Boolean)[1]
   const requestedView = searchParams.get('view')
+  const isProductRoute = routeModule === 'commerce' || routeModule === 'production'
   const view: ProductId = routeModule === 'production' || requestedView === 'production' || requestedView === 'plant' ? 'production' : 'commerce'
   const commerceTab = commerceTabs.some((tab) => tab.id === searchParams.get('tab')) ? searchParams.get('tab') as CommerceTab : 'today'
   const productionTab = productionTabs.some((tab) => tab.id === searchParams.get('tab')) ? searchParams.get('tab') as ProductionTab : 'today'
   const activeTab = view === 'commerce' ? commerceTab : productionTab
-  const activeTemplate = templateFor(view, setup.product === view ? setup.template : '')
-  const configuredProfile = setup.product === view && Boolean(setup.savedAt)
-  const profileLabel = configuredProfile && setup.workspace.trim() ? setup.workspace : 'Template profile'
-  const profileMeasure = configuredProfile && setup.targetOutcome.trim() ? setup.targetOutcome : activeTemplate.metric
-  const operationsCopy = view === 'commerce'
-    ? 'Orders from the channels customers use, then stock, fulfilment, payment, and close.'
-    : 'Plan, output, equipment, quality, maintenance, and shift exceptions in one operating record.'
 
   useEffect(() => {
+    if (!isProductRoute && !requestedView) return
     const canonicalPath = `/operations/${view}/`
     if (location.pathname !== canonicalPath || requestedView) navigate(`${canonicalPath}?tab=${activeTab}`, { replace: true })
-  }, [activeTab, location.pathname, navigate, requestedView, view])
-
-  function setMode(nextView: ProductId) {
-    navigate(`/operations/${nextView}/?tab=today`)
-  }
+  }, [activeTab, isProductRoute, location.pathname, navigate, requestedView, view])
 
   function setTab(tab: CommerceTab | ProductionTab) {
     navigate(`/operations/${view}/?tab=${tab}`, { replace: true })
   }
 
   const tabs = view === 'commerce' ? commerceTabs : productionTabs
+  const productCopy = view === 'commerce'
+    ? 'Orders, payments, and stock in one place.'
+    : 'Jobs, output, equipment, and problems in one place.'
+
+  if (!isProductRoute && !requestedView) {
+    return <div className="workspace-screen product-catalog-screen">
+      <PageHeading eyebrow="Products" title="Apps" copy="Choose the workspace for the job you need to do." />
+      <nav aria-label="SuperMega apps" className="product-launcher product-catalog">
+        <Link to="/operations/commerce/?tab=today"><span><strong>Commerce</strong><small>Orders, payments, and stock</small></span><b>Open</b></Link>
+        <Link to="/operations/production/?tab=today"><span><strong>Production</strong><small>Jobs, output, and problems</small></span><b>Open</b></Link>
+        <Link to="/products/website/"><span><strong>Website</strong><small>Edit, preview, and prepare to publish</small></span><b>Open</b></Link>
+      </nav>
+    </div>
+  }
 
   return (
     <div className="workspace-screen operations-screen">
-      <PageHeading eyebrow="Products" title={view === 'commerce' ? 'Commerce' : 'Production'} copy={`${operationsCopy} Measure: ${profileMeasure}.`} actions={<div className="operations-profile"><span>{profileLabel}</span><strong>{activeTemplate.name}</strong><Link className="text-link" to="/settings/">Configure</Link></div>} />
-      <div className="workspace-toolbar operations-toolbar">
-        <div className="segmented-control" role="group" aria-label="Operating workspace"><button aria-pressed={view === 'commerce'} onClick={() => setMode('commerce')} type="button">Commerce</button><button aria-pressed={view === 'production'} onClick={() => setMode('production')} type="button">Production</button></div>
-        <div className="operations-toolbar-actions"><nav className="view-tabs" aria-label="Module views">{tabs.map((tab) => <button aria-current={activeTab === tab.id ? 'page' : undefined} key={tab.id} onClick={() => setTab(tab.id)} type="button">{tab.label}</button>)}</nav></div>
-      </div>
+      <PageHeading eyebrow={view === 'commerce' ? 'Commerce' : 'Production'} title={view === 'commerce' ? 'Commerce' : 'Production'} copy={productCopy} actions={<Link className="text-link all-apps-link" to="/operations/">All apps</Link>} />
+      <nav className="workspace-toolbar view-tabs product-task-tabs" aria-label={`${view === 'commerce' ? 'Commerce' : 'Production'} tasks`}>{tabs.map((tab) => <button aria-current={activeTab === tab.id ? 'page' : undefined} key={tab.id} onClick={() => setTab(tab.id)} type="button">{tab.label}</button>)}</nav>
       <div className="workspace-view">{view === 'commerce' ? <CommercePage managedIdentity={managedIdentity} tab={commerceTab} /> : <ProductionPage tab={productionTab} />}</div>
     </div>
   )
+}
+
+type ChannelAttributionDraft = { kind: ChannelOrderAttributionInput['kind']; quote: string }
+
+const channelFieldLabels: Record<ChannelOrderField, string> = {
+  customer: 'Customer',
+  sku: 'Item',
+  quantity: 'Quantity',
+  payment: 'Payment',
+}
+
+function emptyChannelAttributions(): Record<ChannelOrderField, ChannelAttributionDraft> {
+  return {
+    customer: { kind: 'quote', quote: '' },
+    sku: { kind: 'quote', quote: '' },
+    quantity: { kind: 'quote', quote: '' },
+    payment: { kind: 'quote', quote: '' },
+  }
+}
+
+function channelDraftBlockerLabel(blocker: string) {
+  const field = channelOrderFields.find((candidate) => blocker.startsWith(`${candidate}_`))
+  const fieldLabel = field ? channelFieldLabels[field] : ''
+  if (blocker === 'source_label_required') return 'Add a message ID or approved sample label.'
+  if (blocker === 'source_message_required') return 'Paste one approved or synthetic message.'
+  if (blocker === 'source_message_too_long') return `Keep the single message under ${CHANNEL_ORDER_MESSAGE_MAX.toLocaleString()} characters.`
+  if (blocker === 'channel_invalid') return 'Choose Messenger, Viber, or Phone.'
+  if (blocker === 'customer_required') return 'Add a customer reference.'
+  if (blocker === 'sku_required') return 'Choose a catalog item.'
+  if (blocker === 'sku_unknown') return 'The selected item is not in the current catalog.'
+  if (blocker === 'quantity_invalid') return 'Enter a whole quantity from 1 to 9,999.'
+  if (blocker === 'payment_invalid') return 'Choose a supported payment intent.'
+  if (blocker === 'source_quote_required') return 'Map at least one field to exact words from the message.'
+  if (blocker.endsWith('_attribution_required')) return `${fieldLabel} needs an exact quote or Operator supplied.`
+  if (blocker.endsWith('_quote_required')) return `Add the exact ${fieldLabel.toLowerCase()} words from the message.`
+  if (blocker.endsWith('_quote_must_be_excerpt')) return `Use a short ${fieldLabel.toLowerCase()} excerpt, not the full message.`
+  if (blocker.endsWith('_quote_not_found')) return `The ${fieldLabel.toLowerCase()} quote is not in this message.`
+  if (blocker.endsWith('_quote_ambiguous')) return `Use a longer, unique ${fieldLabel.toLowerCase()} quote.`
+  return blocker.replaceAll('_', ' ')
+}
+
+function ChannelOrderIntake({ disabled, items, onAcceptedFocus, onUse }: {
+  disabled: boolean
+  items: CommerceItem[]
+  onAcceptedFocus: () => void
+  onUse: (draft: ChannelOrderDraft) => void
+}) {
+  const [sourceLabel, setSourceLabel] = useState('')
+  const [message, setMessage] = useState('')
+  const [channel, setChannel] = useState('Messenger')
+  const [customer, setCustomer] = useState('')
+  const [sku, setSku] = useState(items[0]?.sku ?? '')
+  const [quantity, setQuantity] = useState('1')
+  const [payment, setPayment] = useState('KBZPay')
+  const [attributions, setAttributions] = useState(emptyChannelAttributions)
+  const [reviewedDraft, setReviewedDraft] = useState<ChannelOrderDraft | null>(null)
+  const selectedSku = items.some((item) => item.sku === sku) ? sku : items[0]?.sku ?? ''
+
+  function invalidateReview() {
+    if (reviewedDraft) setReviewedDraft(null)
+  }
+
+  function updateAttribution(field: ChannelOrderField, patch: Partial<ChannelAttributionDraft>) {
+    setAttributions((current) => ({ ...current, [field]: { ...current[field], ...patch } }))
+    invalidateReview()
+  }
+
+  function reviewMessage(event: FormEvent) {
+    event.preventDefault()
+    const normalizedAttributions = Object.fromEntries(channelOrderFields.map((field) => {
+      const attribution = attributions[field]
+      const value: ChannelOrderAttributionInput = attribution.kind === 'operator_supplied'
+        ? { kind: 'operator_supplied' }
+        : { kind: 'quote', quote: attribution.quote }
+      return [field, value]
+    })) as Record<ChannelOrderField, ChannelOrderAttributionInput>
+    setReviewedDraft(buildChannelOrderDraft({
+      sourceLabel,
+      message,
+      channel,
+      customer,
+      sku: selectedSku,
+      quantity: Number(quantity),
+      payment,
+      catalogSkus: items.map((item) => item.sku),
+      attributions: normalizedAttributions,
+    }))
+  }
+
+  function useReviewedDraft() {
+    if (!reviewedDraft || !channelOrderDraftIsReady(reviewedDraft)) return
+    onUse(reviewedDraft)
+    setSourceLabel('')
+    setMessage('')
+    setCustomer('')
+    setQuantity('1')
+    setAttributions(emptyChannelAttributions())
+    setReviewedDraft(null)
+    onAcceptedFocus()
+  }
+
+  return <section className="channel-intake-panel">
+    <div className="channel-intake-heading"><span className="core-eyebrow">Human-mapped intake</span><h3>Start from a channel message</h3><p>Paste one approved or synthetic message. Nothing is sent, and AI is not connected.</p></div>
+    <form className="core-form channel-intake-form" onSubmit={reviewMessage}>
+      <div className="channel-intake-boundary"><p>Use one message, not a full conversation history. Map at least one exact excerpt.</p></div>
+      <div className="form-row">
+        <label>Message reference<input disabled={disabled} maxLength={120} onChange={(event) => { setSourceLabel(event.target.value); invalidateReview() }} placeholder="Message ID or approved sample" required value={sourceLabel} /></label>
+        <label>Channel<select disabled={disabled} onChange={(event) => { setChannel(event.target.value); invalidateReview() }} value={channel}>{channelOrderChannels.map((entry) => <option key={entry}>{entry}</option>)}</select></label>
+      </div>
+      <label>Single message<textarea disabled={disabled} maxLength={CHANNEL_ORDER_MESSAGE_MAX} onChange={(event) => { setMessage(event.target.value); invalidateReview() }} placeholder="Paste only the message needed to prepare this order." required value={message} /></label>
+      <div className="channel-mapping-list">
+        <div className="channel-mapping-row">
+          <label>Customer reference<input disabled={disabled} maxLength={80} onChange={(event) => { setCustomer(event.target.value); invalidateReview() }} placeholder="Name or internal reference" required value={customer} /></label>
+          <ChannelAttributionControl attribution={attributions.customer} disabled={disabled} field="customer" onChange={updateAttribution} />
+        </div>
+        <div className="channel-mapping-row">
+          <label>Catalog item<select disabled={disabled} onChange={(event) => { setSku(event.target.value); invalidateReview() }} value={selectedSku}>{items.map((item) => <option key={item.sku} value={item.sku}>{item.name} / {item.sku}</option>)}</select></label>
+          <ChannelAttributionControl attribution={attributions.sku} disabled={disabled} field="sku" onChange={updateAttribution} />
+        </div>
+        <div className="channel-mapping-row">
+          <label>Quantity<input disabled={disabled} max="9999" min="1" onChange={(event) => { setQuantity(event.target.value); invalidateReview() }} required step="1" type="number" value={quantity} /></label>
+          <ChannelAttributionControl attribution={attributions.quantity} disabled={disabled} field="quantity" onChange={updateAttribution} />
+        </div>
+        <div className="channel-mapping-row">
+          <label>Payment intent<select disabled={disabled} onChange={(event) => { setPayment(event.target.value); invalidateReview() }} value={payment}>{channelOrderPayments.map((entry) => <option key={entry}>{entry}</option>)}</select></label>
+          <ChannelAttributionControl attribution={attributions.payment} disabled={disabled} field="payment" onChange={updateAttribution} />
+        </div>
+      </div>
+      <button className="core-button compact" disabled={disabled} type="submit">Review field mapping</button>
+    </form>
+    {reviewedDraft ? <div aria-live="polite" className={`channel-draft-result ${channelOrderDraftIsReady(reviewedDraft) ? 'ready' : 'review'}`}>
+      <div><span className="core-eyebrow">Ephemeral draft</span><strong>{channelOrderDraftIsReady(reviewedDraft) ? 'Ready for accountable confirmation' : 'Needs review'}</strong></div>
+      {channelOrderDraftIsReady(reviewedDraft) ? <>
+        <p>{reviewedDraft.sourceRecordId} / {reviewedDraft.provenance.filter((entry) => entry.kind === 'quote').length} exact source mappings</p>
+        <button className="core-button primary compact" disabled={disabled} onClick={useReviewedDraft} type="button">Use reviewed draft</button>
+      </> : <ul>{reviewedDraft.blockers.slice(0, 4).map((blocker) => <li key={blocker}>{channelDraftBlockerLabel(blocker)}</li>)}</ul>}
+      <small>The full message is not part of the order record.</small>
+    </div> : null}
+  </section>
+}
+
+function ChannelAttributionControl({ attribution, disabled, field, onChange }: {
+  attribution: ChannelAttributionDraft
+  disabled: boolean
+  field: ChannelOrderField
+  onChange: (field: ChannelOrderField, patch: Partial<ChannelAttributionDraft>) => void
+}) {
+  return <div className="channel-attribution">
+    <label className="channel-operator-check"><input aria-label={`${channelFieldLabels[field]} is operator supplied`} checked={attribution.kind === 'operator_supplied'} disabled={disabled} onChange={(event) => onChange(field, { kind: event.target.checked ? 'operator_supplied' : 'quote' })} type="checkbox" /><span>Operator supplied</span></label>
+    {attribution.kind === 'quote' ? <label>Exact words<input aria-label={`${channelFieldLabels[field]} exact source words`} disabled={disabled} maxLength={CHANNEL_ORDER_QUOTE_MAX} onChange={(event) => onChange(field, { quote: event.target.value })} placeholder="Copy a short, unique excerpt" required value={attribution.quote} /></label> : <small>Human-entered; no source quote claimed.</small>}
+  </div>
 }
 
 function CommercePage({ managedIdentity, tab }: { managedIdentity: ManagedIdentity | null; tab: CommerceTab }) {
@@ -1258,6 +1450,10 @@ function CommercePage({ managedIdentity, tab }: { managedIdentity: ManagedIdenti
   const [customer, setCustomer] = useState('')
   const [channel, setChannel] = useState('Messenger')
   const [payment, setPayment] = useState('KBZPay')
+  const [preparedChannelDraft, setPreparedChannelDraft] = useState<ChannelOrderDraft | null>(null)
+  const [orderEntryMode, setOrderEntryMode] = useState<'manual' | 'message' | 'website'>('manual')
+  const preparedChannelRef = useRef<HTMLDivElement>(null)
+  const [actionTrigger, setActionTrigger] = useState<HTMLElement | null>(null)
   const [notice, setNotice] = useState('')
   const [catalogDraft, setCatalogDraft] = useState({ sku: '', name: '', onHand: '', reorderAt: '', price: '', reason: '', evidenceReference: '' })
   const [itemDraft, setItemDraft] = useState({ sku: '', name: '', onHand: '', reorderAt: '', price: '' })
@@ -1340,6 +1536,7 @@ function CommercePage({ managedIdentity, tab }: { managedIdentity: ManagedIdenti
       setNotice(`Finish or cancel ${pendingAction.id} before reviewing another change.`)
       return false
     }
+    setActionTrigger(document.activeElement instanceof HTMLElement ? document.activeElement : null)
     setPendingAction({ ...action, id: uid('ACT'), commandId: commandUuid(), domain: 'commerce' })
     setNotice('Review the change, accountable operator, and evidence before it is applied.')
     return true
@@ -1381,6 +1578,10 @@ function CommercePage({ managedIdentity, tab }: { managedIdentity: ManagedIdenti
 
   async function confirmAction(details: ActionDetails) {
     if (!pendingAction) return
+    if (pendingAction.evidenceReferenceLocked
+      && details.evidenceReference.trim() !== pendingAction.evidenceReferenceSuggestion) {
+      throw new Error('Source-backed evidence is fixed to the reviewed message mapping. Cancel and review the source again to change it.')
+    }
     const record = confirmAccountableAction(
       pendingAction,
       managedIdentity ? { ...details, actor: managedIdentity.userId } : details,
@@ -1396,25 +1597,72 @@ function CommercePage({ managedIdentity, tab }: { managedIdentity: ManagedIdenti
     setPendingAction(null)
   }
 
+  function useChannelDraft(draft: ChannelOrderDraft) {
+    if (pendingAction || !channelOrderDraftIsReady(draft)) {
+      setNotice('Finish the current accountable action before using another channel draft.')
+      return
+    }
+    setCustomer(draft.customer)
+    setChannel(draft.channel)
+    setSku(draft.sku)
+    setQuantity(draft.quantity)
+    setPayment(draft.payment)
+    setPreparedChannelDraft(draft)
+    setOrderEntryMode('manual')
+    setNotice(`${draft.sourceRecordId} mapped locally. Review the structured order before any stock changes.`)
+  }
+
   function recordOrder(event: FormEvent) {
     event.preventDefault()
     if (!selected || quantity < 1 || selected.onHand < quantity) {
       setNotice('Quantity is not available. Review stock before confirming the order.')
       return
     }
-    const order: CommerceOrder = { id: uid('ORD'), createdAt: new Date().toISOString(), customer: customer.trim() || 'Guest', channel, item: selected.name, itemSku: selected.sku, quantity, payment, paymentStatus: 'pending', refundStatus: 'none', total: selected.price * quantity, status: 'confirmed' }
+    const sourceDraft = preparedChannelDraft && channelOrderDraftIsReady(preparedChannelDraft) ? preparedChannelDraft : null
+    if (sourceDraft && (customer.trim() !== sourceDraft.customer
+      || channel !== sourceDraft.channel
+      || selected.sku !== sourceDraft.sku
+      || quantity !== sourceDraft.quantity
+      || payment !== sourceDraft.payment)) {
+      setPreparedChannelDraft(null)
+      setNotice('The structured order changed after source review. Review the channel mapping again or continue as a manual order.')
+      return
+    }
+    if (sourceDraft && commerce.orders.some((candidate) => candidate.sourceRecordId === sourceDraft.sourceRecordId)) {
+      setNotice(`${sourceDraft.sourceRecordId} is already linked to an order. No duplicate was queued.`)
+      return
+    }
+    const order: CommerceOrder = {
+      id: uid('ORD'),
+      createdAt: new Date().toISOString(),
+      customer: customer.trim() || 'Guest',
+      channel,
+      item: selected.name,
+      itemSku: selected.sku,
+      quantity,
+      payment,
+      paymentStatus: 'pending',
+      refundStatus: 'none',
+      sourceRecordId: sourceDraft?.sourceRecordId,
+      evidenceReference: sourceDraft?.evidenceReference,
+      total: selected.price * quantity,
+      status: 'confirmed',
+    }
     const itemSku = selected.sku
     const beforeStock = selected.onHand
     queueAction({
       kind: 'order_create',
       subjectId: order.id,
-      summary: `Confirm ${order.id} from ${channel}`,
-      before: `${itemSku} · ${beforeStock} on hand`,
+      summary: `Confirm ${order.id} from ${sourceDraft ? `${channel} source ${sourceDraft.sourceRecordId}` : channel}`,
+      before: `${itemSku} · ${beforeStock} on hand${sourceDraft ? ` · ${sourceDraft.sourceRecordId} reviewed` : ''}`,
       after: `${order.status} · ${beforeStock - quantity} on hand`,
+      evidenceReferenceSuggestion: sourceDraft?.evidenceReference,
+      evidenceReferenceLocked: Boolean(sourceDraft),
       apply: async (action) => {
         await mutateCommerce('commerce.order.created', action.commandId, commerceActionProof(action), (current) => reserveCommerceOrder(current, order, commerceActionProof(action)))
         setQuantity(1)
         setCustomer('')
+        setPreparedChannelDraft(null)
       },
     })
   }
@@ -1542,28 +1790,41 @@ function CommercePage({ managedIdentity, tab }: { managedIdentity: ManagedIdenti
     queueAction({ kind: 'daily_close', subjectId: close.id, summary: `Save ${close.id} daily close`, before: `${commerce.closes.length} snapshots`, after: `${commerce.closes.length + 1} snapshots · ${formatMoney(close.total)}`, apply: (action) => mutateCommerce('commerce.close.saved', action.commandId, commerceActionProof(action), (current) => current.closes.some((candidate) => candidate.id === close.id) ? current : { ...current, closes: [close, ...current.closes] }) })
   }
 
-  const actionControls = <><AccountableActionGate authenticatedActor={managedIdentity ? { id: managedIdentity.userId, label: managedIdentity.email } : undefined} key={pendingAction?.id ?? 'commerce-idle'} action={pendingAction} onCancel={() => setPendingAction(null)} onConfirm={confirmAction} />{managedIdentity ? null : <ActionHistory actions={actions} domain="commerce" />}</>
+  const actionControls = <><AccountableActionGate authenticatedActor={managedIdentity ? { id: managedIdentity.userId, label: managedIdentity.email } : undefined} key={pendingAction?.id ?? 'commerce-idle'} action={pendingAction} onCancel={() => setPendingAction(null)} onConfirm={confirmAction} returnFocus={actionTrigger} />{managedIdentity ? null : <ActionHistory actions={actions} domain="commerce" />}</>
 
-  if (tab === 'orders') return <div className="operation-module">{sourceNotice}<WebsiteCommerceIntake catalog={commerce.items} importedSourceIds={importedWebsiteOrderIds} key={`${managedIdentity ? 'managed' : 'local'}:${websiteIntakes.find((intake) => intake.status === 'pending_confirmation')?.id ?? 'none'}`} managedIntakes={websiteIntakes} mode={managedIdentity ? 'managed' : 'local'} onQueueManagedIntake={queueManagedWebsiteIntake} onQueueReadyOrder={queueWebsiteOrder} /><div className="split-workspace order-view">
+  if (tab === 'orders') return <div className="operation-module"><div className="split-workspace order-view">
     <section className="core-panel order-form-panel">
-      <div className="panel-head"><div><span className="core-eyebrow">Channel order</span><h2>Enter an order</h2></div><span className="status-pill ready">Stock checked</span></div>
-      <form className="core-form compact-form" onSubmit={recordOrder}>
-        <div className="form-row">
-          <label>Customer<input maxLength={80} value={customer} onChange={(event) => setCustomer(event.target.value)} placeholder="Name or reference" /></label>
-          <label>Channel<select value={channel} onChange={(event) => setChannel(event.target.value)}><option>Messenger</option><option>Viber</option><option>Phone</option><option>Website</option><option>Walk-in</option></select></label>
-        </div>
-        <label>Item<select value={selectedSku} onChange={(event) => setSku(event.target.value)}>{commerce.items.map((item) => <option key={item.sku} value={item.sku}>{item.name} · {item.onHand} available</option>)}</select></label>
-        <div className="form-row">
-          <label>Quantity<input min="1" max={selected?.onHand ?? 1} type="number" value={quantity} onChange={(event) => setQuantity(Number(event.target.value))} /></label>
-          <label>Payment<select value={payment} onChange={(event) => setPayment(event.target.value)}><option>KBZPay</option><option>WavePay</option><option>Cash on delivery</option><option>Cash</option><option>Card</option></select></label>
-        </div>
-        <div className="order-total"><span>Order total</span><strong>{formatMoney((selected?.price ?? 0) * Math.max(quantity, 0))}</strong></div>
-        <button className="core-button primary" type="submit">Review order</button>
-        <p className="form-notice" aria-live="polite">{notice || commerceStorageError || 'A responsible operator confirms the change before stock moves. No customer message is sent.'}</p>
-      </form>
+      <div className="panel-head"><div><span className="core-eyebrow">New order</span><h2>How did this order arrive?</h2></div><span className="status-pill ready">Stock checked</span></div>
+      <div aria-label="Order source" className="order-entry-methods" role="tablist">
+        <button aria-selected={orderEntryMode === 'manual'} disabled={Boolean(pendingAction)} onClick={() => setOrderEntryMode('manual')} role="tab" type="button">Manual</button>
+        <button aria-selected={orderEntryMode === 'message'} disabled={Boolean(pendingAction)} onClick={() => setOrderEntryMode('message')} role="tab" type="button">Message</button>
+        <button aria-selected={orderEntryMode === 'website'} disabled={Boolean(pendingAction)} onClick={() => setOrderEntryMode('website')} role="tab" type="button">Website</button>
+      </div>
+      {orderEntryMode === 'website' ? <div className="order-entry-panel" role="tabpanel"><WebsiteCommerceIntake catalog={commerce.items} importedSourceIds={importedWebsiteOrderIds} key={`${managedIdentity ? 'managed' : 'local'}:${websiteIntakes.find((intake) => intake.status === 'pending_confirmation')?.id ?? 'none'}`} managedIntakes={websiteIntakes} mode={managedIdentity ? 'managed' : 'local'} onQueueManagedIntake={queueManagedWebsiteIntake} onQueueReadyOrder={queueWebsiteOrder} /></div> : null}
+      {orderEntryMode === 'message' ? <div className="order-entry-panel" role="tabpanel"><ChannelOrderIntake disabled={Boolean(pendingAction)} items={commerce.items} onAcceptedFocus={() => requestAnimationFrame(() => preparedChannelRef.current?.focus())} onUse={useChannelDraft} /></div> : null}
+      {orderEntryMode === 'manual' ? <div className="order-entry-panel" role="tabpanel">
+        {preparedChannelDraft && channelOrderDraftIsReady(preparedChannelDraft) ? <div className="channel-source-ready" ref={preparedChannelRef} tabIndex={-1}>
+          <div><span className="core-eyebrow">Mapped source</span><strong>{preparedChannelDraft.sourceRecordId}</strong><small>Exact excerpts reviewed; the full message was discarded.</small></div>
+          <button className="text-link" disabled={Boolean(pendingAction)} onClick={() => { setPreparedChannelDraft(null); setNotice('Source link removed. The structured fields remain as a manual order draft.') }} type="button">Remove source link</button>
+        </div> : null}
+        <form className="core-form compact-form" onSubmit={recordOrder}>
+          <div className="form-row">
+            <label>Customer<input disabled={Boolean(pendingAction)} maxLength={80} value={customer} onChange={(event) => { setCustomer(event.target.value); setPreparedChannelDraft(null) }} placeholder="Name or reference" /></label>
+            <label>Channel<select disabled={Boolean(pendingAction)} value={channel} onChange={(event) => { setChannel(event.target.value); setPreparedChannelDraft(null) }}><option>Messenger</option><option>Viber</option><option>Phone</option><option>Website</option><option>Walk-in</option></select></label>
+          </div>
+          <label>Item<select disabled={Boolean(pendingAction)} value={selectedSku} onChange={(event) => { setSku(event.target.value); setPreparedChannelDraft(null) }}>{commerce.items.map((item) => <option key={item.sku} value={item.sku}>{item.name} · {item.onHand} available</option>)}</select></label>
+          <div className="form-row">
+            <label>Quantity<input disabled={Boolean(pendingAction)} min="1" max={selected?.onHand ?? 1} type="number" value={quantity} onChange={(event) => { setQuantity(Number(event.target.value)); setPreparedChannelDraft(null) }} /></label>
+            <label>Payment<select disabled={Boolean(pendingAction)} value={payment} onChange={(event) => { setPayment(event.target.value); setPreparedChannelDraft(null) }}><option>KBZPay</option><option>WavePay</option><option>Cash on delivery</option><option>Cash</option><option>Card</option></select></label>
+          </div>
+          <div className="order-total"><span>Order total</span><strong>{formatMoney((selected?.price ?? 0) * Math.max(quantity, 0))}</strong></div>
+          <button className="core-button primary" disabled={Boolean(pendingAction)} type="submit">Review order</button>
+          <p className="form-notice" aria-live="polite">{notice || commerceStorageError || 'A responsible operator confirms the change before stock moves. No customer message is sent.'}</p>
+        </form>
+      </div> : null}
     </section>
     <section className="core-panel order-queue-panel"><div className="panel-head"><div><span className="core-eyebrow">Fulfilment</span><h2>{openOrders.length} open orders</h2></div><span className="panel-note">{paymentReview.length} payment review</span></div><OrderList canCancel={(orderId) => commerceOrderHasReleasableReservation(commerce, orderId)} onAdvance={advanceOrder} onCancel={cancelOrder} onReconcilePayment={reconcilePayment} orders={commerce.orders} /></section>
-  </div>{actionControls}</div>
+  </div>{sourceNotice}{actionControls}</div>
 
   if (tab === 'inventory') return <div className="operation-module">
     {sourceNotice}
@@ -1586,7 +1847,13 @@ function CommercePage({ managedIdentity, tab }: { managedIdentity: ManagedIdenti
     {actionControls}
   </div>
 
-  return <div className="operation-module">{sourceNotice}<div className="module-today"><section className="summary-strip"><span><small>Order value</small><strong>{formatMoney(orderValue)}</strong></span><span><small>Open orders</small><strong>{openOrders.length}</strong></span><span><small>Payment review</small><strong>{paymentReview.length}</strong></span><span><small>Low stock</small><strong>{lowStock.length}</strong></span></section><div className="split-workspace ops-today-grid"><section className="core-panel"><div className="panel-head"><div><span className="core-eyebrow">Order flow</span><h2>Latest channel orders</h2></div><Link className="text-link" to="/operations/commerce/?tab=orders">Open orders</Link></div><OrderList canCancel={(orderId) => commerceOrderHasReleasableReservation(commerce, orderId)} onAdvance={advanceOrder} onCancel={cancelOrder} onReconcilePayment={reconcilePayment} orders={commerce.orders.slice(0, 5)} /></section><section className="core-panel"><div className="panel-head"><div><span className="core-eyebrow">Daily control</span><h2>Exceptions and close</h2></div><span className="panel-note">{commerce.closes.length} snapshots</span></div><div className="exception-summary"><span><strong>{paymentReview.length}</strong><small>payment review</small></span><span><strong>{lowStock.length}</strong><small>reorder boundaries</small></span></div><div className="boundary-list">{lowStock.map((item) => <Link key={item.sku} to="/operations/commerce/?tab=inventory"><strong>{item.name}</strong><small>{item.onHand} on hand</small></Link>)}</div><button className="core-button" onClick={closeDay} type="button">Save daily close</button><p className="form-notice" aria-live="polite">{notice || commerceStorageError || `${closableOrders.length} completed, reconciled orders · ${formatMoney(reconciledValue)} ready to close.`}</p></section></div></div>{actionControls}</div>
+  return <div className="operation-module">{sourceNotice}<div className="module-today">
+    <section className="summary-strip compact-summary"><span><small>Open orders</small><strong>{openOrders.length}</strong></span><span><small>Order value</small><strong>{formatMoney(orderValue)}</strong></span></section>
+    <div className="ops-today-grid task-first-grid">
+      <section className="core-panel"><div className="panel-head"><div><span className="core-eyebrow">Next work</span><h2>Open orders</h2></div><Link className="core-button primary compact" to="/operations/commerce/?tab=orders">Handle orders</Link></div><OrderList canCancel={(orderId) => commerceOrderHasReleasableReservation(commerce, orderId)} onAdvance={advanceOrder} onCancel={cancelOrder} onReconcilePayment={reconcilePayment} orders={openOrders.slice(0, 3)} /></section>
+      <details className="core-panel today-more"><summary><span>Daily controls</span><small>{paymentReview.length + lowStock.length} items need attention</small></summary><div className="today-more-content"><div className="exception-summary"><span><strong>{paymentReview.length}</strong><small>payment review</small></span><span><strong>{lowStock.length}</strong><small>reorder boundaries</small></span></div><div className="boundary-list">{lowStock.map((item) => <Link key={item.sku} to="/operations/commerce/?tab=inventory"><strong>{item.name}</strong><small>{item.onHand} on hand</small></Link>)}</div><button className="core-button" onClick={closeDay} type="button">Save daily close</button><p className="form-notice" aria-live="polite">{notice || commerceStorageError || `${closableOrders.length} completed, reconciled orders · ${formatMoney(reconciledValue)} ready to close.`}</p></div></details>
+    </div>
+  </div>{actionControls}</div>
 }
 
 function OrderList({
@@ -1677,6 +1944,7 @@ function ProductionPage({ tab }: { tab: ProductionTab }) {
   const [kind, setKind] = useState<ProductionIssue['kind']>('quality')
   const [summary, setSummary] = useState('')
   const [notice, setNotice] = useState('')
+  const [actionTrigger, setActionTrigger] = useState<HTMLElement | null>(null)
   const output = production.jobs.reduce((total, job) => total + job.output, 0)
   const target = production.jobs.reduce((total, job) => total + job.target, 0)
   const openIssues = production.issues.filter((issue) => issue.status === 'open')
@@ -1689,6 +1957,7 @@ function ProductionPage({ tab }: { tab: ProductionTab }) {
       setNotice(`Finish or cancel ${pendingAction.id} before reviewing another change.`)
       return
     }
+    setActionTrigger(document.activeElement instanceof HTMLElement ? document.activeElement : null)
     setPendingAction({ ...action, id: uid('ACT'), commandId: commandUuid(), domain: 'production' })
     setNotice('Review the change, accountable operator, and evidence before it is applied.')
   }
@@ -1779,7 +2048,7 @@ function ProductionPage({ tab }: { tab: ProductionTab }) {
 
   const actionControls = <>
     <p className="form-notice" aria-live="polite">{productionStorageError || notice}</p>
-    <AccountableActionGate key={pendingAction?.id ?? 'production-idle'} action={pendingAction} onCancel={() => { setPendingAction(null); setNotice('Change cancelled. Production data was not modified.') }} onConfirm={confirmAction} />
+    <AccountableActionGate key={pendingAction?.id ?? 'production-idle'} action={pendingAction} onCancel={() => { setPendingAction(null); setNotice('Change cancelled. Production data was not modified.') }} onConfirm={confirmAction} returnFocus={actionTrigger} />
     <ProductionEventHistory events={production.events} />
   </>
 
@@ -1826,10 +2095,10 @@ function ProductionPage({ tab }: { tab: ProductionTab }) {
 
   return <div className="operation-module">
     <div className="module-today">
-      <section className="summary-strip"><span><small>Output</small><strong>{output.toLocaleString()}</strong></span><span><small>Target</small><strong>{target.toLocaleString()}</strong></span><span><small>Completion</small><strong>{completion}%</strong></span><span><small>Open issues</small><strong>{openIssues.length}</strong></span><span><small>Machines running</small><strong>{production.machines.filter((item) => item.state === 'running').length}/{production.machines.length}</strong></span></section>
-      <div className="split-workspace ops-today-grid">
-        <section className="core-panel"><div className="panel-head"><div><span className="core-eyebrow">Plan vs actual</span><h2>Active production</h2></div><Link className="text-link" to="/operations/production/?tab=production">Record output</Link></div><JobList jobs={production.jobs} /></section>
-        <section className="core-panel"><div className="panel-head"><div><span className="core-eyebrow">Exceptions</span><h2>Quality and equipment</h2></div><Link className="text-link" to="/operations/production/?tab=control">Open controls</Link></div><IssueList issues={openIssues} onResolve={resolveIssue} /></section>
+      <section className="summary-strip compact-summary"><span><small>Completion</small><strong>{completion}%</strong></span><span><small>Open problems</small><strong>{openIssues.length}</strong></span></section>
+      <div className="ops-today-grid task-first-grid">
+        <section className="core-panel"><div className="panel-head"><div><span className="core-eyebrow">Current jobs</span><h2>Production progress</h2></div><Link className="core-button primary compact" to="/operations/production/?tab=production">Record output</Link></div><JobList jobs={production.jobs} /><p className="form-notice">{output.toLocaleString()} of {target.toLocaleString()} good units recorded.</p></section>
+        <details className="core-panel today-more"><summary><span>Problems and equipment</span><small>{openIssues.length} open</small></summary><div className="today-more-content"><IssueList issues={openIssues} onResolve={resolveIssue} /><Link className="core-button" to="/operations/production/?tab=control">Open problems</Link></div></details>
       </div>
     </div>
     {actionControls}

--- a/showroom/src/core/TeamWorkspace.tsx
+++ b/showroom/src/core/TeamWorkspace.tsx
@@ -312,13 +312,15 @@ export function TeamsPage() {
         {activeView === 'work' && !intakeOpen ? <div className="split-workspace team-board-view">
           <section className="core-panel queue-panel">
             <div className="panel-head"><div><span className="core-eyebrow">Owned work</span><h2>{openItems.length} open</h2></div></div>
-            {teamItems.length ? <div className="record-list" role="list">{teamItems.map((item) => (
-              <button aria-current={selectedItem?.id === item.id ? 'true' : undefined} className="record-row" key={item.id} onClick={() => navigate(activeTeam, 'work', item.id)} type="button">
-                <span className={`record-status ${item.status}`} />
-                <span><strong>{item.title}</strong><small>{item.id} / {item.owner}</small></span>
-                <span><b>{item.priority}</b><small>{statusLabel(item.status)}</small></span>
-              </button>
-            ))}</div> : <Empty>No work is recorded for this team.</Empty>}
+            {teamItems.length ? <ul className="record-list">{teamItems.map((item) => (
+              <li key={item.id}>
+                <button aria-current={selectedItem?.id === item.id ? 'true' : undefined} className="record-row" onClick={() => navigate(activeTeam, 'work', item.id)} type="button">
+                  <span className={`record-status ${item.status}`} />
+                  <span><strong>{item.title}</strong><small>{item.id} / {item.owner}</small></span>
+                  <span><b>{item.priority}</b><small>{statusLabel(item.status)}</small></span>
+                </button>
+              </li>
+            ))}</ul> : <Empty>No work is recorded for this team.</Empty>}
           </section>
           <section className="core-panel record-detail-panel">
             {selectedItem ? <>

--- a/showroom/src/core/channel-order-intake.ts
+++ b/showroom/src/core/channel-order-intake.ts
@@ -1,0 +1,212 @@
+export const CHANNEL_ORDER_DRAFT_SCHEMA = 'supermega.channel_order_draft.v1' as const
+export const CHANNEL_ORDER_MESSAGE_MAX = 2_000
+export const CHANNEL_ORDER_QUOTE_MAX = 120
+
+export const channelOrderChannels = ['Messenger', 'Viber', 'Phone'] as const
+export const channelOrderPayments = ['KBZPay', 'WavePay', 'Cash on delivery', 'Cash', 'Card'] as const
+export const channelOrderFields = ['customer', 'sku', 'quantity', 'payment'] as const
+
+export type ChannelOrderChannel = (typeof channelOrderChannels)[number]
+export type ChannelOrderPayment = (typeof channelOrderPayments)[number]
+export type ChannelOrderField = (typeof channelOrderFields)[number]
+export type ChannelOrderAttributionInput =
+  | { kind: 'quote'; quote: string }
+  | { kind: 'operator_supplied' }
+
+export type ChannelOrderDraftInput = {
+  sourceLabel: string
+  message: string
+  channel: string
+  customer: string
+  sku: string
+  quantity: number
+  payment: string
+  catalogSkus: string[]
+  attributions: Record<ChannelOrderField, ChannelOrderAttributionInput>
+}
+
+export type ChannelOrderProvenance =
+  | { field: ChannelOrderField; kind: 'operator_supplied' }
+  | { field: ChannelOrderField; kind: 'quote'; quote: string; start: number; end: number }
+
+export type ChannelOrderDraft = {
+  schema: typeof CHANNEL_ORDER_DRAFT_SCHEMA
+  sourceRecordId: string | null
+  evidenceReference: string | null
+  sourceLabel: string
+  messageFingerprint: string | null
+  channel: ChannelOrderChannel | null
+  customer: string
+  sku: string
+  quantity: number
+  payment: ChannelOrderPayment | null
+  status: 'needs_review' | 'ready_for_confirmation'
+  blockers: string[]
+  provenance: ChannelOrderProvenance[]
+}
+
+function boundedText(value: unknown, maximum: number) {
+  if (typeof value !== 'string') return ''
+  const normalized = value.trim()
+  return normalized.length <= maximum ? normalized : ''
+}
+
+function fingerprint(value: string) {
+  let hash = 0xcbf29ce484222325n
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= BigInt(value.charCodeAt(index))
+    hash = BigInt.asUintN(64, hash * 0x100000001b3n)
+  }
+  return hash.toString(16).padStart(16, '0')
+}
+
+function occurrences(message: string, quote: string) {
+  const indexes: number[] = []
+  let cursor = 0
+  while (cursor <= message.length - quote.length) {
+    const index = message.indexOf(quote, cursor)
+    if (index < 0) break
+    indexes.push(index)
+    cursor = index + 1
+  }
+  return indexes
+}
+
+function expectedEvidenceReference(draft: Pick<ChannelOrderDraft, 'sourceRecordId' | 'messageFingerprint' | 'customer' | 'sku' | 'quantity' | 'payment' | 'provenance'>) {
+  if (!draft.sourceRecordId || !draft.messageFingerprint) return null
+  const mappingFingerprint = fingerprint(JSON.stringify({
+    sourceRecordId: draft.sourceRecordId,
+    messageFingerprint: draft.messageFingerprint,
+    customer: draft.customer,
+    sku: draft.sku,
+    quantity: draft.quantity,
+    payment: draft.payment,
+    provenance: draft.provenance,
+  }))
+  return `channel-message://${draft.sourceRecordId}#msg-${draft.messageFingerprint.slice(4).toLowerCase()}-map-${mappingFingerprint}`
+}
+
+export function buildChannelOrderDraft(input: ChannelOrderDraftInput): ChannelOrderDraft {
+  const blockers: string[] = []
+  const provenance: ChannelOrderProvenance[] = []
+  const sourceLabel = boundedText(input.sourceLabel, 120)
+  const message = typeof input.message === 'string' ? input.message : ''
+  const channel = channelOrderChannels.includes(input.channel as ChannelOrderChannel)
+    ? input.channel as ChannelOrderChannel
+    : null
+  const customer = boundedText(input.customer, 80)
+  const sku = boundedText(input.sku, 80).toUpperCase()
+  const payment = channelOrderPayments.includes(input.payment as ChannelOrderPayment)
+    ? input.payment as ChannelOrderPayment
+    : null
+  const catalogSkus = new Set(input.catalogSkus.map((entry) => boundedText(entry, 80).toUpperCase()).filter(Boolean))
+
+  if (!sourceLabel) blockers.push('source_label_required')
+  if (!message.trim()) blockers.push('source_message_required')
+  else if (message.length > CHANNEL_ORDER_MESSAGE_MAX) blockers.push('source_message_too_long')
+  if (!channel) blockers.push('channel_invalid')
+  if (!customer) blockers.push('customer_required')
+  if (!sku) blockers.push('sku_required')
+  else if (!catalogSkus.has(sku)) blockers.push('sku_unknown')
+  if (!Number.isSafeInteger(input.quantity) || input.quantity < 1 || input.quantity > 9_999) blockers.push('quantity_invalid')
+  if (!payment) blockers.push('payment_invalid')
+
+  for (const field of channelOrderFields) {
+    const attribution = input.attributions[field]
+    if (!attribution || (attribution.kind !== 'quote' && attribution.kind !== 'operator_supplied')) {
+      blockers.push(`${field}_attribution_required`)
+      continue
+    }
+    if (attribution.kind === 'operator_supplied') {
+      provenance.push({ field, kind: 'operator_supplied' })
+      continue
+    }
+
+    const quote = boundedText(attribution.quote, CHANNEL_ORDER_QUOTE_MAX)
+    if (!quote) {
+      blockers.push(`${field}_quote_required`)
+      continue
+    }
+    if (quote === message.trim()) {
+      blockers.push(`${field}_quote_must_be_excerpt`)
+      continue
+    }
+    const matches = message ? occurrences(message, quote) : []
+    if (matches.length === 0) {
+      blockers.push(`${field}_quote_not_found`)
+      continue
+    }
+    if (matches.length > 1) {
+      blockers.push(`${field}_quote_ambiguous`)
+      continue
+    }
+    provenance.push({ field, kind: 'quote', quote, start: matches[0], end: matches[0] + quote.length })
+  }
+
+  if (!provenance.some((entry) => entry.kind === 'quote')) blockers.push('source_quote_required')
+
+  const sourceRecordId = sourceLabel && channel
+    ? `CHN-${fingerprint(`${channel}\u001f${sourceLabel.toUpperCase()}`).toUpperCase()}`
+    : null
+  const messageFingerprint = message ? `MSG-${fingerprint(message).toUpperCase()}` : null
+  const draft: ChannelOrderDraft = {
+    schema: CHANNEL_ORDER_DRAFT_SCHEMA,
+    sourceRecordId,
+    evidenceReference: null,
+    sourceLabel,
+    messageFingerprint,
+    channel,
+    customer,
+    sku,
+    quantity: input.quantity,
+    payment,
+    status: blockers.length ? 'needs_review' : 'ready_for_confirmation',
+    blockers: [...new Set(blockers)],
+    provenance,
+  }
+  draft.evidenceReference = expectedEvidenceReference(draft)
+  return draft
+}
+
+export function channelOrderDraftIsReady(draft: ChannelOrderDraft): draft is ChannelOrderDraft & {
+  sourceRecordId: string
+  evidenceReference: string
+  channel: ChannelOrderChannel
+  payment: ChannelOrderPayment
+  status: 'ready_for_confirmation'
+} {
+  if (!draft || draft.schema !== CHANNEL_ORDER_DRAFT_SCHEMA || !Array.isArray(draft.provenance)) return false
+  const provenanceFields = new Set(draft.provenance.map((entry) => entry?.field))
+  const validProvenance = draft.provenance.every((entry) => {
+    if (!entry || !channelOrderFields.includes(entry.field)) return false
+    if (entry.kind === 'operator_supplied') return Object.keys(entry).length === 2
+    return entry.kind === 'quote'
+      && Object.keys(entry).length === 5
+      && typeof entry.quote === 'string'
+      && entry.quote === entry.quote.trim()
+      && entry.quote.length > 0
+      && entry.quote.length <= CHANNEL_ORDER_QUOTE_MAX
+      && Number.isSafeInteger(entry.start)
+      && entry.start >= 0
+      && Number.isSafeInteger(entry.end)
+      && entry.end === entry.start + entry.quote.length
+  })
+  return draft.status === 'ready_for_confirmation'
+    && draft.blockers.length === 0
+    && /^CHN-[A-F0-9]{16}$/.test(draft.sourceRecordId ?? '')
+    && /^MSG-[A-F0-9]{16}$/.test(draft.messageFingerprint ?? '')
+    && draft.evidenceReference === expectedEvidenceReference(draft)
+    && Boolean(draft.channel)
+    && channelOrderChannels.includes(draft.channel as ChannelOrderChannel)
+    && Boolean(draft.customer)
+    && Boolean(draft.sku)
+    && Number.isSafeInteger(draft.quantity)
+    && draft.quantity > 0
+    && Boolean(draft.payment)
+    && channelOrderPayments.includes(draft.payment as ChannelOrderPayment)
+    && draft.provenance.length === channelOrderFields.length
+    && provenanceFields.size === channelOrderFields.length
+    && channelOrderFields.every((field) => provenanceFields.has(field))
+    && draft.provenance.some((entry) => entry.kind === 'quote')
+    && validProvenance
+}

--- a/showroom/src/core/commerce-workspace.ts
+++ b/showroom/src/core/commerce-workspace.ts
@@ -783,6 +783,8 @@ export function registerCommerceItem(state: CommerceState, item: CommerceItem, p
 
 export function reserveCommerceOrder(state: CommerceState, order: CommerceOrder, proof: CommerceActionProof) {
   if (!validProof(proof) || order.status !== 'confirmed' || !order.itemSku || order.quantity < 1 || order.paymentStatus !== 'pending' || order.refundStatus !== 'none') return null
+  if (Boolean(order.sourceRecordId) !== Boolean(order.evidenceReference)
+    || (order.evidenceReference && order.evidenceReference !== proof.evidenceReference)) return null
   const proofMovement = state.movements.find((movement) => movement.actionId === proof.actionId)
   if (proofMovement) {
     const storedOrder = state.orders.find((candidate) => candidate.id === order.id)

--- a/showroom/src/core/core-app.css
+++ b/showroom/src/core/core-app.css
@@ -1,18 +1,20 @@
 :root {
   color-scheme: light;
-  --core-bg: #f4f6f2;
+  --core-bg: #f5f6fa;
   --core-panel: #ffffff;
-  --core-panel-raised: #edf3ef;
-  --core-ink: #10251c;
-  --core-muted: #52635a;
-  --core-quiet: #738077;
-  --core-line: rgba(31, 68, 51, .12);
-  --core-line-strong: rgba(31, 68, 51, .2);
-  --core-green: #08775e;
-  --core-green-soft: rgba(8, 119, 94, .1);
-  --core-warn: #946200;
+  --core-panel-raised: #eef0f7;
+  --core-ink: #182033;
+  --core-muted: #586174;
+  --core-quiet: #626b7c;
+  --core-line: rgba(27, 36, 59, .11);
+  --core-line-strong: rgba(27, 36, 59, .2);
+  --core-green: #4355d9;
+  --core-green-soft: rgba(67, 85, 217, .09);
+  --core-success: #087a5b;
+  --core-success-soft: rgba(8, 122, 91, .09);
+  --core-warn: #9a6500;
   --core-danger: #b42336;
-  --core-radius: 12px;
+  --core-radius: 14px;
   --core-mono: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
 }
 
@@ -20,14 +22,14 @@
 html, body, #root { width: 100%; height: 100%; }
 html { min-width: 320px; background: var(--core-bg); }
 body { min-width: 320px; margin: 0; overflow: hidden; background: var(--core-bg); color: var(--core-ink); font-family: Geist, Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; text-rendering: optimizeLegibility; }
-body::before { position: fixed; inset: 0; z-index: -2; background: radial-gradient(circle at 78% -12%, rgba(8,119,94,.08), transparent 32%), linear-gradient(180deg, #fbfcfa, var(--core-bg) 60%); content: ""; }
+body::before { position: fixed; inset: 0; z-index: -2; background: linear-gradient(180deg, #fbfbfd, var(--core-bg) 64%); content: ""; }
 button, input, select, textarea { font: inherit; }
 button, a { -webkit-tap-highlight-color: transparent; }
 a { color: inherit; }
 .sr-only { position: absolute; width: 1px; height: 1px; overflow: hidden; clip: rect(0,0,0,0); white-space: nowrap; }
 
 .core-shell { height: 100svh; display: grid; grid-template-columns: 184px minmax(0, 1fr); }
-.core-sidebar { position: fixed; inset: 0 auto 0 0; z-index: 30; width: 184px; display: flex; flex-direction: column; border-right: 1px solid var(--core-line); padding: 20px 16px 16px; background: rgba(238,244,239,.96); backdrop-filter: blur(20px); }
+.core-sidebar { position: fixed; inset: 0 auto 0 0; z-index: 30; width: 184px; display: flex; flex-direction: column; border-right: 1px solid var(--core-line); padding: 20px 16px 16px; background: rgba(248,249,252,.97); backdrop-filter: blur(20px); }
 .core-stage { min-width: 0; min-height: 0; grid-column: 2; display: grid; grid-template-rows: 56px minmax(0,1fr); }
 .core-main { width: min(calc(100% - 40px), 1420px); height: 100%; min-width: 0; min-height: 0; margin: 0 auto; padding: 20px 0; overflow: hidden; }
 .core-skip { position: fixed; z-index: 100; top: -60px; left: 230px; border: 1px solid var(--core-green); border-radius: 5px; padding: 9px 12px; background: var(--core-panel); text-decoration: none; }
@@ -49,7 +51,7 @@ a { color: inherit; }
 .sidebar-foot p { margin: 0; color: var(--core-quiet); font-size: 8px; line-height: 1.55; }
 .sidebar-foot a { min-height: 36px; display: inline-flex; align-items: center; color: var(--core-muted); font-size: 12px; text-decoration: none; }
 
-.core-topbar { position: relative; z-index: 20; display: flex; align-items: center; justify-content: space-between; gap: 14px; border-bottom: 1px solid var(--core-line); padding: 0 20px; background: rgba(246,244,238,.9); backdrop-filter: blur(18px); }
+.core-topbar { position: relative; z-index: 20; display: flex; align-items: center; justify-content: space-between; gap: 14px; border-bottom: 1px solid var(--core-line); padding: 0 20px; background: rgba(255,255,255,.92); backdrop-filter: blur(18px); }
 .core-topbar > div { display: flex; align-items: center; gap: 9px; }
 .mobile-brand { display: none !important; }
 .terminal-prompt { color: var(--core-green); font-family: var(--core-mono); font-size: 14px; font-weight: 850; }
@@ -75,17 +77,12 @@ a { color: inherit; }
 .page-heading h1 { margin: 5px 0 4px; font-size: clamp(32px, 3.3vw, 46px); line-height: .98; letter-spacing: -.045em; }
 .page-heading p { max-width: 760px; margin: 0; overflow: hidden; color: var(--core-muted); font-size: 14px; line-height: 1.45; text-overflow: ellipsis; white-space: nowrap; }
 .heading-actions { flex: 0 0 auto; }
-.operations-profile { width: min(340px,35vw); display: grid; grid-template-columns: minmax(0,1fr) auto; align-items: center; gap: 3px 12px; border-left: 1px solid var(--core-line); padding: 3px 0 3px 14px; }
-.operations-profile > span { overflow: hidden; color: var(--core-quiet); font-family: var(--core-mono); font-size: 9px; font-weight: 720; letter-spacing: .05em; text-overflow: ellipsis; text-transform: uppercase; white-space: nowrap; }
-.operations-profile > strong { grid-column: 1; overflow: hidden; font-size: 11px; text-overflow: ellipsis; white-space: nowrap; }
-.operations-profile .text-link { grid-column: 2; grid-row: 1/3; min-height: 32px; }
-
-.core-button { min-height: 44px; display: inline-flex; align-items: center; justify-content: center; gap: 7px; border: 1px solid var(--core-line-strong); border-radius: 10px; padding: 0 14px; background: #fff; color: var(--core-ink); font-size: 12px; font-weight: 760; text-decoration: none; cursor: pointer; }
+.core-button { min-height: 44px; display: inline-flex; align-items: center; justify-content: center; gap: 7px; border: 1px solid var(--core-line-strong); border-radius: 10px; padding: 0 15px; background: #fff; color: var(--core-ink); font-size: 13px; font-weight: 760; text-decoration: none; cursor: pointer; }
 .core-button:hover { border-color: var(--core-green); background: var(--core-green-soft); }
 .core-button.primary { border-color: var(--core-green); background: var(--core-green); color: #fff; }
 .core-button.compact { min-height: 36px; padding-inline: 11px; font-size: 11px; }
 .core-button.danger { border-color: rgba(255,123,141,.4); color: var(--core-danger); }
-.text-link { min-height: 34px; display: inline-flex; align-items: center; border: 0; padding: 0; background: transparent; color: var(--core-green); font-family: var(--core-mono); font-size: 10px; font-weight: 760; text-decoration: none; text-transform: uppercase; cursor: pointer; }
+.text-link { min-height: 34px; display: inline-flex; align-items: center; border: 0; padding: 0; background: transparent; color: var(--core-green); font-size: 11px; font-weight: 760; text-decoration: none; cursor: pointer; }
 .text-link:hover { color: var(--core-ink); }
 .danger-text { color: var(--core-danger); }
 
@@ -96,6 +93,24 @@ a { color: inherit; }
 .product-launcher strong { font-size: 15px; letter-spacing: -.015em; }
 .product-launcher small { overflow: hidden; color: var(--core-muted); font-size: 11px; text-overflow: ellipsis; white-space: nowrap; }
 .product-launcher b { flex: 0 0 auto; color: var(--core-green); font-family: var(--core-mono); font-size: 10px; text-transform: uppercase; }
+.product-catalog-screen { max-width: 980px; }
+.product-catalog { align-content: start; }
+.product-catalog > a { min-height: 108px; }
+
+.next-task-card { min-height: 116px; display: flex; align-items: center; justify-content: space-between; gap: 24px; border-color: rgba(67,85,217,.2); background: linear-gradient(135deg, rgba(67,85,217,.07), #fff 48%); }
+.next-task-card > div { min-width: 0; }
+.next-task-card h2 { margin: 6px 0 5px; font-size: clamp(22px,2.2vw,30px); line-height: 1.08; letter-spacing: -.035em; }
+.next-task-card p { margin: 0; color: var(--core-muted); font-size: 14px; line-height: 1.5; }
+.next-task-card .core-button { flex: 0 0 auto; }
+.home-more { min-height: 54px; border: 1px solid var(--core-line); border-radius: var(--core-radius); background: rgba(255,255,255,.74); }
+.home-more > summary { min-height: 54px; display: flex; align-items: center; justify-content: space-between; gap: 14px; padding: 0 17px; cursor: pointer; list-style: none; }
+.home-more > summary::-webkit-details-marker { display: none; }
+.home-more > summary::after { color: var(--core-green); font-size: 18px; content: "+"; }
+.home-more[open] > summary::after { content: "−"; }
+.home-more > summary span { margin-right: auto; font-size: 14px; font-weight: 760; }
+.home-more > summary small { color: var(--core-quiet); font-size: 12px; }
+.home-more[open] > summary { border-bottom: 1px solid var(--core-line); }
+.home-more .command-grid { min-height: 560px; padding: 12px; }
 
 .workspace-toolbar { min-height: 44px; display: flex; align-items: center; justify-content: space-between; gap: 14px; border-bottom: 1px solid var(--core-line); }
 .segmented-control, .view-tabs { display: flex; min-width: 0; align-items: center; gap: 3px; }
@@ -104,6 +119,9 @@ a { color: inherit; }
 .segmented-control button[aria-pressed="true"] { border-color: rgba(11,116,94,.2); background: var(--core-green-soft); color: var(--core-green); }
 .view-tabs button[aria-selected="true"], .view-tabs button[aria-current="page"] { border-bottom-color: var(--core-green); border-radius: 0; color: var(--core-ink); }
 .segmented-control.wide { display: grid; grid-template-columns: repeat(2,minmax(0,1fr)); }
+.product-task-tabs { justify-content: flex-start; overflow-x: auto; }
+.product-task-tabs button { min-width: 88px; justify-content: center; font-size: 13px; }
+.all-apps-link { min-height: 40px; }
 
 .summary-strip { min-height: 62px; display: grid; grid-template-columns: repeat(auto-fit,minmax(120px,1fr)); overflow: hidden; border: 1px solid var(--core-line); border-radius: var(--core-radius); background: var(--core-panel); }
 .summary-strip.compact-summary { grid-template-columns: repeat(3,minmax(0,1fr)); }
@@ -121,14 +139,16 @@ a { color: inherit; }
 .panel-head h2, .core-panel > h2 { margin: 4px 0 0; font-size: 18px; line-height: 1.15; letter-spacing: -.025em; }
 .panel-head p { margin: 4px 0 0; color: var(--core-muted); font-size: 11px; }
 .panel-note { color: var(--core-quiet); font-family: var(--core-mono); font-size: 10px; text-align: right; }
-.panel-copy, .authority-note { margin: 10px 0 0; color: var(--core-quiet); font-size: 11px; line-height: 1.55; }
+.panel-copy, .authority-note { margin: 10px 0 0; color: var(--core-quiet); font-size: 13px; line-height: 1.55; }
 .authority-note { border-left: 2px solid var(--core-green); padding-left: 10px; }
 .status-pill { min-height: 26px; display: inline-flex; align-items: center; gap: 5px; border: 1px solid var(--core-line); border-radius: 999px; padding: 0 8px; color: var(--core-muted); font-family: var(--core-mono); font-size: 9px; font-weight: 740; text-transform: uppercase; white-space: nowrap; }
 .status-pill::before { width: 4px; height: 4px; border-radius: 50%; background: currentColor; content: ""; }
-.status-pill.ready, .status-pill.approved, .status-pill.bounded { border-color: rgba(11,116,94,.2); background: var(--core-green-soft); color: var(--core-green); }
+.status-pill.bounded { border-color: rgba(67,85,217,.2); background: var(--core-green-soft); color: var(--core-green); }
+.status-pill.ready, .status-pill.approved { border-color: rgba(8,122,91,.2); background: var(--core-success-soft); color: var(--core-success); }
 .status-pill.pending { border-color: rgba(255,184,107,.28); color: var(--core-warn); }
 
 .record-list, .order-list, .issue-list, .decision-list, .attention-list, .approval-list, .job-list { min-height: 0; overflow: auto; scrollbar-color: rgba(11,116,94,.26) transparent; }
+.record-list { margin: 0; padding: 0; list-style: none; }
 .record-row { width: 100%; min-height: 66px; display: grid; grid-template-columns: 8px minmax(0,1fr) auto; gap: 10px; align-items: center; border: 0; border-bottom: 1px solid var(--core-line); padding: 9px 6px; background: transparent; color: var(--core-ink); text-align: left; text-decoration: none; cursor: pointer; }
 .record-row:hover, .record-row[aria-current="true"] { background: rgba(11,116,94,.07); }
 .record-status { width: 5px; height: 5px; border-radius: 50%; background: var(--core-quiet); }
@@ -149,8 +169,8 @@ a { color: inherit; }
 .record-detail-head h2 { margin: 5px 0; font-size: 18px; }
 .record-detail-head p { margin: 0; color: var(--core-muted); font-size: 12px; line-height: 1.5; }
 .record-controls { display: grid; grid-template-columns: repeat(4,minmax(0,1fr)); gap: 8px; margin-top: 12px; }
-label { display: grid; gap: 6px; color: var(--core-muted); font-size: 11px; font-weight: 700; }
-input, select, textarea { width: 100%; min-width: 0; min-height: 44px; border: 1px solid var(--core-line); border-radius: 9px; padding: 9px 10px; background: #fff; color: var(--core-ink); font-size: 12px; outline: none; }
+label { display: grid; gap: 6px; color: var(--core-muted); font-size: 13px; font-weight: 700; }
+input, select, textarea { width: 100%; min-width: 0; min-height: 44px; border: 1px solid var(--core-line); border-radius: 10px; padding: 9px 11px; background: #fff; color: var(--core-ink); font-size: 14px; outline: none; }
 input:focus, select:focus, textarea:focus { border-color: var(--core-green); box-shadow: 0 0 0 3px rgba(11,116,94,.1); }
 textarea { min-height: 72px; resize: vertical; }
 .evidence-register { margin-top: 12px; border-top: 1px solid var(--core-line); padding-top: 10px; }
@@ -172,13 +192,15 @@ textarea { min-height: 72px; resize: vertical; }
 .template-contract strong { overflow: hidden; font-size: 8px; font-weight: 680; text-overflow: ellipsis; white-space: nowrap; }
 .template-contract small { grid-column: 2; color: var(--core-quiet); font-size: 7px; }
 .form-actions { display: flex; justify-content: flex-end; gap: 8px; }
-.form-notice { min-height: 16px; margin: 7px 0 0; color: var(--core-quiet); font-size: 10px; line-height: 1.45; }
-.accountable-action-gate { flex: 0 0 auto; display: grid; grid-template-columns: minmax(200px,.55fr) minmax(0,1.45fr); gap: 18px; align-items: end; border-color: rgba(11,116,94,.24); background: linear-gradient(110deg, rgba(11,116,94,.09), #fff 42%); }
-.action-change h2 { margin: 4px 0 8px; font-size: 15px; }
+.form-notice { min-height: 16px; margin: 7px 0 0; color: var(--core-quiet); font-size: 12px; line-height: 1.5; }
+.accountable-action-gate { position: fixed; inset: 0; width: min(680px,calc(100% - 36px)); max-height: calc(100svh - 36px); margin: auto; overflow: auto; border: 1px solid var(--core-line-strong); border-radius: 16px; padding: 24px; color: var(--core-ink); background: #fff; box-shadow: 0 30px 90px rgba(20,28,48,.24); }
+.accountable-action-gate[open] { display: grid; gap: 20px; }
+.accountable-action-gate::backdrop { background: rgba(19,25,41,.5); backdrop-filter: blur(6px); }
+.action-change h2 { margin: 5px 0 10px; font-size: 22px; }
 .action-change p { display: flex; flex-wrap: wrap; align-items: center; gap: 7px; margin: 0; color: var(--core-quiet); font-family: var(--core-mono); font-size: 8px; }
 .action-change p strong { color: var(--core-muted); font-weight: 700; }
 .action-change p span { color: var(--core-green); }
-.action-confirm-form { grid-template-columns: minmax(130px,.7fr) minmax(170px,1fr) minmax(200px,1.2fr) auto; align-items: end; gap: 8px; }
+.action-confirm-form { grid-template-columns: 1fr; align-items: end; gap: 12px; }
 .action-confirm-form .form-actions { min-width: max-content; align-items: center; }
 .action-confirm-form > .form-notice { grid-column: 1/-1; }
 .action-history { flex: 0 0 auto; min-height: 0; padding: 0; }
@@ -269,16 +291,59 @@ textarea { min-height: 72px; resize: vertical; }
 .operations-screen .workspace-view { overflow: hidden; }
 .module-today .summary-strip { flex: 0 0 54px; }
 .ops-today-grid { flex: 1; }
+.task-first-grid { min-height: 0; display: grid; grid-template-columns: minmax(0,1fr) minmax(260px,.42fr); gap: 11px; }
+.today-more { padding: 0; }
+.today-more > summary { min-height: 56px; display: flex; align-items: center; justify-content: space-between; gap: 12px; padding: 0 16px; cursor: pointer; list-style: none; }
+.today-more > summary::-webkit-details-marker { display: none; }
+.today-more > summary::after { color: var(--core-green); font-size: 18px; content: "+"; }
+.today-more[open] > summary::after { content: "−"; }
+.today-more > summary span { margin-right: auto; font-size: 14px; font-weight: 760; }
+.today-more > summary small { color: var(--core-quiet); font-size: 11px; }
+.today-more[open] > summary { border-bottom: 1px solid var(--core-line); }
+.today-more-content { display: grid; gap: 12px; padding: 15px 16px 17px; }
+
+.order-entry-methods { display: grid; grid-template-columns: repeat(3,minmax(0,1fr)); gap: 4px; margin-bottom: 14px; border-radius: 12px; padding: 4px; background: var(--core-panel-raised); }
+.order-entry-methods button { min-height: 42px; border: 0; border-radius: 9px; background: transparent; color: var(--core-muted); font-size: 13px; font-weight: 740; cursor: pointer; }
+.order-entry-methods button[aria-selected="true"] { background: #fff; color: var(--core-ink); box-shadow: 0 2px 10px rgba(27,36,59,.09); }
+.order-entry-methods button:disabled { cursor: not-allowed; opacity: .55; }
+.order-entry-panel { min-width: 0; }
+.order-entry-panel > .website-intake { border-color: var(--core-line); box-shadow: none; }
+.channel-intake-panel { display: grid; gap: 12px; }
+.channel-intake-heading { display: grid; gap: 4px; border-bottom: 1px solid var(--core-line); padding-bottom: 11px; }
+.channel-intake-heading h3 { margin: 0; font-size: 18px; letter-spacing: -.02em; }
+.channel-intake-heading p { margin: 0; color: var(--core-muted); font-size: 13px; line-height: 1.5; }
+.channel-intake-disclosure { margin: 10px 0; border-block: 1px solid var(--core-line); padding: 9px 0; }
+.channel-intake-disclosure > summary { width: 100%; justify-content: center; }
+.channel-intake-disclosure > summary::before { margin-right: 7px; color: var(--core-green); font-family: var(--core-mono); content: ">_"; }
+.channel-intake-form { max-width: none; gap: 10px; }
+.channel-intake-boundary { display: grid; gap: 3px; border-left: 2px solid var(--core-green); padding-left: 9px; }
+.channel-intake-boundary p { margin: 0; color: var(--core-muted); font-size: 12px; line-height: 1.5; }
+.channel-intake-form > label > textarea { min-height: 66px; }
+.channel-mapping-list { max-height: 290px; overflow: auto; border: 1px solid var(--core-line); border-radius: 6px; }
+.channel-mapping-row { display: grid; grid-template-columns: minmax(130px,.8fr) minmax(180px,1.2fr); gap: 9px; border-bottom: 1px solid var(--core-line); padding: 8px; }
+.channel-mapping-row:last-child { border-bottom: 0; }
+.channel-attribution { display: grid; gap: 5px; align-content: start; }
+.channel-attribution > small { align-self: center; color: var(--core-quiet); font-size: 11px; }
+.channel-operator-check { min-height: 28px; display: flex; align-items: center; gap: 6px; color: var(--core-muted); font-size: 12px; }
+.channel-operator-check input { width: auto; min-height: 0; margin: 0; }
+.channel-draft-result, .channel-source-ready { display: flex; align-items: center; justify-content: space-between; gap: 10px; margin-top: 9px; border: 1px solid var(--core-line); border-radius: 6px; padding: 9px 10px; background: rgba(11,116,94,.04); }
+.channel-draft-result > div, .channel-source-ready > div { min-width: 0; display: grid; gap: 3px; }
+.channel-draft-result strong, .channel-source-ready strong { overflow: hidden; font-size: 13px; text-overflow: ellipsis; white-space: nowrap; }
+.channel-draft-result p, .channel-draft-result small, .channel-source-ready small { margin: 0; color: var(--core-quiet); font-size: 11px; line-height: 1.4; }
+.channel-draft-result.review { display: grid; border-color: rgba(150,94,31,.22); background: rgba(150,94,31,.05); }
+.channel-draft-result ul { margin: 0; padding-left: 17px; color: var(--core-muted); font-size: 12px; line-height: 1.5; }
+.channel-source-ready { margin: 0 0 10px; }
+.channel-source-ready:focus-visible { outline: 2px solid var(--core-green); outline-offset: 3px; }
 .order-total { display: flex; align-items: center; justify-content: space-between; border: 1px solid var(--core-line); border-radius: 4px; padding: 10px; }
-.order-total span { color: var(--core-muted); font-size: 8px; }
+.order-total span { color: var(--core-muted); font-size: 12px; }
 .order-total strong { color: var(--core-green); font-size: 16px; }
 .order-list article { min-height: 58px; display: grid; grid-template-columns: minmax(0,1fr) auto; gap: 10px; align-items: center; border-bottom: 1px solid var(--core-line); padding: 7px 2px; }
 .order-list article > div { min-width: 0; display: grid; gap: 3px; }
 .order-list article > div:last-child { justify-items: end; }
 .order-list strong, .order-list small { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.order-list strong { font-size: 11px; }
-.order-list small { color: var(--core-quiet); font-size: 9px; }
-.order-list b { color: var(--core-green); font-family: var(--core-mono); font-size: 9px; }
+.order-list strong { font-size: 13px; }
+.order-list small { color: var(--core-quiet); font-size: 11px; }
+.order-list b { color: var(--core-green); font-family: var(--core-mono); font-size: 10px; }
 .order-list article .order-statuses, .order-list article .order-row-actions { display: flex; flex-wrap: wrap; align-items: center; gap: 5px 8px; }
 .order-row-actions { justify-content: flex-end; }
 .order-row-actions .subtle { color: var(--core-quiet); }
@@ -303,8 +368,8 @@ textarea { min-height: 72px; resize: vertical; }
 
 .job-list article { min-height: 55px; display: grid; grid-template-columns: minmax(0,.8fr) minmax(150px,1.2fr); gap: 12px; align-items: center; border-bottom: 1px solid var(--core-line); }
 .job-list article > div { min-width: 0; display: grid; gap: 3px; }
-.job-list span, .job-list small { color: var(--core-quiet); font-size: 8px; }
-.job-list strong { font-size: 10px; }
+.job-list span, .job-list small { color: var(--core-quiet); font-size: 11px; }
+.job-list strong { font-size: 13px; }
 .job-progress > span { height: 5px; overflow: hidden; border-radius: 999px; background: rgba(255,255,255,.06); }
 .job-progress i { display: block; height: 100%; background: var(--core-green); }
 .control-workspace > .split-workspace { flex: 1 1 55%; }
@@ -313,8 +378,8 @@ textarea { min-height: 72px; resize: vertical; }
 .machine-list { display: grid; gap: 5px; }
 .machine-list button { min-height: 46px; display: grid; grid-template-columns: 8px 1fr auto; gap: 10px; align-items: center; border: 1px solid var(--core-line); border-radius: 4px; padding: 0 10px; background: rgba(255,255,255,.018); color: var(--core-ink); text-align: left; cursor: pointer; }
 .machine-list button > span:nth-child(2) { display: grid; gap: 2px; }
-.machine-list strong { font-size: 10px; }
-.machine-list small, .machine-list b { color: var(--core-quiet); font-size: 8px; }
+.machine-list strong { font-size: 13px; }
+.machine-list small, .machine-list b { color: var(--core-quiet); font-size: 11px; }
 .machine-dot { width: 6px; height: 6px; border-radius: 50%; background: var(--core-quiet); }
 .machine-dot.running { background: var(--core-green); }
 .machine-dot.attention { background: var(--core-warn); }
@@ -477,7 +542,6 @@ textarea { min-height: 72px; resize: vertical; }
   .page-heading p { white-space: normal; }
   .operations-screen .page-heading { flex-direction: column; gap: 8px; }
   .operations-screen .heading-actions { width: 100%; }
-  .operations-profile { width: 100%; max-width: none; border-top: 1px solid var(--core-line); border-left: 0; padding: 7px 0 0; }
   .workspace-toolbar { align-items: flex-start; overflow-x: auto; }
   .operations-toolbar { overflow: visible; }
   .segmented-control, .view-tabs { flex: 0 0 auto; }
@@ -491,9 +555,11 @@ textarea { min-height: 72px; resize: vertical; }
   .summary-strip.compact-summary > span:last-child { grid-column: auto; border-right: 0; }
   .summary-strip small { font-size: 7px; }
   .split-workspace, .settings-grid, .command-grid { height: auto; display: grid; grid-template-columns: 1fr; grid-template-rows: auto; }
+  .task-first-grid { grid-template-columns: 1fr; }
+  .home-more .command-grid { min-height: 0; }
   .command-queue-panel { grid-row: auto; }
   .core-panel { min-height: 0; overflow: visible; }
-  .record-list, .order-list, .issue-list, .decision-list, .attention-list, .approval-list, .job-list { max-height: 420px; }
+  .record-list, .order-list, .issue-list, .decision-list, .attention-list, .approval-list, .job-list { max-height: none; overflow: visible; }
   .queue-panel .record-list, .decision-list-panel .decision-list, .order-queue-panel .order-list, .job-panel .job-list { flex: none; }
   .workspace-view { overflow: visible !important; }
   .operation-module { height: auto; }
@@ -518,11 +584,22 @@ textarea { min-height: 72px; resize: vertical; }
   .core-main { width: min(calc(100% - 18px),760px); }
   .page-heading { min-height: 0; display: grid; gap: 14px; }
   .page-heading h1 { font-size: 32px; }
+  .next-task-card { min-height: 0; display: grid; gap: 16px; padding: 18px; }
+  .next-task-card h2 { font-size: 23px; }
+  .next-task-card .core-button { width: 100%; }
+  .home-more > summary { min-height: 58px; padding-inline: 14px; }
+  .home-more > summary small { max-width: 150px; overflow: hidden; text-align: right; text-overflow: ellipsis; white-space: nowrap; }
+  .home-more .command-grid { padding: 9px; }
   .heading-actions, .heading-actions .core-button { width: 100%; }
   .heading-actions .core-button { min-height: 48px; padding-inline: 12px; }
+  .operations-screen .page-heading { grid-template-columns: minmax(0,1fr) auto; align-items: end; gap: 8px 12px; }
+  .operations-screen .heading-actions { width: auto; }
+  .operations-screen .heading-actions .text-link { min-height: 44px; display: inline-flex; align-items: center; }
   .product-launcher { grid-template-columns: 1fr; gap: 8px; }
   .product-launcher > a { min-height: 68px; }
   .workspace-toolbar { display: grid; justify-content: stretch; }
+  .product-task-tabs { width: 100%; grid-template-columns: repeat(3,minmax(0,1fr)); overflow: visible; }
+  .product-task-tabs button { min-width: 0; justify-content: center; }
   .summary-strip > span { display: grid; align-content: center; justify-content: stretch; gap: 3px; }
   .summary-strip small { line-height: 1.25; white-space: normal; }
   .summary-strip strong { font-size: 16px; }
@@ -536,6 +613,7 @@ textarea { min-height: 72px; resize: vertical; }
   .operations-toolbar-actions .view-tabs { min-width: 0; overflow-x: auto; }
   .form-row, .record-controls { grid-template-columns: 1fr; }
   .decision-dialog { inset: auto 0 0; width: 100%; max-height: 92svh; margin: 0 auto; border-radius: 10px 10px 0 0; padding: 15px; }
+  .accountable-action-gate { inset: auto 0 0; width: 100%; max-height: 92svh; margin: 0 auto; border-radius: 16px 16px 0 0; padding: 18px; }
   .decision-packet-meta, .decision-outcomes, .decision-fields { grid-template-columns: 1fr; }
   .decision-packet-meta span, .decision-outcomes span { border-right: 0; border-bottom: 1px solid var(--core-line); }
   .decision-packet-meta span:last-child, .decision-outcomes span:last-child { border-bottom: 0; }
@@ -559,6 +637,9 @@ textarea { min-height: 72px; resize: vertical; }
   .data-row > span:nth-child(4)::before { content: "Price"; }
   .inventory-panel { overflow-x: hidden; }
   .job-list article { grid-template-columns: 1fr; padding: 9px 0; }
+  .channel-mapping-list { max-height: none; overflow: visible; }
+  .channel-mapping-row { grid-template-columns: 1fr; }
+  .channel-draft-result, .channel-source-ready { display: grid; align-items: start; }
   .order-list article { grid-template-columns: 1fr; }
   .order-list article > div:last-child { justify-items: start; }
   .order-row-actions { justify-content: flex-start; }
@@ -574,7 +655,13 @@ textarea { min-height: 72px; resize: vertical; }
   .agent-create-form { position: static; width: min(100%,300px); margin-top: 8px; }
   .agent-roster-panel .panel-head { align-items: flex-start; }
   .compact-disclosure > summary { min-height: 44px; }
-  .core-button, .core-button.compact, .text-link, .operations-profile .text-link, .core-topbar .mobile-brand .core-brand, .topbar-meta > a, .segmented-control button, .segmented-control a, .view-tabs button, .mobile-nav a { min-height: 44px; }
+  .core-button, .core-button.compact, .text-link, .core-topbar .mobile-brand .core-brand, .topbar-meta > a, .segmented-control button, .segmented-control a, .view-tabs button, .mobile-nav a { min-height: 44px; }
+  input, select, textarea { font-size: 16px; }
+  .module-today .summary-strip.compact-summary { grid-template-columns: repeat(2,minmax(0,1fr)); }
+  .module-today .summary-strip.compact-summary > span { border-bottom: 0; }
+  .module-today .summary-strip.compact-summary > span:first-child { border-right: 1px solid var(--core-line); }
+  .module-today .summary-strip.compact-summary > span:last-child { border-right: 0; }
+  .order-entry-methods button { min-height: 46px; font-size: 14px; }
 }
 
 @media (max-width: 720px) {

--- a/showroom/src/core/core-app.css
+++ b/showroom/src/core/core-app.css
@@ -1,18 +1,18 @@
 :root {
   color-scheme: light;
-  --core-bg: #f5f6fa;
+  --core-bg: #f6f4ee;
   --core-panel: #ffffff;
-  --core-panel-raised: #eef0f7;
-  --core-ink: #182033;
-  --core-muted: #586174;
-  --core-quiet: #626b7c;
-  --core-line: rgba(27, 36, 59, .11);
-  --core-line-strong: rgba(27, 36, 59, .2);
-  --core-green: #4355d9;
-  --core-green-soft: rgba(67, 85, 217, .09);
-  --core-success: #087a5b;
-  --core-success-soft: rgba(8, 122, 91, .09);
-  --core-warn: #9a6500;
+  --core-panel-raised: #eef4ef;
+  --core-ink: #17231d;
+  --core-muted: #56665d;
+  --core-quiet: #5f6f67;
+  --core-line: rgba(31, 68, 51, .12);
+  --core-line-strong: rgba(31, 68, 51, .2);
+  --core-green: #0b745e;
+  --core-green-soft: rgba(11, 116, 94, .1);
+  --core-success: #0b745e;
+  --core-success-soft: rgba(11, 116, 94, .1);
+  --core-warn: #946200;
   --core-danger: #b42336;
   --core-radius: 14px;
   --core-mono: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
@@ -22,14 +22,14 @@
 html, body, #root { width: 100%; height: 100%; }
 html { min-width: 320px; background: var(--core-bg); }
 body { min-width: 320px; margin: 0; overflow: hidden; background: var(--core-bg); color: var(--core-ink); font-family: Geist, Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; text-rendering: optimizeLegibility; }
-body::before { position: fixed; inset: 0; z-index: -2; background: linear-gradient(180deg, #fbfbfd, var(--core-bg) 64%); content: ""; }
+body::before { position: fixed; inset: 0; z-index: -2; background: radial-gradient(circle at 78% -12%, rgba(11,116,94,.1), transparent 32%), linear-gradient(180deg, #fbfaf6, var(--core-bg) 60%); content: ""; }
 button, input, select, textarea { font: inherit; }
 button, a { -webkit-tap-highlight-color: transparent; }
 a { color: inherit; }
 .sr-only { position: absolute; width: 1px; height: 1px; overflow: hidden; clip: rect(0,0,0,0); white-space: nowrap; }
 
 .core-shell { height: 100svh; display: grid; grid-template-columns: 184px minmax(0, 1fr); }
-.core-sidebar { position: fixed; inset: 0 auto 0 0; z-index: 30; width: 184px; display: flex; flex-direction: column; border-right: 1px solid var(--core-line); padding: 20px 16px 16px; background: rgba(248,249,252,.97); backdrop-filter: blur(20px); }
+.core-sidebar { position: fixed; inset: 0 auto 0 0; z-index: 30; width: 184px; display: flex; flex-direction: column; border-right: 1px solid var(--core-line); padding: 20px 16px 16px; background: rgba(238,244,239,.96); backdrop-filter: blur(20px); }
 .core-stage { min-width: 0; min-height: 0; grid-column: 2; display: grid; grid-template-rows: 56px minmax(0,1fr); }
 .core-main { width: min(calc(100% - 40px), 1420px); height: 100%; min-width: 0; min-height: 0; margin: 0 auto; padding: 20px 0; overflow: hidden; }
 .core-skip { position: fixed; z-index: 100; top: -60px; left: 230px; border: 1px solid var(--core-green); border-radius: 5px; padding: 9px 12px; background: var(--core-panel); text-decoration: none; }
@@ -97,7 +97,7 @@ a { color: inherit; }
 .product-catalog { align-content: start; }
 .product-catalog > a { min-height: 108px; }
 
-.next-task-card { min-height: 116px; display: flex; align-items: center; justify-content: space-between; gap: 24px; border-color: rgba(67,85,217,.2); background: linear-gradient(135deg, rgba(67,85,217,.07), #fff 48%); }
+.next-task-card { min-height: 116px; display: flex; align-items: center; justify-content: space-between; gap: 24px; border-color: rgba(11,116,94,.2); background: linear-gradient(135deg, rgba(11,116,94,.075), #fff 48%); }
 .next-task-card > div { min-width: 0; }
 .next-task-card h2 { margin: 6px 0 5px; font-size: clamp(22px,2.2vw,30px); line-height: 1.08; letter-spacing: -.035em; }
 .next-task-card p { margin: 0; color: var(--core-muted); font-size: 14px; line-height: 1.5; }
@@ -143,7 +143,7 @@ a { color: inherit; }
 .authority-note { border-left: 2px solid var(--core-green); padding-left: 10px; }
 .status-pill { min-height: 26px; display: inline-flex; align-items: center; gap: 5px; border: 1px solid var(--core-line); border-radius: 999px; padding: 0 8px; color: var(--core-muted); font-family: var(--core-mono); font-size: 9px; font-weight: 740; text-transform: uppercase; white-space: nowrap; }
 .status-pill::before { width: 4px; height: 4px; border-radius: 50%; background: currentColor; content: ""; }
-.status-pill.bounded { border-color: rgba(67,85,217,.2); background: var(--core-green-soft); color: var(--core-green); }
+.status-pill.bounded { border-color: rgba(11,116,94,.2); background: var(--core-green-soft); color: var(--core-green); }
 .status-pill.ready, .status-pill.approved { border-color: rgba(8,122,91,.2); background: var(--core-success-soft); color: var(--core-success); }
 .status-pill.pending { border-color: rgba(255,184,107,.28); color: var(--core-warn); }
 
@@ -193,7 +193,7 @@ textarea { min-height: 72px; resize: vertical; }
 .template-contract small { grid-column: 2; color: var(--core-quiet); font-size: 7px; }
 .form-actions { display: flex; justify-content: flex-end; gap: 8px; }
 .form-notice { min-height: 16px; margin: 7px 0 0; color: var(--core-quiet); font-size: 12px; line-height: 1.5; }
-.accountable-action-gate { position: fixed; inset: 0; width: min(680px,calc(100% - 36px)); max-height: calc(100svh - 36px); margin: auto; overflow: auto; border: 1px solid var(--core-line-strong); border-radius: 16px; padding: 24px; color: var(--core-ink); background: #fff; box-shadow: 0 30px 90px rgba(20,28,48,.24); }
+.accountable-action-gate { position: fixed; inset: 0; width: min(680px,calc(100% - 36px)); max-height: calc(100svh - 36px); margin: auto; overflow: auto; border: 1px solid var(--core-line-strong); border-radius: 16px; padding: 24px; color: var(--core-ink); background: #fff; box-shadow: 0 30px 90px rgba(25,54,42,.24); }
 .accountable-action-gate[open] { display: grid; gap: 20px; }
 .accountable-action-gate::backdrop { background: rgba(19,25,41,.5); backdrop-filter: blur(6px); }
 .action-change h2 { margin: 5px 0 10px; font-size: 22px; }
@@ -304,7 +304,7 @@ textarea { min-height: 72px; resize: vertical; }
 
 .order-entry-methods { display: grid; grid-template-columns: repeat(3,minmax(0,1fr)); gap: 4px; margin-bottom: 14px; border-radius: 12px; padding: 4px; background: var(--core-panel-raised); }
 .order-entry-methods button { min-height: 42px; border: 0; border-radius: 9px; background: transparent; color: var(--core-muted); font-size: 13px; font-weight: 740; cursor: pointer; }
-.order-entry-methods button[aria-selected="true"] { background: #fff; color: var(--core-ink); box-shadow: 0 2px 10px rgba(27,36,59,.09); }
+.order-entry-methods button[aria-selected="true"] { background: #fff; color: var(--core-ink); box-shadow: 0 2px 10px rgba(31,68,51,.09); }
 .order-entry-methods button:disabled { cursor: not-allowed; opacity: .55; }
 .order-entry-panel { min-width: 0; }
 .order-entry-panel > .website-intake { border-color: var(--core-line); box-shadow: none; }

--- a/tools/verify_app_build.mjs
+++ b/tools/verify_app_build.mjs
@@ -6,16 +6,18 @@ const root = resolve(import.meta.dirname, '..')
 const dist = resolve(root, 'showroom', 'dist')
 const failures = []
 let orderCompletionRuntimeChecks = 0
+let channelOrderRuntimeChecks = 0
 let websiteRuntimeChecks = 0
 let commerceRuntimeChecks = 0
 let productionRuntimeChecks = 0
 const fail = (reason) => failures.push(reason)
-const [manifestText, appPackageText, appSource, coreSource, commerceSource, managedTrialSource, managedCommerceRuntime, productionSource, teamSource, agentTeamsSource, teamModel, websiteSource, publishSource, sitePreviewSource, websiteModelSource, websiteWorkspaceSource, websiteCssSource, commerceIntakeSource, handoffSource] = await Promise.all([
+const [manifestText, appPackageText, appSource, coreSource, commerceSource, channelOrderSource, managedTrialSource, managedCommerceRuntime, productionSource, teamSource, agentTeamsSource, teamModel, websiteSource, publishSource, sitePreviewSource, websiteModelSource, websiteWorkspaceSource, websiteCssSource, commerceIntakeSource, handoffSource] = await Promise.all([
   readFile(resolve(root, 'site-manifest.json'), 'utf8'),
   readFile(resolve(root, 'showroom', 'package.json'), 'utf8'),
   readFile(resolve(root, 'showroom', 'src', 'App.tsx'), 'utf8'),
   readFile(resolve(root, 'showroom', 'src', 'core', 'CoreApp.tsx'), 'utf8'),
   readFile(resolve(root, 'showroom', 'src', 'core', 'commerce-workspace.ts'), 'utf8'),
+  readFile(resolve(root, 'showroom', 'src', 'core', 'channel-order-intake.ts'), 'utf8'),
   readFile(resolve(root, 'showroom', 'src', 'core', 'managed-trial.ts'), 'utf8'),
   readFile(resolve(root, 'supermega_runtime', 'commerce_runtime.py'), 'utf8'),
   readFile(resolve(root, 'showroom', 'src', 'core', 'production-workspace.ts'), 'utf8'),
@@ -77,7 +79,7 @@ else {
 const files = await walk(dist)
 const textFiles = files.filter((path) => /\.(?:html|js|css|json|svg)$/.test(path))
 const corpus = (await Promise.all(textFiles.map((path) => readFile(path, 'utf8')))).join('\n')
-for (const required of ['SUPERMEGA', 'Teams', 'Product', 'Acceptance outcome', 'Prepare brief', 'Evidence register', 'Record evidence', 'Verified evidence', 'verifiedAt', 'Operations', 'Human confirmation', 'Confirm and record', 'Action history', 'actorKind', 'evidenceReference', 'accountableActions', 'decision_packet.v1', 'Claims and provenance', 'claimType', 'claim_type', 'source_reference', 'artifact_reference', 'managedApprovalRequests', 'packetFingerprint', 'uncertainty', 'visibility', 'artifactReference', 'Human reviewer', 'Decision note', 'Approve and record', 'Local trial', 'Delegation control', 'Pilot definition', 'Template profile', 'Workflow', 'workflowProfile', 'Current record', 'Baseline', 'Target outcome', 'Human authority boundary', 'Acceptance evidence', 'Operating mode', 'Write path', manifest.brand.colors.accent, manifest.brand.colors.ink]) {
+for (const required of ['SUPERMEGA', 'Teams', 'Product', 'Acceptance outcome', 'Prepare brief', 'Evidence register', 'Record evidence', 'Verified evidence', 'verifiedAt', 'Operations', 'Confirm change', 'Action history', 'actorKind', 'evidenceReference', 'accountableActions', 'decision_packet.v1', 'Claims and provenance', 'claimType', 'claim_type', 'source_reference', 'artifact_reference', 'managedApprovalRequests', 'packetFingerprint', 'uncertainty', 'visibility', 'artifactReference', 'Human reviewer', 'Decision note', 'Approve and record', 'Local trial', 'Delegation control', 'Pilot definition', 'Workflow', 'workflowProfile', 'Current record', 'Baseline', 'Target outcome', 'Human authority boundary', 'Acceptance evidence', 'Operating mode', 'Write path', manifest.brand.colors.accent, manifest.brand.colors.ink]) {
   if (!corpus.includes(required)) fail(`missing_context:${required}`)
 }
 if (!coreSource.includes("import siteManifest from '../../../site-manifest.json'")) fail('workflow_contract_not_shared')
@@ -123,6 +125,31 @@ const websiteMobileCss = websiteCssSource.slice(websiteCssSource.indexOf('@media
 if (!websiteMobileCss.includes('.website-preview-controls') || !websiteMobileCss.includes('display: flex') || websiteMobileCss.includes('.website-preview-controls {\n    display: none')) fail('website_mobile_review_controls_hidden')
 if (!websiteMobileCss.includes('.website-handoff-controls input') || !websiteMobileCss.includes('min-height: 44px') || !websiteMobileCss.includes('font-size: 12px')) fail('website_mobile_handoff_controls_undersized')
 if (!commerceIntakeSource.includes('Browser-local evidence only.') || !commerceIntakeSource.includes('No customer message, payment, delivery request, or external write occurs.')) fail('commerce_intake_boundary_missing')
+if (!coreSource.includes('Start from a channel message')
+  || !coreSource.includes('Human-mapped intake')
+  || !coreSource.includes('AI is not connected')
+  || !coreSource.includes('The full message is not part of the order record.')
+  || !coreSource.includes('sourceRecordId: sourceDraft?.sourceRecordId')
+  || !coreSource.includes('evidenceReferenceSuggestion: sourceDraft?.evidenceReference')
+  || !coreSource.includes('evidenceReferenceLocked: Boolean(sourceDraft)')
+  || !coreSource.includes('onAcceptedFocus')
+  || !coreSource.includes("setOrderEntryMode('manual')")
+  || !coreSource.includes('channelOrderDraftIsReady')) fail('channel_order_intake_ui_missing')
+if (!coreSource.includes('className="core-panel next-task-card"')
+  || !coreSource.includes('<details className="home-more">')
+  || !coreSource.includes('className="product-launcher product-catalog"')
+  || !coreSource.includes("useState<'manual' | 'message' | 'website'>('manual')")
+  || !coreSource.includes('aria-label="Order source" className="order-entry-methods" role="tablist"')
+  || !coreSource.includes('<dialog aria-labelledby="action-confirm-title" className="accountable-action-gate"')
+  || !coreSource.includes('<details className="core-panel today-more">')
+  || coreSource.includes('className="operations-profile"')) fail('task_first_core_ui_contract_changed')
+if (!channelOrderSource.includes("supermega.channel_order_draft.v1")
+  || !channelOrderSource.includes('ready_for_confirmation')
+  || !channelOrderSource.includes('operator_supplied')
+  || !channelOrderSource.includes('quote_not_found')
+  || !channelOrderSource.includes('source_quote_required')
+  || !channelOrderSource.includes('channel-message://')
+  || ['localStorage', 'sessionStorage', 'fetch(', 'XMLHttpRequest', 'openai'].some((marker) => channelOrderSource.toLowerCase().includes(marker.toLowerCase()))) fail('channel_order_intake_contract_missing_or_side_effectful')
 if (!handoffSource.includes("schema: 'website_ecommerce_handoff.v1'") || !handoffSource.includes("state: 'pending_acceptance'") || !handoffSource.includes('hasExactKeys') || !handoffSource.includes('validateAgainstWorkspace') || !handoffSource.includes('readinessChecks(workspace, fingerprint).every') || !handoffSource.includes('acceptWebsiteEcommerceHandoff')) fail('website_ecommerce_handoff_contract_missing')
 const handoffIntakeSource = handoffSource.slice(handoffSource.indexOf('type HandoffIntake'), handoffSource.indexOf('type PendingHandoff'))
 if (!handoffIntakeSource.includes('sku: string') || !handoffIntakeSource.includes('quantity: number') || ['customer', 'phone', 'township', 'payment', 'delivery', 'fulfilment'].some((field) => handoffIntakeSource.toLowerCase().includes(field))) fail('website_handoff_contains_pii_shaped_fields')
@@ -151,17 +178,17 @@ if (!coreSource.includes("mode: 'managed-unprovisioned'") || !coreSource.include
 if (!coreSource.includes('confirmation?: AccountableAction') || !coreSource.includes('if (action.confirmation) return action.confirmation') || !coreSource.includes('Retry same confirmation') || !coreSource.includes('result.idempotent_replay') || !coreSource.includes('before the replay could be reconciled')) fail('managed_command_retry_not_frozen_or_reconciled')
 if (!managedCommerceRuntime.includes('commerce.workspace.initialized') || managedCommerceRuntime.includes('commerce.snapshot.saved') || !managedCommerceRuntime.includes('_one_changed') || !managedCommerceRuntime.includes('_validate_event_evidence') || !managedCommerceRuntime.includes('daily close totals must match completed, reconciled orders')) fail('managed_commerce_server_transition_contract_missing')
 if (!commerceSource.includes('registerCommerceItem') || !coreSource.includes('Add catalog item') || !coreSource.includes('Review catalog item') || !coreSource.includes('The opening balance may be zero.') || !managedCommerceRuntime.includes('one exact attributable opening balance')) fail('commerce_catalog_creation_contract_missing')
-if (!coreSource.includes("const commerceTabs") || !coreSource.includes("{ id: 'today', label: 'Today' }") || !coreSource.includes("{ id: 'orders', label: 'Orders' }") || !coreSource.includes("{ id: 'inventory', label: 'Inventory' }") || coreSource.includes("{ id: 'payments'")) fail('commerce_three_tab_contract_changed')
+if (!coreSource.includes("const commerceTabs") || !coreSource.includes("{ id: 'today', label: 'Today' }") || !coreSource.includes("{ id: 'orders', label: 'Orders' }") || !coreSource.includes("{ id: 'inventory', label: 'Stock' }") || coreSource.includes("{ id: 'payments'")) fail('commerce_three_tab_contract_changed')
 if (!productionSource.includes("supermega.production.workspace.v2") || !productionSource.includes('mutateProductionWorkspace') || !productionSource.includes('lockManager.request') || !productionSource.includes('next.revision !== current.revision + 1')) fail('production_v2_locked_store_missing')
 if (!productionSource.includes("'output_recorded' | 'issue_opened' | 'issue_resolved' | 'machine_state_changed'") || !productionSource.includes('events: [event, ...state.events]') || !productionSource.includes('Production revision must equal the append-only event count.')) fail('production_append_only_record_missing')
 if (!productionSource.includes('currentRaw !== null') || !productionSource.includes('Migration failed closed') || !productionSource.includes('events: []')) fail('production_migration_fail_closed_contract_missing')
 const productionTabsContract = coreSource.slice(coreSource.indexOf('const productionTabs'), coreSource.indexOf('function uid'))
-if (!productionTabsContract.includes("{ id: 'today', label: 'Today' }") || !productionTabsContract.includes("{ id: 'production', label: 'Production' }") || !productionTabsContract.includes("{ id: 'control', label: 'Issues & equipment' }") || (productionTabsContract.match(/^\s*\{ id:/gm) || []).length !== 3) fail('production_three_tab_contract_changed')
+if (!productionTabsContract.includes("{ id: 'today', label: 'Today' }") || !productionTabsContract.includes("{ id: 'production', label: 'Jobs' }") || !productionTabsContract.includes("{ id: 'control', label: 'Problems' }") || (productionTabsContract.match(/^\s*\{ id:/gm) || []).length !== 3) fail('production_three_tab_contract_changed')
 const productionPageContract = coreSource.slice(coreSource.indexOf('function ProductionPage'), coreSource.indexOf('function JobList'))
 if (coreSource.includes('Math.min(quantity') || !productionPageContract.includes('No output was recorded.') || !productionPageContract.includes('Number.isSafeInteger(quantity)') || productionPageContract.includes('max={selectedRemaining')) fail('production_output_silently_clamped')
 if (!productionPageContract.includes('persisted with attributed Production evidence.') || productionPageContract.includes('<ActionHistory actions={actions} domain="production"')) fail('production_confirmation_record_not_domain_specific')
 if (!coreSource.includes("addEventListener('storage', refreshFromStorage)") || !coreSource.includes("removeEventListener('storage', refreshFromStorage)")) fail('production_cross_tab_refresh_missing')
-if (!coreSource.includes('headingRef.current?.focus()') || !coreSource.includes('previousFocusRef.current.focus()') || !coreSource.includes('aria-live="polite"') || !coreSource.includes('current state ${machine.state}')) fail('production_confirmation_accessibility_missing')
+if (!coreSource.includes('headingRef.current?.focus()') || !coreSource.includes('returnFocus?.isConnected') || !coreSource.includes('previousFocus.focus()') || !coreSource.includes('aria-live="polite"') || !coreSource.includes('current state ${machine.state}')) fail('production_confirmation_accessibility_missing')
 let workflowProfiles = 0
 for (const product of manifest.products || []) {
   if (product.templates?.length !== 3) fail(`wrong_template_count:${product.id}`)
@@ -181,6 +208,195 @@ for (const forbidden of ['pos.supermega.dev', 'ytf.supermega.dev', 'Yangon Tyre'
 }
 for (const marker of ['\uFFFD', '\u00e2\u20ac\u201d', '\u00e2\u20ac\u201c', '\u00c2', '\u00f0\u0178']) {
   if (corpus.includes(marker)) fail('app_copy_encoding_corrupt')
+}
+
+async function verifyChannelOrderRuntime() {
+  const assert = (condition, reason) => {
+    if (!condition) throw new Error(reason)
+    channelOrderRuntimeChecks += 1
+  }
+  try {
+    const nonce = Date.now()
+    const [intake, commerce] = await Promise.all([
+      import(`${pathToFileURL(resolve(root, 'showroom', 'src', 'core', 'channel-order-intake.ts')).href}?channel-order-verify=${nonce}`),
+      import(`${pathToFileURL(resolve(root, 'showroom', 'src', 'core', 'commerce-workspace.ts')).href}?channel-order-verify=${nonce}`),
+    ])
+    const fixtures = [
+      {
+        id: 'english',
+        sourceLabel: 'MSG-EN-001',
+        message: 'May wants SM-1001, 2 baskets, pay with KBZPay on Messenger.',
+        channel: 'Messenger',
+        customer: 'May',
+        sku: 'SM-1001',
+        quantity: 2,
+        payment: 'KBZPay',
+        quotes: { customer: 'May', sku: 'SM-1001', quantity: '2 baskets', payment: 'KBZPay' },
+      },
+      {
+        id: 'burmese',
+        sourceLabel: 'MSG-MY-001',
+        message: 'မမေအတွက် SM-1002 ၂ ထုပ်ယူမယ်၊ WavePay နဲ့ရှင်းမယ်။',
+        channel: 'Viber',
+        customer: 'မမေ',
+        sku: 'SM-1002',
+        quantity: 2,
+        payment: 'WavePay',
+        quotes: { customer: 'မမေ', sku: 'SM-1002', quantity: '၂ ထုပ်', payment: 'WavePay' },
+      },
+      {
+        id: 'mixed',
+        sourceLabel: 'CALL-MIX-001',
+        message: 'Ko Aung က SM-1003 qty 1 မှာပြီး Cash on delivery ပါ။',
+        channel: 'Phone',
+        customer: 'Ko Aung',
+        sku: 'SM-1003',
+        quantity: 1,
+        payment: 'Cash on delivery',
+        quotes: { customer: 'Ko Aung', sku: 'SM-1003', quantity: 'qty 1', payment: 'Cash on delivery' },
+      },
+    ]
+    const drafts = fixtures.map((fixture) => intake.buildChannelOrderDraft({
+      ...fixture,
+      catalogSkus: ['SM-1001', 'SM-1002', 'SM-1003'],
+      attributions: Object.fromEntries(Object.entries(fixture.quotes).map(([field, quote]) => [field, { kind: 'quote', quote }])),
+    }))
+    drafts.forEach((draft, index) => {
+      assert(intake.channelOrderDraftIsReady(draft), `channel_order_${fixtures[index].id}_not_ready`)
+      assert(draft.provenance.every((entry) => entry.kind === 'operator_supplied' || fixtures[index].message.slice(entry.start, entry.end) === entry.quote), `channel_order_${fixtures[index].id}_span_not_exact`)
+    })
+    assert(drafts.every((draft, index) => !JSON.stringify(draft).includes(fixtures[index].message)), 'channel_order_draft_retained_full_message')
+    assert(drafts.every((draft) => /^CHN-[A-F0-9]{16}$/.test(draft.sourceRecordId)
+      && /^MSG-[A-F0-9]{16}$/.test(draft.messageFingerprint)
+      && draft.evidenceReference.startsWith(`channel-message://${draft.sourceRecordId}#msg-${draft.messageFingerprint.slice(4).toLowerCase()}-map-`)), 'channel_order_source_identity_invalid')
+    assert(!intake.channelOrderDraftIsReady({ ...drafts[0], provenance: drafts[0].provenance.slice(1) }), 'channel_order_ready_guard_accepted_missing_provenance')
+    assert(!intake.channelOrderDraftIsReady({ ...drafts[0], sourceRecordId: 'CHN-TAMPERED' }), 'channel_order_ready_guard_accepted_tampered_source')
+    assert(!intake.channelOrderDraftIsReady({ ...drafts[0], schema: 'supermega.channel_order_draft.v0' }), 'channel_order_ready_guard_accepted_stale_schema')
+    assert(!intake.channelOrderDraftIsReady({ ...drafts[0], evidenceReference: `${drafts[0].evidenceReference}tampered` }), 'channel_order_ready_guard_accepted_tampered_evidence')
+    assert(!intake.channelOrderDraftIsReady({
+      ...drafts[0],
+      provenance: drafts[0].provenance.map((entry) => entry.kind === 'quote' ? { ...entry, end: entry.end + 1 } : entry),
+    }), 'channel_order_ready_guard_accepted_invalid_quote_span')
+
+    const seed = commerce.createSeedCommerce()
+    const seedBefore = JSON.stringify(seed)
+    const incomplete = intake.buildChannelOrderDraft({
+      ...fixtures[0],
+      customer: '',
+      catalogSkus: seed.items.map((item) => item.sku),
+      attributions: {
+        customer: { kind: 'quote', quote: 'missing customer' },
+        sku: { kind: 'quote', quote: 'SM-1001' },
+        quantity: { kind: 'quote', quote: '2 baskets' },
+        payment: { kind: 'quote', quote: 'KBZPay' },
+      },
+    })
+    assert(incomplete.status === 'needs_review' && incomplete.blockers.includes('customer_required') && incomplete.blockers.includes('customer_quote_not_found'), 'channel_order_missing_fields_did_not_fail_closed')
+    assert(JSON.stringify(seed) === seedBefore, 'channel_order_draft_changed_commerce_state')
+
+    const operatorSupplied = intake.buildChannelOrderDraft({
+      ...fixtures[0],
+      customer: 'Counter customer 7',
+      catalogSkus: seed.items.map((item) => item.sku),
+      attributions: {
+        customer: { kind: 'operator_supplied' },
+        sku: { kind: 'quote', quote: 'SM-1001' },
+        quantity: { kind: 'quote', quote: '2 baskets' },
+        payment: { kind: 'quote', quote: 'KBZPay' },
+      },
+    })
+    assert(intake.channelOrderDraftIsReady(operatorSupplied) && operatorSupplied.provenance.some((entry) => entry.field === 'customer' && entry.kind === 'operator_supplied'), 'channel_order_operator_supplied_provenance_missing')
+    const fullMessageQuote = intake.buildChannelOrderDraft({
+      ...fixtures[0],
+      message: 'May',
+      catalogSkus: seed.items.map((item) => item.sku),
+      attributions: {
+        customer: { kind: 'quote', quote: 'May' },
+        sku: { kind: 'operator_supplied' },
+        quantity: { kind: 'operator_supplied' },
+        payment: { kind: 'operator_supplied' },
+      },
+    })
+    assert(fullMessageQuote.status === 'needs_review'
+      && fullMessageQuote.blockers.includes('customer_quote_must_be_excerpt')
+      && !JSON.stringify(fullMessageQuote).includes('"quote":"May"'), 'channel_order_full_message_quote_was_retained')
+    const overlappingQuote = intake.buildChannelOrderDraft({
+      ...fixtures[0],
+      message: 'aaa / SM-1001 / 2 baskets / KBZPay',
+      customer: 'aa',
+      catalogSkus: seed.items.map((item) => item.sku),
+      attributions: {
+        customer: { kind: 'quote', quote: 'aa' },
+        sku: { kind: 'quote', quote: 'SM-1001' },
+        quantity: { kind: 'quote', quote: '2 baskets' },
+        payment: { kind: 'quote', quote: 'KBZPay' },
+      },
+    })
+    assert(overlappingQuote.status === 'needs_review' && overlappingQuote.blockers.includes('customer_quote_ambiguous'), 'channel_order_overlapping_quote_was_not_ambiguous')
+    const exactRetry = intake.buildChannelOrderDraft({
+      ...fixtures[0],
+      catalogSkus: seed.items.map((item) => item.sku),
+      attributions: Object.fromEntries(Object.entries(fixtures[0].quotes).map(([field, quote]) => [field, { kind: 'quote', quote }])),
+    })
+    assert(exactRetry.sourceRecordId === drafts[0].sourceRecordId && exactRetry.evidenceReference === drafts[0].evidenceReference, 'channel_order_exact_draft_retry_changed_identity')
+    const changedBody = intake.buildChannelOrderDraft({
+      ...fixtures[0],
+      message: `${fixtures[0].message} Confirmed again.`,
+      catalogSkus: seed.items.map((item) => item.sku),
+      attributions: Object.fromEntries(Object.entries(fixtures[0].quotes).map(([field, quote]) => [field, { kind: 'quote', quote }])),
+    })
+    assert(changedBody.sourceRecordId === drafts[0].sourceRecordId
+      && changedBody.messageFingerprint !== drafts[0].messageFingerprint
+      && changedBody.evidenceReference !== drafts[0].evidenceReference, 'channel_order_reference_identity_changed_with_message_body')
+    const normalizedReference = intake.buildChannelOrderDraft({
+      ...fixtures[0],
+      sourceLabel: '  msg-en-001  ',
+      catalogSkus: seed.items.map((item) => item.sku),
+      attributions: Object.fromEntries(Object.entries(fixtures[0].quotes).map(([field, quote]) => [field, { kind: 'quote', quote }])),
+    })
+    assert(normalizedReference.sourceRecordId === drafts[0].sourceRecordId, 'channel_order_reference_identity_was_case_or_space_sensitive')
+    const conflictingMapping = intake.buildChannelOrderDraft({
+      ...fixtures[0],
+      customer: 'May revised',
+      catalogSkus: seed.items.map((item) => item.sku),
+      attributions: {
+        customer: { kind: 'operator_supplied' },
+        sku: { kind: 'quote', quote: 'SM-1001' },
+        quantity: { kind: 'quote', quote: '2 baskets' },
+        payment: { kind: 'quote', quote: 'KBZPay' },
+      },
+    })
+    assert(conflictingMapping.sourceRecordId === drafts[0].sourceRecordId && conflictingMapping.evidenceReference !== drafts[0].evidenceReference, 'channel_order_conflicting_mapping_not_detectable')
+
+    const item = seed.items.find((candidate) => candidate.sku === drafts[0].sku)
+    const proof = { actionId: 'ACT-CHANNEL-RUNTIME-01', capturedAt: '2026-07-23T12:00:00.000Z', actor: 'Commerce lead', reason: 'Confirmed source-backed channel order.', evidenceReference: drafts[0].evidenceReference }
+    const order = {
+      id: 'ORD-CHANNEL-RUNTIME-01',
+      createdAt: proof.capturedAt,
+      customer: drafts[0].customer,
+      channel: drafts[0].channel,
+      item: item.name,
+      itemSku: item.sku,
+      quantity: drafts[0].quantity,
+      payment: drafts[0].payment,
+      paymentStatus: 'pending',
+      refundStatus: 'none',
+      sourceRecordId: drafts[0].sourceRecordId,
+      evidenceReference: drafts[0].evidenceReference,
+      total: item.price * drafts[0].quantity,
+      status: 'confirmed',
+    }
+    const accepted = commerce.reserveCommerceOrder(seed, order, proof)
+    assert(commerce.reserveCommerceOrder(seed, order, { ...proof, evidenceReference: 'MSG-CONFLICTING-EVIDENCE' }) === null, 'channel_order_mismatched_action_evidence_succeeded')
+    assert(accepted?.orders.some((candidate) => candidate.id === order.id && candidate.sourceRecordId === drafts[0].sourceRecordId), 'channel_order_human_confirmation_not_recorded')
+    assert(accepted?.items.find((candidate) => candidate.sku === item.sku)?.onHand === item.onHand - order.quantity, 'channel_order_confirmation_did_not_reserve_stock_once')
+    assert(commerce.reserveCommerceOrder(accepted, order, proof) === accepted, 'channel_order_exact_confirmation_retry_not_idempotent')
+    const conflictingOrder = { ...order, id: 'ORD-CHANNEL-RUNTIME-02', customer: 'Changed customer', evidenceReference: conflictingMapping.evidenceReference }
+    const conflictingProof = { ...proof, actionId: 'ACT-CHANNEL-RUNTIME-02', evidenceReference: conflictingMapping.evidenceReference }
+    assert(commerce.reserveCommerceOrder(accepted, conflictingOrder, conflictingProof) === null, 'channel_order_conflicting_source_reuse_succeeded')
+  } catch (error) {
+    fail(`channel_order_runtime:${error instanceof Error ? error.message : 'unknown'}`)
+  }
 }
 
 async function verifyWebsiteRuntime() {
@@ -741,6 +957,7 @@ async function verifyCommerceRuntime() {
     assert(model.registerCommerceItem(withItem, newItem, openingProof) === withItem, 'catalog_item_retry_not_idempotent')
     assert(model.registerCommerceItem(withItem, { ...newItem, price: 251 }, openingProof) === null, 'catalog_item_conflicting_retry_succeeded')
     assert(model.registerCommerceItem(withItem, newItem, proof('ACT-ITEM-DUPLICATE')) === null, 'duplicate_catalog_sku_succeeded')
+    const reserveProof = proof('ACT-RESERVE')
     const order = {
       id: 'ORD-1',
       createdAt: '2026-07-23T09:00:00.000Z',
@@ -753,10 +970,10 @@ async function verifyCommerceRuntime() {
       paymentStatus: 'pending',
       refundStatus: 'none',
       sourceRecordId: 'WEB-1',
+      evidenceReference: reserveProof.evidenceReference,
       total: 200,
       status: 'confirmed',
     }
-    const reserveProof = proof('ACT-RESERVE')
     const reserved = model.reserveCommerceOrder(base, order, reserveProof)
     assert(reserved?.items[0].onHand === 8 && reserved.orders.length === 1 && reserved.movements.length === 1, 'reservation_did_not_apply_once')
     assert(model.reserveCommerceOrder(reserved, order, reserveProof) === reserved, 'exact_reservation_retry_not_idempotent')
@@ -775,8 +992,9 @@ async function verifyCommerceRuntime() {
     const completed = model.advanceCommerceOrder(reconciled, order.id, 'ready')
     assert(completed?.orders[0].status === 'completed' && model.cancelCommerceOrder(completed, order.id, proof('ACT-CANCEL-COMPLETED')) === null, 'completed_order_was_cancellable')
 
-    const cancelOrder = { ...order, id: 'ORD-CANCEL', sourceRecordId: 'WEB-CANCEL' }
-    const cancelReserved = model.reserveCommerceOrder(base, cancelOrder, proof('ACT-RESERVE-CANCEL'))
+    const cancelReserveProof = proof('ACT-RESERVE-CANCEL')
+    const cancelOrder = { ...order, id: 'ORD-CANCEL', sourceRecordId: 'WEB-CANCEL', evidenceReference: cancelReserveProof.evidenceReference }
+    const cancelReserved = model.reserveCommerceOrder(base, cancelOrder, cancelReserveProof)
     const cancelProof = proof('ACT-CANCEL', 2_000)
     const cancelled = model.cancelCommerceOrder(cancelReserved, cancelOrder.id, cancelProof)
     assert(cancelled?.items[0].onHand === 10 && cancelled.orders[0].status === 'cancelled' && cancelled.movements.filter((movement) => movement.kind === 'release').length === 1, 'cancellation_did_not_release_once')
@@ -784,8 +1002,9 @@ async function verifyCommerceRuntime() {
     assert(model.cancelCommerceOrder(cancelled, cancelOrder.id, proof('ACT-CANCEL-OTHER')) === null, 'different_cancellation_retry_succeeded')
     assert(model.cancelCommerceOrder(migrated, 'ORD-LEGACY', proof('ACT-CANCEL-LEGACY')) === null && migrated.items[0].onHand === 10, 'untracked_legacy_order_invented_stock')
 
-    const paidOrder = { ...order, id: 'ORD-PAID-CANCEL', sourceRecordId: 'WEB-PAID-CANCEL' }
-    const paidReserved = model.reserveCommerceOrder(base, paidOrder, proof('ACT-RESERVE-PAID'))
+    const paidReserveProof = proof('ACT-RESERVE-PAID')
+    const paidOrder = { ...order, id: 'ORD-PAID-CANCEL', sourceRecordId: 'WEB-PAID-CANCEL', evidenceReference: paidReserveProof.evidenceReference }
+    const paidReserved = model.reserveCommerceOrder(base, paidOrder, paidReserveProof)
     const paid = model.reconcileCommercePayment(paidReserved, paidOrder.id, proof('ACT-PAY-PAID'))
     const paidCancelled = model.cancelCommerceOrder(paid, paidOrder.id, proof('ACT-CANCEL-PAID'))
     assert(paidCancelled?.orders[0].paymentStatus === 'reconciled' && paidCancelled.orders[0].refundStatus === 'due', 'paid_cancellation_erased_reconciliation_or_refund_exception')
@@ -815,16 +1034,18 @@ async function verifyCommerceRuntime() {
     assert(legacySnapshot.source === 'legacy' && JSON.parse(values.get(model.COMMERCE_KEY)).movements.length === 0, 'absent_v2_migration_failed')
 
     values.clear()
-    const concurrentReserved = model.reserveCommerceOrder(base, cancelOrder, proof('ACT-CONCURRENT-RESERVE'))
+    const concurrentReserveProof = proof('ACT-CONCURRENT-RESERVE')
+    const concurrentOrder = { ...cancelOrder, evidenceReference: concurrentReserveProof.evidenceReference }
+    const concurrentReserved = model.reserveCommerceOrder(base, concurrentOrder, concurrentReserveProof)
     values.set(model.COMMERCE_KEY, JSON.stringify(concurrentReserved))
     const concurrentResults = await Promise.all([
-      model.mutateCommerceWorkspace((state) => model.cancelCommerceOrder(state, cancelOrder.id, proof('ACT-CONCURRENT-CANCEL-A')), storage, locks),
-      model.mutateCommerceWorkspace((state) => model.cancelCommerceOrder(state, cancelOrder.id, proof('ACT-CONCURRENT-CANCEL-B')), storage, locks),
+      model.mutateCommerceWorkspace((state) => model.cancelCommerceOrder(state, concurrentOrder.id, proof('ACT-CONCURRENT-CANCEL-A')), storage, locks),
+      model.mutateCommerceWorkspace((state) => model.cancelCommerceOrder(state, concurrentOrder.id, proof('ACT-CONCURRENT-CANCEL-B')), storage, locks),
     ])
     const concurrentState = JSON.parse(values.get(model.COMMERCE_KEY))
     assert(lockRequests === 2 && concurrentResults.filter((result) => result.ok).length === 1, 'concurrent_cancellation_not_serialized')
     assert(concurrentState.items[0].onHand === 10 && concurrentState.movements.filter((movement) => movement.kind === 'release').length === 1, 'concurrent_cancellation_released_twice')
-    const replay = await model.mutateCommerceWorkspace((state) => model.cancelCommerceOrder(state, cancelOrder.id, proof('ACT-CONCURRENT-CANCEL-A')), storage, locks)
+    const replay = await model.mutateCommerceWorkspace((state) => model.cancelCommerceOrder(state, concurrentOrder.id, proof('ACT-CONCURRENT-CANCEL-A')), storage, locks)
     assert(replay.ok && replay.replayed === true && JSON.parse(values.get(model.COMMERCE_KEY)).movements.length === 2, 'persisted_cancellation_replay_changed_ledger')
 
     const beforeFailure = values.get(model.COMMERCE_KEY)
@@ -1021,6 +1242,7 @@ async function verifyProductionRuntime() {
   }
 }
 
+await verifyChannelOrderRuntime()
 await verifyWebsiteRuntime()
 await verifyWebsiteOrderCompletionRuntime()
 await verifyCommerceRuntime()
@@ -1033,4 +1255,4 @@ if (failures.length) {
   console.error(JSON.stringify({ ok: false, contract: 'supermega_app_build', failures }, null, 2))
   process.exit(1)
 }
-console.log(JSON.stringify({ ok: true, contract: 'supermega_app_build', primaryRoutes: 4, operatingModules: 2, prototypeRoutes: 1, compatibilityRedirects: 1, workflowProfiles, websiteRuntimeChecks, orderCompletionRuntimeChecks, commerceRuntimeChecks, productionRuntimeChecks, bytes }, null, 2))
+console.log(JSON.stringify({ ok: true, contract: 'supermega_app_build', primaryRoutes: 4, operatingModules: 2, prototypeRoutes: 1, compatibilityRedirects: 1, workflowProfiles, channelOrderRuntimeChecks, websiteRuntimeChecks, orderCompletionRuntimeChecks, commerceRuntimeChecks, productionRuntimeChecks, bytes }, null, 2))


### PR DESCRIPTION
## Outcome

Makes the SuperMega app materially simpler on mobile and desktop while preserving the operational models and human confirmation boundary.

- Replaces layered Operations navigation with a three-app chooser and one task bar per product.
- Gives Home one clear next action; secondary activity is collapsed.
- Reduces Commerce and Production Today to their primary work plus optional detail.
- Separates Manual, Message, and Website order intake so only one path is visible at a time.
- Adds deterministic, source-attributed channel-message mapping without retaining the full message.
- Moves consequential changes into a focused confirmation dialog with locked source evidence and correct focus return.
- Fixes Work list semantics and AA text contrast.

## Proof

- `npm.cmd --prefix showroom run lint`
- `npm.cmd --prefix showroom run build`
- `node tools/verify_app_build.mjs`
  - channel order: 27 checks
  - Website: 24 checks
  - order completion: 12 checks
  - Commerce: 48 checks
  - Production: 51 checks
- Browser verification at 390x844 and desktop widths: no horizontal overflow.
- Axe WCAG A/AA: 0 violations on Home, Work, Commerce Orders, and Production Today.
- Channel-message flow verified end to end: reviewed mapping, full message discarded, stable source retained, evidence locked, no order mutation before human confirmation.

## Boundaries

Draft only. No merge, deployment, Supabase mutation, external message, or writes enablement is included.