### PR TITLE
Align Website trial catalog with real download

### DIFF
--- a/site-manifest.json
+++ b/site-manifest.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": "supermega.site-context.v2",
   "contextVersion": "2026-07-27.1",
-  "catalogVersion": "2026-07-27.1",
+  "catalogVersion": "2026-07-27.2",
   "brand": {
     "name": "SuperMega",
     "domain": "supermega.dev",
@@ -246,26 +246,26 @@
       "name": "Website",
       "publicAnchor": "/#website",
       "appRoute": "https://app.supermega.dev/website/",
-      "status": "release-candidate-local",
+      "status": "available-in-app",
       "eyebrow": "Website maker",
-      "headline": "Turn an approved brief into a reviewable website.",
+      "headline": "Turn a short business brief into a usable website.",
       "workspaceSchema": "supermega.website.workspace.v2",
-      "views": ["Site", "Preview", "Publish"],
-      "workflow": ["Edit finite pages", "Review responsive preview", "Record attributed evidence", "Approve exact evidence set", "Create downloadable site file", "Optionally prepare Shop intake"],
+      "views": ["Start", "Edit", "Preview", "Download"],
+      "workflow": ["Answer a short business brief", "Edit finite pages", "Review responsive preview", "Save ready pages", "Download standalone website", "Request managed hosting when needed"],
       "templates": [
         {
           "id": "business-presence",
           "name": "Business presence",
           "outcome": "Create a clear mobile-first company website with services, proof, and one contact path.",
-          "workflow": ["Define audience", "Shape offer", "Add proof", "Review mobile", "Approve site file"],
+          "workflow": ["Define audience", "Shape offer", "Add proof", "Review mobile", "Download website"],
           "entryPoints": ["Business brief", "Existing website", "Company profile"],
-          "metric": "Qualified contact starts and content approval time"
+          "metric": "Time to first usable website download and qualified contact starts"
         },
         {
           "id": "lead-generation",
           "name": "Lead generation",
           "outcome": "Turn one offer into a focused landing experience with attributable proof and enquiry intent.",
-          "workflow": ["Choose offer", "Write promise", "Add evidence", "Review conversion path", "Approve site file"],
+          "workflow": ["Choose offer", "Write promise", "Add evidence", "Review conversion path", "Download website"],
           "entryPoints": ["Campaign brief", "Sales deck", "Service list"],
           "metric": "Qualified enquiry rate and response readiness"
         },
@@ -273,12 +273,12 @@
           "id": "catalog-showcase",
           "name": "Catalog showcase",
           "outcome": "Present a finite product or service collection and route approved interest into accountable follow-up.",
-          "workflow": ["Structure collection", "Add product proof", "Review navigation", "Test enquiry path", "Approve site file"],
+          "workflow": ["Structure collection", "Add product proof", "Review navigation", "Test enquiry path", "Download website"],
           "entryPoints": ["Catalog CSV", "Product sheet", "Existing brochure"],
           "metric": "Catalog completion and enquiry handoff accuracy"
         }
       ],
-      "proof": ["Monotonic content revision", "Source digest", "Artifact digest", "Evidence IDs", "Human approval", "Append-only events", "Confirmed browser write"],
+      "proof": ["Content revision", "Safe destination checks", "Responsive preview", "Standalone HTML export", "Confirmed browser write", "Managed approval history when connected"],
       "boundaries": ["No CMS", "No domain write", "No analytics connection", "No deployment", "No customer send", "No payment action"]
     },
     {

--- a/tools/verify_app_build.mjs
+++ b/tools/verify_app_build.mjs
@@ -1975,6 +1975,12 @@ if (coreSource.includes('>All apps</Link>')
 let workflowProfiles = 0
 const solutionProducts = manifest.customerProducts || []
 if (solutionProducts.map((product) => `${product.id}:${product.runtimeId}`).join(',') !== 'shop:commerce,plant:production,website:website,ecommerce:ecommerce') fail('canonical_four_product_order_missing')
+const websiteProductContract = solutionProducts.find((product) => product.id === 'website')
+if (websiteProductContract?.status !== 'available-in-app'
+  || websiteProductContract?.views?.join(',') !== 'Start,Edit,Preview,Download'
+  || websiteProductContract?.templates?.some((template) => template.workflow?.at(-1) !== 'Download website')
+  || manifestText.includes('Approve site file')
+  || manifestText.includes('content approval time')) fail('website_trial_catalog_not_aligned_with_download_outcome')
 for (const product of solutionProducts) {
   if (product.templates?.length !== 3) fail(`wrong_template_count:${product.id}`)
   for (const template of product.templates || []) {

--- a/tools/verify_public_vercel_output.mjs
+++ b/tools/verify_public_vercel_output.mjs
@@ -38,7 +38,11 @@ if (manifest.customerProducts?.map((product) => product.appRoute).join(',') !== 
 const operatingProducts = manifest.customerProducts?.filter((product) => product.kind === 'operating-product') || []
 const makerProducts = manifest.customerProducts?.filter((product) => product.kind === 'maker-product') || []
 if (operatingProducts.map((product) => product.id).join(',') !== 'shop,plant') fail('operating_product_portfolio_drift')
-if (makerProducts.map((product) => `${product.id}:${product.status}`).join(',') !== 'website:release-candidate-local,ecommerce:release-candidate-local') fail('maker_product_portfolio_drift')
+if (makerProducts.map((product) => `${product.id}:${product.status}`).join(',') !== 'website:available-in-app,ecommerce:release-candidate-local') fail('maker_product_portfolio_drift')
+const website = manifest.customerProducts?.find((product) => product.id === 'website')
+if (website?.views?.join(',') !== 'Start,Edit,Preview,Download'
+  || website?.templates?.some((template) => template.workflow?.at(-1) !== 'Download website')
+  || website?.headline !== 'Turn a short business brief into a usable website.') fail('website_download_trial_contract_drift')
 const ecommerce = manifest.customerProducts?.find((product) => product.id === 'ecommerce')
 if (ecommerce?.views?.join(',') !== 'Storefront,Preview,Request receipt,Shop inbox,Shop review'
   || !ecommerce?.proof?.includes('Idempotent receipt and exact managed replay')


### PR DESCRIPTION
## Outcome
- replaces stale Website setup promises about site-file approval with the actual download outcome
- marks the proven Website trial available in the app
- aligns public Website headline, views, workflow, proof, and success metric
- bumps the product catalog identity to 2026-07-27.2

## Verification
- production Website mobile journey exposed the stale copy
- full app:verify
- production showroom build
- public:prebuilt including contact behavior and Vercel contracts