### PR TITLE
Stop HQ evidence updates from redeploying products

### DIFF
--- a/.github/workflows/supermega-public-release.yml
+++ b/.github/workflows/supermega-public-release.yml
@@ -6,7 +6,6 @@ on:
       - main
     paths:
       - CURRENT.md
-      - 'hq/**'
       - site-manifest.json
       - package.json
       - package-lock.json
@@ -38,7 +37,6 @@ on:
       - tools/verify_app_security_contract.mjs
       - tools/verify_private_trial_migrations.mjs
       - tools/verify_coordinated_release_live.mjs
-      - tools/verify_hq_contract.mjs
       - tools/verify_vercel_project_state.mjs
       - tools/test_vercel_project_state.mjs
       - tools/verify_vercel_environment_state.mjs

--- a/tools/verify_app_deploy_workflow.mjs
+++ b/tools/verify_app_deploy_workflow.mjs
@@ -140,6 +140,11 @@ requireContract('native Git deployment disabled in config', config.git?.deployme
 requireContract('deployment control files trigger coordinated release', workflow.includes('- vercel.json') && workflow.includes('- .vercelignore'))
 requireContract('retired alias control triggers coordinated release', workflow.includes('tools/verify_retired_vercel_alias_state.mjs'))
 requireContract('app and public changes trigger one release authority', workflow.includes("- 'showroom/**'") && workflow.includes('tools/create_public_vercel_output.mjs') && workflow.includes('tools/verify_coordinated_release_live.mjs'))
+requireContract('HQ-only evidence validates without redeploying unchanged products',
+  !workflow.includes("- 'hq/**'")
+  && !workflow.includes('tools/verify_hq_contract.mjs')
+  && ciWorkflow.includes("- 'hq/**'")
+  && ciWorkflow.includes("- 'tools/verify_hq_contract.mjs'"))
 requireContract('all API tests trigger and execute', workflow.includes("- 'tests/**'") && workflow.includes("python -m unittest discover -s tests -p 'test_*.py' -v"))
 requireContract('runtime package changes trigger release', workflow.includes("- 'supermega_runtime/**'"))
 requireContract('database activation controls trigger release', workflow.includes('tools/validate_supermega_database_url.py') && workflow.includes('tools/activate_supermega_database.ps1'))


### PR DESCRIPTION
## Outcome
- Keep HQ and its verifier in normal pull-request CI.
- Remove HQ-only paths from the production release trigger.
- Prevent the circular state where recording release X deploys unchanged products as release Y and immediately makes HQ stale.
- Add a static workflow contract so the boundary cannot regress.

## Verification
- `node tools/verify_app_deploy_workflow.mjs` (69 checks)
- `npm.cmd run hq:verify`
- `npm.cmd run hq:verify:live` (exact live release `f00b1e3e`)
- `npm.cmd run app:verify`

The accidental HQ-only release run was cancelled before build, deployment candidate, promotion, alias, or rollback steps. Production remained on `f00b1e3e`.