### PR TITLE
fix(hq): remove stale release drift evidence

### DIFF
--- a/hq/readiness/managed-pilot-readiness.json
+++ b/hq/readiness/managed-pilot-readiness.json
@@ -1,7 +1,7 @@
 {
   "contract": "supermega.managed-pilot-readiness.v1",
   "asOf": "2026-08-02T16:29:10.990Z",
-  "sourceDigest": "sha256:1e3e46a258a853639227212e3e0649aaad82f1672affe6176ff6494b86f3c40c",
+  "sourceDigest": "sha256:03d12aaa34828ef699cbd204cfaf9427bb254fa391719799193de9463fb7d0ec",
   "overall": {
     "status": "blocked",
     "localDatabaseProofReady": true,
@@ -31,8 +31,8 @@
     {
       "id": "live_product_contract",
       "status": "blocked",
-      "evidence": "HQ records app_product_contract_drift.",
-      "nextAction": "Reconcile and verify the exact paired release before any pilot claim."
+      "evidence": "The exact paired release is verified, but its managed product contract remains isolated_demo.",
+      "nextAction": "Prove managed persistence and security on the approved isolated target before any managed-pilot claim."
     },
     {
       "id": "managed_persistence",
@@ -144,7 +144,7 @@
     },
     {
       "path": "kernel/managed-pilot-readiness.mjs",
-      "digest": "sha256:0af39f6159b579a2ada18faa9a0f71cd9aa4a3d3ebac75cf4b49081683f9f052"
+      "digest": "sha256:62a11077c9d6f89d5353771acd148612af3a461120d71e5369a0bf05bce527b5"
     }
   ]
 }

--- a/kernel/managed-pilot-readiness.mjs
+++ b/kernel/managed-pilot-readiness.mjs
@@ -90,7 +90,7 @@ export function buildManagedPilotReadiness(input = {}) {
     gate('local_postgres17', 'ready-local', '52 checks, TLS, RLS, tenant isolation, durable owner control, backup and restore.', 'Keep the digest-bound rehearsal current.'),
     gate('hosted_postgres17', 'blocked', 'Local evidence explicitly does not prove hosted activation.', 'Run the approved isolated Supabase rehearsal and validator.'),
     gate('hosted_storage_privacy', 'blocked', 'The six-request verifier is ready, but hosted proof is absent.', 'Run the verifier against an owner-approved isolated private bucket.'),
-    gate('live_product_contract', 'blocked', 'HQ records app_product_contract_drift.', 'Reconcile and verify the exact paired release before any pilot claim.'),
+    gate('live_product_contract', 'blocked', 'The exact paired release is verified, but its managed product contract remains isolated_demo.', 'Prove managed persistence and security on the approved isolated target before any managed-pilot claim.'),
     gate('managed_persistence', 'blocked', 'Live managed persistence ready is false.', 'Prove durable commands, recovery, and tenant isolation on the isolated target.'),
     gate('security', 'blocked', 'Live security ready is false.', 'Resolve hosted Security Advisor and exact policy evidence.'),
     gate('named_pilot', 'blocked', 'HQ records no named pilot customer or measured baseline.', 'Select one Shop design partner, named operator, baseline, and acceptance evidence.'),

--- a/kernel/managed-pilot-readiness.test.mjs
+++ b/kernel/managed-pilot-readiness.test.mjs
@@ -36,6 +36,11 @@ test('derives one blocked four-product ledger from current bounded evidence', ()
   const ledger = buildManagedPilotReadiness(input)
   assert.equal(ledger.overall.blockingGateCount, 7)
   assert.equal(ledger.gates[0].status, 'ready-local')
+  assert.equal(
+    ledger.gates.find((gate) => gate.id === 'live_product_contract')?.evidence,
+    'The exact paired release is verified, but its managed product contract remains isolated_demo.',
+  )
+  assert.doesNotMatch(JSON.stringify(ledger), /app_product_contract_drift/)
   assert.equal(ledger.products.length, 4)
   assert.equal(ledger.controls.modelCallsRequiredToBuild, 0)
   assert.equal(validateManagedPilotReadiness(ledger), ledger)


### PR DESCRIPTION
Correct the generated managed-pilot ledger after the exact paired release was verified. The live-product gate remains blocked truthfully because the managed contract is still isolated_demo, but it no longer claims release drift. Adds a regression assertion, regenerates digest-bound evidence, and passes readiness self-test, HQ live verification, and the full app verifier. No provider, database, customer, or deployment mutation.