### PR TITLE
Refresh HQ live release evidence

### DIFF
--- a/hq/NOW.md
+++ b/hq/NOW.md
@@ -4,8 +4,8 @@ Updated: 2026-07-27
 Owner: founder / CEO
 Mode: Codex-only guarded production release; managed operation remains isolated
 Live state contract: `supermega.hq-live-state.v1`
-Live release commit: `e18fc6bc8f392e398dfb89a8efa152b69ac8550d`
-Live state observed: `2026-07-27T18:17:54Z`
+Live release commit: `1a1c7ae42f86f9ceb0a0c5377549ceec23977e69`
+Live state observed: `2026-07-27T18:45:45Z`
 Live operating mode: `isolated_demo`
 Live scheduler status: `degraded`
 Live scheduler configured: `false`


### PR DESCRIPTION
## What changed

Updates the HQ live release snapshot to the independently verified production commit `1a1c7ae42f86f9ceb0a0c5377549ceec23977e69` and its observation time.

## Why

The coordinated release and both live-domain verifiers passed, but the fail-closed HQ contract correctly rejected its previous release pointer as stale.

## Validation

- `npm run hq:verify`
- `npm run hq:verify:live`
- `npm run app:verify:live`
- `npm run public:verify:live`

This is evidence-only. It changes no product artifact, hosted runtime, database, scheduler, domain, or customer data.