### PR TITLE
Fix minified Owner Control release verification

### DIFF
--- a/tools/verify_app_release_live.mjs
+++ b/tools/verify_app_release_live.mjs
@@ -184,7 +184,7 @@ for (const required of ['supermega.setup.v3', 'First source named', 'Acceptance 
 for (const required of ['supermega.managed_company_brief.v1', '/api/trial/v1/company-brief', '/api/trial/v1/company-brief/receipts']) {
   if (!operatingModelsChunk.includes(required)) throw new Error(`missing_live_managed_company_brief_context:${required}`)
 }
-for (const required of ['supermega.managed_owner_control_run.v1', 'supermega.managed_owner_control_retention.v1', '/api/trial/v1/owner-control', '/api/trial/v1/owner-control/acknowledgements', 'acknowledgedCount', 'expectedManagedOwnerControlRank', 'Managed Owner Control baseline digest is invalid.', 'Managed Owner Control run digest is invalid.']) {
+for (const required of ['supermega.managed_owner_control_run.v1', 'supermega.managed_owner_control_retention.v1', '/api/trial/v1/owner-control', '/api/trial/v1/owner-control/acknowledgements', 'acknowledgedCount', 'Managed Owner Control baseline digest is invalid.', 'Managed Owner Control run digest is invalid.']) {
   if (!operatingModelsChunk.includes(required)) throw new Error(`missing_live_managed_owner_control_context:${required}`)
 }
 for (const required of ['supermega.managed_context_profile_request.v1', 'supermega.managed_context_profile_validation.v1', 'supermega.managed_context_profile_retention.v1', '/api/trial/v1/managed-context/validate', '/api/trial/v1/managed-context/retain', 'rank_next_actions', 'model_training']) {


### PR DESCRIPTION
## Fix
The guarded release for #297 stopped before promotion because the live verifier required the private function name `expectedManagedOwnerControlRank`. Vite minification legitimately removes private function names.

Keep the source-level verifier for that implementation detail, while the candidate/live verifier continues to require the durable public contracts and integrity error markers that survive minification.

## Proof
- failed release 30514914451 stopped at candidate inspection before any alias promotion
- app verifier passes with 16 Owner Control runtime checks
- coordinated release workflow verifier passes 71 checks