### PR TITLE
Bind managed requests to trial proof

### DIFF
--- a/showroom/src/core/CoreApp.tsx
+++ b/showroom/src/core/CoreApp.tsx
@@ -29,6 +29,7 @@ import {
   type ManagedStateRecord,
 } from './managed-trial'
 import { recordBehaviorSignal, type BehaviorProductId } from './behavior-trail'
+import { managedTrialProofFragmentFields, type ManagedTrialProof } from './managed-trial-proof'
 import { formatTime, teamDefinitions, useTeamWorkspace } from './team-work'
 import {
   advanceCommerceOrder,
@@ -550,6 +551,7 @@ export function clientSetupPath(product: SetupProductId) {
 export type ManagedTrialRequestPrefill = {
   company?: string
   goal?: string
+  proof?: ManagedTrialProof
 }
 
 export function managedTrialRequestUrl(product: SetupProductId, templateId: string, prefill?: ManagedTrialRequestPrefill) {
@@ -564,6 +566,11 @@ export function managedTrialRequestUrl(product: SetupProductId, templateId: stri
   const goal = prefill?.goal?.trim().slice(0, 4_000)
   if (company) fragment.set('company', company)
   if (goal) fragment.set('goal', goal)
+  if (prefill?.proof) {
+    for (const [name, value] of managedTrialProofFragmentFields(prefill.proof, productContracts[product].slug, templateId)) {
+      fragment.set(name, value)
+    }
+  }
   const handoff = fragment.toString()
   return `https://supermega.dev/contact/?${query.toString()}${handoff ? `#${handoff}` : ''}`
 }

--- a/showroom/src/core/SettingsPage.tsx
+++ b/showroom/src/core/SettingsPage.tsx
@@ -74,6 +74,7 @@ import {
 } from '../products/ecommerce/ecommerce-order-review-packet'
 import { LEGACY_PRODUCTION_KEYS, PRODUCTION_KEY } from './production-workspace'
 import { formatTime, LEGACY_TEAM_WORK_KEYS, TEAM_WORK_KEY, useTeamWorkspace } from './team-work'
+import { buildManagedTrialProof } from './managed-trial-proof'
 
 const ClientDataOnboarding = lazy(() => import('./ClientDataOnboarding').then((module) => ({ default: module.ClientDataOnboarding })))
 const ManagedActivationRunbook = lazy(() => import('./ManagedActivationRunbook').then((module) => ({ default: module.ManagedActivationRunbook })))
@@ -742,6 +743,14 @@ export function SettingsPage() {
       setup.currentRecord ? `Current: ${setup.currentRecord}` : '',
       setup.targetOutcome ? `Target: ${setup.targetOutcome}` : '',
     ].filter(Boolean).join('\n'),
+    proof: buildManagedTrialProof({
+      product: selectedProduct.slug,
+      templateId: selectedTemplate.id,
+      readinessScore: aiMemoryReadinessScore,
+      sourceRecordCount: aiMemorySourceRecordCount,
+      behaviorSignalCount: agentBehaviorSignals.length,
+      reviewedDecisionCount: managedApprovalRequests.length || approvals.length,
+    }),
   }
   const premiumPilotProofKept = managedPilotRetained || managedPilotBrief?.retention === 'persisted_managed_audit'
   const premiumPilotRows = [

--- a/showroom/src/core/managed-trial-proof.ts
+++ b/showroom/src/core/managed-trial-proof.ts
@@ -1,0 +1,168 @@
+export const MANAGED_TRIAL_PROOF_CONTRACT = 'supermega.managed_trial_proof.v1'
+
+const MANAGED_TRIAL_PROOF_VERSION = 1
+const DIGEST_PATTERN = /^sha256:[0-9a-f]{64}$/
+const PRODUCT_PATTERN = /^(shop|plant|website|ecommerce)$/
+const TEMPLATE_PATTERN = /^[a-z0-9][a-z0-9._-]{0,119}$/
+const MAX_COUNT = 1_000_000
+
+export type ManagedTrialProof = {
+  contract: typeof MANAGED_TRIAL_PROOF_CONTRACT
+  version: typeof MANAGED_TRIAL_PROOF_VERSION
+  summaryDigest: string
+  readinessScore: number
+  sourceRecordCount: number
+  behaviorSignalCount: number
+  reviewedDecisionCount: number
+  product: string
+  templateId: string
+  rawRecordsIncluded: false
+}
+
+export type ManagedTrialProofInput = Omit<ManagedTrialProof, 'contract' | 'version' | 'summaryDigest' | 'rawRecordsIncluded'>
+
+function boundedInteger(value: number, max: number, field: string) {
+  if (!Number.isSafeInteger(value) || value < 0 || value > max) throw new Error(`${field} is outside the trial proof boundary.`)
+  return value
+}
+
+function normalizedIdentity(value: string, pattern: RegExp, field: string) {
+  const normalized = value.trim().toLowerCase()
+  if (!pattern.test(normalized)) throw new Error(`${field} is invalid for trial proof.`)
+  return normalized
+}
+
+export function managedTrialProofProjection(input: ManagedTrialProofInput) {
+  const product = normalizedIdentity(input.product, PRODUCT_PATTERN, 'Product')
+  const templateId = normalizedIdentity(input.templateId, TEMPLATE_PATTERN, 'Template')
+  const readinessScore = boundedInteger(input.readinessScore, 100, 'Readiness score')
+  const sourceRecordCount = boundedInteger(input.sourceRecordCount, MAX_COUNT, 'Source record count')
+  const behaviorSignalCount = boundedInteger(input.behaviorSignalCount, MAX_COUNT, 'Behavior signal count')
+  const reviewedDecisionCount = boundedInteger(input.reviewedDecisionCount, MAX_COUNT, 'Reviewed decision count')
+  return [
+    MANAGED_TRIAL_PROOF_CONTRACT,
+    MANAGED_TRIAL_PROOF_VERSION,
+    product,
+    templateId,
+    readinessScore,
+    sourceRecordCount,
+    behaviorSignalCount,
+    reviewedDecisionCount,
+    false,
+  ] as const
+}
+
+function rotateRight(value: number, bits: number) {
+  return (value >>> bits) | (value << (32 - bits))
+}
+
+const sha256RoundConstants = new Uint32Array([
+  0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
+  0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
+  0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+  0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
+  0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
+  0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+  0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+  0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2,
+])
+
+function sha256Hex(source: string) {
+  const input = new TextEncoder().encode(source)
+  const paddedLength = Math.ceil((input.length + 9) / 64) * 64
+  const padded = new Uint8Array(paddedLength)
+  padded.set(input)
+  padded[input.length] = 0x80
+  const view = new DataView(padded.buffer)
+  const bitLength = BigInt(input.length) * 8n
+  view.setUint32(paddedLength - 8, Number(bitLength >> 32n), false)
+  view.setUint32(paddedLength - 4, Number(bitLength & 0xffffffffn), false)
+  const hash = new Uint32Array([0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19])
+  const words = new Uint32Array(64)
+  for (let offset = 0; offset < paddedLength; offset += 64) {
+    for (let index = 0; index < 16; index += 1) words[index] = view.getUint32(offset + index * 4, false)
+    for (let index = 16; index < 64; index += 1) {
+      const before15 = words[index - 15]
+      const before2 = words[index - 2]
+      const sigma0 = rotateRight(before15, 7) ^ rotateRight(before15, 18) ^ (before15 >>> 3)
+      const sigma1 = rotateRight(before2, 17) ^ rotateRight(before2, 19) ^ (before2 >>> 10)
+      words[index] = (words[index - 16] + sigma0 + words[index - 7] + sigma1) >>> 0
+    }
+    let [a, b, c, d, e, f, g, h] = hash
+    for (let index = 0; index < 64; index += 1) {
+      const sum1 = rotateRight(e, 6) ^ rotateRight(e, 11) ^ rotateRight(e, 25)
+      const choice = (e & f) ^ (~e & g)
+      const temporary1 = (h + sum1 + choice + sha256RoundConstants[index] + words[index]) >>> 0
+      const sum0 = rotateRight(a, 2) ^ rotateRight(a, 13) ^ rotateRight(a, 22)
+      const majority = (a & b) ^ (a & c) ^ (b & c)
+      const temporary2 = (sum0 + majority) >>> 0
+      h = g
+      g = f
+      f = e
+      e = (d + temporary1) >>> 0
+      d = c
+      c = b
+      b = a
+      a = (temporary1 + temporary2) >>> 0
+    }
+    hash[0] = (hash[0] + a) >>> 0
+    hash[1] = (hash[1] + b) >>> 0
+    hash[2] = (hash[2] + c) >>> 0
+    hash[3] = (hash[3] + d) >>> 0
+    hash[4] = (hash[4] + e) >>> 0
+    hash[5] = (hash[5] + f) >>> 0
+    hash[6] = (hash[6] + g) >>> 0
+    hash[7] = (hash[7] + h) >>> 0
+  }
+  return Array.from(hash, (word) => word.toString(16).padStart(8, '0')).join('')
+}
+
+export function buildManagedTrialProof(input: ManagedTrialProofInput): ManagedTrialProof {
+  const projection = managedTrialProofProjection(input)
+  return {
+    contract: MANAGED_TRIAL_PROOF_CONTRACT,
+    version: MANAGED_TRIAL_PROOF_VERSION,
+    product: projection[2],
+    templateId: projection[3],
+    readinessScore: projection[4],
+    sourceRecordCount: projection[5],
+    behaviorSignalCount: projection[6],
+    reviewedDecisionCount: projection[7],
+    rawRecordsIncluded: false,
+    summaryDigest: `sha256:${sha256Hex(JSON.stringify(projection))}`,
+  }
+}
+
+export function managedTrialProofFragmentFields(proof: ManagedTrialProof, product: string, templateId: string) {
+  try {
+    const expected = buildManagedTrialProof({
+      product,
+      templateId,
+      readinessScore: proof.readinessScore,
+      sourceRecordCount: proof.sourceRecordCount,
+      behaviorSignalCount: proof.behaviorSignalCount,
+      reviewedDecisionCount: proof.reviewedDecisionCount,
+    })
+    if (proof.contract !== expected.contract
+      || proof.version !== expected.version
+      || proof.product !== expected.product
+      || proof.templateId !== expected.templateId
+      || proof.rawRecordsIncluded !== false
+      || !DIGEST_PATTERN.test(proof.summaryDigest)
+      || proof.summaryDigest !== expected.summaryDigest) return []
+    return [
+      ['proof_contract', proof.contract],
+      ['proof_version', String(proof.version)],
+      ['proof_digest', proof.summaryDigest],
+      ['proof_product', proof.product],
+      ['proof_template', proof.templateId],
+      ['proof_readiness', String(proof.readinessScore)],
+      ['proof_sources', String(proof.sourceRecordCount)],
+      ['proof_behavior', String(proof.behaviorSignalCount)],
+      ['proof_decisions', String(proof.reviewedDecisionCount)],
+      ['proof_raw_records', 'false'],
+    ] as const
+  } catch {
+    return []
+  }
+}

--- a/tools/create_public_vercel_output.mjs
+++ b/tools/create_public_vercel_output.mjs
@@ -1,4 +1,5 @@
 import { execFile } from 'node:child_process'
+import { createHash } from 'node:crypto'
 import { mkdir, readFile, rm, writeFile } from 'node:fs/promises'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -193,6 +194,14 @@ const sharedStyle = `
   .contact-layout { display: grid; grid-template-columns: minmax(0,.78fr) minmax(430px,1.22fr); gap: 76px; align-items: start; padding-bottom: 110px; }
   .contact-copy { padding-top: 24px; }
   .contact-copy p { color: var(--muted); font-size: 18px; }
+  .trial-proof-summary { margin-top: 34px; padding: 24px 0; border-block: 1px solid var(--line); }
+  .trial-proof-summary[hidden] { display: none; }
+  .trial-proof-summary h3 { margin-top: 8px; }
+  .trial-proof-summary > p { font-size: 14px; }
+  .trial-proof-metrics { display: grid; grid-template-columns: repeat(2,minmax(0,1fr)); gap: 1px; margin: 22px 0 0; background: var(--line); }
+  .trial-proof-metrics div { min-width: 0; padding: 14px; background: var(--background); }
+  .trial-proof-metrics dt { color: var(--quiet); font-size: 11px; font-weight: 700; text-transform: uppercase; }
+  .trial-proof-metrics dd { margin: 4px 0 0; color: var(--ink); font-size: 18px; font-weight: 800; }
   .direct-links { display: grid; margin-top: 34px; border-top: 1px solid var(--line); }
   .direct-links a { min-height: 55px; display: flex; align-items: center; justify-content: space-between; gap: 16px; border-bottom: 1px solid var(--line); color: var(--muted); text-decoration: none; }
   .direct-links a:hover { color: var(--ink); }
@@ -205,6 +214,7 @@ const sharedStyle = `
   textarea { min-height: 150px; resize: vertical; }
   .form-note, .form-status { margin: 0; color: var(--quiet); font-size: 12px; }
   .form-status { min-height: 1.5em; color: var(--green); }
+  .contact-honeypot { position: absolute; left: -9999px; }
   .prose { max-width: 820px; padding-bottom: 100px; }
   .prose section { display: grid; grid-template-columns: 220px 1fr; gap: 42px; border-top: 1px solid var(--line); padding: 30px 0; }
   .prose p { color: var(--muted); }
@@ -343,20 +353,79 @@ const homeHtml = documentHtml({
   </main>`,
 })
 
-const contactScript = `<script>(function(){var form=document.querySelector('[data-contact-form]');if(!form)return;var query=new URLSearchParams(location.search),handoff=new URLSearchParams(location.hash.slice(1)),status=form.querySelector('[data-form-status]'),submit=form.querySelector('button[type="submit"]'),product=form.querySelector('[name="product"]'),template=form.querySelector('[name="template"]'),company=form.querySelector('[name="company"]'),goal=form.querySelector('[name="goal"]'),heading=document.querySelector('[data-contact-heading]'),lede=document.querySelector('[data-contact-lede]'),copyHeading=document.querySelector('[data-contact-copy-heading]'),copy=document.querySelector('[data-contact-copy]'),requestKey=form.querySelector('[name="idempotency_key"]'),source=form.querySelector('[name="source_url"]'),referrer=form.querySelector('[name="referrer"]');function newKey(){if(window.crypto&&crypto.randomUUID)return crypto.randomUUID();var bytes=new Uint8Array(24);crypto.getRandomValues(bytes);return Array.from(bytes,function(value){return value.toString(16).padStart(2,'0')}).join('')}if(query.get('product')&&product)product.value=query.get('product');if(query.get('template')&&template)template.value=query.get('template');if(handoff.get('company')&&company)company.value=handoff.get('company').slice(0,180);if(handoff.get('goal')&&goal)goal.value=handoff.get('goal').slice(0,4000);if(handoff.toString()){var productName=product&&product.selectedOptions.length?product.selectedOptions[0].textContent:'managed AI';if(heading)heading.textContent='Finish your '+productName+' request.';if(lede)lede.textContent='Your company and goal are already filled. Add your name and reply email, review the request, then send it.';if(copyHeading)copyHeading.textContent='Your setup is ready.';if(copy)copy.textContent='Only this summary moves forward. No raw product records, account connection, automation, or external action begins from this form.';status.textContent='Company and goal are ready for review from your AI memory.';history.replaceState(null,'',location.pathname+location.search)}form.addEventListener('submit',async function(event){event.preventDefault();status.textContent='Sending...';submit.disabled=true;if(!requestKey.value)requestKey.value=newKey();source.value=location.href;referrer.value=document.referrer||'';var payload=Object.fromEntries(new FormData(form).entries());try{var response=await fetch('/api/contact-submissions',{method:'POST',headers:{'content-type':'application/json','accept':'application/json','x-idempotency-key':requestKey.value},body:JSON.stringify(payload)});var body=await response.json().catch(function(){return {};});if(!response.ok)throw new Error(body.reason||'send_failed');form.reset();requestKey.value='';status.textContent='Request received. We will reply with the clearest next step.';}catch(error){status.textContent=error&&error.message==='rate_limited'?'Too many requests from this connection. Please wait ten minutes and try again.':'Could not route the request here. Please wait and try again.';}finally{submit.disabled=false;}});})();</script>`
+const contactScript = `<script>(function(){
+  var form=document.querySelector('[data-contact-form]');if(!form)return;
+  var query=new URLSearchParams(location.search),handoff=new URLSearchParams(location.hash.slice(1)),status=form.querySelector('[data-form-status]'),submit=form.querySelector('button[type="submit"]'),product=form.querySelector('[name="product"]'),template=form.querySelector('[name="template"]'),company=form.querySelector('[name="company"]'),goal=form.querySelector('[name="goal"]'),heading=document.querySelector('[data-contact-heading]'),lede=document.querySelector('[data-contact-lede]'),copyHeading=document.querySelector('[data-contact-copy-heading]'),copy=document.querySelector('[data-contact-copy]'),requestKey=form.querySelector('[name="idempotency_key"]'),source=form.querySelector('[name="source_url"]'),referrer=form.querySelector('[name="referrer"]'),proofSummary=document.querySelector('[data-trial-proof]');
+  var proofNames=['proof_contract','proof_version','proof_digest','proof_product','proof_template','proof_readiness','proof_sources','proof_behavior','proof_decisions','proof_raw_records'];
+  function newKey(){if(window.crypto&&crypto.randomUUID)return crypto.randomUUID();var bytes=new Uint8Array(24);crypto.getRandomValues(bytes);return Array.from(bytes,function(value){return value.toString(16).padStart(2,'0')}).join('')}
+  function boundedInteger(value,max){return /^(?:0|[1-9][0-9]{0,6})$/.test(value)&&Number(value)<=max}
+  function readProof(){
+    var values=Object.fromEntries(proofNames.map(function(name){return [name,handoff.get(name)||'']}));
+    var attempted=proofNames.some(function(name){return values[name]});
+    if(!attempted)return {attempted:false,proof:null};
+    var valid=values.proof_contract==='supermega.managed_trial_proof.v1'&&values.proof_version==='1'&&/^sha256:[0-9a-f]{64}$/.test(values.proof_digest)&&/^(shop|plant|website|ecommerce)$/.test(values.proof_product)&&/^[a-z0-9][a-z0-9._-]{0,119}$/.test(values.proof_template)&&boundedInteger(values.proof_readiness,100)&&boundedInteger(values.proof_sources,1000000)&&boundedInteger(values.proof_behavior,1000000)&&boundedInteger(values.proof_decisions,1000000)&&values.proof_raw_records==='false'&&values.proof_product===(query.get('product')||'')&&values.proof_template===(query.get('template')||'');
+    return {attempted:true,proof:valid?values:null};
+  }
+  if(query.get('product')&&product)product.value=query.get('product');
+  if(query.get('template')&&template)template.value=query.get('template');
+  if(handoff.get('company')&&company)company.value=handoff.get('company').slice(0,180);
+  if(handoff.get('goal')&&goal)goal.value=handoff.get('goal').slice(0,4000);
+  var proofResult=readProof(),proof=proofResult.proof;
+  if(proof){
+    proofNames.forEach(function(name){var input=form.querySelector('[name="'+name+'"]');if(input)input.value=proof[name]});
+    if(proofSummary){proofSummary.hidden=false;proofSummary.querySelector('[data-proof-readiness]').textContent=proof.proof_readiness+'%';proofSummary.querySelector('[data-proof-sources]').textContent=proof.proof_sources;proofSummary.querySelector('[data-proof-behavior]').textContent=proof.proof_behavior;proofSummary.querySelector('[data-proof-decisions]').textContent=proof.proof_decisions;}
+  }
+  function detachProofIfChanged(){
+    if(!proof)return;
+    if(proof.proof_product===(product&&product.value||'')&&proof.proof_template===(template&&template.value.trim().toLowerCase()||''))return;
+    proof=null;proofNames.forEach(function(name){var input=form.querySelector('[name="'+name+'"]');if(input)input.value=''});if(proofSummary)proofSummary.hidden=true;
+    if(copyHeading)copyHeading.textContent='Your setup is ready.';if(copy)copy.textContent='Only the company and goal remain attached. The trial summary was removed because the product or template changed.';status.textContent='Trial summary detached. Review the updated request before sending.';
+  }
+  if(product)product.addEventListener('change',detachProofIfChanged);
+  if(template)template.addEventListener('input',detachProofIfChanged);
+  if(handoff.toString()){
+    var productName=product&&product.selectedOptions.length?product.selectedOptions[0].textContent:'managed AI';
+    if(heading)heading.textContent='Finish your '+productName+' request.';
+    if(lede)lede.textContent='Your company and goal are already filled. Add your name and reply email, review the request, then send it.';
+    if(copyHeading)copyHeading.textContent=proof?'Your trial proof is attached.':'Your setup is ready.';
+    if(copy)copy.textContent=proof?'Readiness, source count, behavior count, and reviewed decisions move forward. Raw records, questions, approval contents, and account details stay out.':'Only this summary moves forward. No raw product records, account connection, automation, or external action begins from this form.';
+    status.textContent=proof?'Trial summary attached for review. Nothing has been sent.':proofResult.attempted?'Company and goal are ready. Trial proof was not attached because it did not match this request.':'Company and goal are ready for review from your AI memory.';
+    history.replaceState(null,'',location.pathname+location.search);
+  }
+  form.addEventListener('submit',async function(event){
+    event.preventDefault();status.textContent='Sending...';submit.disabled=true;if(!requestKey.value)requestKey.value=newKey();source.value=location.href;referrer.value=document.referrer||'';
+    var payload=Object.fromEntries(new FormData(form).entries());
+    try{
+      var response=await fetch('/api/contact-submissions',{method:'POST',headers:{'content-type':'application/json','accept':'application/json','x-idempotency-key':requestKey.value},body:JSON.stringify(payload)});
+      var body=await response.json().catch(function(){return {}});if(!response.ok)throw new Error(body.reason||'send_failed');form.reset();requestKey.value='';status.textContent='Request received: '+(body.request_id||'confirmed')+'. Keep this ID for follow-up.';
+    }catch(error){status.textContent=error&&error.message==='rate_limited'?'Too many requests from this connection. Please wait ten minutes and try again.':error&&error.message==='trial_proof_invalid'?'The attached trial summary changed or does not match this request. Open the request again from SuperMega.':'Could not route the request here. Please wait and try again.';}finally{submit.disabled=false;}
+  });
+})();</script>`
+
+const inlineDigest = (value) => createHash('sha256').update(value).digest('base64')
+const contactScriptBody = contactScript.slice('<script>'.length, -'</script>'.length)
+const publicSecurityHeaders = {
+  'content-security-policy': `default-src 'self'; base-uri 'none'; object-src 'none'; frame-ancestors 'none'; form-action 'self'; script-src 'self' 'sha256-${inlineDigest(contactScriptBody)}'; script-src-attr 'none'; style-src 'self' 'sha256-${inlineDigest(sharedStyle)}'; style-src-attr 'none'; img-src 'self' data:; font-src 'self' data:; connect-src 'self'; media-src 'none'; worker-src 'none'; manifest-src 'self'`,
+  'cross-origin-opener-policy': 'same-origin',
+  'cross-origin-resource-policy': 'same-origin',
+  'permissions-policy': 'camera=(), microphone=(), geolocation=(), payment=()',
+  'referrer-policy': 'strict-origin-when-cross-origin',
+  'x-content-type-options': 'nosniff',
+  'x-frame-options': 'DENY',
+}
 
 const contactHtml = documentHtml({
   route: '/contact/',
   title: 'Contact | SuperMega',
   description: 'Tell SuperMega which company workflow should run better.',
-  content: `<main class="frame"><section class="page-hero"><span class="eyebrow">Start a system</span><h1 data-contact-heading>What should run better?</h1><p class="lede" data-contact-lede>Describe one real workflow or recurring handoff, and note any screenshot or spreadsheet you can share. We will reply with the smallest useful system step.</p></section><section class="contact-layout"><div class="contact-copy"><h2 data-contact-copy-heading>Start with the work.</h2><p data-contact-copy>No account, data connection, automation, or external action begins from this form. We first identify the operating records, owner, acceptance test, and authority boundary.</p></div><form class="contact-form" action="/api/contact-submissions" method="post" data-contact-form><h3>Send the workflow</h3><div class="field-grid"><label>Name<input name="name" autocomplete="name" required maxlength="120" /></label><label>Reply email<input name="email" type="email" autocomplete="email" required maxlength="180" /></label><label class="wide">Company<input name="company" autocomplete="organization" required maxlength="180" /></label><label>Starting point<select name="product"><option value="guide">Help me choose</option><option value="shop">Shop</option><option value="plant">Plant</option><option value="website">Website</option><option value="ecommerce">Ecommerce</option></select></label><label>Template, if known<input name="template" maxlength="120" /></label><label class="wide">What happens now, and what should be better?<textarea name="goal" required maxlength="4000"></textarea></label></div><input type="hidden" name="source_url" /><input type="hidden" name="referrer" /><input type="hidden" name="idempotency_key" /><input name="website" tabindex="-1" autocomplete="off" aria-hidden="true" inert style="position:absolute;left:-9999px" /><button class="button primary" type="submit">Send workflow</button><p class="form-note">Your note is used only to respond and prepare the agreed next step.</p><p class="form-status" data-form-status aria-live="polite"></p></form></section></main>${contactScript}`,
+  content: `<main class="frame"><section class="page-hero"><span class="eyebrow">Start a system</span><h1 data-contact-heading>What should run better?</h1><p class="lede" data-contact-lede>Describe one real workflow or recurring handoff, and note any screenshot or spreadsheet you can share. We will reply with the smallest useful system step.</p></section><section class="contact-layout"><div class="contact-copy"><h2 data-contact-copy-heading>Start with the work.</h2><p data-contact-copy>No account, data connection, automation, or external action begins from this form. We first identify the operating records, owner, acceptance test, and authority boundary.</p><section class="trial-proof-summary" data-trial-proof hidden><span class="eyebrow">Client-provided trial proof</span><h3>Reviewed setup summary</h3><p>Attached from this browser. SuperMega checks that the summary belongs to this request after you send; it does not verify a managed account.</p><dl class="trial-proof-metrics"><div><dt>Readiness</dt><dd data-proof-readiness>0%</dd></div><div><dt>Sources</dt><dd data-proof-sources>0</dd></div><div><dt>Behavior</dt><dd data-proof-behavior>0</dd></div><div><dt>Decisions</dt><dd data-proof-decisions>0</dd></div></dl></section></div><form class="contact-form" action="/api/contact-submissions" method="post" data-contact-form><h3>Send the workflow</h3><div class="field-grid"><label>Name<input name="name" autocomplete="name" required maxlength="120" /></label><label>Reply email<input name="email" type="email" autocomplete="email" required maxlength="180" /></label><label class="wide">Company<input name="company" autocomplete="organization" required maxlength="180" /></label><label>Starting point<select name="product"><option value="guide">Help me choose</option><option value="shop">Shop</option><option value="plant">Plant</option><option value="website">Website</option><option value="ecommerce">Ecommerce</option></select></label><label>Template, if known<input name="template" maxlength="120" /></label><label class="wide">What happens now, and what should be better?<textarea name="goal" required maxlength="4000"></textarea></label></div><input type="hidden" name="source_url" /><input type="hidden" name="referrer" /><input type="hidden" name="idempotency_key" /><input type="hidden" name="proof_contract" /><input type="hidden" name="proof_version" /><input type="hidden" name="proof_digest" /><input type="hidden" name="proof_product" /><input type="hidden" name="proof_template" /><input type="hidden" name="proof_readiness" /><input type="hidden" name="proof_sources" /><input type="hidden" name="proof_behavior" /><input type="hidden" name="proof_decisions" /><input type="hidden" name="proof_raw_records" /><input class="contact-honeypot" name="website" tabindex="-1" autocomplete="off" aria-hidden="true" inert /><button class="button primary" type="submit">Send workflow</button><p class="form-note">Your note is used only to respond and prepare the agreed next step.</p><p class="form-status" data-form-status aria-live="polite"></p></form></section></main>${contactScript}`,
 })
 
 const privacyHtml = documentHtml({
   route: '/privacy/',
   title: 'Privacy | SuperMega',
   description: 'How SuperMega handles public contact requests and product implementation data.',
-  content: `<main class="frame"><section class="page-hero"><span class="eyebrow">Privacy</span><h1>Collect what the work requires. Protect the rest.</h1><p class="lede">The public site uses the details you choose to send so SuperMega can respond to your request.</p></section><div class="prose"><section><h3>Contact requests</h3><p>We receive your name, work email, company, selected product or template, request, source page, and referrer. We use them to reply, qualify the workflow, and prepare the next agreed step.</p></section><section><h3>Product data</h3><p>Sending a request does not create an account or connect a source. Product access, imports, retention, roles, and integrations are agreed separately before implementation.</p></section><section><h3>AI processing</h3><p>Governed assistance is configured only against approved sources and roles. Consequential external actions remain behind explicit approval.</p></section><section><h3>Sharing</h3><p>We do not sell contact details. Service providers are used only where needed to host, secure, communicate, or deliver the agreed system.</p></section><section><h3>Deletion</h3><p>Email <a href="mailto:swanhtet@supermega.dev">swanhtet@supermega.dev</a> to request correction or deletion of a public contact record.</p></section></div></main>`,
+  content: `<main class="frame"><section class="page-hero"><span class="eyebrow">Privacy</span><h1>Collect what the work requires. Protect the rest.</h1><p class="lede">The public site uses the details you choose to send so SuperMega can respond to your request.</p></section><div class="prose"><section><h3>Contact requests</h3><p>We receive your name, work email, company, selected product or template, request, source page, referrer, and an optional trial proof summary and digest. We use them to reply, qualify the workflow, and prepare the next agreed step.</p></section><section><h3>Product data</h3><p>Trial proof includes bounded readiness, source, behavior, and reviewed-decision counts, but no raw product records, questions, approval contents, or account details. Sending a request does not create an account or connect a source.</p></section><section><h3>AI processing</h3><p>Governed assistance is configured only against approved sources and roles. Consequential external actions remain behind explicit approval.</p></section><section><h3>Sharing</h3><p>We do not sell contact details. Service providers are used only where needed to host, secure, communicate, or deliver the agreed system.</p></section><section><h3>Deletion</h3><p>Email <a href="mailto:swanhtet@supermega.dev">swanhtet@supermega.dev</a> to request correction or deletion of a public contact record.</p></section></div></main>`,
 })
 
 const notFoundHtml = documentHtml({
@@ -393,8 +462,12 @@ const RATE_LIMIT = 5
 const RATE_WINDOW_MS = 10 * 60 * 1000
 const IDEMPOTENCY_TTL_MS = 24 * 60 * 60 * 1000
 const CACHE_LIMIT = 2000
-const CONTACT_FINGERPRINT_VERSION = 1
+const CONTACT_FINGERPRINT_CURRENT_VERSION = 2
+const CONTACT_FINGERPRINT_LEGACY_VERSION = 1
 const CONTACT_FINGERPRINT_ALGORITHM = 'sha256'
+const TRIAL_PROOF_CONTRACT = 'supermega.managed_trial_proof.v1'
+const TRIAL_PROOF_VERSION = 1
+const TRIAL_PROOF_FIELDS = ['proof_contract', 'proof_version', 'proof_digest', 'proof_product', 'proof_template', 'proof_readiness', 'proof_sources', 'proof_behavior', 'proof_decisions', 'proof_raw_records']
 const replayCache = new Map()
 const rateBuckets = new Map()
 
@@ -434,27 +507,96 @@ async function parseBody(req) {
   return Object.fromEntries(new URLSearchParams(raw))
 }
 
+function privacyUrl(value, max = 700) {
+  const source = text(value, max)
+  if (!source) return ''
+  try {
+    const parsed = new URL(source)
+    parsed.hash = ''
+    return text(parsed.toString(), max)
+  } catch {
+    return text(source.split('#')[0], max)
+  }
+}
+
+function canonicalInteger(value, max) {
+  const source = text(value, 24)
+  if (!/^(?:0|[1-9][0-9]{0,6})$/.test(source)) return null
+  const parsed = Number(source)
+  return Number.isSafeInteger(parsed) && parsed <= max ? parsed : null
+}
+
+function publicProduct(product) {
+  return product === 'commerce' ? 'shop' : product === 'production' ? 'plant' : product
+}
+
+function trialProofProjection(proof) {
+  return [proof.contract, proof.version, proof.product, proof.template, proof.readiness_score, proof.source_record_count, proof.behavior_signal_count, proof.reviewed_decision_count, false]
+}
+
+function normalizeTrialProof(payload, product, template) {
+  const attempted = TRIAL_PROOF_FIELDS.some((field) => text(payload[field], 160))
+  if (!attempted) return null
+  if (!TRIAL_PROOF_FIELDS.every((field) => text(payload[field], 160))) throw new Error('trial_proof_invalid')
+  const proof = {
+    contract: text(payload.proof_contract, 80),
+    version: canonicalInteger(payload.proof_version, 1),
+    summary_digest: text(payload.proof_digest, 80),
+    product: text(payload.proof_product, 40).toLowerCase(),
+    template: text(payload.proof_template, 120).toLowerCase(),
+    readiness_score: canonicalInteger(payload.proof_readiness, 100),
+    source_record_count: canonicalInteger(payload.proof_sources, 1000000),
+    behavior_signal_count: canonicalInteger(payload.proof_behavior, 1000000),
+    reviewed_decision_count: canonicalInteger(payload.proof_decisions, 1000000),
+    raw_records_included: false,
+    verification: 'client_provided_summary',
+  }
+  if (proof.contract !== TRIAL_PROOF_CONTRACT
+    || proof.version !== TRIAL_PROOF_VERSION
+    || !/^sha256:[0-9a-f]{64}$/.test(proof.summary_digest)
+    || !/^(shop|plant|website|ecommerce)$/.test(proof.product)
+    || !/^[a-z0-9][a-z0-9._-]{0,119}$/.test(proof.template)
+    || proof.readiness_score === null
+    || proof.source_record_count === null
+    || proof.behavior_signal_count === null
+    || proof.reviewed_decision_count === null
+    || text(payload.proof_raw_records, 20) !== 'false'
+    || proof.product !== publicProduct(product)
+    || proof.template !== template.toLowerCase()) throw new Error('trial_proof_invalid')
+  const expectedDigest = 'sha256:' + createHash('sha256').update(JSON.stringify(trialProofProjection(proof))).digest('hex')
+  if (proof.summary_digest !== expectedDigest) throw new Error('trial_proof_invalid')
+  return proof
+}
+
 function normalizePayload(payload) {
   const requestedProduct = text(payload.product, 40).toLowerCase()
   const product = requestedProduct === 'shop' ? 'commerce' : requestedProduct === 'plant' ? 'production' : requestedProduct
-  return {
+  const template = text(payload.template, 120)
+  const safe = {
     name: text(payload.name, 120),
     email: text(payload.email, 180).toLowerCase(),
     company: text(payload.company, 180),
     product: ['commerce', 'production', 'website', 'ecommerce', 'guide'].includes(product) ? product : 'guide',
-    template: text(payload.template, 120),
+    template,
     goal: text(payload.goal, 4000),
-    source_url: text(payload.source_url, 700),
-    referrer: text(payload.referrer, 700),
+    source_url: privacyUrl(payload.source_url, 700),
+    referrer: privacyUrl(payload.referrer, 700),
   }
+  return { ...safe, trial_proof: normalizeTrialProof(payload, safe.product, template) }
 }
 
 function keyedDigest(value) {
   return createHmac('sha256', idempotencySecret()).update(value).digest('hex')
 }
 
-function payloadFingerprint(safe) {
-  return createHash(CONTACT_FINGERPRINT_ALGORITHM).update('supermega.contact.payload.v1\\n' + JSON.stringify(safe)).digest('hex')
+function fingerprintVersion(safe) {
+  return safe.trial_proof ? CONTACT_FINGERPRINT_CURRENT_VERSION : CONTACT_FINGERPRINT_LEGACY_VERSION
+}
+
+function payloadFingerprint(safe, version = fingerprintVersion(safe)) {
+  const { trial_proof: _trialProof, ...legacySafe } = safe
+  const projection = version === CONTACT_FINGERPRINT_LEGACY_VERSION ? legacySafe : safe
+  return createHash(CONTACT_FINGERPRINT_ALGORITHM).update('supermega.contact.payload.v' + version + '\\n' + JSON.stringify(projection)).digest('hex')
 }
 
 function pruneCaches(now) {
@@ -517,6 +659,7 @@ function recordFrom(safe, req, idempotencyKey, fingerprint) {
   const leadId = 'LEAD-' + keyedDigest('lead:' + idempotencyKey).slice(0, 16).toUpperCase()
   const taskId = 'TASK-' + keyedDigest('task:' + idempotencyKey).slice(0, 16).toUpperCase()
   const attribution = sourceAttribution(safe.source_url)
+  const { trial_proof: trialProof, ...contactSafe } = safe
   return {
     lead_id: leadId,
     task_id: taskId,
@@ -544,10 +687,11 @@ function recordFrom(safe, req, idempotencyKey, fingerprint) {
     next_step: 'Review the workflow and reply with the smallest useful next step.',
     submitted_at: submittedAt,
     raw: {
-      ...safe,
+      ...contactSafe,
+      ...(trialProof ? { trial_proof: trialProof } : {}),
       user_agent: text(req.headers?.['user-agent'], 240),
       contact_idempotency: {
-        version: CONTACT_FINGERPRINT_VERSION,
+        version: fingerprintVersion(safe),
         algorithm: CONTACT_FINGERPRINT_ALGORITHM,
         payload_fingerprint: fingerprint,
       },
@@ -586,7 +730,7 @@ function storedFingerprint(row) {
     !marker ||
     typeof marker !== 'object' ||
     Array.isArray(marker) ||
-    marker.version !== CONTACT_FINGERPRINT_VERSION ||
+    ![CONTACT_FINGERPRINT_LEGACY_VERSION, CONTACT_FINGERPRINT_CURRENT_VERSION].includes(marker.version) ||
     marker.algorithm !== CONTACT_FINGERPRINT_ALGORITHM ||
     typeof marker.payload_fingerprint !== 'string' ||
     !/^[a-f0-9]{64}$/.test(marker.payload_fingerprint)
@@ -674,7 +818,7 @@ module.exports = async function handler(req, res) {
   const method = String(req.method || 'GET').toUpperCase()
   if (method === 'GET') {
     const accepting = configured()
-    send(res, 200, { status: accepting ? 'ready' : 'attention', service: 'supermega-contact', accepting, controls: { idempotency: 'required', edge_rate_limit: 'required' } })
+    send(res, 200, { status: accepting ? 'ready' : 'attention', service: 'supermega-contact', accepting, controls: { idempotency: 'required', edge_rate_limit: 'required', trial_proof: 'optional_client_provided' } })
     return
   }
   if (method !== 'POST') { send(res, 405, { status: 'error', reason: 'method_not_allowed' }); return }
@@ -682,7 +826,11 @@ module.exports = async function handler(req, res) {
   try { payload = await parseBody(req) } catch { send(res, 400, { status: 'error', reason: 'invalid_request' }); return }
   if (text(payload.website, 120)) { send(res, 202, { status: 'ready' }); return }
   if (!sameOrigin(req)) { send(res, 403, { status: 'error', reason: 'origin_not_allowed' }); return }
-  const safe = normalizePayload(payload)
+  let safe
+  try { safe = normalizePayload(payload) } catch (error) {
+    send(res, 400, { status: 'error', reason: error?.message === 'trial_proof_invalid' ? 'trial_proof_invalid' : 'invalid_request' })
+    return
+  }
   if (!safe.name || !safe.company || !safe.goal || !emailOk(safe.email)) { send(res, 400, { status: 'error', reason: 'required_fields_missing' }); return }
   if (!idempotencySecret()) { send(res, 503, { status: 'error', reason: 'contact_controls_unavailable', fallback_email: 'swanhtet@supermega.dev' }); return }
   const idempotencyKey = idempotencyKeyFrom(payload, req)
@@ -705,7 +853,7 @@ module.exports = async function handler(req, res) {
     send(res, 503, { status: 'error', reason: 'contact_persistence_unavailable', fallback_email: 'swanhtet@supermega.dev' })
     return
   }
-  const acceptedBody = { status: 'ready', request_id: record.lead_id }
+  const acceptedBody = { status: 'ready', request_id: record.lead_id, proof_bound: Boolean(safe.trial_proof) }
   if (storeResult.status === 'conflict') {
     send(res, 409, { status: 'error', reason: 'idempotency_conflict' })
     return
@@ -734,6 +882,7 @@ const pageFiles = new Map([
 const vercelConfig = {
   version: 3,
   routes: [
+    { src: '^/(.*)$', headers: publicSecurityHeaders, continue: true },
     { src: '^/api/contact-submissions/status/?$', dest: '/api/contact-submissions.js' },
     { src: '^/api/contact-submissions/?$', dest: '/api/contact-submissions.js' },
     { src: '^/api/health/?$', dest: '/api/health.js' },

--- a/tools/test_public_contact_function.mjs
+++ b/tools/test_public_contact_function.mjs
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict'
+import { createHash } from 'node:crypto'
 import { createRequire } from 'node:module'
 import { resolve } from 'node:path'
 
@@ -72,6 +73,30 @@ const validSubmission = {
   source_url: 'https://supermega.dev/contact/?product=production',
 }
 
+function trialProofFields({
+  product = 'plant',
+  template = 'production-control',
+  readiness = 67,
+  sources = 12,
+  behavior = 4,
+  decisions = 2,
+} = {}) {
+  const contract = 'supermega.managed_trial_proof.v1'
+  const projection = [contract, 1, product, template, readiness, sources, behavior, decisions, false]
+  return {
+    proof_contract: contract,
+    proof_version: '1',
+    proof_digest: `sha256:${createHash('sha256').update(JSON.stringify(projection)).digest('hex')}`,
+    proof_product: product,
+    proof_template: template,
+    proof_readiness: String(readiness),
+    proof_sources: String(sources),
+    proof_behavior: String(behavior),
+    proof_decisions: String(decisions),
+    proof_raw_records: 'false',
+  }
+}
+
 try {
   clearChannels()
   globalThis.fetch = async () => { throw new Error('unexpected_external_request') }
@@ -82,7 +107,7 @@ try {
     status: 'attention',
     service: 'supermega-contact',
     accepting: false,
-    controls: { idempotency: 'required', edge_rate_limit: 'required' },
+    controls: { idempotency: 'required', edge_rate_limit: 'required', trial_proof: 'optional_client_provided' },
   })
 
   process.env.SUPERMEGA_LEAD_WEBHOOK_URL = 'https://lead-router.example.test/events'
@@ -139,6 +164,7 @@ try {
   assert.equal(event.record.workflow, 'guide')
   assert.equal(event.record.email, 'operator@example.com')
   assert.equal(event.record.source, 'supermega.dev')
+  assert.equal(accepted.body.proof_bound, false)
 
   const replay = await invoke({ body: { ...validSubmission, product: 'UNRECOGNIZED' }, headers: withKey(3) })
   assert.equal(replay.status, 202)
@@ -177,6 +203,68 @@ try {
   const ecommerceEvent = JSON.parse(delivered.options.body)
   assert.equal(ecommerceEvent.record.workflow, 'ecommerce')
   assert.equal(ecommerceEvent.record.requested_package, 'social-storefront')
+
+  const attachedProof = trialProofFields()
+  const proofAccepted = await invoke({
+    body: {
+      ...validSubmission,
+      ...attachedProof,
+      source_url: `https://supermega.dev/contact/?product=plant&template=production-control#${new URLSearchParams(attachedProof)}`,
+      referrer: 'https://app.supermega.dev/settings/?product=plant#private-fragment',
+    },
+    headers: withKey(6, { 'x-forwarded-for': '203.0.113.13' }),
+  })
+  assert.equal(proofAccepted.status, 202)
+  assert.equal(proofAccepted.body.proof_bound, true)
+  const proofEvent = JSON.parse(delivered.options.body)
+  assert.equal(proofEvent.record.workflow, 'production')
+  assert.equal(proofEvent.record.source_url, 'https://supermega.dev/contact/?product=plant&template=production-control')
+  assert.equal(proofEvent.record.referrer, 'https://app.supermega.dev/settings/?product=plant')
+  assert.deepEqual(proofEvent.record.raw.trial_proof, {
+    contract: 'supermega.managed_trial_proof.v1',
+    version: 1,
+    summary_digest: attachedProof.proof_digest,
+    product: 'plant',
+    template: 'production-control',
+    readiness_score: 67,
+    source_record_count: 12,
+    behavior_signal_count: 4,
+    reviewed_decision_count: 2,
+    raw_records_included: false,
+    verification: 'client_provided_summary',
+  })
+  assert.equal(proofEvent.record.raw.contact_idempotency.version, 2)
+  assert.equal(JSON.stringify(proofEvent.record.raw).includes('private-fragment'), false)
+
+  const tamperedProof = await invoke({
+    body: { ...validSubmission, ...attachedProof, proof_sources: '13' },
+    headers: withKey(7, { 'x-forwarded-for': '203.0.113.14' }),
+  })
+  assert.equal(tamperedProof.status, 400)
+  assert.equal(tamperedProof.body.reason, 'trial_proof_invalid')
+
+  const partialProof = await invoke({
+    body: { ...validSubmission, proof_contract: attachedProof.proof_contract },
+    headers: withKey(8, { 'x-forwarded-for': '203.0.113.15' }),
+  })
+  assert.equal(partialProof.status, 400)
+  assert.equal(partialProof.body.reason, 'trial_proof_invalid')
+
+  const wrongProductProof = trialProofFields({ product: 'shop' })
+  const mismatchedProof = await invoke({
+    body: { ...validSubmission, ...wrongProductProof },
+    headers: withKey(9, { 'x-forwarded-for': '203.0.113.16' }),
+  })
+  assert.equal(mismatchedProof.status, 400)
+  assert.equal(mismatchedProof.body.reason, 'trial_proof_invalid')
+
+  const changedProofFields = trialProofFields({ sources: 13 })
+  const proofConflict = await invoke({
+    body: { ...validSubmission, ...changedProofFields },
+    headers: withKey(6, { 'x-forwarded-for': '203.0.113.17' }),
+  })
+  assert.equal(proofConflict.status, 409)
+  assert.equal(proofConflict.body.reason, 'idempotency_conflict')
 
   const rateHeaders = { 'x-forwarded-for': '203.0.113.77' }
   for (let index = 0; index < 5; index += 1) {
@@ -266,6 +354,35 @@ try {
     durableRecord.raw.contact_idempotency.payload_fingerprint,
   )
 
+  const durableProofSubmission = {
+    ...validSubmission,
+    ...trialProofFields(),
+    source_url: 'https://supermega.dev/contact/?product=plant&template=production-control#proof_digest=must-not-persist',
+  }
+  const durableProofAccepted = await invoke({
+    activeHandler: loadHandler({ fresh: true }),
+    body: durableProofSubmission,
+    headers: withKey(203, { 'x-forwarded-for': '203.0.113.96' }),
+  })
+  assert.equal(durableProofAccepted.status, 202)
+  assert.equal(durableProofAccepted.body.proof_bound, true)
+  const durableProofRecord = persistedLeads.get(durableProofAccepted.body.request_id)
+  assert.equal(durableProofRecord.raw.contact_idempotency.version, 2)
+  assert.equal(durableProofRecord.raw.trial_proof.verification, 'client_provided_summary')
+  assert.equal(durableProofRecord.raw.trial_proof.summary_digest, durableProofSubmission.proof_digest)
+  assert.equal(durableProofRecord.raw.trial_proof.raw_records_included, false)
+  assert.equal(durableProofRecord.source_url.includes('#'), false)
+
+  const durableProofReplay = await invoke({
+    activeHandler: loadHandler({ fresh: true }),
+    body: durableProofSubmission,
+    headers: withKey(203, { 'x-forwarded-for': '203.0.113.97' }),
+  })
+  assert.equal(durableProofReplay.status, 202)
+  assert.equal(durableProofReplay.body.request_id, durableProofAccepted.body.request_id)
+  assert.equal(durableProofReplay.body.proof_bound, true)
+  assert.equal(durableProofReplay.headers['x-idempotent-replay'], 'true')
+
   const legacyAccepted = await invoke({ activeHandler: loadHandler({ fresh: true }), body: validSubmission, headers: withKey(201, { 'x-forwarded-for': '203.0.113.91' }) })
   assert.equal(legacyAccepted.status, 202)
   const legacyRecord = persistedLeads.get(legacyAccepted.body.request_id)
@@ -292,7 +409,7 @@ try {
   assert.equal(ambiguousReplay.body.reason, 'contact_persistence_unavailable')
   assert.equal(unexpectedDeliveryCalls, 0)
 
-  console.log(JSON.stringify({ ok: true, contract: 'supermega_public_contact_behavior', checks: 87 }, null, 2))
+  console.log(JSON.stringify({ ok: true, contract: 'supermega_public_contact_behavior', checks: 120 }, null, 2))
 } finally {
   globalThis.fetch = originalFetch
   for (const name of environmentNames) {

--- a/tools/verify_app_build.mjs
+++ b/tools/verify_app_build.mjs
@@ -1,4 +1,5 @@
 import { readdir, readFile as readRawFile, stat } from 'node:fs/promises'
+import { createHash } from 'node:crypto'
 import { resolve } from 'node:path'
 import { pathToFileURL } from 'node:url'
 
@@ -93,6 +94,7 @@ const shopInventoryUiSource = await readFile(resolve(root, 'showroom', 'src', 'c
 const shopInventoryPythonSource = await readFile(resolve(root, 'supermega_runtime', 'shop_inventory_runtime.py'), 'utf8')
 const managedActivationRunbookSource = await readFile(resolve(root, 'showroom', 'src', 'core', 'ManagedActivationRunbook.tsx'), 'utf8')
 const settingsPageSource = await readFile(resolve(root, 'showroom', 'src', 'core', 'SettingsPage.tsx'), 'utf8')
+const managedTrialProofSource = await readFile(resolve(root, 'showroom', 'src', 'core', 'managed-trial-proof.ts'), 'utf8')
 const channelOrderUiSource = await readFile(resolve(root, 'showroom', 'src', 'core', 'ChannelOrderIntake.tsx'), 'utf8')
 const plantOrderSource = await readFile(resolve(root, 'showroom', 'src', 'core', 'plant-order-foundation.ts'), 'utf8')
 const plantOrderUiSource = await readFile(resolve(root, 'showroom', 'src', 'core', 'PlantOrderFoundation.tsx'), 'utf8')
@@ -1148,13 +1150,44 @@ if (!settingsPageSource.includes("contract: 'supermega.ai_memory_preview.v1'")
   || !coreSource.includes('export type ManagedTrialRequestPrefill = {')
   || !coreSource.includes("fragment.set('company', company)")
   || !coreSource.includes("fragment.set('goal', goal)")
+  || !coreSource.includes('managedTrialProofFragmentFields(prefill.proof, productContracts[product].slug, templateId)')
   || !settingsPageSource.includes('const managedTrialPrefill = {')
+  || !settingsPageSource.includes('proof: buildManagedTrialProof({')
+  || !settingsPageSource.includes('readinessScore: aiMemoryReadinessScore')
+  || !settingsPageSource.includes('sourceRecordCount: aiMemorySourceRecordCount')
+  || !settingsPageSource.includes('behaviorSignalCount: agentBehaviorSignals.length')
+  || !settingsPageSource.includes('reviewedDecisionCount: managedApprovalRequests.length || approvals.length')
   || !settingsPageSource.includes('managedTrialRequestUrl(setup.product, selectedTemplate.id, managedTrialPrefill)')
   || !settingsPageSource.includes('Raw product records stay out of this preview.')
   || !settingsPageSource.includes('No customer message, payment, stock move, production write, domain publish, managed write, or model training runs from this preview.')
   || !coreCssSource.includes('.ai-memory-preview')
   || !coreCssSource.includes('.ai-memory-preview-rows')
   || !coreCssSource.includes('.ai-memory-next')) fail('ai_memory_preview_missing')
+if (!managedTrialProofSource.includes("MANAGED_TRIAL_PROOF_CONTRACT = 'supermega.managed_trial_proof.v1'")
+  || !managedTrialProofSource.includes("const PRODUCT_PATTERN = /^(shop|plant|website|ecommerce)$/")
+  || !managedTrialProofSource.includes('rawRecordsIncluded: false')
+  || !managedTrialProofSource.includes('managedTrialProofProjection')
+  || !managedTrialProofSource.includes('sha256Hex(JSON.stringify(projection))')
+  || !managedTrialProofSource.includes("['proof_digest', proof.summaryDigest]")
+  || !managedTrialProofSource.includes("['proof_raw_records', 'false']")) fail('managed_trial_proof_contract_missing')
+try {
+  const proofModel = await import(`${pathToFileURL(resolve(root, 'showroom', 'src', 'core', 'managed-trial-proof.ts')).href}?verify=${Date.now()}`)
+  const input = { product: 'plant', templateId: 'production-control', readinessScore: 67, sourceRecordCount: 12, behaviorSignalCount: 4, reviewedDecisionCount: 2 }
+  const projection = ['supermega.managed_trial_proof.v1', 1, 'plant', 'production-control', 67, 12, 4, 2, false]
+  const expectedDigest = `sha256:${createHash('sha256').update(JSON.stringify(projection)).digest('hex')}`
+  const proof = proofModel.buildManagedTrialProof(input)
+  const fields = proofModel.managedTrialProofFragmentFields(proof, 'plant', 'production-control')
+  if (proof.summaryDigest !== expectedDigest
+    || proof.rawRecordsIncluded !== false
+    || fields.length !== 10
+    || !fields.some(([name, value]) => name === 'proof_digest' && value === expectedDigest)
+    || proofModel.managedTrialProofFragmentFields({ ...proof, sourceRecordCount: 13 }, 'plant', 'production-control').length !== 0) fail('managed_trial_proof_runtime_invalid')
+  let invalidCountRejected = false
+  try { proofModel.buildManagedTrialProof({ ...input, sourceRecordCount: 1_000_001 }) } catch { invalidCountRejected = true }
+  if (!invalidCountRejected) fail('managed_trial_proof_count_boundary_missing')
+} catch (error) {
+  fail(`managed_trial_proof_runtime_failed:${error instanceof Error ? error.message : String(error)}`)
+}
 if (!settingsPageSource.includes('aria-label="Premium pilot"')
   || !settingsPageSource.includes('Your business context, remembered.')
   || !settingsPageSource.includes('SuperMega combines approved product data and owner patterns, then prepares one next move for review.')

--- a/tools/verify_app_release_live.mjs
+++ b/tools/verify_app_release_live.mjs
@@ -207,6 +207,9 @@ for (const required of ['Start guided sample', 'Request managed trial', 'Your AI
 for (const required of ['supermega.ai_memory_preview.v1', 'AI memory preview', 'Download AI memory', 'Request managed AI', 'Raw product records stay out of this preview.', 'No customer message, payment, stock move, production write, domain publish, managed write, or model training runs from this preview.']) {
   if (!settingsChunk.includes(required)) throw new Error(`missing_live_ai_memory_preview_context:${required}`)
 }
+for (const required of ['supermega.managed_trial_proof.v1', 'proof_contract', 'proof_digest', 'proof_readiness', 'proof_sources', 'proof_behavior', 'proof_decisions', 'proof_raw_records']) {
+  if (!assetCorpus.includes(required)) throw new Error(`missing_live_managed_trial_proof_contract:${required}`)
+}
 for (const required of ['Premium pilot', 'Your business context, remembered.', 'SuperMega combines approved product data and owner patterns, then prepares one next move for review.', 'Owner pattern', 'Managed account', 'Approved sources', 'Pilot proof', 'Counts only; raw source records are not shown here.', 'Managed company brief', 'Reviewed next move', 'Verify this company, not a generic demo.', 'Connect and verify', 'Verify context', 'Keep pilot proof', 'Pilot proof kept in the managed audit. No external action ran.', 'Review only. No customer send, payment, stock move, production write, domain publish, or model training runs from this pilot.', 'Managed access recovery', 'Connect an existing workspace before rebuilding a local trial.', 'Recover managed access', 'Connect through Premium pilot after saving a trial.']) {
   if (!settingsChunk.includes(required)) throw new Error(`missing_live_premium_pilot_context:${required}`)
 }

--- a/tools/verify_public_release_live.mjs
+++ b/tools/verify_public_release_live.mjs
@@ -36,6 +36,18 @@ async function request(path, options = {}) {
 async function readPage(route) {
   const response = await request(route)
   assert(response.status === 200, 'page_http_error', { route, status: response.status })
+  const csp = response.headers.get('content-security-policy') || ''
+  assert(csp.includes("default-src 'self'")
+    && csp.includes("frame-ancestors 'none'")
+    && csp.includes("script-src-attr 'none'")
+    && csp.includes("style-src-attr 'none'")
+    && /script-src 'self' 'sha256-[A-Za-z0-9+/=]+'/.test(csp)
+    && /style-src 'self' 'sha256-[A-Za-z0-9+/=]+'/.test(csp)
+    && !csp.includes("'unsafe-inline'")
+    && !csp.includes("'unsafe-eval'"), 'page_csp_wrong', { route, csp })
+  for (const [name, value] of Object.entries({ 'cross-origin-opener-policy': 'same-origin', 'cross-origin-resource-policy': 'same-origin', 'permissions-policy': 'camera=(), microphone=(), geolocation=(), payment=()', 'referrer-policy': 'strict-origin-when-cross-origin', 'x-content-type-options': 'nosniff', 'x-frame-options': 'DENY' })) {
+    assert(response.headers.get(name) === value, 'page_security_header_wrong', { route, name, expected: value, actual: response.headers.get(name) })
+  }
   const html = await response.text()
   for (const token of [
     `meta name="supermega-brand-version" content="${manifest.brand.version}"`,
@@ -79,6 +91,12 @@ async function verifyOnce() {
   }
   for (const internalLabel of ['SuperMega HQ', 'One next action for the company', 'Gated R&amp;D']) assert(!pages.get('/')?.includes(internalLabel), 'internal_system_exposed', { internalLabel })
   assert(pages.get('/')?.includes('id="trust"'), 'control_boundary_missing')
+  const contactPage = pages.get('/contact/') || ''
+  for (const token of ['supermega.managed_trial_proof.v1', 'data-trial-proof', 'Client-provided trial proof', 'name="proof_digest"', 'name="proof_readiness"', 'name="proof_sources"', 'name="proof_behavior"', 'name="proof_decisions"', 'trial_proof_invalid', 'Trial summary detached.', 'Request received:']) {
+    assert(contactPage.includes(token), 'contact_trial_proof_contract_missing', { token })
+  }
+  const privacyPage = pages.get('/privacy/') || ''
+  assert(privacyPage.includes('optional trial proof summary and digest') && privacyPage.includes('no raw product records, questions, approval contents, or account details'), 'trial_proof_privacy_copy_missing')
 
   const [{ body: release, headers: releaseHeaders }, { body: health }, { body: contact }] = await Promise.all([
     readJson(manifest.release.releaseEndpoint),
@@ -95,7 +113,7 @@ async function verifyOnce() {
   assert(health.ok === true && health.status === 'ready' && health.service === 'supermega-public-site', 'health_contract_wrong', health)
   assert(health.brand_version === manifest.brand.version && health.context_version === manifest.contextVersion && health.catalog_version === manifest.catalogVersion, 'health_version_wrong', health)
   assert(contact.status === 'ready' && contact.accepting === true, 'contact_not_accepting', contact)
-  assert(contact.controls?.idempotency === 'required' && contact.controls?.edge_rate_limit === 'required', 'contact_controls_wrong', contact)
+  assert(contact.controls?.idempotency === 'required' && contact.controls?.edge_rate_limit === 'required' && contact.controls?.trial_proof === 'optional_client_provided', 'contact_controls_wrong', contact)
 
   await Promise.all([
     verifyRedirect('/products/shop/', '/#shop'),

--- a/tools/verify_public_vercel_output.mjs
+++ b/tools/verify_public_vercel_output.mjs
@@ -1,4 +1,5 @@
 import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs'
+import { createHash } from 'node:crypto'
 import { join, relative, resolve } from 'node:path'
 
 const root = process.cwd()
@@ -179,14 +180,15 @@ if (home.includes('Commerce and Production carry real records and actions.')) fa
 if ((home.match(/<a\b/g) || []).length > 8) fail('homepage_link_surface_too_large')
 
 const contact = pages.get('/contact/')?.html || ''
-for (const token of ['data-contact-form', 'action="/api/contact-submissions"', 'name="name"', 'name="email"', 'name="company"', 'name="product"', 'value="shop"', 'value="plant"', 'value="website"', 'value="ecommerce"', 'name="template"', 'name="goal"', 'name="idempotency_key"', 'name="website" tabindex="-1" autocomplete="off" aria-hidden="true" inert', 'x-idempotency-key', 'rate_limited', 'Describe one real workflow or recurring handoff, and note any screenshot or spreadsheet you can share.', '>Shop<', '>Plant<', '>Website<', '>Ecommerce<', 'No account, data connection, automation, or external action begins from this form.', 'Reply email', 'data-contact-heading', 'data-contact-lede', 'data-contact-copy-heading', 'data-contact-copy', 'location.hash.slice(1)', "handoff.get('company')", "handoff.get('goal')", "history.replaceState(null,'',location.pathname+location.search)", "heading.textContent='Finish your '+productName+' request.'", 'Your company and goal are already filled. Add your name and reply email, review the request, then send it.', 'Only this summary moves forward. No raw product records, account connection, automation, or external action begins from this form.', 'Company and goal are ready for review from your AI memory.', 'Too many requests from this connection. Please wait ten minutes and try again.', 'Could not route the request here. Please wait and try again.']) {
+for (const token of ['data-contact-form', 'action="/api/contact-submissions"', 'name="name"', 'name="email"', 'name="company"', 'name="product"', 'value="shop"', 'value="plant"', 'value="website"', 'value="ecommerce"', 'name="template"', 'name="goal"', 'name="idempotency_key"', 'name="proof_contract"', 'name="proof_version"', 'name="proof_digest"', 'name="proof_product"', 'name="proof_template"', 'name="proof_readiness"', 'name="proof_sources"', 'name="proof_behavior"', 'name="proof_decisions"', 'name="proof_raw_records"', 'class="contact-honeypot" name="website" tabindex="-1" autocomplete="off" aria-hidden="true" inert', 'x-idempotency-key', 'rate_limited', 'trial_proof_invalid', 'Describe one real workflow or recurring handoff, and note any screenshot or spreadsheet you can share.', '>Shop<', '>Plant<', '>Website<', '>Ecommerce<', 'No account, data connection, automation, or external action begins from this form.', 'Reply email', 'data-contact-heading', 'data-contact-lede', 'data-contact-copy-heading', 'data-contact-copy', 'data-trial-proof', 'Client-provided trial proof', 'Reviewed setup summary', 'it does not verify a managed account.', 'location.hash.slice(1)', "handoff.get('company')", "handoff.get('goal')", "history.replaceState(null,'',location.pathname+location.search)", "heading.textContent='Finish your '+productName+' request.'", 'Your company and goal are already filled. Add your name and reply email, review the request, then send it.', 'Only this summary moves forward. No raw product records, account connection, automation, or external action begins from this form.', 'Raw records, questions, approval contents, and account details stay out.', 'Trial summary attached for review. Nothing has been sent.', 'Trial summary detached. Review the updated request before sending.', 'Company and goal are ready for review from your AI memory.', 'Request received:', 'Keep this ID for follow-up.', 'Too many requests from this connection. Please wait ten minutes and try again.', 'Could not route the request here. Please wait and try again.']) {
   if (!contact.includes(token)) fail('contact_contract_missing', { token })
 }
 if (contact.includes('mailto:') || contact.includes('tel:') || contact.includes('Email swanhtet@supermega.dev')) fail('contact_bypass_links_returned')
 if (contact.includes('value="agents"') || contact.includes('>AI Agent Solutions<')) fail('shared_capability_listed_as_contact_product')
+if (/<[^>]+\sstyle=/.test(contact)) fail('contact_inline_style_returned')
 
 const privacy = pages.get('/privacy/')?.html || ''
-for (const token of ['Contact requests', 'Product data', 'AI processing', 'Deletion']) {
+for (const token of ['Contact requests', 'Product data', 'AI processing', 'Deletion', 'optional trial proof summary and digest', 'no raw product records, questions, approval contents, or account details']) {
   if (!privacy.includes(token)) fail('privacy_contract_missing', { token })
 }
 
@@ -223,7 +225,7 @@ for (const name of expectedFunctionNames) {
   if (functionConfig.handler !== 'index.js' || functionConfig.runtime !== 'nodejs24.x') fail('function_runtime_drift', { name, functionConfig })
 }
 const contactFunction = readFileSync(resolve(functionsDir, 'contact-submissions.js.func', 'index.js'), 'utf8')
-for (const token of ['supermega_leads', 'SUPABASE_SERVICE_ROLE_KEY', 'RESEND_API_KEY', 'TELEGRAM_BOT_TOKEN', 'SUPERMEGA_LEAD_WEBHOOK_URL', 'SUPERMEGA_CONTACT_IDEMPOTENCY_SECRET', 'required_fields_missing', 'idempotency_key_required', 'idempotency_conflict', 'rate_limited', 'resolution=ignore-duplicates,return=representation', "'idempotency-key'"]) {
+for (const token of ['supermega_leads', 'SUPABASE_SERVICE_ROLE_KEY', 'RESEND_API_KEY', 'TELEGRAM_BOT_TOKEN', 'SUPERMEGA_LEAD_WEBHOOK_URL', 'SUPERMEGA_CONTACT_IDEMPOTENCY_SECRET', 'required_fields_missing', 'idempotency_key_required', 'idempotency_conflict', 'rate_limited', 'supermega.managed_trial_proof.v1', 'trial_proof_invalid', 'client_provided_summary', 'CONTACT_FINGERPRINT_CURRENT_VERSION', 'proof_bound', 'privacyUrl', 'resolution=ignore-duplicates,return=representation', "'idempotency-key'"]) {
   if (!contactFunction.includes(token)) fail('contact_runtime_contract_missing', { token })
 }
 if (/require\(['"]pg['"]\)|DATABASE_URL|postgres/i.test(contactFunction)) fail('public_contact_has_direct_postgres_access')
@@ -231,6 +233,20 @@ if (/require\(['"]pg['"]\)|DATABASE_URL|postgres/i.test(contactFunction)) fail('
 const config = JSON.parse(readFileSync(configPath, 'utf8'))
 if (config.version !== 3 || !Array.isArray(config.routes)) fail('vercel_config_shape_invalid')
 if (config.crons) fail('public_artifact_must_not_define_crons')
+const securityRoute = config.routes.find((entry) => entry.src === '^/(.*)$' && entry.continue === true && entry.headers?.['content-security-policy'])
+if (!securityRoute) fail('public_security_header_route_missing')
+const csp = securityRoute.headers['content-security-policy']
+const styleBody = contact.match(/<style>([\s\S]*?)<\/style>/)?.[1] ?? ''
+const scriptBody = contact.match(/<script>([\s\S]*?)<\/script>/)?.[1] ?? ''
+const expectedStyleHash = `'sha256-${createHash('sha256').update(styleBody).digest('base64')}'`
+const expectedScriptHash = `'sha256-${createHash('sha256').update(scriptBody).digest('base64')}'`
+for (const token of ["default-src 'self'", "base-uri 'none'", "object-src 'none'", "frame-ancestors 'none'", "form-action 'self'", "script-src-attr 'none'", "style-src-attr 'none'", expectedStyleHash, expectedScriptHash]) {
+  if (!csp.includes(token)) fail('public_csp_contract_missing', { token })
+}
+if (csp.includes("'unsafe-inline'") || csp.includes("'unsafe-eval'")) fail('public_csp_unsafe_policy')
+for (const [name, value] of Object.entries({ 'cross-origin-opener-policy': 'same-origin', 'cross-origin-resource-policy': 'same-origin', 'permissions-policy': 'camera=(), microphone=(), geolocation=(), payment=()', 'referrer-policy': 'strict-origin-when-cross-origin', 'x-content-type-options': 'nosniff', 'x-frame-options': 'DENY' })) {
+  if (securityRoute.headers[name] !== value) fail('public_security_header_missing', { name, expected: value, actual: securityRoute.headers[name] })
+}
 for (const redirect of manifest.redirects) {
   const route = config.routes.find((entry) => entry.src === redirect.source)
   if (route?.status !== 308 || route?.headers?.Location !== redirect.destination) fail('retired_route_redirect_missing', { redirect, actual: route })


### PR DESCRIPTION
## Summary
- bind every saved-trial managed request to a deterministic, counts-only proof envelope
- validate and display the proof on the public contact page, strip the fragment, and persist it in the durable lead record
- preserve v1 contact replays while proof-bound requests use v2 fingerprinting and conflict on changed proof
- add hash-based CSP and public edge security headers

## Safety
- proof contains only product/template, readiness, source count, behavior count, reviewed-decision count, and `rawRecordsIncluded: false`
- no raw records, questions, approval contents, account/session data, customer send, payment, publish, stock, or production write
- changing product/template detaches proof before submit

## Verification
- `npm run public:prebuilt`
- `npm --prefix showroom run build`
- `npm run app:verify`
- 120 focused contact behavior checks
- Edge desktop 1365x900 and mobile 390x844 browser proof: fragment stripped, summary shown, no overflow, no console errors