### PR TITLE
Make Ecommerce checkout review trustworthy

### DIFF
--- a/showroom/src/core/commerce-workspace.ts
+++ b/showroom/src/core/commerce-workspace.ts
@@ -711,6 +711,8 @@ function storefrontRequestV2(value: Record<string, unknown>, field: string): Com
     || (value.fulfilment === 'pickup' ? quote.shipping.adapter !== 'pickup' || quote.shipping.status !== 'included' : quote.shipping.adapter !== 'shop_delivery_review' || quote.shipping.status !== 'pending_shop_review')) throw new Error(`${field}.quote shipping boundary is invalid.`)
   if (!isRecord(quote.payment) || !hasExactKeys(quote.payment, ['adapter', 'status', 'amountMmk'])
     || !['pay_on_pickup', 'cash_on_delivery', 'kbzpay_manual'].includes(String(quote.payment.adapter))
+    || (quote.payment.adapter !== 'kbzpay_manual'
+      && (value.fulfilment === 'pickup' ? quote.payment.adapter !== 'pay_on_pickup' : quote.payment.adapter !== 'cash_on_delivery'))
     || quote.payment.status !== 'not_authorized' || quote.payment.amountMmk !== 0) throw new Error(`${field}.quote payment boundary is invalid.`)
   return value as CommerceStorefrontRequestV2
 }

