### PR TITLE
Align live verifier with trial copy

### DIFF
--- a/tools/verify_app_release_live.mjs
+++ b/tools/verify_app_release_live.mjs
@@ -97,7 +97,7 @@ const rootHtml = pages.get('/')
 const scriptPaths = [...rootHtml.matchAll(/<script[^>]+src="([^"]+)"/g)].map((match) => match[1])
 const cssPaths = [...rootHtml.matchAll(/<link[^>]+href="([^"]+\.css)"/g)].map((match) => match[1])
 const assetCorpus = (await Promise.all([...scriptPaths, ...cssPaths].map(async (path) => (await get(path)).body))).join('\n')
-for (const required of ['SUPERMEGA', 'Start with one product.', 'Start guided sample', 'Request workspace', 'Shop', 'Plant', 'Website', 'Ecommerce', 'Sample workspace', manifest.brand.colors.accent, manifest.brand.colors.ink]) {
+for (const required of ['SUPERMEGA', 'Start with one product.', 'Start guided sample', 'Request managed trial', 'Shop', 'Plant', 'Website', 'Ecommerce', 'Sample workspace', manifest.brand.colors.accent, manifest.brand.colors.ink]) {
   if (!assetCorpus.includes(required)) throw new Error(`missing_live_context:${required}`)
 }
 for (const forbidden of ['SuperMega HQ', 'One next action for the company', 'Agents prepare work', 'pos.supermega.dev', 'ytf.supermega.dev', 'Yangon Tyre', 'ytf-plant-a']) {


### PR DESCRIPTION
## Root cause
Coordinated release run 30296798514 built and deployed a healthy candidate, then failed closed because `verify_app_release_live.mjs` still required the removed copy `Request workspace`.

## Fix
Require the retained, truthful `Request managed trial` copy, matching the build contract and current interface.

## Verification
- `node --check tools/verify_app_release_live.mjs`
- `node tools/verify_app_deploy_workflow.mjs` (69 checks)
- `npm run app:verify`

## Safety
The failed run stopped before promotion. This patch changes only release verification text and does not alter runtime behavior or persistence mode.