### PR TITLE
fix: verify managed proof in shared chunk

### DIFF
--- a/tools/verify_app_build.mjs
+++ b/tools/verify_app_build.mjs
@@ -1293,7 +1293,8 @@ if (!managedTrialProofSource.includes("MANAGED_TRIAL_PROOF_CONTRACT = 'supermega
   || !managedTrialProofSource.includes("['proof_outcome_digest', proof.outcomeDigest ?? '']")
   || !managedTrialProofSource.includes("['proof_outcome_accepted', String(proof.outcomeAccepted)]")
   || !managedTrialProofSource.includes("['proof_raw_records', 'false']")) fail('managed_trial_proof_contract_missing')
-if (!appLiveVerifierSource.includes('if (!operationsChunk.includes(required)) throw new Error(`missing_live_managed_trial_proof_contract:${required}`)')
+if (!appLiveVerifierSource.includes('if (!operatingModelsChunk.includes(required)) throw new Error(`missing_live_managed_trial_proof_contract:${required}`)')
+  || appLiveVerifierSource.includes('if (!operationsChunk.includes(required)) throw new Error(`missing_live_managed_trial_proof_contract:${required}`)')
   || appLiveVerifierSource.includes('if (!assetCorpus.includes(required)) throw new Error(`missing_live_managed_trial_proof_contract:${required}`)')) fail('managed_trial_proof_live_chunk_contract_missing')
 try {
   const proofModel = await import(`${pathToFileURL(resolve(root, 'showroom', 'src', 'core', 'managed-trial-proof.ts')).href}?verify=${Date.now()}`)

--- a/tools/verify_app_release_live.mjs
+++ b/tools/verify_app_release_live.mjs
@@ -249,7 +249,7 @@ for (const required of ['Review one owner decision', 'Finish proof run', 'Start 
   if (!settingsChunk.includes(required)) throw new Error(`missing_live_managed_trial_request_gate:${required}`)
 }
 for (const required of ['supermega.managed_trial_proof.v2', 'proof_contract', 'proof_digest', 'proof_readiness', 'proof_sources', 'proof_behavior', 'proof_decisions', 'proof_outcome', 'proof_outcome_digest', 'proof_outcome_accepted', 'proof_raw_records']) {
-  if (!operationsChunk.includes(required)) throw new Error(`missing_live_managed_trial_proof_contract:${required}`)
+  if (!operatingModelsChunk.includes(required)) throw new Error(`missing_live_managed_trial_proof_contract:${required}`)
 }
 for (const required of ['supermega.pilot_outcome_report.v1', 'Free outcome proof', 'Prove one result from real', 'Start proof run', 'Accept measured result', 'Download accepted proof', 'Aggregate counts only. No raw records', 'Named-owner acceptance and its exact decision proof were saved.', 'Accept the measured', 'local://pilot-outcome/', 'no raw records or external writes were included.', 'Storefront not saved,', 'shop-guided-sale-gap', 'Guided Shop sale gap', 'owner-confirmed guided counter sale', 'Start Shop outcome proof', 'plant-guided-shift-close-gap', 'Guided Plant shift-close gap', 'named-owner Plant shift-close record', 'Start Plant shift-close proof', 'Close one shift packet with output, trace, quality, and WCM evidence.', 'One accountable shift close']) {
   if (!settingsChunk.includes(required)) throw new Error(`missing_live_pilot_outcome_contract:${required}`)


### PR DESCRIPTION
## Fix
- verify the managed trial proof contract in the explicitly loaded shared `operating-models` chunk
- retain a source verifier that rejects both the obsolete `CoreApp` assertion and a broad asset-corpus fallback

## Cause
PR #316 changed chunk ownership because Settings now consumes the Plant production model. The candidate contained the contract, but the live verifier still required it from `CoreApp`.

## Verification
- exact `npm run app:build:checked` command passed
- full app, local full-stack, workflow, security, privacy, database, Vercel contract, and HQ gates passed