### PR TITLE
Harden Windows live release verification

### DIFF
--- a/tools/verify_coordinated_release_live.mjs
+++ b/tools/verify_coordinated_release_live.mjs
@@ -163,6 +163,7 @@ async function readRelease(baseUrl, projectId) {
 
 const sleep = (milliseconds) => new Promise((resolveSleep) => setTimeout(resolveSleep, milliseconds))
 let lastError
+let verified = false
 for (let attempt = 1; attempt <= attempts; attempt += 1) {
   try {
     const [appRelease, publicRelease] = await Promise.all([
@@ -179,19 +180,22 @@ for (let attempt = 1; attempt <= attempts; attempt += 1) {
       pairOnly,
       identity,
     }, null, 2))
-    process.exit(0)
+    verified = true
+    break
   } catch (error) {
     lastError = error
     if (attempt < attempts) await sleep(attempt * retryDelayMs)
   }
 }
 
-console.error(JSON.stringify({
-  ok: false,
-  contract: 'supermega_coordinated_release',
-  appBaseUrl,
-  publicBaseUrl,
-  pairOnly,
-  reason: lastError?.message || 'unknown_failure',
-}, null, 2))
-process.exit(1)
+if (!verified) {
+  console.error(JSON.stringify({
+    ok: false,
+    contract: 'supermega_coordinated_release',
+    appBaseUrl,
+    publicBaseUrl,
+    pairOnly,
+    reason: lastError?.message || 'unknown_failure',
+  }, null, 2))
+  process.exitCode = 1
+}

--- a/tools/verify_public_release_live.mjs
+++ b/tools/verify_public_release_live.mjs
@@ -114,11 +114,13 @@ async function verifyOnce() {
 }
 
 let lastError
+let verified = false
 for (let attempt = 1; attempt <= attempts; attempt += 1) {
   try {
     const result = await verifyOnce()
     console.log(JSON.stringify({ ok: true, contract: 'supermega_public_live_release', baseUrl, attempt, expectedCommit: expectedCommit || null, ...result }, null, 2))
-    process.exit(0)
+    verified = true
+    break
   } catch (error) {
     lastError = error
     if (attempt < attempts) {
@@ -128,5 +130,7 @@ for (let attempt = 1; attempt <= attempts; attempt += 1) {
   }
 }
 
-console.error(JSON.stringify({ ok: false, contract: 'supermega_public_live_release', baseUrl, expectedCommit: expectedCommit || null, reason: lastError?.message || 'unknown_failure' }, null, 2))
-process.exit(1)
+if (!verified) {
+  console.error(JSON.stringify({ ok: false, contract: 'supermega_public_live_release', baseUrl, expectedCommit: expectedCommit || null, reason: lastError?.message || 'unknown_failure' }, null, 2))
+  process.exitCode = 1
+}


### PR DESCRIPTION
## Outcome

Prevents the public and coordinated live verifiers from forcing `process.exit()` while Windows is still closing Node HTTP handles.

## Change

- finish successful retry loops with `break`
- use `process.exitCode = 1` only after all attempts fail
- preserve the existing fail-closed release assertions

## Verified

- syntax checks passed
- coordinated verifier self-test passed
- app, public, and coordinated production verifiers passed against `11076ae9e0c12ca08554330f6054a8a367431ac5`
- prior Windows libuv shutdown assertion no longer occurs