### PR TITLE
fix(release): verify current built app assets

### DIFF
--- a/.github/workflows/supermega-public-release.yml
+++ b/.github/workflows/supermega-public-release.yml
@@ -173,6 +173,9 @@ jobs:
           SUPERMEGA_RELEASE_COMMIT: ${{ github.sha }}
         run: npx --yes vercel@56.1.0 build --prod --yes --token="$VERCEL_TOKEN"
 
+      - name: Verify immutable app asset contract
+        run: node tools/verify_app_release_live.mjs --artifact-self-test
+
       - name: Capture app production rollback target
         id: app-rollback-target
         env:

--- a/hq/readiness/managed-pilot-readiness.json
+++ b/hq/readiness/managed-pilot-readiness.json
@@ -1,7 +1,7 @@
 {
   "contract": "supermega.managed-pilot-readiness.v1",
   "asOf": "2026-08-02T08:20:36.438Z",
-  "sourceDigest": "sha256:7d574f77df2c453550cc0de1ee865dc413962f96c178d85e22f9955879c16e41",
+  "sourceDigest": "sha256:9db5d98833bc7aec54f05779fe762863442b04ae4861acd2653f1820573a8e04",
   "overall": {
     "status": "blocked",
     "localDatabaseProofReady": true,
@@ -140,7 +140,7 @@
     },
     {
       "path": "package.json",
-      "digest": "sha256:4c075476ec00be372db0d2a5893324ea218d9e3e50545a6501c35802d33a9296"
+      "digest": "sha256:2b090f734aed039a76a363f01a0e3dc7f1909b6cca425893c8a3daf47f85264d"
     },
     {
       "path": "kernel/managed-pilot-readiness.mjs",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build": "npm run public:build",
     "app:release:write": "node tools/write_app_release_metadata.mjs",
     "app:build": "npm run app:release:write && npm --prefix showroom run build",
-    "app:build:checked": "npm run app:build && npm run app:verify",
+    "app:build:checked": "npm run app:build && npm run app:verify && node tools/verify_app_release_live.mjs --artifact-self-test",
     "app:verify": "node tools/verify_app_build.mjs && npm run app:dev:verify && node tools/verify_app_deploy_workflow.mjs && node tools/verify_app_security_contract.mjs && npm run client:prepare:self-test && npm run client:pilot:self-test && npm run client:pilot:handoff:self-test && npm run client:install:self-test && npm run workspace:recovery:self-test && npm run storage:privacy:self-test && npm run database:validator:self-test && npm run database:supabase:compatibility && npm run database:migrations:verify && npm run vercel:contracts:test && npm run hq:verify",
     "app:dev:verify": "node tools/verify_local_app_dev.mjs",
     "app:verify:live": "node tools/verify_app_release_live.mjs",

--- a/tools/verify_app_deploy_workflow.mjs
+++ b/tools/verify_app_deploy_workflow.mjs
@@ -234,7 +234,7 @@ requireContract('app build contract',
   config.buildCommand === 'npm run app:build'
   && generator.includes("buildCommand: 'npm run app:build'")
   && packageJson.scripts?.['app:build'] === 'npm run app:release:write && npm --prefix showroom run build'
-  && packageJson.scripts?.['app:build:checked'] === 'npm run app:build && npm run app:verify'
+  && packageJson.scripts?.['app:build:checked'] === 'npm run app:build && npm run app:verify && node tools/verify_app_release_live.mjs --artifact-self-test'
   && ciWorkflow.includes('run: npm run app:build:checked'))
 requireContract('remote dependency install contract', config.installCommand === 'npm --prefix showroom ci' && generator.includes("installCommand: 'npm --prefix showroom ci'"))
 requireContract('remote security inputs are included', generator.includes("'!.env.app.example'"))
@@ -282,6 +282,14 @@ requireContract('real migration proof precedes every production candidate',
   && migrationVerifier.includes('hosted_postgres_17_proof_required: true'))
 requireContract('app guard remains non-mutating but runs API tests', appWorkflow.includes("- 'supermega_runtime/**'") && appWorkflow.includes("python -m unittest discover -s tests -p 'test_*.py' -v") && !/vercel@56\.1\.0\s+(?:deploy|promote|rollback)\b/.test(appWorkflow) && !appWorkflow.includes('VERCEL_TOKEN') && !/environment:\s*production/.test(appWorkflow))
 requireContract('protected app candidate verification', workflow.includes("VERCEL_PROTECTED_PREVIEW: '1'") && appVerifier.includes("'curl', path, '--deployment'") && appVerifier.includes('deploymentFunctions') && appVerifier.includes("JSON.stringify(['api/app'])") && appVerifier.includes('hosted_agent_runtime_contract_wrong'))
+requireContract('current app asset contract gates local build and protected candidate',
+  packageJson.scripts['app:build:checked'] === 'npm run app:build && npm run app:verify && node tools/verify_app_release_live.mjs --artifact-self-test'
+  && workflow.includes('Verify immutable app asset contract')
+  && workflow.includes('node tools/verify_app_release_live.mjs --artifact-self-test')
+  && workflow.indexOf('Verify immutable app asset contract') < workflow.indexOf('Deploy isolated app production candidate')
+  && appVerifier.includes("contract: 'supermega.current-release-assets.v1'")
+  && appVerifier.includes("const legacyCopyAudit = process.env.SUPERMEGA_LEGACY_COPY_AUDIT === '1'")
+  && appVerifier.includes('releaseAssetVerification = verifyCurrentReleaseAssets({'))
 requireContract('app live identity validates brand context and catalog', appVerifier.includes('release.brandVersion !== manifest.brand.version') && appVerifier.includes('release.contextVersion !== manifest.contextVersion') && appVerifier.includes('release.catalogVersion !== manifest.catalogVersion'))
 requireContract('operators can verify the exact checked-out release',
   packageJson.scripts['app:verify:live:current'] === 'node tools/verify_app_release_live.mjs --current-head'

--- a/tools/verify_app_release_live.mjs
+++ b/tools/verify_app_release_live.mjs
@@ -1,14 +1,129 @@
 import { execFileSync } from 'node:child_process'
-import { readFile } from 'node:fs/promises'
-import { dirname, resolve } from 'node:path'
+import { readFile, readdir } from 'node:fs/promises'
+import { dirname, join, resolve } from 'node:path'
 
 const verifyCurrentHead = process.argv.includes('--current-head')
 const selfTest = process.argv.includes('--self-test')
+const artifactSelfTest = process.argv.includes('--artifact-self-test')
 const configuredExpectedCommit = String(process.env.EXPECTED_RELEASE_COMMIT || '').trim().toLowerCase()
 
 export function extractTrialEvidenceVersion(value) {
   const match = /contract\s*:\s*['"]supermega_trial_evidence['"][\s\S]{0,160}?\bversion\s*:\s*(\d+)/.exec(String(value || ''))
   return Number(match?.[1])
+}
+
+export function verifyCurrentReleaseAssets({
+  manifest,
+  assetCorpus,
+  operationsChunk,
+  productSystemNavigatorChunk,
+  productHomeReadinessCorpus,
+  settingsChunk,
+  ecommerceProductCorpus,
+  websiteChunk,
+  clientDataOnboardingChunk,
+  managedLoginChunk,
+  managedAccountChunk,
+  companyBackupCorpus,
+  activationRunbookChunk,
+}) {
+  const groups = [
+    ['launcher', assetCorpus, ['SUPERMEGA', 'Start with one product.', 'Pick one product and use the working demo first. Add your data only after the flow makes sense.', 'Sales and inventory', 'Production and quality', 'Pages and inquiries', 'Storefront and checkout', 'Try demo', 'Add your data', 'Later', manifest.brand.colors.accent, manifest.brand.colors.ink]],
+    ['shop_plant', operationsChunk, ['Complete sale', 'Jobs', 'Problems', 'Record output', 'Close shift', 'Browser-local sample only.', 'No payment is captured']],
+    ['module_drawer', productSystemNavigatorChunk, ['Modules', ' working / ', ' setup', 'Start with the working demo.', 'Use the sample workflow first. Setup and imports can wait.', 'Use now', 'Add data later', 'Advanced modules stay hidden until a real client needs them.']],
+    ['support_helper', productHomeReadinessCorpus, ['Support helper', 'Uses Shop, Plant, Website, and Ecommerce records.', 'Readiness review status', 'Mark reviewed', 'Acknowledgement confirms review only.', 'supermega.local_business_snapshot.v1', 'supermega.local_business_answer.v1']],
+    ['settings', settingsChunk, ['supermega_trial_evidence', 'Premium company learning', 'Advanced controls', 'Save, export, restore, or reset.', 'Export full evidence']],
+    ['website', websiteChunk, ['Make this website yours', 'Download site', 'Website starter brief generated', 'Not online yet']],
+    ['ecommerce', ecommerceProductCorpus, ['Review an order batch', 'Upload CSV or paste channel orders only when needed.', 'Payment and customer messages stay locked.', 'Shop review', 'supermega.ecommerce.order_import_review_packet.v1']],
+    ['data_onboarding', clientDataOnboardingChunk, ['Start with a CSV or sample so SuperMega can map columns and inspect rows locally.', 'No customer message, payment, website publish, or automation runs from this check.']],
+    ['company_login', managedLoginChunk, ['Open your company.', 'Try free demo', 'Request company account']],
+    ['account_recovery', managedAccountChunk, ['Recover your account.', 'Secure your account.', 'Save password and continue']],
+    ['company_backup', companyBackupCorpus, ['supermega.company_backup.v1', 'Customer-owned and encrypted', 'Download encrypted backup', 'Auth sessions, company account IDs, and credentials are excluded.']],
+    ['activation', activationRunbookChunk, ['Evidence to go live', 'proof gates ready']],
+  ]
+  let checks = 0
+  for (const [group, corpus, requiredValues] of groups) {
+    for (const required of requiredValues) {
+      checks += 1
+      if (!corpus.includes(required)) throw new Error(`missing_current_release_asset:${group}:${required}`)
+    }
+  }
+  const completeCorpus = groups.map(([, corpus]) => corpus).join('\n')
+  for (const forbidden of ['pos.supermega.dev', 'ytf.supermega.dev', 'Yangon Tyre', 'ytf-plant-a']) {
+    checks += 1
+    if (completeCorpus.toLowerCase().includes(forbidden.toLowerCase())) throw new Error(`retired_current_release_asset:${forbidden}`)
+  }
+  return { contract: 'supermega.current-release-assets.v1', checks, groups: groups.length }
+}
+
+async function readArtifactChunk(assetsDir, assetNames, pattern) {
+  const name = assetNames.find((candidate) => pattern.test(candidate))
+  if (!name) throw new Error(`artifact_chunk_missing:${pattern.source}`)
+  return readFile(join(assetsDir, name), 'utf8')
+}
+
+if (artifactSelfTest) {
+  const root = resolve(import.meta.dirname, '..')
+  const distDir = resolve(root, 'showroom', 'dist')
+  const assetsDir = resolve(distDir, 'assets')
+  const [rootHtml, artifactManifest, assetNames] = await Promise.all([
+    readFile(resolve(distDir, 'index.html'), 'utf8'),
+    readFile(resolve(root, 'site-manifest.json'), 'utf8').then(JSON.parse),
+    readdir(assetsDir),
+  ])
+  const rootAssetPaths = [
+    ...rootHtml.matchAll(/<script[^>]+src="([^"]+)"/g),
+    ...rootHtml.matchAll(/<link[^>]+href="([^"]+\.(?:js|css))"/g),
+  ].map((match) => match[1].replace(/^\//, ''))
+  const assetCorpus = (await Promise.all(rootAssetPaths.map((path) => readFile(resolve(distDir, path), 'utf8')))).join('\n')
+  const [
+    operationsChunk,
+    productSystemNavigatorChunk,
+    productHomeReadinessChunk,
+    businessCommandChunk,
+    settingsChunk,
+    ecommerceChunk,
+    ecommercePacketChunk,
+    websiteChunk,
+    clientDataOnboardingChunk,
+    managedLoginChunk,
+    managedAccountChunk,
+    companyBackupChunk,
+    activationRunbookChunk,
+  ] = await Promise.all([
+    readArtifactChunk(assetsDir, assetNames, /^(?:CoreApp|core-app)-[A-Za-z0-9_-]+\.js$/),
+    readArtifactChunk(assetsDir, assetNames, /^ProductSystemNavigator-[A-Za-z0-9_-]+\.js$/),
+    readArtifactChunk(assetsDir, assetNames, /^ProductHomeReadiness-[A-Za-z0-9_-]+\.js$/),
+    readArtifactChunk(assetsDir, assetNames, /^business-command-[A-Za-z0-9_-]+\.js$/),
+    readArtifactChunk(assetsDir, assetNames, /^SettingsPage-[A-Za-z0-9_-]+\.js$/),
+    readArtifactChunk(assetsDir, assetNames, /^EcommerceProduct-[A-Za-z0-9_-]+\.js$/),
+    readArtifactChunk(assetsDir, assetNames, /^ecommerce-order-review-packet-[A-Za-z0-9_-]+\.js$/),
+    readArtifactChunk(assetsDir, assetNames, /^WebsiteProduct-[A-Za-z0-9_-]+\.js$/),
+    readArtifactChunk(assetsDir, assetNames, /^ClientDataOnboarding-[A-Za-z0-9_-]+\.js$/),
+    readArtifactChunk(assetsDir, assetNames, /^ManagedLoginPage-[A-Za-z0-9_-]+\.js$/),
+    readArtifactChunk(assetsDir, assetNames, /^ManagedAccountPage-[A-Za-z0-9_-]+\.js$/),
+    readArtifactChunk(assetsDir, assetNames, /^CompanyBackupPanel-[A-Za-z0-9_-]+\.js$/),
+    readArtifactChunk(assetsDir, assetNames, /^ManagedActivationRunbook-[A-Za-z0-9_-]+\.js$/),
+  ])
+  const evidenceVersion = extractTrialEvidenceVersion(settingsChunk)
+  if (!Number.isInteger(evidenceVersion)) throw new Error('artifact_settings_evidence_version_missing')
+  const result = verifyCurrentReleaseAssets({
+    manifest: artifactManifest,
+    assetCorpus,
+    operationsChunk,
+    productSystemNavigatorChunk,
+    productHomeReadinessCorpus: `${productHomeReadinessChunk}\n${businessCommandChunk}`,
+    settingsChunk,
+    ecommerceProductCorpus: `${ecommerceChunk}\n${ecommercePacketChunk}`,
+    websiteChunk,
+    clientDataOnboardingChunk,
+    managedLoginChunk,
+    managedAccountChunk,
+    companyBackupCorpus: `${settingsChunk}\n${companyBackupChunk}`,
+    activationRunbookChunk,
+  })
+  console.log(JSON.stringify({ ok: true, ...result, evidenceVersion }, null, 2))
+  process.exit(0)
 }
 
 if (selfTest) {
@@ -224,6 +339,9 @@ const productHomeReadinessCorpus = `${productHomeReadinessChunk}\n${businessComm
 const operationsChunkPath = /assets\/(?:CoreApp|core-app)-[A-Za-z0-9_-]+\.js/.exec(assetCorpus)?.[0]
 if (!operationsChunkPath) throw new Error('operations_chunk_missing')
 const operationsChunk = (await get(`/${operationsChunkPath}`)).body
+const productSystemNavigatorChunkPath = /assets\/ProductSystemNavigator-[A-Za-z0-9_-]+\.js/.exec(`${assetCorpus}\n${operationsChunk}`)?.[0]
+if (!productSystemNavigatorChunkPath) throw new Error('product_system_navigator_chunk_missing')
+const productSystemNavigatorChunk = (await get(`/${productSystemNavigatorChunkPath}`)).body
 const settingsChunkPath = /assets\/SettingsPage-[A-Za-z0-9_-]+\.js/.exec(assetCorpus)?.[0]
 if (!settingsChunkPath) throw new Error('settings_chunk_missing')
 const settingsChunk = (await get(`/${settingsChunkPath}`)).body
@@ -261,6 +379,23 @@ const websiteChunk = (await get(`/${websiteChunkPath}`)).body
 const activationRunbookChunkPath = /assets\/ManagedActivationRunbook-[A-Za-z0-9_-]+\.js/.exec(settingsChunk)?.[0]
 if (!activationRunbookChunkPath) throw new Error('managed_activation_runbook_chunk_missing')
 const activationRunbookChunk = (await get(`/${activationRunbookChunkPath}`)).body
+const releaseAssetVerification = verifyCurrentReleaseAssets({
+  manifest,
+  assetCorpus,
+  operationsChunk,
+  productSystemNavigatorChunk,
+  productHomeReadinessCorpus,
+  settingsChunk,
+  ecommerceProductCorpus,
+  websiteChunk,
+  clientDataOnboardingChunk,
+  managedLoginChunk,
+  managedAccountChunk,
+  companyBackupCorpus,
+  activationRunbookChunk,
+})
+const legacyCopyAudit = process.env.SUPERMEGA_LEGACY_COPY_AUDIT === '1'
+if (legacyCopyAudit) {
 for (const required of ['SUPERMEGA', 'Company control', 'Start from grounded local records.', 'Free workspace', 'Premium activation', 'Managed data, AI context', 'Check readiness', 'Open product', 'Set up product', 'Shop', 'Plant', 'Website', 'Ecommerce', 'Sample mode', manifest.brand.colors.accent, manifest.brand.colors.ink]) {
   if (!assetCorpus.includes(required)) throw new Error(`missing_live_context:${required}`)
 }
@@ -600,6 +735,7 @@ for (const required of ['Managed activation evidence plan', 'Evidence to go live
 for (const forbidden of ['Pick a track. Run work.', 'Handled by SuperMega', 'Approved by owner', 'Factory MES', 'Website catalog', 'Online orders', 'Open track', 'Set up data', 'Choose what you want to run.', 'Each product opens directly to a working sample.', 'SuperMega HQ', 'One next action for the company', 'Agents prepare work', 'pos.supermega.dev', 'ytf.supermega.dev', 'Yangon Tyre', 'ytf-plant-a']) {
   if (assetCorpus.toLowerCase().includes(forbidden.toLowerCase())) throw new Error(`retired_live_context:${forbidden}`)
 }
+}
 
 let deploymentFunctions = null
 if (protectedPreview) {
@@ -628,4 +764,4 @@ if (protectedPreview) {
   if (JSON.stringify(deploymentFunctions) !== JSON.stringify(['api/app'])) throw new Error(`deployment_function_surface_wrong:${deploymentFunctions.join(',')}`)
 }
 
-console.log(JSON.stringify({ ok: true, contract: 'supermega_app_live', baseUrl, verificationScope, expectedCommit: expectedCommit || null, routes, release, operatingMode: health.operating_mode, agentScheduler: cloud.status, deploymentFunctions }, null, 2))
+console.log(JSON.stringify({ ok: true, contract: 'supermega_app_live', baseUrl, verificationScope, expectedCommit: expectedCommit || null, routes, release, operatingMode: health.operating_mode, agentScheduler: cloud.status, releaseAssetVerification, legacyCopyAudit, deploymentFunctions }, null, 2))


### PR DESCRIPTION
## Root cause
The protected candidate verifier still enforced a large historical copy inventory from before the current simplified four-product UI. A fresh exact build showed 151 false drift failures across moved chunks and intentionally retired wording, so fixing one message at a time would keep blocking valid releases.

## Fix
- adds a 66-check current artifact contract for launcher, Shop/Plant, module drawer, helper, Settings, Website, Ecommerce, data onboarding, account recovery, backup, activation, branding, and retired domains
- verifies the locally built immutable artifact before any Vercel candidate deploy
- verifies the same contract again against the protected candidate
- keeps the historical copy audit opt-in only, not a production release gate
- refreshes the hash-bound managed-readiness ledger for the changed package command without changing its seven blocked hosted gates

## Verification
- `npm.cmd run app:build:checked`
- 80 coordinated release workflow checks
- 95 app security checks
- 66 current built-asset checks
- evidence version 24
- full product, migration, Vercel, and HQ verification