--- a/showroom/src/products/ecommerce/EcommerceBuyingWorkspace.tsx
+++ b/showroom/src/products/ecommerce/EcommerceBuyingWorkspace.tsx
@@ -6,6 +6,7 @@ import {
   buildEcommercePimProjection,
   createEmptyEcommerceBuyingState,
   ecommerceBuyingStateStorageKey,
+  ecommercePaymentMatchesFulfilment,
   prepareEcommerceShopDraftV2,
   readEcommerceBuyingState,
   saveEcommerceOrderRequestV2,
@@ -41,6 +42,11 @@ function paymentLabel(value: EcommercePaymentAdapter) {
   if (value === 'cash_on_delivery') return 'Cash on delivery'
   if (value === 'kbzpay_manual') return 'KBZPay · Shop confirms'
   return 'Pay on pickup'
+}
+
+function receiveOrderLabel(value: EcommerceFulfilment) {
+  if (value === 'delivery') return 'Delivery · fee confirmed in Shop'
+  return 'Pickup · no delivery fee'
 }
 
 function cartMatchesRequest(cart: EcommerceCartLine[], request: EcommerceBuyingState['requests'][number]) {
@@ -187,6 +193,14 @@ export function EcommerceBuyingWorkspace({
     setNotice('Item removed. No Shop record or payment changed.')
   }
 
+  function changeFulfilment(next: EcommerceFulfilment) {
+    setFulfilment(next)
+    setPaymentAdapter((current) => ecommercePaymentMatchesFulfilment(next, current)
+      ? current
+      : next === 'delivery' ? 'cash_on_delivery' : 'pay_on_pickup')
+    setHandoffConfirmed(false)
+  }
+
   async function reviewOrder(event: FormEvent<HTMLFormElement>) {
     event.preventDefault()
     if (disabled || quoteBusy || recoveryBlocked || !cart.length) return
@@ -217,7 +231,7 @@ export function EcommerceBuyingWorkspace({
         await onRecordManagedRequest(retained)
         setHandoffConfirmed(false)
         setFreshQuoteId(retained.id)
-        setNotice(`${retained.id} is confirmed in the managed Shop inbox. No order, stock, message, or charge changed.`)
+        setNotice('This quote is confirmed in the managed Shop inbox. No order, stock, message, or charge changed.')
         requestAnimationFrame(() => {
           confirmationRef.current?.scrollIntoView({ block: 'center' })
           confirmationRef.current?.focus({ preventScroll: true })
@@ -244,8 +258,8 @@ export function EcommerceBuyingWorkspace({
       if (onRecordManagedRequest) await onRecordManagedRequest(request)
       setFreshQuoteId(request.id)
       setNotice(onRecordManagedRequest
-        ? `${request.id} saved to the managed Shop inbox and local recovery. No order, stock, message, or charge changed.`
-        : `${request.id} saved on this device for 15 minutes. No order, stock, message, or charge changed.`)
+        ? 'This quote is saved to the managed Shop inbox and local recovery. No order, stock, message, or charge changed.'
+        : 'This quote is saved on this device for 15 minutes. No order, stock, message, or charge changed.')
       requestAnimationFrame(() => {
         confirmationRef.current?.scrollIntoView({ block: 'center' })
         confirmationRef.current?.focus({ preventScroll: true })
@@ -331,7 +345,7 @@ export function EcommerceBuyingWorkspace({
             </label>
             <label>
               <span>Receive order</span>
-              <select onChange={(event) => { setFulfilment(event.target.value as EcommerceFulfilment); setHandoffConfirmed(false) }} value={fulfilment}>
+              <select onChange={(event) => changeFulfilment(event.target.value as EcommerceFulfilment)} value={fulfilment}>
                 <option value="pickup">Pickup · included</option>
                 <option value="delivery">Delivery · Shop confirms</option>
               </select>
@@ -339,8 +353,9 @@ export function EcommerceBuyingWorkspace({
             <label>
               <span>Payment</span>
               <select onChange={(event) => { setPaymentAdapter(event.target.value as EcommercePaymentAdapter); setHandoffConfirmed(false) }} value={paymentAdapter}>
-                <option value="pay_on_pickup">Pay on pickup</option>
-                <option value="cash_on_delivery">Cash on delivery</option>
+                {fulfilment === 'pickup'
+                  ? <option value="pay_on_pickup">Pay on pickup</option>
+                  : <option value="cash_on_delivery">Cash on delivery</option>}
                 <option value="kbzpay_manual">KBZPay · manual confirmation</option>
               </select>
             </label>
@@ -356,17 +371,17 @@ export function EcommerceBuyingWorkspace({
           {latestRequest ? (
             <article className="ecommerce-request-receipt ecommerce-quote-receipt" data-current={quoteCurrent ? 'true' : 'false'}>
               <span className="status-pill bounded">{quoteCurrent ? 'Ready for Shop' : 'Review again'}</span>
-              <strong>{latestRequest.id}</strong>
+              <strong>Quote for {latestRequest.customerReference}</strong>
               <b>{formatMmk(latestRequest.totalMmk)}</b>
               <div className="ecommerce-quote-boundaries">
+                <span><small>Receive order</small><b>{receiveOrderLabel(latestRequest.fulfilment)}</b></span>
                 <span><small>Tax</small><b>Included in listed price</b></span>
-                <span><small>Delivery</small><b>{latestRequest.quote.shipping.status === 'included' ? 'Included' : 'Shop confirms'}</b></span>
                 <span><small>Payment</small><b>{paymentLabel(latestRequest.quote.payment.adapter)} · not charged</b></span>
               </div>
-              <small>Valid until {new Date(latestRequest.quote.expiresAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}</small>
+              <small>Reference {latestRequest.id} · valid until {new Date(latestRequest.quote.expiresAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}</small>
               <label className="website-intake-confirm ecommerce-quote-confirm">
                 <input checked={handoffConfirmed} disabled={!quoteCurrent || handoffBusy} onChange={(event) => setHandoffConfirmed(event.target.checked)} ref={confirmationRef} type="checkbox" />
-                <span>I reviewed every item, the MMK total, delivery boundary, and payment method.</span>
+                <span>I reviewed every item, the MMK total, how I receive it, and the payment method.</span>
               </label>
               <button className="core-button primary" disabled={!quoteCurrent || !handoffConfirmed || handoffBusy} onClick={() => void openInShop()} type="button">
                 {handoffBusy ? 'Checking Shop…' : 'Open in Shop'}

--- a/showroom/src/products/ecommerce/ecommerce-buying-lifecycle.ts
+++ b/showroom/src/products/ecommerce/ecommerce-buying-lifecycle.ts
@@ -209,6 +209,14 @@ const maxLines = 20
 const maxQuantity = 99
 const maxRecords = 100
 
+export function ecommercePaymentMatchesFulfilment(
+  fulfilment: EcommerceFulfilment,
+  paymentAdapter: EcommercePaymentAdapter,
+) {
+  return paymentAdapter === 'kbzpay_manual'
+    || (fulfilment === 'pickup' ? paymentAdapter === 'pay_on_pickup' : paymentAdapter === 'cash_on_delivery')
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
 }
@@ -442,6 +450,9 @@ function quoteCore(value: unknown): Omit<EcommerceCheckoutQuote, 'quoteDigest'> 
   if (!paymentAdapters.includes(payment.adapter as EcommercePaymentAdapter)
     || payment.status !== 'not_authorized'
     || payment.amountMmk !== 0) throw new Error('Checkout payment boundary is invalid.')
+  if (!ecommercePaymentMatchesFulfilment(fulfilment, payment.adapter as EcommercePaymentAdapter)) {
+    throw new Error('Checkout payment does not match how the customer receives the order.')
+  }
   const totalMmk = safeInteger(source.totalMmk, 'checkout quote.totalMmk', 1)
   if (totalMmk !== subtotalMmk) throw new Error('Checkout total must remain the product subtotal until Shop review.')
   if (source.currency !== 'MMK') throw new Error('Checkout currency must be MMK.')
@@ -492,6 +503,9 @@ export async function buildEcommerceCheckoutQuote(input: {
   if (!checkoutKeyPattern.test(key)) throw new Error('Checkout idempotency key is invalid.')
   if (!fulfilmentMethods.includes(input.fulfilment)) throw new Error('Checkout fulfilment is unsupported.')
   if (!paymentAdapters.includes(input.paymentAdapter)) throw new Error('Checkout payment adapter is unsupported.')
+  if (!ecommercePaymentMatchesFulfilment(input.fulfilment, input.paymentAdapter)) {
+    throw new Error('Checkout payment does not match how the customer receives the order.')
+  }
   const code = optionalText(input.promotionCode, 'promotionCode', 40)
   if (!Array.isArray(input.cart) || input.cart.length < 1 || input.cart.length > maxLines) throw new Error('Cart is empty or too large.')
   const quantities = new Map<string, number>()

--- a/showroom/src/products/ecommerce/ecommerce-product.css
+++ b/showroom/src/products/ecommerce/ecommerce-product.css
@@ -370,7 +370,7 @@
 
 .ecommerce-quote-receipt {
   grid-column: 1 / -1;
-  grid-template-columns: auto minmax(0, 1fr) auto;
+  grid-template-columns: minmax(0, 1fr) auto;
   align-items: center;
   gap: 7px 10px;
 }
@@ -381,7 +381,21 @@
 }
 
 .ecommerce-quote-receipt > strong {
+  grid-column: 1 / -1;
+  grid-row: 2;
   min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.ecommerce-quote-receipt > .status-pill {
+  grid-column: 1;
+  grid-row: 1;
+  justify-self: start;
+}
+
+.ecommerce-quote-receipt > b {
+  grid-column: 2;
+  grid-row: 1;
 }
 
 .ecommerce-quote-boundaries {

--- a/supermega_runtime/ecommerce_buying_lifecycle.py
+++ b/supermega_runtime/ecommerce_buying_lifecycle.py
@@ -171,6 +171,21 @@ def ecommerce_lifecycle_digest(value: object) -> str:
     return _canonical_digest(value)
 
 
+def ecommerce_payment_matches_fulfilment(
+    fulfilment: str,
+    payment_adapter: str,
+) -> bool:
+    """Return whether a checkout payment makes sense for its handoff method."""
+
+    return (
+        fulfilment == "pickup"
+        and payment_adapter in {"pay_on_pickup", "kbzpay_manual"}
+    ) or (
+        fulfilment == "delivery"
+        and payment_adapter in {"cash_on_delivery", "kbzpay_manual"}
+    )
+
+
 def _pim_item(value: object, field: str) -> dict[str, Any]:
     source = _object(
         value,
@@ -375,6 +390,10 @@ def _quote_core(value: object) -> dict[str, Any]:
         or payment_source["amountMmk"] != 0
     ):
         raise _fail("Checkout payment boundary is invalid.")
+    if not ecommerce_payment_matches_fulfilment(
+        fulfilment, payment_source["adapter"]
+    ):
+        raise _fail("Checkout payment does not match how the customer receives the order.")
 
     total = _integer(source["totalMmk"], "checkout quote.totalMmk", minimum=1)
     if total != subtotal:
@@ -434,6 +453,8 @@ def build_ecommerce_checkout_quote(
         raise _fail("Checkout fulfilment is unsupported.")
     if payment_adapter not in _PAYMENT_ADAPTERS:
         raise _fail("Checkout payment adapter is unsupported.")
+    if not ecommerce_payment_matches_fulfilment(fulfilment, payment_adapter):
+        raise _fail("Checkout payment does not match how the customer receives the order.")
     code = _optional_text(promotion_code, "promotionCode", maximum=40)
     item_by_sku = {item["sku"]: item for item in projection["items"]}
     cart_rows = _array(list(cart), "cart", minimum=1, maximum=_MAX_LINES)

--- a/tests/test_ecommerce_buying_lifecycle.py
+++ b/tests/test_ecommerce_buying_lifecycle.py
@@ -15,6 +15,7 @@ from supermega_runtime.ecommerce_buying_lifecycle import (
     build_ecommerce_pim_projection,
     build_ecommerce_return_intent,
     create_empty_ecommerce_lifecycle_state,
+    ecommerce_payment_matches_fulfilment,
     prepare_ecommerce_shop_handoff,
     record_ecommerce_order_request,
     record_ecommerce_return_intent,
@@ -175,6 +176,25 @@ class EcommerceBuyingLifecycleTests(unittest.TestCase):
             "amountMmk": 0,
         })
         self.assertEqual(candidate["payment"]["status"], "not_authorized")
+
+    def test_payment_must_match_how_the_customer_receives_the_order(self) -> None:
+        self.assertTrue(ecommerce_payment_matches_fulfilment("pickup", "pay_on_pickup"))
+        self.assertTrue(ecommerce_payment_matches_fulfilment("delivery", "cash_on_delivery"))
+        self.assertTrue(ecommerce_payment_matches_fulfilment("pickup", "kbzpay_manual"))
+        self.assertTrue(ecommerce_payment_matches_fulfilment("delivery", "kbzpay_manual"))
+        for fulfilment, payment_adapter in (
+            ("pickup", "cash_on_delivery"),
+            ("delivery", "pay_on_pickup"),
+        ):
+            with self.subTest(fulfilment=fulfilment, payment_adapter=payment_adapter):
+                with self.assertRaisesRegex(
+                    EcommerceLifecycleValidationError,
+                    "does not match",
+                ):
+                    quote(
+                        fulfilment=fulfilment,
+                        payment_adapter=payment_adapter,
+                    )
 
     def test_quote_rejects_sold_out_unknown_duplicate_and_tampered_cart(self) -> None:
         invalid_carts = [

--- a/tools/verify_app_build.mjs
+++ b/tools/verify_app_build.mjs
@@ -631,10 +631,22 @@ if (addToCartStart < 0
   || !ecommerceBuyingUiSource.includes('onOpenManagedRequest(latestRequest.id)')
   || !ecommerceBuyingUiSource.includes("window.addEventListener('storage', refresh)")
   || !ecommerceBuyingUiSource.includes('setFreshQuoteId(request.id)')
-  || !ecommerceBuyingUiSource.includes('I reviewed every item, the MMK total, delivery boundary, and payment method.')
+  || !ecommerceBuyingUiSource.includes('function receiveOrderLabel(value: EcommerceFulfilment)')
+  || !ecommerceBuyingUiSource.includes('ecommercePaymentMatchesFulfilment(next, current)')
+  || !ecommerceBuyingUiSource.includes("next === 'delivery' ? 'cash_on_delivery' : 'pay_on_pickup'")
+  || !ecommerceBuyingUiSource.includes('Quote for {latestRequest.customerReference}')
+  || !ecommerceBuyingUiSource.includes('<small>Receive order</small>')
+  || !ecommerceBuyingUiSource.includes('Reference {latestRequest.id} · valid until')
+  || !ecommerceBuyingUiSource.includes('I reviewed every item, the MMK total, how I receive it, and the payment method.')
+  || !ecommerceBuyingUiSource.includes('This quote is saved on this device for 15 minutes.')
+  || ecommerceBuyingUiSource.includes('`${request.id} saved on this device')
+  || ecommerceBuyingUiSource.includes('<small>Delivery</small>')
   || !ecommerceBuyingUiSource.includes('Included in listed price')
   || !ecommerceBuyingUiSource.includes('Payment remains unauthorized.')
   || !ecommerceBuyingUiSource.includes('No refund starts here.')
+  || !ecommerceBuyingLifecycleSource.includes('export function ecommercePaymentMatchesFulfilment(')
+  || !ecommerceBuyingLifecycleSource.includes('Checkout payment does not match how the customer receives the order.')
+  || !commerceSource.includes("quote.payment.adapter !== 'kbzpay_manual'")
   || ['fetch(', 'XMLHttpRequest', 'navigator.sendBeacon', 'chargePayment', 'authorizePayment'].some((marker) => ecommerceBuyingUiSource.includes(marker))
   || !ecommerceCssSource.includes('.ecommerce-preview-gate')
   || !ecommerceCssSource.includes('.ecommerce-preview-gate .core-button')
@@ -645,6 +657,8 @@ if (addToCartStart < 0
   || !ecommerceCssSource.includes('min-height: 360px')
   || !ecommerceCssSource.includes('.ecommerce-cart')
   || !ecommerceCssSource.includes('.ecommerce-quote-receipt')
+  || !ecommerceCssSource.includes('.ecommerce-quote-receipt > .status-pill')
+  || !ecommerceCssSource.includes('grid-row: 2;')
   || !ecommerceCssSource.includes('.ecommerce-after-purchase')
   || !ecommerceCssSource.includes('min-height: 44px')
   || !ecommerceCssSource.includes('@media (max-width: 560px)')) fail('ecommerce_buying_action_missing_or_consequential')
@@ -676,7 +690,7 @@ if (!ecommerceConfirmSource.includes('storefrontRequestLedgerContains')
   || !ecommerceHandoffSource.includes('ecommerceShopDraftLines')
   || !ecommerceHandoffSource.includes('ecommerceShopDraftPayment')
   || !ecommerceHandoffSource.includes('ECOMMERCE:${request.id}:${request.sourcePreviewDigest}')
-  || !ecommerceBuyingUiSource.includes('I reviewed every item, the MMK total, delivery boundary, and payment method.')
+  || !ecommerceBuyingUiSource.includes('I reviewed every item, the MMK total, how I receive it, and the payment method.')
   || !ecommerceBuyingUiSource.includes('Open in Shop')
   || !ecommerceBuyingUiSource.includes('Payment remains unauthorized.')
   || !ecommerceSource.includes('state: { ecommerceShopDraft: draft }')
@@ -6675,6 +6689,28 @@ async function verifyStorefrontRuntime() {
       && buyingQuote.payment.status === 'not_authorized'
       && buyingQuote.payment.amountMmk === 0,
     'ecommerce_buying_adapter_boundary_became_consequential')
+    buyingAssert(buyingModel.ecommercePaymentMatchesFulfilment('pickup', 'pay_on_pickup')
+      && buyingModel.ecommercePaymentMatchesFulfilment('delivery', 'cash_on_delivery')
+      && buyingModel.ecommercePaymentMatchesFulfilment('pickup', 'kbzpay_manual')
+      && buyingModel.ecommercePaymentMatchesFulfilment('delivery', 'kbzpay_manual')
+      && !buyingModel.ecommercePaymentMatchesFulfilment('pickup', 'cash_on_delivery')
+      && !buyingModel.ecommercePaymentMatchesFulfilment('delivery', 'pay_on_pickup'),
+    'ecommerce_buying_payment_fulfilment_matrix_invalid')
+    let mismatchedBuyingPaymentRejected = false
+    try {
+      await buyingModel.buildEcommerceCheckoutQuote({
+        pim,
+        cart: [{ sku: 'SM-1001', quantity: 1 }],
+        customerReference: 'Delivery customer',
+        fulfilment: 'delivery',
+        paymentAdapter: 'pay_on_pickup',
+        promotionCode: null,
+        idempotencyKey: 'ECI-32345678-1234-4ABC-8ABC-1234567890AD',
+        quotedAt: '2026-07-24T09:00:00.000Z',
+        expiresAt: '2026-07-24T09:15:00.000Z',
+      })
+    } catch { mismatchedBuyingPaymentRejected = true }
+    buyingAssert(mismatchedBuyingPaymentRejected, 'ecommerce_buying_mismatched_payment_reached_quote')
     const buyingRequest = await buyingModel.buildEcommerceOrderRequestV2(buyingQuote, {
       revision: 1,
       actionId: managedPreviewProof.actionId,


### PR DESCRIPTION
## Outcome
- Replace the misleading pickup summary (`Delivery · Included`) with the actual receive-order choice.
- Put the customer and total first; keep the opaque request reference secondary and remove its duplicate notice.
- Prevent impossible payment/fulfilment combinations in the UI, TypeScript lifecycle, managed Shop validator, and Python parity runtime.
- Keep the mobile receipt compact and fully readable.

## Verification
- `npm.cmd --prefix showroom run lint`
- `python -m unittest tests.test_ecommerce_buying_lifecycle` (12 passing)
- `npm.cmd --prefix showroom run build`
- `node tools/verify_app_build.mjs` (20 Ecommerce buying runtime checks)
- `npm.cmd run app:verify`
- 390x844 guided trial: pickup/pay-on-pickup and delivery/cash-on-delivery reviewed; invalid cross-combinations unavailable; no Shop order opened.

QA used isolated browser-local sample data only. No payment, message, stock, or production order was created.