### PR TITLE
Fix managed proof live release gate

### DIFF
--- a/tools/verify_app_build.mjs
+++ b/tools/verify_app_build.mjs
@@ -1170,6 +1170,8 @@ if (!managedTrialProofSource.includes("MANAGED_TRIAL_PROOF_CONTRACT = 'supermega
   || !managedTrialProofSource.includes('sha256Hex(JSON.stringify(projection))')
   || !managedTrialProofSource.includes("['proof_digest', proof.summaryDigest]")
   || !managedTrialProofSource.includes("['proof_raw_records', 'false']")) fail('managed_trial_proof_contract_missing')
+if (!appLiveVerifierSource.includes('if (!operationsChunk.includes(required)) throw new Error(`missing_live_managed_trial_proof_contract:${required}`)')
+  || appLiveVerifierSource.includes('if (!assetCorpus.includes(required)) throw new Error(`missing_live_managed_trial_proof_contract:${required}`)')) fail('managed_trial_proof_live_chunk_contract_missing')
 try {
   const proofModel = await import(`${pathToFileURL(resolve(root, 'showroom', 'src', 'core', 'managed-trial-proof.ts')).href}?verify=${Date.now()}`)
   const input = { product: 'plant', templateId: 'production-control', readinessScore: 67, sourceRecordCount: 12, behaviorSignalCount: 4, reviewedDecisionCount: 2 }

--- a/tools/verify_app_release_live.mjs
+++ b/tools/verify_app_release_live.mjs
@@ -208,7 +208,7 @@ for (const required of ['supermega.ai_memory_preview.v1', 'AI memory preview', '
   if (!settingsChunk.includes(required)) throw new Error(`missing_live_ai_memory_preview_context:${required}`)
 }
 for (const required of ['supermega.managed_trial_proof.v1', 'proof_contract', 'proof_digest', 'proof_readiness', 'proof_sources', 'proof_behavior', 'proof_decisions', 'proof_raw_records']) {
-  if (!assetCorpus.includes(required)) throw new Error(`missing_live_managed_trial_proof_contract:${required}`)
+  if (!operationsChunk.includes(required)) throw new Error(`missing_live_managed_trial_proof_contract:${required}`)
 }
 for (const required of ['Premium pilot', 'Your business context, remembered.', 'SuperMega combines approved product data and owner patterns, then prepares one next move for review.', 'Owner pattern', 'Managed account', 'Approved sources', 'Pilot proof', 'Counts only; raw source records are not shown here.', 'Managed company brief', 'Reviewed next move', 'Verify this company, not a generic demo.', 'Connect and verify', 'Verify context', 'Keep pilot proof', 'Pilot proof kept in the managed audit. No external action ran.', 'Review only. No customer send, payment, stock move, production write, domain publish, or model training runs from this pilot.', 'Managed access recovery', 'Connect an existing workspace before rebuilding a local trial.', 'Recover managed access', 'Connect through Premium pilot after saving a trial.']) {
   if (!settingsChunk.includes(required)) throw new Error(`missing_live_premium_pilot_context:${required}`)


### PR DESCRIPTION
## What changed
- verify the managed trial proof contract in the already-fetched CoreApp chunk where Vite emits it
- add a build-time regression guard against checking only initial shell assets

## Verification
- npm --prefix showroom run build
- npm run app:verify
- git diff --check

## Release context
The prior coordinated release stopped before promotion because the live verifier searched the initial asset corpus. This keeps the proof assertion intact and points it at the correct deployed chunk.