### PR TITLE
fix(ecommerce): honor available Shop payments

### DIFF
--- a/showroom/src/products/ecommerce/EcommerceBuyingWorkspace.tsx
+++ b/showroom/src/products/ecommerce/EcommerceBuyingWorkspace.tsx
@@ -11,6 +11,7 @@ import {
   buildEcommerceReturnIntent,
   buildEcommerceSupportIntent,
   createEmptyEcommerceBuyingState,
+  ecommerceAvailablePaymentAdapters,
   ecommerceBuyingStateStorageKey,
   ecommercePaymentMatchesFulfilment,
   prepareEcommerceShopDraftV2,
@@ -468,6 +469,18 @@ export function EcommerceBuyingWorkspace({
   const cartTotal = cartItems.reduce((total, line) => (
     total + (line.item?.unitPriceMmk ?? 0) * line.quantity
   ), 0)
+  const availablePaymentAdapters = useMemo(() => ecommerceAvailablePaymentAdapters(
+    commerceState.paymentPolicies ?? [],
+    fulfilment,
+    Math.max(1, cartTotal),
+    new Date(quoteClock).toISOString(),
+  ), [cartTotal, commerceState.paymentPolicies, fulfilment, quoteClock])
+  const paymentPolicyReady = availablePaymentAdapters.includes(paymentAdapter)
+  useEffect(() => {
+    if (paymentPolicyReady) return
+    setHandoffConfirmed(false)
+    if (availablePaymentAdapters.length) setPaymentAdapter(availablePaymentAdapters[0])
+  }, [availablePaymentAdapters, paymentPolicyReady])
   const recoveryBlocked = recoveryStatus !== 'empty' && recoveryStatus !== 'ready'
   const quoteMinutesRemaining = latestRequest
     ? Math.max(0, Math.ceil((Date.parse(latestRequest.quote.expiresAt) - quoteClock) / 60000))
@@ -504,10 +517,16 @@ export function EcommerceBuyingWorkspace({
   }
 
   function changeFulfilment(next: EcommerceFulfilment) {
+    const nextPaymentAdapters = ecommerceAvailablePaymentAdapters(
+      commerceState.paymentPolicies ?? [],
+      next,
+      Math.max(1, cartTotal),
+      new Date().toISOString(),
+    )
     setFulfilment(next)
-    setPaymentAdapter((current) => ecommercePaymentMatchesFulfilment(next, current)
+    setPaymentAdapter((current) => nextPaymentAdapters.includes(current)
       ? current
-      : next === 'delivery' ? 'cash_on_delivery' : 'pay_on_pickup')
+      : nextPaymentAdapters[0] ?? (next === 'delivery' ? 'cash_on_delivery' : 'pay_on_pickup'))
     setHandoffConfirmed(false)
   }
 
@@ -1014,6 +1033,10 @@ export function EcommerceBuyingWorkspace({
   async function reviewOrder(event: FormEvent<HTMLFormElement>) {
     event.preventDefault()
     if (disabled || quoteBusy || recoveryBlocked || !cart.length) return
+    if (!paymentPolicyReady) {
+      setNotice(`Shop has no active payment method for ${fulfilment}. Set one up in Shop before reviewing this order.`)
+      return
+    }
     if (!globalThis.crypto?.randomUUID) {
       setNotice('Secure checkout identity is unavailable. Nothing was recorded.')
       return
@@ -1211,18 +1234,18 @@ export function EcommerceBuyingWorkspace({
             </> : null}
             <label>
               <span>Payment</span>
-              <select onChange={(event) => { setPaymentAdapter(event.target.value as EcommercePaymentAdapter); setHandoffConfirmed(false) }} value={paymentAdapter}>
-                {fulfilment === 'pickup'
-                  ? <option value="pay_on_pickup">Pay on pickup</option>
-                  : <option value="cash_on_delivery">Cash on delivery</option>}
-                <option value="kbzpay_manual">KBZPay · manual confirmation</option>
+              <select disabled={!availablePaymentAdapters.length} onChange={(event) => { setPaymentAdapter(event.target.value as EcommercePaymentAdapter); setHandoffConfirmed(false) }} value={paymentPolicyReady ? paymentAdapter : ''}>
+                {availablePaymentAdapters.length
+                  ? availablePaymentAdapters.map((adapter) => <option key={adapter} value={adapter}>{paymentLabel(adapter)}</option>)
+                  : <option value="">No Shop payment method</option>}
               </select>
             </label>
+            {!availablePaymentAdapters.length ? <p className="form-notice" role="status">Set up an active Shop payment method for {fulfilment} before reviewing an order.</p> : null}
             <label>
               <span>Promotion code <small>optional · Shop checks it</small></span>
               <input maxLength={40} onChange={(event) => { setPromotionCode(event.target.value); setHandoffConfirmed(false) }} placeholder="Optional" value={promotionCode} />
             </label>
-            {!quoteCurrent ? <button className="core-button primary" disabled={disabled || quoteBusy || recoveryBlocked || !cart.length} type="submit">
+            {!quoteCurrent ? <button className="core-button primary" disabled={disabled || quoteBusy || recoveryBlocked || !cart.length || !paymentPolicyReady} type="submit">
               {quoteBusy ? 'Checking…' : 'Review order'}
             </button> : null}
           </form>

--- a/showroom/src/products/ecommerce/EcommerceBuyingWorkspace.tsx
+++ b/showroom/src/products/ecommerce/EcommerceBuyingWorkspace.tsx
@@ -446,22 +446,6 @@ export function EcommerceBuyingWorkspace({
     return statuses
   }, [])
   const pendingRescheduleIntents = rescheduleStatuses.filter((status) => status.state !== 'replacement_created')
-  const quoteCurrent = Boolean(latestRequest
-    && latestRequest.id === freshQuoteId
-    && latestRequest.scope === scope
-    && latestRequest.sourcePreviewDigest === sourcePreviewDigest
-    && latestRequest.customerReference === customerReference
-    && (!latestRequest.customerProfile || latestRequest.customerProfile.name === customerName.trim())
-    && (!latestRequest.customerProfile || latestRequest.customerProfile.phone === customerPhone.trim())
-    && (latestRequest.fulfilment !== 'delivery' || Boolean(latestRequest.deliveryAddress
-      && latestRequest.deliveryAddress.line1 === addressLine1.trim()
-      && latestRequest.deliveryAddress.township === addressTownship.trim()
-      && latestRequest.deliveryAddress.city === addressCity.trim()
-      && (latestRequest.deliveryAddress.instructions ?? '') === deliveryInstructions.trim()))
-    && latestRequest.fulfilment === fulfilment
-    && latestRequest.quote.payment.adapter === paymentAdapter
-    && (latestRequest.quote.promotion.code ?? '') === promotionCode.trim()
-    && cartMatchesRequest(cart, latestRequest))
   const cartItems = useMemo(() => cart.map((line) => ({
     ...line,
     item: preview.items.find((item) => item.sku === line.sku),
@@ -475,12 +459,26 @@ export function EcommerceBuyingWorkspace({
     Math.max(1, cartTotal),
     new Date(quoteClock).toISOString(),
   ), [cartTotal, commerceState.paymentPolicies, fulfilment, quoteClock])
-  const paymentPolicyReady = availablePaymentAdapters.includes(paymentAdapter)
-  useEffect(() => {
-    if (paymentPolicyReady) return
-    setHandoffConfirmed(false)
-    if (availablePaymentAdapters.length) setPaymentAdapter(availablePaymentAdapters[0])
-  }, [availablePaymentAdapters, paymentPolicyReady])
+  const effectivePaymentAdapter = availablePaymentAdapters.includes(paymentAdapter)
+    ? paymentAdapter
+    : availablePaymentAdapters[0] ?? paymentAdapter
+  const paymentPolicyReady = availablePaymentAdapters.includes(effectivePaymentAdapter)
+  const quoteCurrent = Boolean(latestRequest
+    && latestRequest.id === freshQuoteId
+    && latestRequest.scope === scope
+    && latestRequest.sourcePreviewDigest === sourcePreviewDigest
+    && latestRequest.customerReference === customerReference
+    && (!latestRequest.customerProfile || latestRequest.customerProfile.name === customerName.trim())
+    && (!latestRequest.customerProfile || latestRequest.customerProfile.phone === customerPhone.trim())
+    && (latestRequest.fulfilment !== 'delivery' || Boolean(latestRequest.deliveryAddress
+      && latestRequest.deliveryAddress.line1 === addressLine1.trim()
+      && latestRequest.deliveryAddress.township === addressTownship.trim()
+      && latestRequest.deliveryAddress.city === addressCity.trim()
+      && (latestRequest.deliveryAddress.instructions ?? '') === deliveryInstructions.trim()))
+    && latestRequest.fulfilment === fulfilment
+    && latestRequest.quote.payment.adapter === effectivePaymentAdapter
+    && (latestRequest.quote.promotion.code ?? '') === promotionCode.trim()
+    && cartMatchesRequest(cart, latestRequest))
   const recoveryBlocked = recoveryStatus !== 'empty' && recoveryStatus !== 'ready'
   const quoteMinutesRemaining = latestRequest
     ? Math.max(0, Math.ceil((Date.parse(latestRequest.quote.expiresAt) - quoteClock) / 60000))
@@ -1062,7 +1060,7 @@ export function EcommerceBuyingWorkspace({
           && retained.deliveryAddress.city === addressCity.trim()
           && (retained.deliveryAddress.instructions ?? '') === deliveryInstructions.trim()))
         && retained.fulfilment === fulfilment
-        && retained.quote.payment.adapter === paymentAdapter
+        && retained.quote.payment.adapter === effectivePaymentAdapter
         && (retained.quote.promotion.code ?? '') === promotionCode.trim()
         && retained.quote.pimDigest === pim.pimDigest
         && Date.parse(retained.quote.expiresAt) > quotedAt.getTime()
@@ -1096,7 +1094,7 @@ export function EcommerceBuyingWorkspace({
           previous: activeBuyingState.requests.find((request) => request.customerProfile?.phone === customerPhone.trim() && request.deliveryAddress)?.deliveryAddress ?? null,
         } : null,
         fulfilment,
-        paymentAdapter,
+        paymentAdapter: effectivePaymentAdapter,
         promotionCode: promotionCode.trim() || null,
         idempotencyKey: `ECI-${globalThis.crypto.randomUUID().toUpperCase()}`,
         quotedAt: quotedAt.toISOString(),
@@ -1234,7 +1232,7 @@ export function EcommerceBuyingWorkspace({
             </> : null}
             <label>
               <span>Payment</span>
-              <select disabled={!availablePaymentAdapters.length} onChange={(event) => { setPaymentAdapter(event.target.value as EcommercePaymentAdapter); setHandoffConfirmed(false) }} value={paymentPolicyReady ? paymentAdapter : ''}>
+              <select disabled={!availablePaymentAdapters.length} onChange={(event) => { setPaymentAdapter(event.target.value as EcommercePaymentAdapter); setHandoffConfirmed(false) }} value={paymentPolicyReady ? effectivePaymentAdapter : ''}>
                 {availablePaymentAdapters.length
                   ? availablePaymentAdapters.map((adapter) => <option key={adapter} value={adapter}>{paymentLabel(adapter)}</option>)
                   : <option value="">No Shop payment method</option>}

--- a/showroom/src/products/ecommerce/ecommerce-buying-lifecycle.ts
+++ b/showroom/src/products/ecommerce/ecommerce-buying-lifecycle.ts
@@ -818,6 +818,25 @@ export function ecommercePaymentMatchesFulfilment(
     || (fulfilment === 'pickup' ? paymentAdapter === 'pay_on_pickup' : paymentAdapter === 'cash_on_delivery')
 }
 
+export function ecommerceAvailablePaymentAdapters(
+  policies: readonly CommercePaymentPolicy[],
+  fulfilment: EcommerceFulfilment,
+  orderAmountMmk: number,
+  reviewedAt: string,
+) {
+  if (!Number.isSafeInteger(orderAmountMmk) || orderAmountMmk < 1) return []
+  const preferred: EcommercePaymentAdapter[] = fulfilment === 'pickup'
+    ? ['pay_on_pickup', 'kbzpay_manual']
+    : ['cash_on_delivery', 'kbzpay_manual']
+  return preferred.filter((adapter) => commercePaymentDecision(
+    policies,
+    adapter,
+    fulfilment,
+    orderAmountMmk,
+    reviewedAt,
+  )?.status === 'approved')
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
 }

--- a/tools/verify_app_build.mjs
+++ b/tools/verify_app_build.mjs
@@ -3052,8 +3052,10 @@ if (addToCartStart < 0
   || !ecommerceBuyingUiSource.includes("window.addEventListener('storage', refresh)")
   || !ecommerceBuyingUiSource.includes('setFreshQuoteId(request.id)')
   || !ecommerceBuyingUiSource.includes('function receiveOrderLabel(value: EcommerceFulfilment)')
-  || !ecommerceBuyingUiSource.includes('ecommercePaymentMatchesFulfilment(next, current)')
-  || !ecommerceBuyingUiSource.includes("next === 'delivery' ? 'cash_on_delivery' : 'pay_on_pickup'")
+  || !ecommerceBuyingUiSource.includes('ecommerceAvailablePaymentAdapters')
+  || !ecommerceBuyingUiSource.includes('nextPaymentAdapters.includes(current)')
+  || !ecommerceBuyingUiSource.includes('No Shop payment method')
+  || !ecommerceBuyingUiSource.includes('!paymentPolicyReady')
   || !ecommerceBuyingUiSource.includes('Quote for {latestRequest.customerReference}')
   || !ecommerceBuyingUiSource.includes('const orderAutopilotNext = recoveryBlocked')
   || !ecommerceBuyingUiSource.includes('const orderAutopilotRows = [')
@@ -13622,6 +13624,20 @@ async function verifyStorefrontRuntime() {
       && !buyingModel.ecommercePaymentMatchesFulfilment('pickup', 'cash_on_delivery')
       && !buyingModel.ecommercePaymentMatchesFulfilment('delivery', 'pay_on_pickup'),
     'ecommerce_buying_payment_fulfilment_matrix_invalid')
+    const stalePickupPolicies = paymentPolicies.filter((policy) => policy.adapter !== 'pay_on_pickup')
+    buyingAssert(JSON.stringify(buyingModel.ecommerceAvailablePaymentAdapters(
+      stalePickupPolicies,
+      'pickup',
+      18_500,
+      '2026-07-24T09:00:00.000Z',
+    )) === JSON.stringify(['kbzpay_manual'])
+      && buyingModel.ecommerceAvailablePaymentAdapters(
+        paymentPolicies.filter((policy) => policy.adapter === 'cash_on_delivery'),
+        'pickup',
+        18_500,
+        '2026-07-24T09:00:00.000Z',
+      ).length === 0,
+    'ecommerce_buying_payment_fallback_not_policy_bound')
     let mismatchedBuyingPaymentRejected = false
     try {
       await buyingModel.buildEcommerceCheckoutQuote({

--- a/tools/verify_app_build.mjs
+++ b/tools/verify_app_build.mjs
@@ -3056,6 +3056,8 @@ if (addToCartStart < 0
   || !ecommerceBuyingUiSource.includes('nextPaymentAdapters.includes(current)')
   || !ecommerceBuyingUiSource.includes('No Shop payment method')
   || !ecommerceBuyingUiSource.includes('!paymentPolicyReady')
+  || !ecommerceBuyingUiSource.includes('latestRequest.quote.payment.adapter === effectivePaymentAdapter')
+  || !ecommerceBuyingUiSource.includes('paymentAdapter: effectivePaymentAdapter')
   || !ecommerceBuyingUiSource.includes('Quote for {latestRequest.customerReference}')
   || !ecommerceBuyingUiSource.includes('const orderAutopilotNext = recoveryBlocked')
   || !ecommerceBuyingUiSource.includes('const orderAutopilotRows = [')


### PR DESCRIPTION
## Outcome

Fix the live Ecommerce checkout failure where a recovered or partially configured Shop workspace offered `Pay on pickup` even when that policy did not exist, then failed at Shop handoff with `not_found`.

## Changes

- resolve eligible payment methods from active Shop policy, fulfilment, amount, and review time
- prefer pickup/COD and safely fall back to the configured manual KBZPay method
- disable quote review with a clear Shop setup message when no eligible method exists
- preserve the final fail-closed policy check at Shop handoff
- add stale-policy and no-policy regression coverage

## Verification

- `npm.cmd run app:build`
- `node tools/verify_app_build.mjs`
- `npm.cmd run app:dev:verify`
- `npm.cmd run app:verify`
- 95 app security checks
- 80 coordinated-release checks
- Supabase compatibility, migrations, Vercel contracts, client pilot/onboarding, privacy, and HQ verification all passed