### PR TITLE
Simplify Website workspace into task-first editing and publishing

### DIFF
--- a/showroom/src/products/website/ContentWorkspace.tsx
+++ b/showroom/src/products/website/ContentWorkspace.tsx
@@ -1,3 +1,5 @@
+import { useState } from 'react'
+
 import {
   createBlankSection,
   formatTimestamp,
@@ -5,6 +7,8 @@ import {
   pageIssues,
   type WebsitePage,
 } from './website-model'
+
+type EditorSection = 'page' | 'hero' | 'sections' | 'seo'
 
 type ContentWorkspaceProps = {
   page: WebsitePage
@@ -24,6 +28,7 @@ export function ContentWorkspace({
   onUpdatePage,
 }: ContentWorkspaceProps) {
   const issues = pageIssues(page)
+  const [editorSection, setEditorSection] = useState<EditorSection>('hero')
 
   function editPage(update: (current: WebsitePage) => WebsitePage) {
     onUpdatePage((current) => ({ ...update(current), stage: 'draft' }))
@@ -54,8 +59,18 @@ export function ContentWorkspace({
         </span>
       </header>
 
-      <div className="website-editor-scroll">
-        <fieldset className="website-fieldset">
+      <div className="website-editor-scroll" data-editor-section={editorSection}>
+        <label className="website-editor-section-picker">
+          <span>Edit</span>
+          <select aria-label="Page section to edit" onChange={(event) => setEditorSection(event.target.value as EditorSection)} value={editorSection}>
+            <option value="hero">Hero</option>
+            <option value="sections">Content sections</option>
+            <option value="page">Page details</option>
+            <option value="seo">Search metadata</option>
+          </select>
+        </label>
+
+        <fieldset className="website-fieldset" data-content-section="page">
           <legend>Page record</legend>
           <div className="website-form-grid two-columns">
             <label>
@@ -79,7 +94,7 @@ export function ContentWorkspace({
           </div>
         </fieldset>
 
-        <fieldset className="website-fieldset">
+        <fieldset className="website-fieldset" data-content-section="hero">
           <legend>Hero</legend>
           <div className="website-form-grid">
             <label>
@@ -146,7 +161,7 @@ export function ContentWorkspace({
           </div>
         </fieldset>
 
-        <fieldset className="website-fieldset has-heading-action">
+        <fieldset className="website-fieldset has-heading-action" data-content-section="sections">
           <legend>Content sections</legend>
           <button
             className="website-text-button website-fieldset-action"
@@ -247,7 +262,7 @@ export function ContentWorkspace({
           </div>
         </fieldset>
 
-        <details className="website-disclosure">
+        <details className="website-disclosure" data-content-section="seo" open>
           <summary>
             <span>Search metadata</span>
             <small>{page.seo.title && page.seo.description ? 'Complete' : 'Needs copy'}</small>

--- a/showroom/src/products/website/PublishWorkspace.tsx
+++ b/showroom/src/products/website/PublishWorkspace.tsx
@@ -1,4 +1,4 @@
-import { type FormEvent, useState } from 'react'
+import { type FormEvent, useRef, useState } from 'react'
 
 import {
   evidenceRequirements,
@@ -7,6 +7,7 @@ import {
   type ReadinessCheck,
   type WebsiteWorkspace,
 } from './website-model'
+import './publish-workspace.css'
 
 type EvidenceInput = {
   kind: EvidenceKind
@@ -40,6 +41,15 @@ type PublishWorkspaceProps = {
   onRecordPublish: () => Promise<void>
 }
 
+type PublishStep = 'checks' | 'evidence' | 'approval' | 'snapshot'
+
+const publishSteps: Array<{ id: PublishStep; label: string }> = [
+  { id: 'checks', label: 'Checks' },
+  { id: 'evidence', label: 'Evidence' },
+  { id: 'approval', label: 'Approval' },
+  { id: 'snapshot', label: 'Snapshot & handoff' },
+]
+
 export function PublishWorkspace({
   approvalIsCurrent,
   checks,
@@ -64,12 +74,51 @@ export function PublishWorkspace({
   const [handoffSku, setHandoffSku] = useState('')
   const [handoffQuantity, setHandoffQuantity] = useState(1)
   const [submitting, setSubmitting] = useState<'evidence' | 'approval' | 'snapshot' | 'handoff' | ''>('')
+  const bodyRef = useRef<HTMLDivElement>(null)
   const passedCount = checks.filter((check) => check.passed).length
   const allChecksPass = passedCount === checks.length
   const latestApproval = workspace.approvals[0]
   const staleEvidenceCount = workspace.evidence.filter((entry) => (
     entry.fingerprint !== fingerprint || entry.source.contentRevision !== workspace.contentRevision
   )).length
+  const currentEvidenceByKind = new Map(
+    evidenceRequirements.map((requirement) => [
+      requirement.id,
+      workspace.evidence.find((entry) => (
+        entry.kind === requirement.id
+        && entry.fingerprint === fingerprint
+        && entry.source.contentRevision === workspace.contentRevision
+      )),
+    ]),
+  )
+  const currentEvidenceCount = [...currentEvidenceByKind.values()].filter(Boolean).length
+  const contentChecks = checks.filter((check) => !check.id.startsWith('evidence-'))
+  const passedContentCheckCount = contentChecks.filter((check) => check.passed).length
+  const contentChecksPass = passedContentCheckCount === contentChecks.length
+  const evidenceIsCurrent = currentEvidenceCount === evidenceRequirements.length
+  const initialStep: PublishStep = !contentChecksPass
+    ? 'checks'
+    : !evidenceIsCurrent
+      ? 'evidence'
+      : !approvalIsCurrent
+        ? 'approval'
+        : 'snapshot'
+  const [activeStep, setActiveStep] = useState<PublishStep>(initialStep)
+  const workflowStatus = publishIsCurrent
+    ? 'Snapshot recorded'
+    : approvalIsCurrent
+      ? 'Ready to record'
+      : evidenceIsCurrent && contentChecksPass
+        ? 'Needs approval'
+        : contentChecksPass
+          ? 'Needs evidence'
+          : 'Needs fixes'
+  const stepStatus: Record<PublishStep, string> = {
+    checks: `${passedContentCheckCount}/${contentChecks.length}`,
+    evidence: `${currentEvidenceCount}/${evidenceRequirements.length}`,
+    approval: approvalIsCurrent ? 'Approved' : 'Required',
+    snapshot: publishIsCurrent ? 'Recorded' : 'Not recorded',
+  }
 
   async function prepareCommerceHandoff() {
     const sku = handoffSku.trim().toUpperCase()
@@ -113,267 +162,397 @@ export function PublishWorkspace({
     setSubmitting('')
   }
 
+  function selectStep(step: PublishStep) {
+    if (bodyRef.current) bodyRef.current.scrollTop = 0
+    setActiveStep(step)
+  }
+
   return (
-    <section className="website-editor-panel website-publish-panel" aria-labelledby="publish-editor-title">
-      <header className="website-panel-head">
+    <section
+      className="website-editor-panel website-publish-panel website-publish-workspace"
+      aria-labelledby="publish-editor-title"
+    >
+      <header className="website-panel-head publish-flow-header">
         <div>
-          <span className="website-eyebrow">Publish control</span>
-          <h2 id="publish-editor-title">Readiness and approval</h2>
-          <p>Checks use only the current workspace revision.</p>
+          <span className="website-eyebrow">Safe publish workflow</span>
+          <h2 id="publish-editor-title">Review and record this revision</h2>
+          <p>Work through one step at a time. Nothing here deploys a website or changes a domain.</p>
         </div>
-        <span className={'website-status ' + (allChecksPass ? 'is-ready' : 'is-pending')}>
-          {passedCount}/{checks.length} passed
+        <span className={'website-status ' + (publishIsCurrent ? 'is-ready' : 'is-pending')}>
+          {workflowStatus}
         </span>
       </header>
 
-      <div className="website-editor-scroll">
-        <section className="website-publish-section" aria-labelledby="readiness-title">
-          <header>
-            <div>
-              <span className="website-step">01</span>
-              <div>
-                <h3 id="readiness-title">Publish-readiness checks</h3>
-                <p>Content checks are derived; evidence is explicitly recorded.</p>
-              </div>
-            </div>
-            <code>{fingerprint}</code>
-          </header>
-          <div className="website-check-list">
-            {checks.map((check) => (
-              <article className={check.passed ? 'is-passed' : 'is-blocked'} key={check.id}>
-                <span aria-hidden="true">{check.passed ? '✓' : '!'}</span>
-                <div>
-                  <strong>{check.label}</strong>
-                  <p>{check.detail}</p>
-                </div>
-              </article>
-            ))}
-          </div>
-        </section>
-
-        <section className="website-publish-section" aria-labelledby="evidence-title">
-          <header>
-            <div>
-              <span className="website-step">02</span>
-              <div>
-                <h3 id="evidence-title">Verified evidence</h3>
-                <p>Recording evidence is an accountable claim. Managed mode binds it to the signed-in actor.</p>
-              </div>
-            </div>
-            {staleEvidenceCount ? <small>{staleEvidenceCount} stale record{staleEvidenceCount === 1 ? '' : 's'}</small> : null}
-          </header>
-
-          <div className="website-evidence-status">
-            {evidenceRequirements.map((requirement) => {
-              const evidence = workspace.evidence.find((entry) => (
-                entry.kind === requirement.id
-                && entry.fingerprint === fingerprint
-                && entry.source.contentRevision === workspace.contentRevision
-              ))
-              return (
-                <article className={evidence ? 'is-current' : ''} key={requirement.id}>
-                  <span>{evidence ? 'verified' : 'required'}</span>
-                  <strong>{requirement.label}</strong>
-                  {evidence ? (
-                    <>
-                      <p>{evidence.finding}</p>
-                      <small>{evidence.reference} · {evidence.verifiedBy} · {formatTimestamp(evidence.verifiedAt)}</small>
-                    </>
-                  ) : (
-                    <p>{requirement.detail}</p>
-                  )}
-                </article>
-              )
-            })}
-          </div>
-
-          <form className="website-evidence-form" onSubmit={submitEvidence}>
-            <label>
-              <span>Requirement</span>
-              <select value={evidenceKind} onChange={(event) => setEvidenceKind(event.target.value as EvidenceKind)}>
-                {evidenceRequirements.map((requirement) => (
-                  <option key={requirement.id} value={requirement.id}>{requirement.label}</option>
-                ))}
-              </select>
-            </label>
-            <label>
-              <span>Finding</span>
-              <input
-                maxLength={180}
-                onChange={(event) => setEvidenceFinding(event.target.value)}
-                placeholder="What the review established"
-                required
-                value={evidenceFinding}
-              />
-            </label>
-            <label>
-              <span>Source or reference</span>
-              <input
-                maxLength={220}
-                onChange={(event) => setEvidenceReference(event.target.value)}
-                placeholder="File, test result, URL, or review record"
-                required
-                value={evidenceReference}
-              />
-            </label>
-            <label>
-              <span>{managedActorId ? 'Signed-in actor' : 'Verified by'}</span>
-              <input
-                disabled={Boolean(managedActorId)}
-                maxLength={80}
-                onChange={(event) => setEvidenceVerifier(event.target.value)}
-                placeholder={managedActorId ? 'Authenticated identity' : 'Accountable person or role'}
-                required
-                value={managedActorId || evidenceVerifier}
-              />
-            </label>
-            <button className="website-button is-secondary" disabled={Boolean(submitting)} type="submit">
-              {submitting === 'evidence' ? 'Saving…' : 'Record evidence'}
-            </button>
-          </form>
-        </section>
-
-        <section className="website-publish-section" aria-labelledby="approval-title">
-          <header>
-            <div>
-              <span className="website-step">03</span>
-              <div>
-                <h3 id="approval-title">Human approval</h3>
-                <p>Approval applies only to the exact fingerprint; managed mode binds the signed-in actor.</p>
-              </div>
-            </div>
-            <span className={'website-status ' + (approvalIsCurrent ? 'is-ready' : 'is-pending')}>
-              {approvalIsCurrent ? 'approved' : latestApproval ? 'stale' : 'required'}
-            </span>
-          </header>
-
-          {latestApproval ? (
-            <div className={'website-approval-record ' + (approvalIsCurrent ? 'is-current' : 'is-stale')}>
-              <strong>{approvalIsCurrent ? 'Current approval' : latestApproval.migratedFromV1 ? 'Historical v1 approval' : 'Superseded by workspace changes'}</strong>
-              <p>{latestApproval.note}</p>
-              <small>{latestApproval.reviewer} · {formatTimestamp(latestApproval.approvedAt)} · content r{latestApproval.source.contentRevision}</small>
-            </div>
-          ) : null}
-
-          <form className="website-approval-form" onSubmit={submitApproval}>
-            <div className="website-form-grid two-columns">
-              <label>
-                <span>Human reviewer</span>
-                <input
-                  disabled={Boolean(managedActorId) || !allChecksPass || approvalIsCurrent}
-                  maxLength={80}
-                  onChange={(event) => setReviewer(event.target.value)}
-                  placeholder={managedActorId ? 'Authenticated identity' : 'Name or accountable role'}
-                  required
-                  value={managedActorId || reviewer}
-                />
-              </label>
-              <label>
-                <span>Decision note</span>
-                <input
-                  disabled={!allChecksPass || approvalIsCurrent}
-                  maxLength={240}
-                  onChange={(event) => setApprovalNote(event.target.value)}
-                  placeholder="Why this revision is approved"
-                  required
-                  value={approvalNote}
-                />
-              </label>
-            </div>
-            <label className="website-confirmation">
-              <input
-                checked={approvalConfirmed}
-                disabled={!allChecksPass || approvalIsCurrent}
-                onChange={(event) => setApprovalConfirmed(event.target.checked)}
-                type="checkbox"
-              />
-              <span>I reviewed this exact content revision and accept the recorded evidence.</span>
-            </label>
-            <div className="website-gate-actions">
-              <small>{approvalIsCurrent
-                ? 'This exact evidence set already has a current human approval.'
-                : allChecksPass ? 'Ready for a named human decision.' : 'Complete all readiness checks to unlock approval.'}</small>
+      <nav className="publish-flow-nav" aria-label="Publish steps">
+        <ol>
+          {publishSteps.map((step, index) => (
+            <li key={step.id}>
               <button
-                className="website-button is-primary"
-                disabled={!allChecksPass || !approvalConfirmed || approvalIsCurrent || Boolean(submitting)}
-                type="submit"
-              >
-                {approvalIsCurrent ? 'Current revision approved' : submitting === 'approval' ? 'Saving…' : 'Record approval'}
-              </button>
-            </div>
-          </form>
-        </section>
-
-        <section className="website-publish-section website-local-publish" aria-labelledby="local-publish-title">
-          <header>
-            <div>
-              <span className="website-step">04</span>
-              <div>
-                <h3 id="local-publish-title">Approved snapshot</h3>
-                <p>No deployment target, domain write, or external connection exists in this prototype.</p>
-              </div>
-            </div>
-            <span className={'website-status ' + (publishIsCurrent ? 'is-ready' : 'is-local')}>
-              {publishIsCurrent ? 'recorded' : 'not recorded'}
-            </span>
-          </header>
-
-          <div className="website-local-publish-action">
-            <div>
-              <strong>{approvalIsCurrent ? 'Approval matches the current revision.' : 'A current approval is required.'}</strong>
-              <p>The action saves an evidence-bound approved snapshot. It does not publish a website.</p>
-            </div>
-            <button
-              className="website-button is-primary"
-              disabled={!approvalIsCurrent || publishIsCurrent || Boolean(submitting)}
-              onClick={recordSnapshot}
-              type="button"
-            >
-              {publishIsCurrent ? 'Current revision recorded' : submitting === 'snapshot' ? 'Saving…' : 'Record approved snapshot'}
-            </button>
-          </div>
-
-          <div className="website-handoff-action">
-            <div>
-              <strong>Website → Commerce intake</strong>
-              <p>Send one catalog SKU and quantity from this approved revision into Commerce. No stock, payment, customer message, or order changes until a human confirms it there.</p>
-            </div>
-            <div className="website-handoff-controls">
-              <label>Commerce SKU<input autoComplete="off" maxLength={80} onChange={(event) => setHandoffSku(event.target.value.toUpperCase())} placeholder="SKU-001" value={handoffSku} /></label>
-              <label>Qty<input max="99" min="1" onChange={(event) => setHandoffQuantity(Number(event.target.value))} step="1" type="number" value={handoffQuantity} /></label>
-              <button
-                className="website-button is-secondary"
-                disabled={!publishIsCurrent || !handoffAvailable || handoffIsCurrent || !handoffSku.trim() || Boolean(submitting)}
-                onClick={() => void prepareCommerceHandoff()}
+                aria-current={activeStep === step.id ? 'step' : undefined}
+                onClick={() => selectStep(step.id)}
                 type="button"
               >
-                {handoffIsCurrent ? 'Intake sent' : submitting === 'handoff' ? 'Sending…' : 'Send intake'}
+                <span className="publish-flow-step-number" aria-hidden="true">{index + 1}</span>
+                <span className="publish-flow-step-label">
+                  <strong>{step.label}</strong>
+                  <small>{stepStatus[step.id]}</small>
+                </span>
               </button>
-              {handoffIsCurrent ? <a className="website-button is-primary" href="/operations/commerce/?tab=orders">Review in Commerce</a> : null}
-            </div>
-          </div>
+            </li>
+          ))}
+        </ol>
+      </nav>
 
-          {workspace.localPublishes.length ? (
-            <div className="website-publish-history">
-              <small>Showing {Math.min(3, workspace.localPublishes.length)} of {workspace.localPublishes.length} retained snapshots</small>
-              {workspace.localPublishes.slice(0, 3).map((record) => (
-                <article key={record.id}>
-                  <span aria-hidden="true">&gt;_</span>
+      <div className="publish-flow-boundary" role="note">
+        <strong>Local record only</strong>
+        <span>No deployment, domain write, payment, stock, customer message, or order change happens here.</span>
+      </div>
+
+      <div className="website-editor-scroll publish-flow-body" ref={bodyRef}>
+        {activeStep === 'checks' ? (
+          <section
+            className="website-publish-section publish-flow-card"
+            id="publish-step-checks"
+            aria-labelledby="readiness-title"
+          >
+            <header>
+              <div>
+                <span className="website-step" aria-hidden="true">1</span>
+                <div>
+                  <h3 id="readiness-title">Check the website</h3>
+                  <p>These checks come from the current content and navigation.</p>
+                </div>
+              </div>
+              <span className={'website-status ' + (contentChecksPass ? 'is-ready' : 'is-pending')}>
+                {passedContentCheckCount}/{contentChecks.length} passed
+              </span>
+            </header>
+
+            <div className="publish-flow-revision">
+              <span>Current revision</span>
+              <code>{fingerprint}</code>
+            </div>
+
+            <div className="website-check-list">
+              {contentChecks.map((check) => (
+                <article className={check.passed ? 'is-passed' : 'is-blocked'} key={check.id}>
+                  <span className="publish-flow-check-state">{check.passed ? 'Pass' : 'Fix'}</span>
                   <div>
-                    <strong>{record.id}</strong>
-                    <small>{record.readyPageIds.length} ready page{record.readyPageIds.length === 1 ? '' : 's'} · {record.recordedBy} · {formatTimestamp(record.recordedAt)}</small>
+                    <strong>{check.label}</strong>
+                    <p>{check.detail}</p>
                   </div>
-                  <code>{record.fingerprint}</code>
                 </article>
               ))}
             </div>
-          ) : (
-            <div className="website-empty compact">
-              <span aria-hidden="true">&gt;_</span>
-              <p>No approved snapshots yet.</p>
+
+            <footer className="publish-flow-actions">
+              <p>{contentChecksPass
+                ? 'Website checks are clear. Add the three review records next.'
+                : 'Fix blocked items in Content or Navigation, then return here.'}</p>
+              <button className="website-button is-primary" onClick={() => selectStep('evidence')} type="button">
+                Review evidence
+              </button>
+            </footer>
+          </section>
+        ) : null}
+
+        {activeStep === 'evidence' ? (
+          <section
+            className="website-publish-section publish-flow-card"
+            id="publish-step-evidence"
+            aria-labelledby="evidence-title"
+          >
+            <header>
+              <div>
+                <span className="website-step" aria-hidden="true">2</span>
+                <div>
+                  <h3 id="evidence-title">Record review evidence</h3>
+                  <p>Each record is an accountable claim for this exact revision.</p>
+                </div>
+              </div>
+              <span className={'website-status ' + (evidenceIsCurrent ? 'is-ready' : 'is-pending')}>
+                {currentEvidenceCount}/{evidenceRequirements.length} current
+              </span>
+            </header>
+
+            {staleEvidenceCount ? (
+              <p className="publish-flow-stale-note">
+                {staleEvidenceCount} older record{staleEvidenceCount === 1 ? '' : 's'} remain in history but do not approve this revision.
+              </p>
+            ) : null}
+
+            <div className="website-evidence-status">
+              {evidenceRequirements.map((requirement) => {
+                const evidence = currentEvidenceByKind.get(requirement.id)
+                return (
+                  <article className={evidence ? 'is-current' : ''} key={requirement.id}>
+                    <span>{evidence ? 'Verified' : 'Required'}</span>
+                    <strong>{requirement.label}</strong>
+                    {evidence ? (
+                      <>
+                        <p>{evidence.finding}</p>
+                        <small>{evidence.reference} · {evidence.verifiedBy} · {formatTimestamp(evidence.verifiedAt)}</small>
+                      </>
+                    ) : (
+                      <p>{requirement.detail}</p>
+                    )}
+                  </article>
+                )
+              })}
             </div>
-          )}
-        </section>
+
+            <form className="website-evidence-form" onSubmit={submitEvidence}>
+              <label>
+                <span>Requirement</span>
+                <select value={evidenceKind} onChange={(event) => setEvidenceKind(event.target.value as EvidenceKind)}>
+                  {evidenceRequirements.map((requirement) => (
+                    <option key={requirement.id} value={requirement.id}>{requirement.label}</option>
+                  ))}
+                </select>
+              </label>
+              <label>
+                <span>Finding</span>
+                <input
+                  maxLength={180}
+                  onChange={(event) => setEvidenceFinding(event.target.value)}
+                  placeholder="What the review established"
+                  required
+                  value={evidenceFinding}
+                />
+              </label>
+              <label>
+                <span>Source or reference</span>
+                <input
+                  maxLength={220}
+                  onChange={(event) => setEvidenceReference(event.target.value)}
+                  placeholder="File, test result, URL, or review record"
+                  required
+                  value={evidenceReference}
+                />
+              </label>
+              <label>
+                <span>{managedActorId ? 'Signed-in actor' : 'Verified by'}</span>
+                <input
+                  disabled={Boolean(managedActorId)}
+                  maxLength={80}
+                  onChange={(event) => setEvidenceVerifier(event.target.value)}
+                  placeholder={managedActorId ? 'Authenticated identity' : 'Accountable person or role'}
+                  required
+                  value={managedActorId || evidenceVerifier}
+                />
+              </label>
+              <button className="website-button is-secondary" disabled={Boolean(submitting)} type="submit">
+                {submitting === 'evidence' ? 'Saving…' : 'Record evidence'}
+              </button>
+            </form>
+
+            <footer className="publish-flow-actions">
+              <button className="website-button is-secondary" onClick={() => selectStep('checks')} type="button">
+                Back to checks
+              </button>
+              <button className="website-button is-primary" onClick={() => selectStep('approval')} type="button">
+                Review approval
+              </button>
+            </footer>
+          </section>
+        ) : null}
+
+        {activeStep === 'approval' ? (
+          <section
+            className="website-publish-section publish-flow-card"
+            id="publish-step-approval"
+            aria-labelledby="approval-title"
+          >
+            <header>
+              <div>
+                <span className="website-step" aria-hidden="true">3</span>
+                <div>
+                  <h3 id="approval-title">Human approval</h3>
+                  <p>Approval is bound to this revision and its current evidence.</p>
+                </div>
+              </div>
+              <span className={'website-status ' + (approvalIsCurrent ? 'is-ready' : 'is-pending')}>
+                {approvalIsCurrent ? 'Approved' : latestApproval ? 'Stale' : 'Required'}
+              </span>
+            </header>
+
+            {!allChecksPass ? (
+              <div className="publish-flow-gate-note" role="status">
+                <strong>Approval is locked</strong>
+                <p>{passedCount}/{checks.length} readiness checks pass. Complete the blocked website checks and evidence first.</p>
+              </div>
+            ) : null}
+
+            {latestApproval ? (
+              <div className={'website-approval-record ' + (approvalIsCurrent ? 'is-current' : 'is-stale')}>
+                <strong>{approvalIsCurrent ? 'Current approval' : latestApproval.migratedFromV1 ? 'Historical v1 approval' : 'Superseded by workspace changes'}</strong>
+                <p>{latestApproval.note}</p>
+                <small>{latestApproval.reviewer} · {formatTimestamp(latestApproval.approvedAt)} · content r{latestApproval.source.contentRevision}</small>
+              </div>
+            ) : null}
+
+            <form className="website-approval-form" onSubmit={submitApproval}>
+              <div className="website-form-grid two-columns">
+                <label>
+                  <span>Human reviewer</span>
+                  <input
+                    disabled={Boolean(managedActorId) || !allChecksPass || approvalIsCurrent}
+                    maxLength={80}
+                    onChange={(event) => setReviewer(event.target.value)}
+                    placeholder={managedActorId ? 'Authenticated identity' : 'Name or accountable role'}
+                    required
+                    value={managedActorId || reviewer}
+                  />
+                </label>
+                <label>
+                  <span>Decision note</span>
+                  <input
+                    disabled={!allChecksPass || approvalIsCurrent}
+                    maxLength={240}
+                    onChange={(event) => setApprovalNote(event.target.value)}
+                    placeholder="Why this revision is approved"
+                    required
+                    value={approvalNote}
+                  />
+                </label>
+              </div>
+              <label className="website-confirmation">
+                <input
+                  checked={approvalConfirmed}
+                  disabled={!allChecksPass || approvalIsCurrent}
+                  onChange={(event) => setApprovalConfirmed(event.target.checked)}
+                  type="checkbox"
+                />
+                <span>I reviewed this exact content revision and accept the recorded evidence.</span>
+              </label>
+              <div className="website-gate-actions">
+                <small>{approvalIsCurrent
+                  ? 'This exact evidence set already has a current human approval.'
+                  : allChecksPass ? 'Ready for a named human decision.' : 'Complete all readiness checks to unlock approval.'}</small>
+                <button
+                  className="website-button is-primary"
+                  disabled={!allChecksPass || !approvalConfirmed || approvalIsCurrent || Boolean(submitting)}
+                  type="submit"
+                >
+                  {approvalIsCurrent ? 'Current revision approved' : submitting === 'approval' ? 'Saving…' : 'Record approval'}
+                </button>
+              </div>
+            </form>
+
+            <footer className="publish-flow-actions">
+              <button className="website-button is-secondary" onClick={() => selectStep('evidence')} type="button">
+                Back to evidence
+              </button>
+              <button className="website-button is-primary" onClick={() => selectStep('snapshot')} type="button">
+                Review snapshot
+              </button>
+            </footer>
+          </section>
+        ) : null}
+
+        {activeStep === 'snapshot' ? (
+          <section
+            className="website-publish-section website-local-publish publish-flow-card"
+            id="publish-step-snapshot"
+            aria-labelledby="local-publish-title"
+          >
+            <header>
+              <div>
+                <span className="website-step" aria-hidden="true">4</span>
+                <div>
+                  <h3 id="local-publish-title">Snapshot and Commerce handoff</h3>
+                  <p>Record an approved snapshot, then optionally prepare one Commerce intake.</p>
+                </div>
+              </div>
+              <span className={'website-status ' + (publishIsCurrent ? 'is-ready' : 'is-local')}>
+                {publishIsCurrent ? 'Recorded' : 'Not recorded'}
+              </span>
+            </header>
+
+            <div className="website-local-publish-action">
+              <div>
+                <strong>{approvalIsCurrent ? 'Approval matches the current revision.' : 'A current approval is required.'}</strong>
+                <p>This saves an evidence-bound local snapshot. It does not publish a website.</p>
+              </div>
+              <button
+                className="website-button is-primary"
+                disabled={!approvalIsCurrent || publishIsCurrent || Boolean(submitting)}
+                onClick={recordSnapshot}
+                type="button"
+              >
+                {publishIsCurrent ? 'Current revision recorded' : submitting === 'snapshot' ? 'Saving…' : 'Record approved snapshot'}
+              </button>
+            </div>
+
+            <div className="website-handoff-action">
+              <div>
+                <strong>Website → Commerce intake</strong>
+                <p>Send one catalog SKU and quantity from this approved revision into Commerce. A human must still confirm any stock, payment, message, or order change there.</p>
+              </div>
+              <div className="website-handoff-controls">
+                <label>
+                  <span>Commerce SKU</span>
+                  <input
+                    autoComplete="off"
+                    maxLength={80}
+                    onChange={(event) => setHandoffSku(event.target.value.toUpperCase())}
+                    placeholder="SKU-001"
+                    value={handoffSku}
+                  />
+                </label>
+                <label>
+                  <span>Quantity</span>
+                  <input
+                    max="99"
+                    min="1"
+                    onChange={(event) => setHandoffQuantity(Number(event.target.value))}
+                    step="1"
+                    type="number"
+                    value={handoffQuantity}
+                  />
+                </label>
+                <button
+                  className="website-button is-secondary"
+                  disabled={!publishIsCurrent || !handoffAvailable || handoffIsCurrent || !handoffSku.trim() || Boolean(submitting)}
+                  onClick={() => void prepareCommerceHandoff()}
+                  type="button"
+                >
+                  {handoffIsCurrent ? 'Intake sent' : submitting === 'handoff' ? 'Sending…' : 'Send intake'}
+                </button>
+                {handoffIsCurrent ? (
+                  <a className="website-button is-primary" href="/operations/commerce/?tab=orders">Review in Commerce</a>
+                ) : null}
+              </div>
+            </div>
+
+            {workspace.localPublishes.length ? (
+              <div className="website-publish-history">
+                <small>Showing {Math.min(3, workspace.localPublishes.length)} of {workspace.localPublishes.length} retained snapshots</small>
+                {workspace.localPublishes.slice(0, 3).map((record) => (
+                  <article key={record.id}>
+                    <span aria-hidden="true">&gt;_</span>
+                    <div>
+                      <strong>{record.id}</strong>
+                      <small>{record.readyPageIds.length} ready page{record.readyPageIds.length === 1 ? '' : 's'} · {record.recordedBy} · {formatTimestamp(record.recordedAt)}</small>
+                    </div>
+                    <code>{record.fingerprint}</code>
+                  </article>
+                ))}
+              </div>
+            ) : (
+              <div className="website-empty compact">
+                <span aria-hidden="true">&gt;_</span>
+                <p>No approved snapshots yet.</p>
+              </div>
+            )}
+
+            <footer className="publish-flow-actions">
+              <button className="website-button is-secondary" onClick={() => selectStep('approval')} type="button">
+                Back to approval
+              </button>
+            </footer>
+          </section>
+        ) : null}
       </div>
     </section>
   )

--- a/showroom/src/products/website/WebsiteProduct.tsx
+++ b/showroom/src/products/website/WebsiteProduct.tsx
@@ -42,27 +42,24 @@ import {
 } from './website-model'
 import './website-product.css'
 
-const workspaceViews: Array<{ id: WorkspaceView; index: string; label: string }> = [
-  { id: 'content', index: '01', label: 'Content' },
-  { id: 'navigation', index: '02', label: 'Navigation' },
-  { id: 'publish', index: '03', label: 'Publish' },
+const workspaceViews: Array<{ id: WorkspaceView; label: string }> = [
+  { id: 'content', label: 'Content' },
+  { id: 'navigation', label: 'Navigation' },
+  { id: 'publish', label: 'Publish' },
 ]
 
-const viewCopy: Record<WorkspaceView, { eyebrow: string; title: string; copy: string }> = {
+const viewCopy: Record<WorkspaceView, { title: string; copy: string }> = {
   content: {
-    eyebrow: 'Page workspace',
-    title: 'Edit one page at a time.',
-    copy: 'Change the content, then review the result before publishing.',
+    title: 'Edit page',
+    copy: 'Update the selected page, then preview it when you are ready.',
   },
   navigation: {
-    eyebrow: 'Site structure',
-    title: 'Make every destination intentional.',
-    copy: 'Order pages, control visibility, and keep drafts out of public navigation.',
+    title: 'Organize navigation',
+    copy: 'Choose what visitors can see and put pages in the right order.',
   },
   publish: {
-    eyebrow: 'Release control',
-    title: 'Prove the revision before approval.',
-    copy: 'Readiness, evidence, and human approval are bound to the current content fingerprint.',
+    title: 'Review and publish',
+    copy: 'Check readiness, record evidence, and approve the current revision.',
   },
 }
 
@@ -84,8 +81,11 @@ function secureUuid() {
 export function WebsiteProduct() {
   const { workspace, mutateWorkspace, storageMode, storageIssue, managedActorId } = useWebsiteWorkspace()
   const [view, setView] = useState<WorkspaceView>('content')
-  const [mobilePane, setMobilePane] = useState<'edit' | 'preview'>('edit')
-  const [device, setDevice] = useState<PreviewDevice>('desktop')
+  const [surface, setSurface] = useState<'work' | 'preview'>('work')
+  const [splitPreview, setSplitPreview] = useState(false)
+  const [device, setDevice] = useState<PreviewDevice>(() => (
+    typeof window !== 'undefined' && window.matchMedia('(max-width: 900px)').matches ? 'mobile' : 'desktop'
+  ))
   const [notice, setNotice] = useState('Website workspace loaded. No website has been deployed.')
   const [deleteCandidateId, setDeleteCandidateId] = useState('')
   const [preparedHandoffSource, setPreparedHandoffSource] = useState(() => handoffSourceKey(readWebsiteEcommerceHandoff()))
@@ -113,9 +113,19 @@ export function WebsiteProduct() {
     window.scrollTo({ top: 0, behavior: 'instant' })
   }, [])
 
+  useEffect(() => {
+    const compactViewport = window.matchMedia('(max-width: 900px)')
+    const collapseSplitView = (event: MediaQueryListEvent) => {
+      if (event.matches) setSplitPreview(false)
+    }
+    compactViewport.addEventListener('change', collapseSplitView)
+    return () => compactViewport.removeEventListener('change', collapseSplitView)
+  }, [])
+
   function openWorkspaceView(nextView: WorkspaceView) {
     setView(nextView)
-    setMobilePane('edit')
+    setSurface('work')
+    setSplitPreview(false)
   }
 
   async function commitWorkspace(update: WebsiteWorkspaceUpdate, success = '', durable = false) {
@@ -415,15 +425,18 @@ export function WebsiteProduct() {
 
   return (
     <div className="website-product">
-      <a className="website-skip" href="#website-workspace">Skip to website workspace</a>
+      <a className="website-skip" href="#website-workspace">Skip to website task</a>
 
       <header className="website-topbar">
         <a aria-label="Back to SuperMega operations" className="website-brand" href="/operations/">
           <span aria-hidden="true">&gt;_</span>
           <strong>SUPERMEGA</strong>
-          <i>/</i>
-          <b>WEBSITE</b>
+          <b>Website</b>
         </a>
+        <div className="website-site-summary">
+          <strong>{workspace.siteName || 'Untitled site'}</strong>
+          <small>{workspace.pages.length} of {MAX_WEBSITE_PAGES} pages</small>
+        </div>
         <div className="website-runtime">
           <span className="website-local-badge"><i />{storageMode === 'managed' ? 'Managed workspace' : storageMode === 'browser-local' ? 'Local workspace' : 'Session only'}</span>
           <small>{storageMode === 'managed'
@@ -431,20 +444,11 @@ export function WebsiteProduct() {
             : storageMode === 'browser-local'
               ? 'saved · content r' + String(workspace.contentRevision)
               : 'writes paused'}</small>
-          <button className="website-button is-primary is-compact" onClick={() => openWorkspaceView('publish')} type="button">
-            Review publish
-          </button>
         </div>
       </header>
 
       <div className="website-shell">
-        <aside className="website-sidebar">
-          <div className="website-site-record">
-            <span>Website workspace</span>
-            <strong>{workspace.siteName || 'Untitled site'}</strong>
-            <small>{workspace.pages.length} / {MAX_WEBSITE_PAGES} pages · {storageMode === 'managed' ? 'managed draft' : 'local draft'}</small>
-          </div>
-
+        <main id="website-workspace" className="website-main">
           <nav className="website-workspace-nav" aria-label="Website workspace" role="tablist">
             {workspaceViews.map((item, index) => (
               <button
@@ -457,131 +461,160 @@ export function WebsiteProduct() {
                 tabIndex={view === item.id ? 0 : -1}
                 type="button"
               >
-                <span>{item.index}</span>{item.label}
+                {item.label}
               </button>
             ))}
           </nav>
 
-          <section className="website-page-index" aria-labelledby="website-pages-title">
-            <header>
-              <span id="website-pages-title">Pages</span>
-              <button aria-label="Add page" disabled={workspace.pages.length >= MAX_WEBSITE_PAGES} onClick={addPage} title={workspace.pages.length >= MAX_WEBSITE_PAGES ? 'The four-page prototype limit is reached' : 'Add page'} type="button">+</button>
-            </header>
-            <div>
-              {workspace.pages.map((page) => (
-                <button
-                  aria-current={selectedPage.id === page.id ? 'true' : undefined}
-                  key={page.id}
-                  onClick={() => selectPage(page.id)}
-                  type="button"
-                >
-                  <i className={page.stage === 'ready' ? 'is-ready' : ''} />
-                  <span>
-                    <strong>{page.internalName || 'Untitled page'}</strong>
-                    <small>{page.slug || 'No path'}</small>
-                  </span>
-                  <b>{page.stage === 'ready' ? 'R' : 'D'}</b>
-                </button>
-              ))}
-            </div>
-          </section>
+          <div className="website-notice" aria-live="polite" role="status">
+            {storageIssue || notice}
+          </div>
 
-          <footer className="website-sidebar-foot">
-            <span aria-hidden="true">&gt;_</span>
-            <p>{storageMode === 'managed'
-              ? 'Authenticated records are synced. Domain and deployment remain separate approval-gated actions.'
-              : 'Local records only. No CMS, domain, analytics, or deployment target is connected.'}</p>
-          </footer>
-        </aside>
+          {view === 'content' ? (
+            <section className="website-page-switcher" aria-label="Selected page">
+              <label htmlFor="website-page-select">Page</label>
+              <select
+                id="website-page-select"
+                onChange={(event) => void selectPage(event.currentTarget.value)}
+                value={selectedPage.id}
+              >
+                {workspace.pages.map((page) => (
+                  <option key={page.id} value={page.id}>
+                    {page.internalName || 'Untitled page'} — {page.slug || 'No path'} ({page.stage})
+                  </option>
+                ))}
+              </select>
+              <button
+                className="website-button is-secondary"
+                disabled={workspace.pages.length >= MAX_WEBSITE_PAGES}
+                onClick={addPage}
+                title={workspace.pages.length >= MAX_WEBSITE_PAGES ? 'The four-page prototype limit is reached' : 'Add page'}
+                type="button"
+              >
+                New page
+              </button>
+            </section>
+          ) : null}
 
-        <main id="website-workspace" className={'website-main mobile-pane-' + mobilePane}>
           <header className="website-heading">
             <div>
-              <span className="website-eyebrow">{activeViewCopy.eyebrow}</span>
               <h1>{activeViewCopy.title}</h1>
               <p>{activeViewCopy.copy}</p>
             </div>
             <div className="website-heading-actions">
-              <div className="website-mobile-pane-controls" role="group" aria-label="Mobile Website workspace">
-                <button aria-pressed={mobilePane === 'edit'} onClick={() => setMobilePane('edit')} type="button">Edit</button>
-                <button aria-pressed={mobilePane === 'preview'} onClick={() => setMobilePane('preview')} type="button">Preview</button>
-              </div>
-              <div className="website-preview-controls" role="group" aria-label="Responsive preview size">
-                <span>Preview</span>
-                {previewDevices.map((option) => (
-                  <button
-                    aria-pressed={device === option.id}
-                    key={option.id}
-                    onClick={() => setDevice(option.id)}
-                    title={option.label + ' preview'}
-                    type="button"
-                  >
-                    {option.label}
-                  </button>
-                ))}
+              <div className="website-surface-controls" role="group" aria-label="Website workspace surface">
+                <button
+                  aria-pressed={surface === 'work' && !splitPreview}
+                  onClick={() => {
+                    setSurface('work')
+                    setSplitPreview(false)
+                  }}
+                  type="button"
+                >
+                  Work
+                </button>
+                <button
+                  aria-pressed={surface === 'preview' && !splitPreview}
+                  onClick={() => {
+                    setSurface('preview')
+                    setSplitPreview(false)
+                  }}
+                  type="button"
+                >
+                  Preview
+                </button>
+                <button
+                  aria-pressed={splitPreview}
+                  className="website-split-control"
+                  onClick={() => setSplitPreview((current) => !current)}
+                  type="button"
+                >
+                  Split
+                </button>
               </div>
             </div>
           </header>
 
           <div
             aria-label={workspaceViews.find((item) => item.id === view)?.label}
-            className={'website-workspace-grid view-' + view + ' mobile-pane-' + mobilePane}
+            className={'website-workspace-grid view-' + view}
+            data-split={splitPreview ? 'true' : 'false'}
+            data-surface={surface}
             id="website-active-panel"
             role="tabpanel"
           >
-            {view === 'content' ? (
-              <ContentWorkspace
-                canDuplicate={workspace.pages.length < MAX_WEBSITE_PAGES}
-                deleteArmed={deleteCandidateId === selectedPage.id}
-                onDuplicate={copySelectedPage}
-                onRequestDelete={requestDeletePage}
-                onUpdatePage={(update) => updatePage(selectedPage.id, update)}
-                page={selectedPage}
-              />
-            ) : null}
+            <div className="website-work-surface">
+              {view === 'content' ? (
+                <ContentWorkspace
+                  canDuplicate={workspace.pages.length < MAX_WEBSITE_PAGES}
+                  deleteArmed={deleteCandidateId === selectedPage.id}
+                  onDuplicate={copySelectedPage}
+                  onRequestDelete={requestDeletePage}
+                  onUpdatePage={(update) => updatePage(selectedPage.id, update)}
+                  page={selectedPage}
+                />
+              ) : null}
 
-            {view === 'navigation' ? (
-              <NavigationWorkspace
-                onMovePage={movePage}
+              {view === 'navigation' ? (
+                <NavigationWorkspace
+                  onMovePage={movePage}
+                  onSelectPage={selectPage}
+                  onSiteNameChange={(siteName) => {
+                    void commitWorkspace((current) => ({ ...current, siteName }), 'Site identity updated.')
+                  }}
+                  onUpdatePage={updatePage}
+                  workspace={workspace}
+                />
+              ) : null}
+
+              {view === 'publish' ? (
+                <PublishWorkspace
+                  approvalIsCurrent={approvalIsCurrent}
+                  checks={checks}
+                  fingerprint={fingerprint}
+                  handoffAvailable={storageMode !== 'session-only'}
+                  handoffIsCurrent={handoffIsCurrent}
+                  managedActorId={managedActorId}
+                  onAddEvidence={addEvidence}
+                  onApprove={approveCurrentRevision}
+                  onPrepareCommerceHandoff={prepareCommerceHandoff}
+                  onRecordPublish={recordLocalPublish}
+                  publishIsCurrent={publishIsCurrent}
+                  workspace={workspace}
+                />
+              ) : null}
+            </div>
+
+            <div className="website-preview-surface">
+              <header className="website-preview-surface-head">
+                <div>
+                  <strong>Preview</strong>
+                  <small>{selectedPage.internalName || 'Untitled page'}</small>
+                </div>
+                <div className="website-preview-controls" role="group" aria-label="Responsive preview size">
+                  {previewDevices.map((option) => (
+                    <button
+                      aria-pressed={device === option.id}
+                      key={option.id}
+                      onClick={() => setDevice(option.id)}
+                      title={option.label + ' preview'}
+                      type="button"
+                    >
+                      {option.label}
+                    </button>
+                  ))}
+                </div>
+              </header>
+              <SitePreview
+                device={device}
                 onSelectPage={selectPage}
-                onSiteNameChange={(siteName) => {
-                  void commitWorkspace((current) => ({ ...current, siteName }), 'Site identity updated.')
-                }}
-                onUpdatePage={updatePage}
-                workspace={workspace}
+                page={selectedPage}
+                pages={workspace.pages}
+                siteName={workspace.siteName}
               />
-            ) : null}
-
-            {view === 'publish' ? (
-              <PublishWorkspace
-                approvalIsCurrent={approvalIsCurrent}
-                checks={checks}
-                fingerprint={fingerprint}
-                handoffAvailable={storageMode !== 'session-only'}
-                handoffIsCurrent={handoffIsCurrent}
-                managedActorId={managedActorId}
-                onAddEvidence={addEvidence}
-                onApprove={approveCurrentRevision}
-                onPrepareCommerceHandoff={prepareCommerceHandoff}
-                onRecordPublish={recordLocalPublish}
-                publishIsCurrent={publishIsCurrent}
-                workspace={workspace}
-              />
-            ) : null}
-
-            <SitePreview
-              device={device}
-              onSelectPage={selectPage}
-              page={selectedPage}
-              pages={workspace.pages}
-              siteName={workspace.siteName}
-            />
+            </div>
           </div>
         </main>
-      </div>
-
-      <div className="website-notice" aria-live="polite" role="status">
-        <span aria-hidden="true">&gt;_</span>{storageIssue || notice}
       </div>
     </div>
   )

--- a/showroom/src/products/website/publish-workspace.css
+++ b/showroom/src/products/website/publish-workspace.css
@@ -1,0 +1,598 @@
+.website-publish-workspace {
+  --publish-accent: var(--website-green);
+  --publish-accent-soft: var(--website-green-soft);
+  --publish-surface: color-mix(in srgb, var(--website-panel) 94%, var(--publish-accent) 6%);
+}
+
+.website-publish-workspace .publish-flow-header {
+  min-height: 88px;
+  align-items: center;
+  padding: 16px 18px;
+}
+
+.website-publish-workspace .publish-flow-header > div {
+  max-width: 640px;
+}
+
+.website-publish-workspace .publish-flow-header h2 {
+  font-size: clamp(19px, 2vw, 22px);
+}
+
+.website-publish-workspace .publish-flow-header p {
+  max-width: 620px;
+  font-size: 13px;
+}
+
+.website-publish-workspace .website-button,
+.website-publish-workspace a.website-button {
+  min-height: 44px;
+}
+
+.publish-flow-nav {
+  flex: 0 0 auto;
+  border-bottom: 1px solid var(--website-line);
+  background: var(--website-panel);
+}
+
+.publish-flow-nav ol {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.publish-flow-nav li {
+  min-width: 0;
+  border-right: 1px solid var(--website-line);
+}
+
+.publish-flow-nav li:last-child {
+  border-right: 0;
+}
+
+.publish-flow-nav button {
+  width: 100%;
+  min-height: 58px;
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  border: 0;
+  border-bottom: 3px solid transparent;
+  padding: 8px 11px 7px;
+  background: transparent;
+  color: var(--website-muted);
+  text-align: left;
+  cursor: pointer;
+}
+
+.publish-flow-nav button:hover {
+  background: var(--website-panel-raised);
+  color: var(--website-ink);
+}
+
+.publish-flow-nav button[aria-current="step"] {
+  border-bottom-color: var(--publish-accent);
+  background: var(--publish-accent-soft);
+  color: var(--website-ink);
+}
+
+.publish-flow-nav button:focus-visible,
+.website-publish-workspace button:focus-visible,
+.website-publish-workspace a:focus-visible,
+.website-publish-workspace input:focus-visible,
+.website-publish-workspace select:focus-visible {
+  outline: 3px solid color-mix(in srgb, var(--publish-accent) 32%, transparent);
+  outline-offset: -2px;
+}
+
+.publish-flow-step-number {
+  width: 28px;
+  height: 28px;
+  flex: 0 0 28px;
+  display: grid;
+  place-items: center;
+  border: 1px solid var(--website-line-strong);
+  border-radius: 8px;
+  background: var(--website-panel);
+  color: var(--website-muted);
+  font-size: 12px;
+  font-weight: 800;
+}
+
+.publish-flow-nav button[aria-current="step"] .publish-flow-step-number {
+  border-color: var(--publish-accent);
+  background: var(--publish-accent);
+  color: #fff;
+}
+
+.publish-flow-step-label {
+  min-width: 0;
+  display: grid;
+  gap: 2px;
+}
+
+.publish-flow-step-label strong,
+.publish-flow-step-label small {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.publish-flow-step-label strong {
+  font-size: 13px;
+  line-height: 1.2;
+}
+
+.publish-flow-step-label small {
+  color: var(--website-muted);
+  font-size: 11px;
+  font-weight: 650;
+}
+
+.publish-flow-boundary {
+  min-height: 42px;
+  display: flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 8px;
+  border-bottom: 1px solid var(--website-line);
+  padding: 8px 18px;
+  background: var(--publish-surface);
+  color: var(--website-muted);
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.publish-flow-boundary strong {
+  flex: 0 0 auto;
+  color: var(--publish-accent);
+  font-size: 12px;
+}
+
+.website-publish-workspace.website-publish-panel .publish-flow-body {
+  display: block;
+  align-content: initial;
+  gap: 0;
+  padding: 16px;
+}
+
+.website-publish-workspace .publish-flow-card {
+  overflow: hidden;
+  border: 1px solid var(--website-line);
+  border-radius: 12px;
+  background: var(--website-panel);
+  box-shadow: 0 8px 24px rgba(23, 33, 28, .045);
+}
+
+.website-publish-workspace .publish-flow-card > header {
+  min-height: 76px;
+  align-items: center;
+  padding: 14px 16px;
+}
+
+.website-publish-workspace .publish-flow-card > header > div {
+  align-items: center;
+}
+
+.website-publish-workspace .publish-flow-card > header h3 {
+  margin-top: 0;
+  font-size: 17px;
+}
+
+.website-publish-workspace .publish-flow-card > header p {
+  margin-top: 4px;
+  font-size: 13px;
+}
+
+.website-publish-workspace .website-step {
+  min-width: 30px;
+  min-height: 30px;
+  border-radius: 8px;
+  font-size: 13px;
+}
+
+.publish-flow-revision {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  border-bottom: 1px solid var(--website-line);
+  padding: 10px 16px;
+  background: var(--website-panel-raised);
+  color: var(--website-muted);
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.website-publish-workspace .publish-flow-revision code {
+  color: var(--website-ink);
+  font-size: 12px;
+}
+
+.website-publish-workspace .website-check-list {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+  padding: 12px;
+}
+
+.website-publish-workspace .website-check-list > article,
+.website-publish-workspace .website-check-list > article:nth-child(2n),
+.website-publish-workspace .website-check-list > article:nth-last-child(-n+2) {
+  min-height: 76px;
+  grid-template-columns: auto minmax(0, 1fr);
+  border: 1px solid var(--website-line);
+  border-radius: 9px;
+  padding: 12px;
+  background: var(--website-panel-raised);
+}
+
+.website-publish-workspace .website-check-list > article > .publish-flow-check-state {
+  width: auto;
+  min-width: 38px;
+  height: 24px;
+  border-radius: 999px;
+  padding: 0 7px;
+  font-size: 11px;
+  font-weight: 800;
+}
+
+.website-publish-workspace .website-check-list > article.is-passed {
+  border-color: color-mix(in srgb, var(--publish-accent) 24%, var(--website-line));
+  background: var(--publish-accent-soft);
+}
+
+.website-publish-workspace .website-check-list strong,
+.website-publish-workspace .website-evidence-status strong,
+.website-publish-workspace .website-approval-record strong,
+.website-publish-workspace .website-local-publish-action strong,
+.website-publish-workspace .website-handoff-action strong,
+.website-publish-workspace .website-publish-history strong {
+  font-size: 14px;
+}
+
+.website-publish-workspace .website-check-list p,
+.website-publish-workspace .website-evidence-status p,
+.website-publish-workspace .website-approval-record p,
+.website-publish-workspace .website-local-publish-action p,
+.website-publish-workspace .website-handoff-action p,
+.website-publish-workspace .website-publish-history small {
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+.publish-flow-stale-note,
+.publish-flow-gate-note {
+  margin: 12px 12px 0;
+  border: 1px solid color-mix(in srgb, var(--website-warn) 30%, var(--website-line));
+  border-radius: 9px;
+  padding: 10px 12px;
+  background: color-mix(in srgb, var(--website-warn) 6%, var(--website-panel));
+  color: var(--website-muted);
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+.publish-flow-gate-note strong {
+  color: var(--website-ink);
+  font-size: 14px;
+}
+
+.publish-flow-gate-note p {
+  margin: 3px 0 0;
+}
+
+.website-publish-workspace .website-evidence-status {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 8px;
+  padding: 12px;
+}
+
+.website-publish-workspace .website-evidence-status > article {
+  min-height: 120px;
+  border-radius: 9px;
+  padding: 12px;
+  background: var(--website-panel-raised);
+}
+
+.website-publish-workspace .website-evidence-status > article > span,
+.website-publish-workspace .website-evidence-status small,
+.website-publish-workspace .website-approval-record small {
+  font-size: 12px;
+}
+
+.website-publish-workspace .website-evidence-status small,
+.website-publish-workspace .website-approval-record small {
+  white-space: normal;
+  overflow-wrap: anywhere;
+}
+
+.website-publish-workspace .website-evidence-form,
+.website-publish-workspace .website-approval-form {
+  gap: 12px;
+  padding: 14px;
+}
+
+.website-publish-workspace .website-evidence-form {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.website-publish-workspace .website-evidence-form label,
+.website-publish-workspace .website-approval-form label,
+.website-publish-workspace .website-handoff-controls label {
+  color: var(--website-muted);
+  font-size: 13px;
+}
+
+.website-publish-workspace .website-evidence-form .website-button {
+  width: 100%;
+  min-height: 44px;
+  grid-column: 1 / -1;
+  justify-self: stretch;
+}
+
+.website-publish-workspace .website-approval-record {
+  margin: 12px 12px 0;
+  border-radius: 0 8px 8px 0;
+  padding: 11px 12px;
+}
+
+.website-publish-workspace .website-confirmation {
+  min-height: 44px;
+  align-items: center;
+}
+
+.website-publish-workspace .website-gate-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.website-publish-workspace .website-gate-actions > small {
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.website-publish-workspace .website-local-publish {
+  border-color: color-mix(in srgb, var(--publish-accent) 22%, var(--website-line));
+  background: var(--website-panel);
+}
+
+.website-publish-workspace .website-local-publish-action,
+.website-publish-workspace .website-handoff-action {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 18px;
+  padding: 14px 16px;
+}
+
+.website-publish-workspace .website-local-publish-action {
+  background: var(--publish-accent-soft);
+}
+
+.website-publish-workspace .website-handoff-action > div:first-child,
+.website-publish-workspace .website-handoff-action > div:last-child {
+  min-width: 0;
+}
+
+.website-publish-workspace .website-handoff-action > div:last-child {
+  display: grid;
+  grid-template-columns: minmax(140px, 1fr) 84px auto;
+  align-items: end;
+  justify-content: stretch;
+  gap: 8px;
+}
+
+.website-publish-workspace .website-handoff-controls input {
+  width: 100%;
+  min-height: 44px;
+  font-size: 14px;
+}
+
+.website-publish-workspace .website-handoff-controls label:nth-child(2) input {
+  width: 100%;
+}
+
+.website-publish-workspace .website-handoff-controls a {
+  grid-column: 1 / -1;
+  justify-self: end;
+}
+
+.website-publish-workspace .website-publish-history {
+  padding: 0 14px;
+}
+
+.website-publish-workspace .website-publish-history > article {
+  min-height: 54px;
+}
+
+.website-publish-workspace .website-publish-history code {
+  max-width: 120px;
+  font-size: 12px;
+}
+
+.website-publish-workspace .website-empty.compact {
+  min-height: 72px;
+}
+
+.publish-flow-actions {
+  min-height: 66px;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 10px;
+  border-top: 1px solid var(--website-line);
+  padding: 10px 14px;
+  background: var(--website-panel-raised);
+}
+
+.publish-flow-actions p {
+  flex: 1;
+  margin: 0;
+  color: var(--website-muted);
+  font-size: 13px;
+  line-height: 1.4;
+}
+
+.publish-flow-actions .website-button,
+.website-publish-workspace .website-local-publish-action .website-button,
+.website-publish-workspace .website-handoff-controls .website-button,
+.website-publish-workspace .website-handoff-controls a {
+  min-height: 44px;
+}
+
+@media (max-width: 760px) {
+  .website-publish-workspace .publish-flow-header {
+    min-height: 0;
+    align-items: flex-start;
+    padding: 14px;
+  }
+
+  .website-publish-workspace .publish-flow-header .website-status {
+    margin-top: 2px;
+  }
+
+  .publish-flow-nav ol {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .publish-flow-nav li:nth-child(2) {
+    border-right: 0;
+  }
+
+  .publish-flow-nav li:nth-child(-n+2) {
+    border-bottom: 1px solid var(--website-line);
+  }
+
+  .publish-flow-nav button {
+    min-height: 52px;
+    padding: 7px 9px 6px;
+  }
+
+  .publish-flow-step-number {
+    width: 26px;
+    height: 26px;
+    flex-basis: 26px;
+  }
+
+  .publish-flow-step-label strong {
+    font-size: 12px;
+  }
+
+  .publish-flow-step-label small {
+    font-size: 11px;
+  }
+
+  .publish-flow-boundary {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 2px;
+    padding: 10px 14px;
+  }
+
+  .website-publish-workspace.website-publish-panel .publish-flow-body {
+    padding: 12px;
+  }
+
+  .website-publish-workspace .publish-flow-card > header {
+    min-height: 0;
+    align-items: flex-start;
+    padding: 13px;
+  }
+
+  .website-publish-workspace .publish-flow-card > header h3 {
+    font-size: 16px;
+  }
+
+  .website-publish-workspace .website-check-list,
+  .website-publish-workspace .website-evidence-status,
+  .website-publish-workspace .website-evidence-form,
+  .website-publish-workspace .website-form-grid.two-columns {
+    grid-template-columns: 1fr;
+  }
+
+  .website-publish-workspace .website-check-list,
+  .website-publish-workspace .website-evidence-status {
+    padding: 10px;
+  }
+
+  .website-publish-workspace .website-check-list > article,
+  .website-publish-workspace .website-check-list > article:nth-child(2n),
+  .website-publish-workspace .website-check-list > article:nth-last-child(-n+2),
+  .website-publish-workspace .website-evidence-status > article {
+    min-height: 0;
+  }
+
+  .website-publish-workspace .website-evidence-form,
+  .website-publish-workspace .website-approval-form {
+    padding: 12px;
+  }
+
+  .website-publish-workspace input:not([type="checkbox"]):not([type="radio"]),
+  .website-publish-workspace select {
+    min-height: 48px;
+    font-size: 16px;
+  }
+
+  .website-publish-workspace .website-confirmation {
+    min-height: 48px;
+  }
+
+  .website-publish-workspace .website-gate-actions,
+  .website-publish-workspace .website-local-publish-action,
+  .website-publish-workspace .website-handoff-action {
+    display: grid;
+    grid-template-columns: 1fr;
+    align-items: stretch;
+  }
+
+  .website-publish-workspace .website-gate-actions .website-button,
+  .website-publish-workspace .website-local-publish-action .website-button {
+    width: 100%;
+  }
+
+  .website-publish-workspace .website-local-publish-action,
+  .website-publish-workspace .website-handoff-action {
+    gap: 12px;
+    padding: 13px;
+  }
+
+  .website-publish-workspace .website-handoff-action > div:last-child {
+    grid-template-columns: minmax(0, 1fr) 88px;
+  }
+
+  .website-publish-workspace .website-handoff-controls .website-button,
+  .website-publish-workspace .website-handoff-controls a {
+    width: 100%;
+    grid-column: 1 / -1;
+    justify-content: center;
+    justify-self: stretch;
+  }
+
+  .website-publish-workspace .website-publish-history > article {
+    grid-template-columns: auto minmax(0, 1fr);
+    padding: 8px 0;
+  }
+
+  .website-publish-workspace .website-publish-history code {
+    max-width: none;
+    grid-column: 2;
+  }
+
+  .publish-flow-actions {
+    min-height: 0;
+    align-items: stretch;
+    flex-direction: column;
+    padding: 10px;
+  }
+
+  .publish-flow-actions p {
+    padding: 2px 2px 4px;
+  }
+
+  .publish-flow-actions .website-button {
+    width: 100%;
+  }
+}

--- a/showroom/src/products/website/website-product.css
+++ b/showroom/src/products/website/website-product.css
@@ -1593,7 +1593,7 @@
 
 .preview-hero > span,
 .preview-section-grid article > span {
-  color: #18884c;
+  color: #137943;
   font-family: var(--website-mono);
   font-size: clamp(7px, 1vw, 9px);
   font-weight: 780;
@@ -3123,5 +3123,51 @@
 
   .website-preview-site {
     min-height: 0;
+  }
+}
+
+.website-editor-section-picker {
+  display: grid;
+  grid-template-columns: auto minmax(180px, 280px);
+  align-items: center;
+  gap: 12px;
+  border: 1px solid var(--website-line);
+  border-radius: 10px;
+  padding: 10px 12px;
+  background: var(--website-panel-raised);
+}
+
+.website-editor-section-picker > span {
+  color: var(--website-muted);
+  font-size: 13px;
+  font-weight: 750;
+}
+
+.website-editor-section-picker > select {
+  min-height: 42px;
+  border-radius: 8px;
+}
+
+.website-editor-scroll[data-editor-section] > [data-content-section] {
+  display: none;
+}
+
+.website-editor-scroll[data-editor-section="page"] > [data-content-section="page"],
+.website-editor-scroll[data-editor-section="hero"] > [data-content-section="hero"],
+.website-editor-scroll[data-editor-section="sections"] > [data-content-section="sections"],
+.website-editor-scroll[data-editor-section="seo"] > [data-content-section="seo"] {
+  display: block;
+}
+
+@media (max-width: 640px) {
+  .website-editor-section-picker {
+    grid-template-columns: 1fr;
+    gap: 6px;
+  }
+
+  .website-editor-section-picker > select {
+    width: 100%;
+    min-height: 48px;
+    font-size: 16px;
   }
 }

--- a/showroom/src/products/website/website-product.css
+++ b/showroom/src/products/website/website-product.css
@@ -251,13 +251,13 @@
   color: var(--website-ink);
 }
 
-.website-workspace-nav > button[aria-current="page"] {
+.website-workspace-nav > button[aria-selected="true"] {
   border-color: rgba(11, 116, 94, .2);
   background: var(--website-green-soft);
   color: var(--website-ink);
 }
 
-.website-workspace-nav > button[aria-current="page"] > span {
+.website-workspace-nav > button[aria-selected="true"] > span {
   color: var(--website-green);
 }
 
@@ -2157,5 +2157,971 @@
 @media (prefers-reduced-motion: reduce) {
   .website-preview-frame {
     transition: none;
+  }
+}
+
+/* Task-first workspace shell */
+.website-product {
+  --website-bg: #f3f5f2;
+  --website-panel: #ffffff;
+  --website-panel-raised: #f7f9f7;
+  --website-ink: #17211c;
+  --website-muted: #4d5d54;
+  --website-quiet: #5f6d65;
+  --website-line: #dce3de;
+  --website-line-strong: #c7d1ca;
+  --website-green: #08745d;
+  --website-green-soft: #e8f4ef;
+  --website-warn: #8a5a00;
+  --website-danger: #aa273b;
+  --website-sans: Geist, Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --website-code: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+  --website-mono: var(--website-sans);
+  height: 100svh;
+  overflow: hidden;
+  background: var(--website-bg);
+  font-size: 14px;
+}
+
+.website-product button,
+.website-product input,
+.website-product select,
+.website-product textarea {
+  font-size: 14px;
+}
+
+.website-product label,
+.website-product label > span:first-child,
+.website-product p {
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+.website-product small {
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.website-product code,
+.website-brand > span,
+.website-navigation-copy code,
+.website-publish-section code,
+.website-publish-history code,
+.website-preview-toolbar code {
+  font-family: var(--website-code);
+}
+
+.website-skip {
+  min-height: 44px;
+  display: flex;
+  align-items: center;
+}
+
+.website-topbar {
+  height: 64px;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  gap: 20px;
+  padding: 0 24px;
+  background: rgba(255, 255, 255, .96);
+  backdrop-filter: blur(12px);
+}
+
+.website-brand {
+  min-height: 44px;
+  gap: 10px;
+}
+
+.website-brand > span {
+  font-size: 19px;
+}
+
+.website-brand > strong {
+  font-size: 12px;
+  letter-spacing: .08em;
+}
+
+.website-brand > b {
+  border-left: 1px solid var(--website-line);
+  padding-left: 10px;
+  color: var(--website-ink);
+  font-family: inherit;
+  font-size: 14px;
+  font-weight: 700;
+  letter-spacing: 0;
+  text-transform: none;
+}
+
+.website-site-summary {
+  min-width: 0;
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+}
+
+.website-site-summary > strong {
+  overflow: hidden;
+  font-size: 14px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.website-site-summary > small {
+  flex: 0 0 auto;
+  color: var(--website-quiet);
+}
+
+.website-runtime {
+  gap: 10px;
+}
+
+.website-runtime > small {
+  color: var(--website-quiet);
+  font-family: inherit;
+  font-size: 12px;
+}
+
+.website-local-badge,
+.website-status {
+  min-height: 30px;
+  padding: 0 10px;
+  font-family: inherit;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0;
+  text-transform: none;
+}
+
+.website-shell {
+  height: calc(100svh - 64px);
+  display: block;
+}
+
+.website-main {
+  width: min(1440px, 100%);
+  height: 100%;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin: 0 auto;
+  padding: 16px 24px 24px;
+}
+
+.website-workspace-nav {
+  min-height: 44px;
+  display: flex;
+  align-items: stretch;
+  gap: 4px;
+  margin: 0;
+  border-bottom: 1px solid var(--website-line);
+}
+
+.website-workspace-nav > button {
+  min-width: 112px;
+  min-height: 44px;
+  justify-content: center;
+  border: 0;
+  border-bottom: 2px solid transparent;
+  border-radius: 0;
+  padding: 0 16px;
+  color: var(--website-muted);
+  font-size: 14px;
+  font-weight: 700;
+  text-align: center;
+}
+
+.website-workspace-nav > button:hover {
+  background: var(--website-panel-raised);
+  color: var(--website-ink);
+}
+
+.website-workspace-nav > button[aria-selected="true"] {
+  border-bottom-color: var(--website-green);
+  background: transparent;
+  color: var(--website-green);
+}
+
+.website-notice {
+  position: static;
+  z-index: auto;
+  width: 100%;
+  max-width: none;
+  min-height: 38px;
+  display: flex;
+  align-items: center;
+  margin: 0;
+  border: 1px solid var(--website-line);
+  border-radius: 8px;
+  padding: 8px 12px;
+  background: var(--website-panel-raised);
+  color: var(--website-muted);
+  font-size: 13px;
+  line-height: 1.4;
+  box-shadow: none;
+  backdrop-filter: none;
+}
+
+.website-page-switcher {
+  display: grid;
+  grid-template-columns: auto minmax(220px, 520px) auto;
+  align-items: center;
+  align-self: flex-start;
+  gap: 10px;
+}
+
+.website-page-switcher > label {
+  color: var(--website-ink);
+  font-size: 14px;
+  font-weight: 700;
+}
+
+.website-page-switcher > select {
+  min-height: 44px;
+  border-radius: 8px;
+}
+
+.website-page-switcher > .website-button {
+  min-height: 44px;
+}
+
+.website-heading {
+  min-height: 60px;
+  flex: 0 0 auto;
+  gap: 18px;
+}
+
+.website-heading h1 {
+  margin: 0;
+  font-size: clamp(24px, 2.2vw, 32px);
+  line-height: 1.15;
+  letter-spacing: -.035em;
+}
+
+.website-heading p {
+  margin: 5px 0 0;
+  overflow: visible;
+  color: var(--website-muted);
+  font-size: 14px;
+  line-height: 1.45;
+  text-overflow: clip;
+  white-space: normal;
+}
+
+.website-heading-actions {
+  gap: 8px;
+}
+
+.website-surface-controls {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(78px, auto));
+  gap: 4px;
+  border: 1px solid var(--website-line);
+  border-radius: 9px;
+  padding: 4px;
+  background: var(--website-panel);
+}
+
+.website-surface-controls > button {
+  min-height: 38px;
+  border: 0;
+  border-radius: 6px;
+  padding: 0 14px;
+  background: transparent;
+  color: var(--website-muted);
+  font-size: 14px;
+  font-weight: 700;
+}
+
+.website-surface-controls > button:hover {
+  background: var(--website-panel-raised);
+  color: var(--website-ink);
+}
+
+.website-surface-controls > button[aria-pressed="true"] {
+  background: var(--website-green-soft);
+  color: var(--website-green);
+}
+
+.website-workspace-grid,
+.website-workspace-grid.view-publish {
+  min-height: 0;
+  display: grid;
+  flex: 1;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 14px;
+}
+
+.website-work-surface,
+.website-preview-surface {
+  min-width: 0;
+  min-height: 0;
+}
+
+.website-work-surface {
+  display: flex;
+}
+
+.website-work-surface > .website-editor-panel {
+  width: 100%;
+  height: 100%;
+}
+
+.website-preview-surface {
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
+  gap: 8px;
+}
+
+.website-preview-surface > .website-preview-panel {
+  height: 100%;
+}
+
+.website-workspace-grid[data-surface="work"] > .website-preview-surface,
+.website-workspace-grid[data-surface="preview"] > .website-work-surface {
+  display: none;
+}
+
+.website-workspace-grid[data-split="true"] {
+  grid-template-columns: minmax(420px, .95fr) minmax(420px, 1.05fr);
+}
+
+.website-workspace-grid[data-split="true"] > .website-work-surface {
+  display: flex;
+}
+
+.website-workspace-grid[data-split="true"] > .website-preview-surface {
+  display: grid;
+}
+
+.website-preview-surface-head {
+  min-height: 48px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  border: 1px solid var(--website-line);
+  border-radius: 9px;
+  padding: 4px 5px 4px 14px;
+  background: var(--website-panel);
+}
+
+.website-preview-surface-head > div:first-child {
+  min-width: 0;
+  display: flex;
+  align-items: baseline;
+  gap: 9px;
+}
+
+.website-preview-surface-head strong {
+  font-size: 14px;
+}
+
+.website-preview-surface-head small {
+  overflow: hidden;
+  color: var(--website-quiet);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.website-preview-controls {
+  gap: 3px;
+  border: 0;
+  border-radius: 7px;
+  padding: 3px;
+  background: var(--website-panel-raised);
+}
+
+.website-preview-controls > button {
+  min-width: 76px;
+  min-height: 36px;
+  border-radius: 6px;
+  padding: 0 10px;
+  color: var(--website-muted);
+  font-size: 13px;
+}
+
+.website-preview-controls > button[aria-pressed="true"] {
+  border-color: transparent;
+  background: var(--website-panel);
+  color: var(--website-green);
+  box-shadow: 0 1px 3px rgba(23, 33, 28, .08);
+}
+
+.website-editor-panel,
+.website-preview-panel {
+  border-color: var(--website-line);
+  border-radius: 10px;
+  box-shadow: 0 6px 20px rgba(23, 33, 28, .045);
+}
+
+.website-panel-head {
+  min-height: 84px;
+  padding: 16px 18px;
+}
+
+.website-panel-head h2 {
+  margin-top: 4px;
+  font-size: 20px;
+}
+
+.website-panel-head p {
+  margin-top: 5px;
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+.website-eyebrow {
+  color: var(--website-muted);
+  font-family: inherit;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0;
+  text-transform: none;
+}
+
+.website-eyebrow::before {
+  display: none;
+}
+
+.website-editor-scroll {
+  padding: 18px;
+}
+
+.website-fieldset,
+.website-disclosure,
+.website-navigation-editor,
+.website-publish-section {
+  border-radius: 9px;
+  background: var(--website-panel);
+}
+
+.website-fieldset {
+  gap: 12px;
+  margin-bottom: 14px;
+  padding: 16px;
+}
+
+.website-fieldset > legend {
+  color: var(--website-ink);
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.website-product input,
+.website-product select,
+.website-product textarea {
+  min-height: 44px;
+  border-radius: 8px;
+  padding: 10px 12px;
+  background: #ffffff;
+}
+
+.website-product textarea {
+  line-height: 1.5;
+}
+
+.website-button {
+  min-height: 40px;
+  border-radius: 8px;
+  font-size: 14px;
+}
+
+.website-button.is-compact {
+  min-height: 36px;
+  font-size: 13px;
+}
+
+.website-inline-actions > button,
+.website-navigation-actions > button,
+.website-text-button {
+  min-height: 36px;
+  border-radius: 7px;
+  font-family: inherit;
+  font-size: 13px;
+}
+
+.website-section-editor {
+  border-radius: 8px;
+  background: var(--website-panel-raised);
+}
+
+.website-section-editor > header > strong,
+.website-record-count,
+.website-field-help,
+.website-navigation-editor > header > small,
+.website-publish-section > header > small,
+.website-gate-actions > small {
+  font-family: inherit;
+  font-size: 12px;
+}
+
+.website-disclosure > summary {
+  min-height: 46px;
+  font-size: 14px;
+}
+
+.website-disclosure > summary::before {
+  display: none;
+}
+
+.website-disclosure > summary > small {
+  font-family: inherit;
+  font-size: 12px;
+}
+
+.website-page-check strong,
+.website-boundary-note strong,
+.website-approval-record strong,
+.website-local-publish-action strong,
+.website-handoff-action strong,
+.website-publish-history strong,
+.website-check-list strong,
+.website-evidence-status strong {
+  font-size: 14px;
+}
+
+.website-page-check small,
+.website-page-check p,
+.website-page-check ul,
+.website-boundary-note p,
+.website-publish-section > header p,
+.website-check-list p,
+.website-evidence-status p,
+.website-approval-record p,
+.website-local-publish-action p,
+.website-handoff-action p,
+.website-publish-history small,
+.website-empty > p {
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+.website-navigation-editor > header h3,
+.website-publish-section > header h3 {
+  font-size: 16px;
+}
+
+.website-navigation-row {
+  min-height: 92px;
+  padding: 12px;
+}
+
+.website-switch,
+.website-confirmation {
+  min-height: 36px;
+}
+
+.website-switch > input,
+.website-confirmation > input {
+  width: 18px;
+  min-width: 18px;
+  min-height: 18px;
+}
+
+.website-navigation-copy code,
+.website-publish-section code,
+.website-publish-history code,
+.website-preview-toolbar code {
+  font-size: 12px;
+}
+
+.website-step {
+  min-width: 28px;
+  min-height: 28px;
+  border-radius: 7px;
+  font-family: inherit;
+  font-size: 12px;
+}
+
+.website-check-list > article {
+  min-height: 74px;
+  padding: 12px;
+}
+
+.website-check-list > article > span {
+  width: 22px;
+  height: 22px;
+  font-family: inherit;
+  font-size: 11px;
+}
+
+.website-evidence-status > article {
+  border-radius: 8px;
+  padding: 11px;
+}
+
+.website-evidence-status > article > span,
+.website-evidence-status small,
+.website-approval-record small {
+  font-family: inherit;
+  font-size: 12px;
+  text-transform: none;
+}
+
+.website-confirmation > span {
+  font-size: 14px;
+}
+
+.website-local-publish {
+  background: var(--website-green-soft);
+}
+
+.website-handoff-controls label {
+  font-size: 13px;
+}
+
+.website-handoff-controls input {
+  font-size: 14px;
+}
+
+.website-preview-panel {
+  grid-template-rows: 44px minmax(0, 1fr);
+}
+
+.website-preview-toolbar {
+  grid-template-columns: minmax(0, 1fr);
+  min-height: 44px;
+  padding: 0 14px;
+  background: var(--website-panel);
+}
+
+.website-preview-toolbar > div:nth-child(2) {
+  gap: 10px;
+}
+
+.website-preview-toolbar strong {
+  font-size: 13px;
+}
+
+.website-window-dots,
+.website-preview-toolbar > span {
+  display: none;
+}
+
+.website-preview-stage {
+  padding: 16px;
+  background: #eef2ef;
+  background-image: none;
+}
+
+.website-preview-frame {
+  border-color: var(--website-line);
+  border-radius: 9px;
+  background: #ffffff;
+  box-shadow: 0 8px 24px rgba(23, 33, 28, .09);
+}
+
+.website-preview-site {
+  background: #f7f8f5;
+}
+
+.preview-site-header > strong > span {
+  font-family: var(--website-code);
+}
+
+.preview-site-header > nav > button,
+.preview-hero > .preview-cta {
+  font-size: 14px;
+}
+
+.preview-hero > span,
+.preview-section-grid article > span {
+  font-family: inherit;
+  font-size: 12px;
+}
+
+.preview-hero > p,
+.preview-section-grid p {
+  font-size: 14px;
+}
+
+.preview-site-footer > small {
+  font-family: inherit;
+  font-size: 12px;
+}
+
+@media (max-width: 900px) {
+  .website-product {
+    height: auto;
+    min-height: 100svh;
+    overflow: visible;
+  }
+
+  .website-topbar {
+    position: sticky;
+    z-index: 40;
+    top: 0;
+    height: 58px;
+    grid-template-columns: auto minmax(0, 1fr) auto;
+    gap: 10px;
+    padding: 0 14px;
+  }
+
+  .website-brand {
+    min-height: 44px;
+  }
+
+  .website-brand > strong,
+  .website-site-summary > small,
+  .website-runtime > small {
+    display: none;
+  }
+
+  .website-brand > b {
+    display: block;
+    padding-left: 8px;
+  }
+
+  .website-site-summary {
+    display: block;
+  }
+
+  .website-site-summary > strong {
+    display: block;
+    font-size: 13px;
+    text-align: center;
+  }
+
+  .website-local-badge {
+    min-height: 30px;
+    padding-inline: 8px;
+    font-size: 11px;
+  }
+
+  .website-shell {
+    height: auto;
+  }
+
+  .website-main {
+    height: auto;
+    min-height: calc(100svh - 58px);
+    gap: 12px;
+    padding: 12px 14px 32px;
+  }
+
+  .website-workspace-nav {
+    width: 100%;
+    min-height: 46px;
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .website-workspace-nav > button {
+    min-width: 0;
+    min-height: 46px;
+    padding: 0 8px;
+  }
+
+  .website-notice {
+    min-height: 42px;
+    margin: 0;
+    font-size: 13px;
+  }
+
+  .website-page-switcher {
+    width: 100%;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-self: stretch;
+    gap: 7px;
+  }
+
+  .website-page-switcher > label {
+    grid-column: 1 / -1;
+  }
+
+  .website-page-switcher > select {
+    min-width: 0;
+  }
+
+  .website-heading {
+    min-height: 0;
+    align-items: stretch;
+    flex-direction: column;
+    gap: 12px;
+    padding: 4px 0 0;
+  }
+
+  .website-heading h1 {
+    font-size: 25px;
+  }
+
+  .website-heading p {
+    font-size: 14px;
+  }
+
+  .website-heading-actions,
+  .website-surface-controls {
+    width: 100%;
+  }
+
+  .website-surface-controls {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .website-surface-controls > button {
+    min-height: 44px;
+  }
+
+  .website-split-control {
+    display: none;
+  }
+
+  .website-workspace-grid,
+  .website-workspace-grid.view-publish,
+  .website-workspace-grid[data-split="true"] {
+    min-height: 0;
+    display: block;
+  }
+
+  .website-workspace-grid[data-surface="work"] > .website-work-surface {
+    display: block;
+  }
+
+  .website-workspace-grid[data-surface="work"] > .website-preview-surface {
+    display: none;
+  }
+
+  .website-workspace-grid[data-surface="preview"] > .website-work-surface {
+    display: none;
+  }
+
+  .website-workspace-grid[data-surface="preview"] > .website-preview-surface {
+    display: grid;
+  }
+
+  .website-work-surface,
+  .website-preview-surface,
+  .website-work-surface > .website-editor-panel,
+  .website-preview-surface > .website-preview-panel,
+  .website-editor-panel,
+  .website-preview-panel {
+    height: auto;
+    min-height: 0;
+    overflow: visible;
+  }
+
+  .website-editor-scroll,
+  .website-preview-stage {
+    min-height: 0;
+    overflow: visible;
+  }
+
+  .website-editor-panel {
+    display: block;
+  }
+
+  .website-panel-actions {
+    min-height: 0;
+  }
+
+  .website-preview-surface {
+    gap: 8px;
+  }
+
+  .website-preview-surface-head {
+    align-items: stretch;
+    flex-direction: column;
+    padding: 10px;
+  }
+
+  .website-preview-surface-head > div:first-child {
+    padding-inline: 2px;
+  }
+
+  .website-preview-controls {
+    width: 100%;
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .website-preview-controls > button {
+    min-width: 0;
+    min-height: 44px;
+  }
+
+  .website-preview-panel {
+    display: block;
+  }
+
+  .website-preview-toolbar {
+    min-height: 48px;
+  }
+
+  .website-preview-stage {
+    padding: 10px;
+  }
+
+  .website-preview-frame.is-desktop,
+  .website-preview-frame.is-tablet,
+  .website-preview-frame.is-mobile {
+    width: 100%;
+    min-height: 0;
+  }
+
+  .website-product input:not([type="checkbox"]):not([type="radio"]),
+  .website-product select,
+  .website-product textarea {
+    min-height: 48px;
+    font-size: 16px;
+  }
+
+  .website-product button,
+  .website-button,
+  .website-button.is-compact,
+  .website-text-button,
+  .website-inline-actions > button,
+  .website-navigation-actions > button {
+    min-height: 44px;
+  }
+
+  .website-switch,
+  .website-confirmation {
+    min-height: 44px;
+  }
+}
+
+@media (max-width: 640px) {
+  .website-brand > b {
+    font-size: 13px;
+  }
+
+  .website-local-badge {
+    max-width: 108px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .website-page-switcher > .website-button {
+    padding-inline: 12px;
+  }
+
+  .website-panel-head {
+    min-height: 0;
+    align-items: flex-start;
+    padding: 16px;
+  }
+
+  .website-editor-scroll {
+    padding: 14px;
+  }
+
+  .website-form-grid.two-columns,
+  .website-check-list,
+  .website-evidence-form {
+    grid-template-columns: 1fr;
+  }
+
+  .website-navigation-row {
+    grid-template-columns: 64px minmax(0, 1fr);
+  }
+
+  .website-panel-actions {
+    padding: 12px 14px;
+  }
+
+  .website-preview-site {
+    min-height: 0;
   }
 }

--- a/tools/verify_app_build.mjs
+++ b/tools/verify_app_build.mjs
@@ -10,7 +10,7 @@ let websiteRuntimeChecks = 0
 let commerceRuntimeChecks = 0
 let productionRuntimeChecks = 0
 const fail = (reason) => failures.push(reason)
-const [manifestText, appPackageText, appSource, coreSource, commerceSource, managedTrialSource, managedCommerceRuntime, productionSource, teamSource, agentTeamsSource, teamModel, websiteSource, publishSource, sitePreviewSource, websiteModelSource, websiteWorkspaceSource, websiteCssSource, commerceIntakeSource, handoffSource] = await Promise.all([
+const [manifestText, appPackageText, appSource, coreSource, commerceSource, managedTrialSource, managedCommerceRuntime, productionSource, teamSource, agentTeamsSource, teamModel, websiteSource, contentSource, publishSource, sitePreviewSource, websiteModelSource, websiteWorkspaceSource, websiteCssSource, commerceIntakeSource, handoffSource] = await Promise.all([
   readFile(resolve(root, 'site-manifest.json'), 'utf8'),
   readFile(resolve(root, 'showroom', 'package.json'), 'utf8'),
   readFile(resolve(root, 'showroom', 'src', 'App.tsx'), 'utf8'),
@@ -23,6 +23,7 @@ const [manifestText, appPackageText, appSource, coreSource, commerceSource, mana
   readFile(resolve(root, 'showroom', 'src', 'core', 'AgentTeamsPanel.tsx'), 'utf8'),
   readFile(resolve(root, 'showroom', 'src', 'core', 'team-work.ts'), 'utf8'),
   readFile(resolve(root, 'showroom', 'src', 'products', 'website', 'WebsiteProduct.tsx'), 'utf8'),
+  readFile(resolve(root, 'showroom', 'src', 'products', 'website', 'ContentWorkspace.tsx'), 'utf8'),
   readFile(resolve(root, 'showroom', 'src', 'products', 'website', 'PublishWorkspace.tsx'), 'utf8'),
   readFile(resolve(root, 'showroom', 'src', 'products', 'website', 'SitePreview.tsx'), 'utf8'),
   readFile(resolve(root, 'showroom', 'src', 'products', 'website', 'website-model.ts'), 'utf8'),
@@ -98,7 +99,10 @@ if (!coreSource.includes('view=work&item=${item.id}') || !coreSource.includes('v
 if (!appSource.includes("lazy(() => import('./products/website/WebsiteProduct')") || !appSource.includes('Suspense') || appSource.includes("import('./products/ecommerce/EcommerceOrdersProduct')")) fail('website_prototype_route_not_isolated')
 if (!appSource.includes('<Navigate replace to="/operations/commerce/?tab=orders" />') || !appSource.includes('path="products/ecommerce/*"')) fail('legacy_ecommerce_route_not_redirected')
 if (!appPackage.scripts?.lint?.includes('src/products')) fail('prototype_sources_not_linted')
-if (!websiteSource.includes('No website has been deployed.') || !websiteSource.includes('No deployment occurred.') || !websiteSource.includes('Domain and deployment remain separate approval-gated actions.')) fail('website_deployment_boundary_missing')
+if (!websiteSource.includes('No website has been deployed.')
+  || !websiteSource.includes('No deployment occurred.')
+  || !publishSource.includes('No deployment target, domain write, or external connection exists in this prototype.')
+  || !publishSource.includes('It does not publish a website.')) fail('website_deployment_boundary_missing')
 if (!websiteModelSource.includes("supermega.website.workspace.v2") || !websiteModelSource.includes('LEGACY_WEBSITE_STORAGE_KEY') || !websiteModelSource.includes('mutateWebsiteWorkspace') || !websiteModelSource.includes('WEBSITE_MUTATION_LOCK') || !websiteModelSource.includes('preservesAppendOnlyHistory') || !websiteModelSource.includes('canonicalJson')) fail('website_v2_locked_store_missing')
 if (!websiteModelSource.includes('contentRevision') || !websiteModelSource.includes('evidenceIds') || !websiteModelSource.includes('migratedFromV1') || !websiteModelSource.includes('getCurrentApproval') || !websiteModelSource.includes('getCurrentPublish')) fail('website_release_provenance_missing')
 if (!sitePreviewSource.includes("ctaHref.startsWith('https://')") || !sitePreviewSource.includes("ctaHref.startsWith('#')") || !sitePreviewSource.includes('aria-disabled="true"')) fail('website_preview_destination_guard_missing')
@@ -111,13 +115,21 @@ const websiteHydration = websiteWorkspaceSource.slice(websiteHydrationStart, web
 if (websiteHydration.indexOf('try {') < 0 || websiteHydration.indexOf('try {') > websiteHydration.indexOf('currentManagedIdentity()') || websiteHydration.indexOf('finally') < websiteHydration.indexOf('currentManagedIdentity()')) fail('managed_website_identity_failure_can_stick_hydration')
 const websiteTabsContract = websiteSource.slice(websiteSource.indexOf('const workspaceViews'), websiteSource.indexOf('const viewCopy'))
 if ((websiteTabsContract.match(/^\s*\{ id:/gm) || []).length !== 3 || !websiteTabsContract.includes("label: 'Content'") || !websiteTabsContract.includes("label: 'Navigation'") || !websiteTabsContract.includes("label: 'Publish'") || !websiteSource.includes('role="tablist"') || !websiteSource.includes('role="tabpanel"') || !websiteSource.includes("event.key === 'ArrowRight'") || !websiteSource.includes('tabIndex={view === item.id ? 0 : -1}')) fail('website_three_view_accessibility_contract_changed')
-if (!websiteSource.includes("const [mobilePane, setMobilePane] = useState<'edit' | 'preview'>('edit')")
-  || !websiteSource.includes('aria-label="Mobile Website workspace"')
-  || !websiteSource.includes("className={'website-workspace-grid view-' + view + ' mobile-pane-' + mobilePane}")
-  || !websiteSource.includes("setMobilePane('edit')")) fail('website_mobile_focus_mode_missing')
-if (!websiteCssSource.includes('.website-workspace-grid.mobile-pane-edit > .website-preview-panel')
-  || !websiteCssSource.includes('.website-workspace-grid.mobile-pane-preview > :not(.website-preview-panel)')
-  || !websiteCssSource.includes('height: clamp(480px, calc(100svh - 310px), 620px)')) fail('website_mobile_panels_not_bounded')
+if (!websiteSource.includes("const [surface, setSurface] = useState<'work' | 'preview'>('work')")
+  || !websiteSource.includes('aria-label="Website workspace surface"')
+  || !websiteSource.includes('data-surface={surface}')
+  || !websiteSource.includes("setSurface('work')")
+  || !websiteSource.includes('data-split={splitPreview')
+  || !websiteSource.includes('setSplitPreview(false)')) fail('website_mobile_focus_mode_missing')
+if (!websiteCssSource.includes('.website-workspace-grid[data-surface="work"] > .website-preview-surface')
+  || !websiteCssSource.includes('.website-workspace-grid[data-surface="preview"] > .website-work-surface')
+  || !websiteCssSource.includes('.website-workspace-grid[data-surface="preview"] > .website-preview-surface')
+  || !websiteCssSource.includes('.website-split-control')
+  || !websiteCssSource.includes('display: none')) fail('website_mobile_panels_not_bounded')
+if (!contentSource.includes("type EditorSection = 'page' | 'hero' | 'sections' | 'seo'")
+  || !contentSource.includes('aria-label="Page section to edit"')
+  || !contentSource.includes('data-editor-section={editorSection}')
+  || !websiteCssSource.includes('.website-editor-scroll[data-editor-section] > [data-content-section]')) fail('website_content_focus_contract_missing')
 const websiteMobileCss = websiteCssSource.slice(websiteCssSource.indexOf('@media (max-width: 640px)'), websiteCssSource.indexOf('@media (prefers-reduced-motion'))
 const websitePreviewControlsHiddenUnconditionally = /(?:^|\n)\s*\.website-preview-controls\s*\{\s*display:\s*none/.test(websiteMobileCss)
 if (!websiteMobileCss.includes('.website-preview-controls') || !websiteMobileCss.includes('display: flex') || websitePreviewControlsHiddenUnconditionally) fail('website_mobile_review_controls_hidden')

--- a/tools/verify_app_build.mjs
+++ b/tools/verify_app_build.mjs
@@ -10,7 +10,7 @@ let websiteRuntimeChecks = 0
 let commerceRuntimeChecks = 0
 let productionRuntimeChecks = 0
 const fail = (reason) => failures.push(reason)
-const [manifestText, appPackageText, appSource, coreSource, commerceSource, managedTrialSource, managedCommerceRuntime, productionSource, teamSource, agentTeamsSource, teamModel, websiteSource, contentSource, publishSource, sitePreviewSource, websiteModelSource, websiteWorkspaceSource, websiteCssSource, commerceIntakeSource, handoffSource] = await Promise.all([
+const [manifestText, appPackageText, appSource, coreSource, commerceSource, managedTrialSource, managedCommerceRuntime, productionSource, teamSource, agentTeamsSource, teamModel, websiteSource, contentSource, publishSource, publishCssSource, sitePreviewSource, websiteModelSource, websiteWorkspaceSource, websiteCssSource, commerceIntakeSource, handoffSource] = await Promise.all([
   readFile(resolve(root, 'site-manifest.json'), 'utf8'),
   readFile(resolve(root, 'showroom', 'package.json'), 'utf8'),
   readFile(resolve(root, 'showroom', 'src', 'App.tsx'), 'utf8'),
@@ -25,6 +25,7 @@ const [manifestText, appPackageText, appSource, coreSource, commerceSource, mana
   readFile(resolve(root, 'showroom', 'src', 'products', 'website', 'WebsiteProduct.tsx'), 'utf8'),
   readFile(resolve(root, 'showroom', 'src', 'products', 'website', 'ContentWorkspace.tsx'), 'utf8'),
   readFile(resolve(root, 'showroom', 'src', 'products', 'website', 'PublishWorkspace.tsx'), 'utf8'),
+  readFile(resolve(root, 'showroom', 'src', 'products', 'website', 'publish-workspace.css'), 'utf8'),
   readFile(resolve(root, 'showroom', 'src', 'products', 'website', 'SitePreview.tsx'), 'utf8'),
   readFile(resolve(root, 'showroom', 'src', 'products', 'website', 'website-model.ts'), 'utf8'),
   readFile(resolve(root, 'showroom', 'src', 'products', 'website', 'useWebsiteWorkspace.ts'), 'utf8'),
@@ -101,7 +102,7 @@ if (!appSource.includes('<Navigate replace to="/operations/commerce/?tab=orders"
 if (!appPackage.scripts?.lint?.includes('src/products')) fail('prototype_sources_not_linted')
 if (!websiteSource.includes('No website has been deployed.')
   || !websiteSource.includes('No deployment occurred.')
-  || !publishSource.includes('No deployment target, domain write, or external connection exists in this prototype.')
+  || !publishSource.includes('No deployment, domain write, payment, stock, customer message, or order change happens here.')
   || !publishSource.includes('It does not publish a website.')) fail('website_deployment_boundary_missing')
 if (!websiteModelSource.includes("supermega.website.workspace.v2") || !websiteModelSource.includes('LEGACY_WEBSITE_STORAGE_KEY') || !websiteModelSource.includes('mutateWebsiteWorkspace') || !websiteModelSource.includes('WEBSITE_MUTATION_LOCK') || !websiteModelSource.includes('preservesAppendOnlyHistory') || !websiteModelSource.includes('canonicalJson')) fail('website_v2_locked_store_missing')
 if (!websiteModelSource.includes('contentRevision') || !websiteModelSource.includes('evidenceIds') || !websiteModelSource.includes('migratedFromV1') || !websiteModelSource.includes('getCurrentApproval') || !websiteModelSource.includes('getCurrentPublish')) fail('website_release_provenance_missing')
@@ -130,6 +131,19 @@ if (!contentSource.includes("type EditorSection = 'page' | 'hero' | 'sections' |
   || !contentSource.includes('aria-label="Page section to edit"')
   || !contentSource.includes('data-editor-section={editorSection}')
   || !websiteCssSource.includes('.website-editor-scroll[data-editor-section] > [data-content-section]')) fail('website_content_focus_contract_missing')
+if (!publishSource.includes("type PublishStep = 'checks' | 'evidence' | 'approval' | 'snapshot'")
+  || !publishSource.includes("{ id: 'checks', label: 'Checks' }")
+  || !publishSource.includes("{ id: 'evidence', label: 'Evidence' }")
+  || !publishSource.includes("{ id: 'approval', label: 'Approval' }")
+  || !publishSource.includes("{ id: 'snapshot', label: 'Snapshot & handoff' }")
+  || !publishSource.includes('aria-current={activeStep === step.id')
+  || !publishSource.includes("activeStep === 'checks'")
+  || !publishSource.includes("activeStep === 'evidence'")
+  || !publishSource.includes("activeStep === 'approval'")
+  || !publishSource.includes("activeStep === 'snapshot'")
+  || !publishCssSource.includes('grid-template-columns: repeat(4, minmax(0, 1fr))')
+  || !publishCssSource.includes('grid-template-columns: repeat(2, minmax(0, 1fr))')
+  || !publishCssSource.includes('font-size: 16px')) fail('website_publish_task_flow_missing')
 const websiteMobileCss = websiteCssSource.slice(websiteCssSource.indexOf('@media (max-width: 640px)'), websiteCssSource.indexOf('@media (prefers-reduced-motion'))
 const websitePreviewControlsHiddenUnconditionally = /(?:^|\n)\s*\.website-preview-controls\s*\{\s*display:\s*none/.test(websiteMobileCss)
 if (!websiteMobileCss.includes('.website-preview-controls') || !websiteMobileCss.includes('display: flex') || websitePreviewControlsHiddenUnconditionally) fail('website_mobile_review_controls_hidden')
@@ -146,7 +160,7 @@ if (!websiteSource.includes('approvalIsCurrent || !publishIsCurrent')
   || !websiteSource.includes('writeWebsiteEcommerceHandoff(handoff, workspace)')
   || !websiteSource.includes('createCommerceWebsiteIntake(current')
   || !websiteSource.includes("storageMode === 'managed' ? 'managed' : 'local'")
-  || !publishSource.includes('No stock, payment, customer message, or order changes')) fail('website_handoff_gate_missing')
+  || !publishSource.includes('No deployment, domain write, payment, stock, customer message, or order change happens here.')) fail('website_handoff_gate_missing')
 if (!commerceIntakeSource.includes('acceptWebsiteEcommerceHandoff') || !commerceIntakeSource.includes('matches.length === 1') || !commerceIntakeSource.includes('createWebsiteOrderDraft(context.handoff.id') || !commerceIntakeSource.includes('I reviewed this SKU, quantity, and Website evidence.')) fail('commerce_intake_approval_contract_missing')
 if (!commerceIntakeSource.includes('await completeWebsiteOrderDraft') || !commerceIntakeSource.includes('opaque customer reference generated on completion') || !commerceIntakeSource.includes('Create ready order') || !commerceIntakeSource.includes('Confirm into orders')) fail('commerce_order_completion_ui_missing')
 if (!coreSource.includes('function queueWebsiteOrder') || !coreSource.includes('sourceRecordId') || !coreSource.includes('item.price !== line.unitPriceMmk') || !coreSource.includes('Website order confirmation failed closed') || !coreSource.includes('Confirm ${record.id} from Website')) fail('website_order_not_integrated_with_commerce')


### PR DESCRIPTION
## Outcome

Makes the Website product substantially easier to understand and use without adding deployment behavior.

- replaces the permanent editor sidebar with three clear tasks: Content, Navigation, Publish
- shows one editor section at a time instead of one long form
- gives mobile users a single Work or Preview surface and desktop users an optional Split view
- turns publishing into four explicit stages: Checks, Evidence, Approval, Snapshot & handoff
- aligns the product with the warm neutral and emerald SuperMega theme
- keeps every publish, domain, payment, stock, message, and order boundary local and human-gated

## Review stack

This draft is intentionally based on `agent/supermega-website-mobile-focus` (#252). It does not target `main` directly and should not be released independently of the reviewed stack.

## Verification

- `npm --prefix showroom run lint`
- `npm --prefix showroom run build`
- `node tools/verify_app_build.mjs`
- 24 Website runtime checks plus the existing Commerce and Production contracts
- mobile audit at 390x844: no horizontal overflow; all four publish stages separately verified
- desktop audit at 1280x800: one-viewport shell; no document overflow
- axe WCAG A/AA: 0 violations on audited Content, Preview, and all Publish states
- clean browser reload: no runtime errors

## Safety boundary

No merge, deployment, Vercel domain change, Supabase production mutation, external message, payment, stock change, or order change is included or performed by this draft.