### PR TITLE
Fix no-data company control first use

### DIFF
--- a/showroom/src/core/CoreShell.tsx
+++ b/showroom/src/core/CoreShell.tsx
@@ -389,7 +389,10 @@ export function ProductHomePage() {
 
   return (
     <div className="workspace-screen product-home-screen">
-      <PageHeading copy="Use a local workspace first. Activate managed data and AI when ready." eyebrow="Products" title="Choose a product. Run work." />
+      <PageHeading copy="Start from grounded local records. Managed data and AI activate only after approval." title="Company control" />
+      <Suspense fallback={<p className="form-notice" role="status">Loading company control...</p>}>
+        <ProductHomeReadiness activationCoverage={activationCoverage} hostedReady={hostedReady} nextHostedAction={nextHostedAction} progress={setup.progress} ready={setup.ready} />
+      </Suspense>
       <section className="product-home-operating-model" aria-label="SuperMega operating model">
         <div>
           <span className="core-eyebrow">Free workspace</span>
@@ -414,9 +417,6 @@ export function ProductHomePage() {
           {autopilotRows.map(([label, value, detail]) => <span key={label}><small>{label}</small><strong>{value}</strong><em>{detail}</em></span>)}
         </div>
       </section>
-      <Suspense fallback={<p className="form-notice" role="status">Loading launch readiness...</p>}>
-        <ProductHomeReadiness activationCoverage={activationCoverage} hostedReady={hostedReady} nextHostedAction={nextHostedAction} progress={setup.progress} ready={setup.ready} />
-      </Suspense>
       <nav aria-label="Business tracks" className="product-track-grid">
         {customerTracks.map(([name, fit, outcome, path, setupPath]) => (
           <article className="product-track-card" key={name}>

--- a/showroom/src/core/ProductHomeReadiness.tsx
+++ b/showroom/src/core/ProductHomeReadiness.tsx
@@ -307,25 +307,6 @@ export function ProductHomeReadiness({ activationCoverage, hostedReady, nextHost
 
   return (
     <>
-      <section className="product-home-readiness product-home-business-tracks" aria-label="Product starter paths">
-        <div className="product-home-readiness-head">
-          <div>
-            <span className="core-eyebrow">Starter paths</span>
-            <h2>Start one product in 2 clicks.</h2>
-            <p>Choose a local template, then open the working app. AI prepares the setup and keeps business changes behind owner approval.</p>
-          </div>
-          <Link className="core-button" to="/settings/">Open setup hub</Link>
-        </div>
-        <div className="product-home-track-actions" aria-label="Product starter actions">
-          {trackActionRows.map(([label, product, setupPath, workPath, setupAction, openAction]) => (
-            <span key={label}>
-              <strong>{label}</strong>
-              <Link onClick={() => recordLaunchPackChoice(product, label, 'prepare data')} to={setupPath}>{setupAction}</Link>
-              <Link onClick={() => recordLaunchPackChoice(product, label, 'open workspace')} to={workPath}>{openAction}</Link>
-            </span>
-          ))}
-        </div>
-      </section>
       <section className="product-home-readiness product-home-command-queue" id="command-center" aria-label="Ask SuperMega business command center">
         <div className="product-home-readiness-head">
           <div>
@@ -350,7 +331,7 @@ export function ProductHomeReadiness({ activationCoverage, hostedReady, nextHost
               <small>{ownerControlPrimary.summary}</small>
             </div>
             <div className="form-actions">
-              <button className="core-button" disabled={ownerControlPending} onClick={() => void acknowledgeOwnerControl()} type="button">Acknowledge review</button>
+              {ownerControl.sourceCount > 0 ? <button className="core-button" disabled={ownerControlPending} onClick={() => void acknowledgeOwnerControl()} type="button">Acknowledge review</button> : null}
               <Link className="core-button primary" onClick={() => recordOwnerControlFollow(ownerControlPrimary)} to={ownerControlPrimary.nextAction.path}>{ownerControlPrimary.nextAction.label}</Link>
             </div>
           </div> : <p className="owner-control-clear">No repeated check is required for unchanged evidence. A new validated source revision opens the next run automatically.</p>}
@@ -358,7 +339,7 @@ export function ProductHomeReadiness({ activationCoverage, hostedReady, nextHost
             <summary>Review queue <span>{ownerControl.items.length}</span></summary>
             <div>{ownerControl.items.map((item) => <span key={item.itemId}><strong>{item.product}</strong><small>{item.status} · {item.title}</small></span>)}</div>
           </details> : null}
-          <p className="business-command-boundary">Acknowledgement confirms review only. It does not claim resolution or run any product or external action.</p>
+          <p className="business-command-boundary">{ownerControl.sourceCount > 0 ? 'Acknowledgement confirms review only. It does not claim resolution or run any product or external action.' : 'Missing evidence cannot be acknowledged. Open a working sample or import records first.'}</p>
           {ownerControlNotice ? <p className="form-notice" role="status">{ownerControlNotice}</p> : null}
         </div>
         <form className="business-command-form" onSubmit={submitBusinessQuestion}>
@@ -421,6 +402,25 @@ export function ProductHomeReadiness({ activationCoverage, hostedReady, nextHost
           </div>
           <Link className="text-link" to={commandPath}>{commandLabel}</Link>
         </details>
+      </section>
+      <section className="product-home-readiness product-home-business-tracks" aria-label="Product starter paths">
+        <div className="product-home-readiness-head">
+          <div>
+            <span className="core-eyebrow">Starter paths</span>
+            <h2>Start one product in 2 clicks.</h2>
+            <p>Choose a local template, then open the working app. AI prepares the setup and keeps business changes behind owner approval.</p>
+          </div>
+          <Link className="core-button" to="/settings/">Open setup hub</Link>
+        </div>
+        <div className="product-home-track-actions" aria-label="Product starter actions">
+          {trackActionRows.map(([label, product, setupPath, workPath, setupAction, openAction]) => (
+            <span key={label}>
+              <strong>{label}</strong>
+              <Link onClick={() => recordLaunchPackChoice(product, label, 'prepare data')} to={setupPath}>{setupAction}</Link>
+              <Link onClick={() => recordLaunchPackChoice(product, label, 'open workspace')} to={workPath}>{openAction}</Link>
+            </span>
+          ))}
+        </div>
       </section>
     </>
   )

--- a/showroom/src/core/business-command.ts
+++ b/showroom/src/core/business-command.ts
@@ -258,6 +258,13 @@ function unavailableAnswer(
 ): BusinessCommandAnswer {
   const productLabel = product === 'ecommerce' ? 'Ecommerce' : product[0].toUpperCase() + product.slice(1)
   const invalid = status === 'invalid'
+  const samplePath = product === 'shop'
+    ? '/shop/?tab=counter'
+    : product === 'plant'
+      ? '/plant/?tab=production'
+      : product === 'website'
+        ? '/website/'
+        : '/ecommerce/'
   return {
     contract: 'supermega.local_business_answer.v1',
     intent,
@@ -265,14 +272,16 @@ function unavailableAnswer(
     title: invalid ? `${productLabel} data needs repair` : `${productLabel} needs source data`,
     summary: invalid
       ? `Saved ${productLabel} data failed validation. SuperMega left it unchanged and will not infer an answer from it.`
-      : `No saved ${productLabel} workspace is available yet. Start with its sample or import flow to get a grounded answer.`,
+      : `No saved ${productLabel} workspace is available yet. Open its working sample or import real records to get a grounded answer.`,
     facts: [
       { label: 'Source', value: invalid ? 'Validation failed' : 'Not connected', detail: invalid ? 'Original browser data remains untouched.' : 'No product records were read.' },
       { label: 'Evidence', value: 'Not enough', detail: 'SuperMega will not invent operational facts.' },
-      { label: 'Action', value: 'Prepare data', detail: 'Use the guided local setup before managed activation.' },
+      { label: 'Action', value: invalid ? 'Repair data' : 'Open sample', detail: invalid ? 'Review the saved source without replacing it.' : 'Start with a working local product before managed activation.' },
       { label: 'Write gate', value: 'Blocked', detail: 'No external or product write can run from this answer.' },
     ],
-    nextAction: { label: `Prepare ${productLabel}`, path: `/settings/?product=${product}`, product },
+    nextAction: invalid
+      ? { label: `Repair ${productLabel} data`, path: `/settings/?product=${product}`, product }
+      : { label: `Open ${productLabel} sample`, path: samplePath, product },
     boundary,
   }
 }
@@ -416,14 +425,14 @@ function attentionAnswer(snapshot: LocalBusinessSnapshot): BusinessCommandAnswer
       intent: 'attention',
       sourceCount: 0,
       title: 'Start with one business source',
-      summary: 'No validated product workspace is saved yet. Load the Shop sample catalog or import your own catalog to create the first grounded operating answer.',
+      summary: 'No validated product workspace is saved yet. Open the working Shop sample or import your own catalog to create the first grounded operating answer.',
       facts: [
         { label: 'Shop', value: 'No source', detail: 'Catalog, stock, orders, and money review are unavailable.' },
         { label: 'Plant', value: 'No source', detail: 'Jobs, issues, quality, and equipment state are unavailable.' },
         { label: 'Website', value: 'No source', detail: 'Pages, readiness, approval, and release evidence are unavailable.' },
         { label: 'Ecommerce', value: 'No source', detail: 'Storefront draft and Shop handoff are unavailable.' },
       ],
-      nextAction: { label: 'Prepare Shop data', path: '/settings/?product=shop', product: 'shop' },
+      nextAction: { label: 'Open Shop sample', path: '/shop/?tab=counter', product: 'shop' },
       boundary,
     }
   }

--- a/showroom/src/core/owner-control.ts
+++ b/showroom/src/core/owner-control.ts
@@ -180,6 +180,9 @@ export function acknowledgeLocalOwnerControlItem(
   run: LocalOwnerControlRun,
   item: OwnerControlItem,
 ) {
+  if (run.sourceCount === 0) {
+    throw new Error('Owner control needs validated source evidence before acknowledgement.')
+  }
   if (!run.items.some((candidate) => candidate.itemId === item.itemId && candidate.product === item.product)) {
     throw new Error('Owner control item does not belong to this run.')
   }

--- a/tools/verify_app_build.mjs
+++ b/tools/verify_app_build.mjs
@@ -731,7 +731,7 @@ if (!coreShellSource.includes('function managedLoginPath(product: string | null)
   || !coreCssSource.includes('.sidebar-foot .account-shell-link { min-height: 44px;')
   || !coreCssSource.includes('.topbar-meta > a { min-width: 58px; min-height: 44px;')) fail('managed_account_entry_not_discoverable')
 const productHomePageContract = coreShellSource.slice(coreShellSource.indexOf('const customerTracks'))
-if (!productHomePageContract.includes('title="Choose a product. Run work."')
+if (!productHomePageContract.includes('title="Company control"')
   || !productHomePageContract.includes('const customerTracks =')
   || !productHomePageContract.includes("'Shop'")
   || !productHomePageContract.includes("'Plant'")
@@ -757,6 +757,7 @@ if (!productHomePageContract.includes('title="Choose a product. Run work."')
   || !productHomePageContract.includes("setup.ready ? 'Ready for managed import' : 'Locked until approval'")
   || !productHomePageContract.includes("to={setup.ready ? '/settings/#controls' : '/settings/'}")
   || !productHomePageContract.includes('runtime.activationManifest?.next_action')
+  || productHomePageContract.indexOf('<ProductHomeReadiness') > productHomePageContract.indexOf('aria-label="SuperMega operating model"')
   || !productHomePageContract.includes("'/shop/?tab=counter'")
   || !productHomePageContract.includes("'/plant/?tab=production'")
   || !productHomePageContract.includes("'/ecommerce/'")
@@ -873,13 +874,19 @@ if (!ownerControlSource.includes('supermega.local_owner_control_run.v1')
   || !managedTrialSource.includes('export async function assertManagedOwnerControlIntegrity')
   || !productHomeReadinessSource.includes('aria-label="Owner Control run"')
   || !productHomeReadinessSource.includes('Acknowledge review')
+  || !productHomeReadinessSource.includes('ownerControl.sourceCount > 0')
+  || !productHomeReadinessSource.includes('Missing evidence cannot be acknowledged. Open a working sample or import records first.')
   || !productHomeReadinessSource.includes('Acknowledgement confirms review only.')
   || !productHomeReadinessSource.includes('Changed records will reopen the run.')
   || !productHomeReadinessSource.includes('currentRun.sourceFingerprint !== localOwnerControl.sourceFingerprint')
   || !productHomeReadinessSource.includes("window.addEventListener('focus', refreshOnFocus)")
   || !productHomeReadinessSource.includes("window.addEventListener('storage', refreshOnStorage)")
   || !productHomeReadinessSource.includes('Follow Owner Control:')
-  || !businessCommandSource.includes('export function rankBusinessAttention')) fail('owner_control_contract_missing')
+  || !ownerControlSource.includes('Owner control needs validated source evidence before acknowledgement.')
+  || !businessCommandSource.includes('export function rankBusinessAttention')
+  || !businessCommandSource.includes("{ label: 'Open Shop sample', path: '/shop/?tab=counter', product: 'shop' }")
+  || !businessCommandSource.includes('Open its working sample or import real records to get a grounded answer.')) fail('owner_control_contract_missing')
+if (productHomeReadinessSource.indexOf('id="command-center"') > productHomeReadinessSource.indexOf('aria-label="Product starter paths"')) fail('company_control_not_first_on_home')
 if (!coreCssSource.includes('.product-home-command-queue')
   || !coreCssSource.includes('.owner-control-run')
   || !coreCssSource.includes('.owner-control-primary')
@@ -11025,7 +11032,19 @@ async function verifyBusinessCommandRuntime() {
     assert(empty.contract === 'supermega.local_business_snapshot.v1', 'business_command_snapshot_contract_wrong')
     assert([empty.shop, empty.plant, empty.website, empty.ecommerce].every((source) => source.status === 'missing'), 'business_command_empty_sources_not_missing')
     const emptyAnswer = command.buildBusinessCommandAnswer(empty, 'attention')
-    assert(emptyAnswer.contract === 'supermega.local_business_answer.v1' && emptyAnswer.sourceCount === 0 && emptyAnswer.nextAction.path === '/settings/?product=shop', 'business_command_empty_answer_not_actionable')
+    assert(emptyAnswer.contract === 'supermega.local_business_answer.v1'
+      && emptyAnswer.sourceCount === 0
+      && emptyAnswer.nextAction.label === 'Open Shop sample'
+      && emptyAnswer.nextAction.path === '/shop/?tab=counter', 'business_command_empty_answer_not_actionable')
+    for (const [intent, label, path] of [
+      ['shop_inventory', 'Open Shop sample', '/shop/?tab=counter'],
+      ['plant_control', 'Open Plant sample', '/plant/?tab=production'],
+      ['website_readiness', 'Open Website sample', '/website/'],
+      ['ecommerce_readiness', 'Open Ecommerce sample', '/ecommerce/'],
+    ]) {
+      const answer = command.buildBusinessCommandAnswer(empty, intent)
+      assert(answer.nextAction.label === label && answer.nextAction.path === path, `business_command_missing_source_sample_route_wrong:${intent}`)
+    }
 
     const commerceState = commerce.createSeedCommerce()
     const productionState = production.createSeedProduction()
@@ -11102,12 +11121,14 @@ async function verifyOwnerControlRuntime() {
     const emptyRun = control.buildLocalOwnerControlRun(emptySnapshot, [])
     assert(emptyRun.contract === 'supermega.local_owner_control_run.v1' && emptyRun.sourceCount === 0, 'owner_control_empty_contract_wrong')
     assert(emptyRun.primary?.product === 'shop' && emptyRun.pendingCount === 1, 'owner_control_empty_start_not_actionable')
-    const acknowledgements = control.acknowledgeLocalOwnerControlItem(storage, emptyRun, emptyRun.primary)
-    const acknowledgedRun = control.buildLocalOwnerControlRun(emptySnapshot, acknowledgements)
-    assert(acknowledgedRun.pendingCount === 0 && acknowledgedRun.acknowledgedCount === 1, 'owner_control_acknowledgement_not_applied')
-    assert(!JSON.stringify(acknowledgements).includes('completed') && !JSON.stringify(acknowledgements).includes('not_relevant'), 'owner_control_claimed_unverified_outcome')
-    const replay = control.acknowledgeLocalOwnerControlItem(storage, emptyRun, emptyRun.primary)
-    assert(replay.length === 1, 'owner_control_acknowledgement_not_idempotent')
+    let emptyAcknowledgementRejected = false
+    try {
+      control.acknowledgeLocalOwnerControlItem(storage, emptyRun, emptyRun.primary)
+    } catch (error) {
+      emptyAcknowledgementRejected = error instanceof Error && error.message.includes('validated source evidence')
+    }
+    assert(emptyAcknowledgementRejected, 'owner_control_missing_source_acknowledgement_succeeded')
+    assert(control.readLocalOwnerControlAcknowledgements(storage).length === 0, 'owner_control_missing_source_acknowledgement_wrote_state')
 
     const productionState = production.createSeedProduction()
     productionState.machines[0] = { ...productionState.machines[0], state: 'stopped' }
@@ -11118,6 +11139,13 @@ async function verifyOwnerControlRuntime() {
     assert(safetyRun.primary?.product === 'plant' && safetyRun.primary?.priority === 'critical', 'owner_control_plant_safety_not_first')
     assert(safetyRun.items.some((item) => item.product === 'shop' && item.priority === 'high'), 'owner_control_invalid_shop_repair_missing')
     assert(safetyRun.runKey !== emptyRun.runKey && safetyRun.primary?.status === 'pending', 'owner_control_changed_source_did_not_reopen')
+    const acknowledgements = control.acknowledgeLocalOwnerControlItem(storage, safetyRun, safetyRun.primary)
+    const acknowledgedRun = control.buildLocalOwnerControlRun(safetySnapshot, acknowledgements)
+    assert(acknowledgedRun.items.find((item) => item.itemId === safetyRun.primary.itemId)?.status === 'acknowledged'
+      && acknowledgedRun.acknowledgedCount === 1, 'owner_control_evidence_acknowledgement_not_applied')
+    assert(!JSON.stringify(acknowledgements).includes('completed') && !JSON.stringify(acknowledgements).includes('not_relevant'), 'owner_control_claimed_unverified_outcome')
+    const replay = control.acknowledgeLocalOwnerControlItem(storage, safetyRun, safetyRun.primary)
+    assert(replay.length === acknowledgements.length, 'owner_control_acknowledgement_not_idempotent')
     const collisionAcknowledgement = {
       ...acknowledgements[0],
       runKey: safetyRun.runKey,


### PR DESCRIPTION
## What changed
- puts Company control and Ask SuperMega first on Home
- routes missing product sources directly to working samples
- blocks zero-source owner-control acknowledgement in UI and domain logic
- keeps evidence-backed acknowledgement and invalid-source repair paths

## Verification
- npm run app:build
- npm run app:verify
- git diff --check
- fresh Edge browser proof at 1365x900 and 390x844
- independent coordinated review: no P0-P2 findings

No hosted writes, managed activation, pricing, DNS, payment, customer data, or external messages changed.