### PR TITLE
feat(plant): enforce recurrence-linked CAPA closeout

### DIFF
--- a/showroom/src/core/CoreApp.tsx
+++ b/showroom/src/core/CoreApp.tsx
@@ -181,6 +181,7 @@ import type {
 import {
   buildProductionShiftHandoff,
   buildProductionBatchGenealogy,
+  buildProductionQualityCorrectiveAction,
   buildProductionRecallTrace,
   closeProductionJob,
   compareProductionJobSchedule,
@@ -200,6 +201,7 @@ import {
   productionMaintenanceFindingSource,
   productionMaintenanceRecords,
   productionMaterialUnits,
+  productionQualityCauseCategories,
   productionMachineStates,
   productionShopDemandSource,
   productionShiftOutput,
@@ -232,6 +234,8 @@ import {
   type ProductionMaterialUnit,
   type ProductionMachineState,
   type ProductionOutputKind,
+  type ProductionQualityCauseCategory,
+  type ProductionQualityCorrectiveAction,
   type ProductionShiftHandoff,
 } from './production-workspace'
 import {
@@ -711,6 +715,15 @@ const productionIssueSeverityLabels: Record<ProductionIssueSeverity, string> = {
   high: 'High',
   medium: 'Medium',
   low: 'Low',
+}
+
+const productionQualityCauseLabels: Record<ProductionQualityCauseCategory, string> = {
+  material: 'Material',
+  method: 'Method',
+  machine: 'Machine',
+  measurement: 'Measurement',
+  people: 'People',
+  environment: 'Environment',
 }
 
 const productionIssueSeverityRank: Record<ProductionIssueSeverity, number> = {
@@ -7621,6 +7634,15 @@ function ProductionPage({ managedIdentity, tab }: { managedIdentity: ManagedIden
     verificationResult: string
     finalDisposition: ProductionMaintenanceReturnToService
   } | null>(null)
+  const [qualityCorrectiveDraft, setQualityCorrectiveDraft] = useState<{
+    issueId: string
+    failureMode: string
+    causeCategory: ProductionQualityCauseCategory
+    rootCause: string
+    correctiveAction: string
+    verificationResult: string
+    effectivenessOwner: string
+  } | null>(null)
   const [machineObservation, setMachineObservation] = useState<{ machineId: string; toState: ProductionMachineState } | null>(null)
   const [downtimeDialogOpen, setDowntimeDialogOpen] = useState(false)
   const [downtimeMachineId, setDowntimeMachineId] = useState(production.machines[0]?.id ?? '')
@@ -7669,6 +7691,7 @@ function ProductionPage({ managedIdentity, tab }: { managedIdentity: ManagedIden
   const [planError, setPlanError] = useState('')
   const issueDialogRef = useRef<HTMLDialogElement>(null)
   const maintenanceCorrectiveDialogRef = useRef<HTMLDialogElement>(null)
+  const qualityCorrectiveDialogRef = useRef<HTMLDialogElement>(null)
   const issueTriggerRef = useRef<HTMLButtonElement>(null)
   const machineDialogRef = useRef<HTMLDialogElement>(null)
   const machineTriggerRef = useRef<HTMLButtonElement | null>(null)
@@ -8123,6 +8146,13 @@ function ProductionPage({ managedIdentity, tab }: { managedIdentity: ManagedIden
     if (maintenanceCorrectiveDraft && !dialog.open) dialog.showModal()
     if (!maintenanceCorrectiveDraft && dialog.open) dialog.close()
   }, [maintenanceCorrectiveDraft, tab])
+
+  useEffect(() => {
+    const dialog = qualityCorrectiveDialogRef.current
+    if (!dialog) return
+    if (qualityCorrectiveDraft && !dialog.open) dialog.showModal()
+    if (!qualityCorrectiveDraft && dialog.open) dialog.close()
+  }, [qualityCorrectiveDraft, tab])
 
   useEffect(() => {
     const dialog = machineDialogRef.current
@@ -8786,6 +8816,18 @@ function ProductionPage({ managedIdentity, tab }: { managedIdentity: ManagedIden
   function resolveIssue(issueId: string) {
     const issue = production.issues.find((candidate) => candidate.id === issueId)
     if (!issue || issue.status === 'resolved') return
+    if (issue.kind === 'quality') {
+      setQualityCorrectiveDraft({
+        issueId,
+        failureMode: issue.summary,
+        causeCategory: 'method',
+        rootCause: '',
+        correctiveAction: '',
+        verificationResult: '',
+        effectivenessOwner: issue.owner ?? managedIdentity?.userId ?? 'Quality owner',
+      })
+      return
+    }
     if (issue.maintenanceFindingSource) {
       setMaintenanceCorrectiveDraft({
         issueId,
@@ -8819,18 +8861,45 @@ function ProductionPage({ managedIdentity, tab }: { managedIdentity: ManagedIden
     queueIssueResolution(issue, result)
   }
 
-  function queueIssueResolution(issue: ProductionIssue, maintenanceCorrectiveAction?: ProductionMaintenanceCorrectiveAction) {
+  function reviewQualityCorrectiveResolution(event: FormEvent) {
+    event.preventDefault()
+    if (!qualityCorrectiveDraft) return
+    const issue = production.issues.find((candidate) => candidate.id === qualityCorrectiveDraft.issueId)
+    if (!issue || issue.kind !== 'quality' || issue.status !== 'open') {
+      setNotice('This quality problem is no longer open for CAPA review.')
+      return
+    }
+    const result = buildProductionQualityCorrectiveAction(production, issue.id, {
+      failureMode: qualityCorrectiveDraft.failureMode.trim(),
+      causeCategory: qualityCorrectiveDraft.causeCategory,
+      rootCause: qualityCorrectiveDraft.rootCause.trim(),
+      correctiveAction: qualityCorrectiveDraft.correctiveAction.trim(),
+      verificationResult: qualityCorrectiveDraft.verificationResult.trim(),
+      effectivenessOwner: qualityCorrectiveDraft.effectivenessOwner.trim(),
+    })
+    if (!result) {
+      setNotice('Record a stable failure mode, cause, corrective action, effectiveness evidence, and owner before review.')
+      return
+    }
+    qualityCorrectiveDialogRef.current?.close()
+    setQualityCorrectiveDraft(null)
+    queueIssueResolution(issue, undefined, result)
+  }
+
+  function queueIssueResolution(issue: ProductionIssue, maintenanceCorrectiveAction?: ProductionMaintenanceCorrectiveAction, qualityCorrectiveAction?: ProductionQualityCorrectiveAction) {
     const issueId = issue.id
     queueAction({
       kind: 'issue_resolution',
       subjectId: issueId,
       summary: `Resolve ${issueId}`,
       before: issue.owner && issue.containment ? `${issue.status} · owner ${issue.owner} · containment: ${issue.containment}` : `${issue.status} · legacy issue without assigned owner`,
-      after: maintenanceCorrectiveAction
-        ? `resolved with corrective action and ${maintenanceCorrectiveAction.finalDisposition.replaceAll('_', ' ')} disposition; machine status unchanged`
-        : 'resolved with operator evidence',
+      after: qualityCorrectiveAction
+        ? `resolved with effective CAPA · ${qualityCorrectiveAction.priorIssueIds.length ? `${qualityCorrectiveAction.priorIssueIds.length} prior matching problem${qualityCorrectiveAction.priorIssueIds.length === 1 ? '' : 's'} linked` : 'first classified occurrence'} · no inventory or customer action`
+        : maintenanceCorrectiveAction
+          ? `resolved with corrective action and ${maintenanceCorrectiveAction.finalDisposition.replaceAll('_', ' ')} disposition; machine status unchanged`
+          : 'resolved with operator evidence',
       apply: async (record) => {
-        await mutateProduction('production.issue.resolved', record.commandId, productionActionProof(record), (current) => resolveProductionIssue(current, issueId, productionActionProof(record), maintenanceCorrectiveAction))
+        await mutateProduction('production.issue.resolved', record.commandId, productionActionProof(record), (current) => resolveProductionIssue(current, issueId, productionActionProof(record), maintenanceCorrectiveAction, qualityCorrectiveAction))
       },
     })
   }
@@ -9318,7 +9387,7 @@ function ProductionPage({ managedIdentity, tab }: { managedIdentity: ManagedIden
     {actionControls}
   </div>
 
-  if (tab === 'control') return <div className="operation-module">
+  if (tab === 'control') return <div className="operation-module production-operation-module">
     {plantToday}
     {plantControlBusinessControls}
     <div className="control-workspace">
@@ -9462,6 +9531,20 @@ function ProductionPage({ managedIdentity, tab }: { managedIdentity: ManagedIden
         </form>
       </> : null}
     </dialog>
+    <dialog aria-labelledby="quality-corrective-title" className="production-issue-dialog" onCancel={(event) => { event.preventDefault(); setQualityCorrectiveDraft(null) }} ref={qualityCorrectiveDialogRef}>
+      {qualityCorrectiveDraft ? <>
+        <div className="panel-head"><div><span className="core-eyebrow">Quality CAPA</span><h2 id="quality-corrective-title">Verify corrective action</h2></div><button aria-label="Close quality CAPA form" className="text-link" onClick={() => setQualityCorrectiveDraft(null)} type="button">Close</button></div>
+        <form autoComplete="off" className="core-form" onSubmit={reviewQualityCorrectiveResolution}>
+          <label>Failure mode<input autoFocus maxLength={120} onChange={(event) => setQualityCorrectiveDraft((current) => current ? { ...current, failureMode: event.target.value } : current)} placeholder="Stable name used to find repeats" required value={qualityCorrectiveDraft.failureMode} /><small>Use the same short name when the same defect happens again.</small></label>
+          <div className="form-row"><label>Cause category<select onChange={(event) => setQualityCorrectiveDraft((current) => current ? { ...current, causeCategory: event.target.value as ProductionQualityCauseCategory } : current)} value={qualityCorrectiveDraft.causeCategory}>{productionQualityCauseCategories.map((category) => <option key={category} value={category}>{productionQualityCauseLabels[category]}</option>)}</select></label><label>Effectiveness owner<input autoComplete="off" maxLength={120} onChange={(event) => setQualityCorrectiveDraft((current) => current ? { ...current, effectivenessOwner: event.target.value } : current)} placeholder="Named person or role" required value={qualityCorrectiveDraft.effectivenessOwner} /></label></div>
+          <label>Verified root cause<textarea maxLength={360} onChange={(event) => setQualityCorrectiveDraft((current) => current ? { ...current, rootCause: event.target.value } : current)} placeholder="What evidence identifies the cause?" required value={qualityCorrectiveDraft.rootCause} /></label>
+          <label>Corrective action<textarea maxLength={360} onChange={(event) => setQualityCorrectiveDraft((current) => current ? { ...current, correctiveAction: event.target.value } : current)} placeholder="What changed to prevent recurrence?" required value={qualityCorrectiveDraft.correctiveAction} /></label>
+          <label>Effectiveness evidence<textarea maxLength={360} onChange={(event) => setQualityCorrectiveDraft((current) => current ? { ...current, verificationResult: event.target.value } : current)} placeholder="What result proves the action worked?" required value={qualityCorrectiveDraft.verificationResult} /></label>
+          <p className="panel-copy">Matching prior CAPA records are linked automatically from the failure mode and cause category. Closing changes only this problem record; it does not release a batch, block stock, contact a customer, or issue a certificate.</p>
+          <div className="form-actions"><button className="core-button" onClick={() => setQualityCorrectiveDraft(null)} type="button">Cancel</button><button className="core-button primary" type="submit">Review CAPA closeout</button></div>
+        </form>
+      </> : null}
+    </dialog>
     {actionControls}
   </div>
 
@@ -9511,8 +9594,9 @@ function IssueList({ disabled = false, issues, now, onResolve }: { disabled?: bo
         {issue.maintenanceFindingSource ? <small style={wrappedIssueDetail}>Maintenance finding · {issue.maintenanceFindingSource.equipmentName} · Strategy R{issue.maintenanceFindingSource.strategyRevision} · Source {issue.maintenanceFindingSource.completionActionId}</small> : null}
         {issue.status === 'resolved' ? <small style={wrappedIssueDetail}>{issue.resolution ? `Resolved by ${issue.resolution.resolvedBy} · Evidence: ${issue.resolution.evidenceReference}` : 'Legacy resolution · no attributed proof was available'}</small> : null}
         {issue.resolution?.maintenanceCorrectiveAction ? <small style={wrappedIssueDetail}>Corrective action: {issue.resolution.maintenanceCorrectiveAction.correctiveAction} · Verified: {issue.resolution.maintenanceCorrectiveAction.verificationResult} · Final disposition: {issue.resolution.maintenanceCorrectiveAction.finalDisposition.replaceAll('_', ' ')}</small> : null}
+        {issue.resolution?.qualityCorrectiveAction ? <><small style={wrappedIssueDetail}>CAPA: {productionQualityCauseLabels[issue.resolution.qualityCorrectiveAction.causeCategory]} · {issue.resolution.qualityCorrectiveAction.failureMode} · Owner {issue.resolution.qualityCorrectiveAction.effectivenessOwner}</small><small style={wrappedIssueDetail}>{issue.resolution.qualityCorrectiveAction.priorIssueIds.length ? `Repeat · linked to ${issue.resolution.qualityCorrectiveAction.priorIssueIds.join(', ')}` : 'First classified occurrence'} · Verified: {issue.resolution.qualityCorrectiveAction.verificationResult}</small></> : null}
       </div>
-      {issue.status === 'open' ? <button className="text-link" disabled={disabled} onClick={() => onResolve(issue.id)} type="button">Review close</button> : <b>Resolved</b>}
+      {issue.status === 'open' ? <button className="text-link" disabled={disabled} onClick={() => onResolve(issue.id)} type="button">{issue.kind === 'quality' ? 'Review CAPA' : 'Review close'}</button> : <b>Resolved</b>}
     </article>
   })}</div>
 }

--- a/showroom/src/core/core-app.css
+++ b/showroom/src/core/core-app.css
@@ -349,6 +349,7 @@ a { color: inherit; }
 .operation-module > .split-workspace, .operation-module > .module-today, .operation-module > .control-workspace, .operation-module > .inventory-panel { height: auto; min-height: 0; flex: 1; }
 .production-operation-module { overflow-y: auto; padding-right: 2px; scrollbar-gutter: stable; }
 .production-operation-module > .production-view { min-height: clamp(420px,62vh,620px); flex: 0 0 auto; }
+.production-operation-module > .control-workspace { min-height: clamp(420px,62vh,620px); flex: 0 0 auto; }
 .production-operation-module > .plant-batch-disclosure { flex: 0 0 auto; }
 .production-operation-module > .production-view > .output-panel { position: sticky; top: 0; height: min(620px,calc(100svh - 240px)); max-height: 620px; align-self: start; }
 .split-workspace { height: 100%; min-height: 0; display: grid; grid-template-columns: minmax(300px,.85fr) minmax(0,1.15fr); gap: 11px; }
@@ -1810,6 +1811,7 @@ textarea { min-height: 72px; resize: vertical; }
   .orders-module > .order-workspace { min-height: 0; flex: none; }
   .production-operation-module { overflow: visible; padding-right: 0; scrollbar-gutter: auto; }
   .production-operation-module > .production-view { min-height: 0; }
+  .production-operation-module > .control-workspace { min-height: 0; flex: none; }
   .production-operation-module > .production-view > .output-panel { position: fixed; top: auto; right: 6px; bottom: calc(67px + env(safe-area-inset-bottom)); z-index: 72; width: min(480px,calc(100% - 12px)); height: auto; max-height: calc(100svh - 78px - env(safe-area-inset-bottom)); overflow-y: auto; border-radius: 18px 18px 8px 8px; padding: 16px; opacity: 0; visibility: hidden; pointer-events: none; transform: translateY(24px) scale(.985); transition: opacity .18s ease, transform .18s ease, visibility .18s; }
   .operation-module > .split-workspace, .operation-module > .module-today, .operation-module > .control-workspace, .operation-module > .inventory-panel { flex: none; }
   .production-view .output-panel.is-open { opacity: 1; visibility: visible; pointer-events: auto; transform: none; }

--- a/showroom/src/core/production-workspace.ts
+++ b/showroom/src/core/production-workspace.ts
@@ -11,12 +11,14 @@ export const PRODUCTION_LOCK = 'supermega-production-workspace-v2'
 export const PRODUCTION_SHOP_DEMAND_SOURCE_CONTRACT = 'supermega.production.shop-demand-source.v1' as const
 export const PRODUCTION_BATCH_GENEALOGY_SCHEMA = 'supermega.production.batch-genealogy.v1' as const
 export const PRODUCTION_RECALL_TRACE_SCHEMA = 'supermega.production.recall-trace.v1' as const
+export const PRODUCTION_QUALITY_CAPA_SCHEMA = 'supermega.production.quality-capa.v1' as const
 
 export type ProductionIssueKind = 'quality' | 'maintenance' | 'materials' | 'operations'
 export type ProductionIssueSeverity = 'critical' | 'high' | 'medium' | 'low'
 export type ProductionJobPriority = 'urgent' | 'normal' | 'low'
 export type ProductionMachineState = 'running' | 'attention' | 'stopped'
 export type ProductionMaterialUnit = 'kg' | 'g' | 'l' | 'ml' | 'pcs' | 'pack' | 'bag' | 'roll' | 'sheet' | 'm' | 'cm'
+export type ProductionQualityCauseCategory = 'material' | 'method' | 'machine' | 'measurement' | 'people' | 'environment'
 
 export type ProductionQualityHold = {
   actionId: string
@@ -65,6 +67,19 @@ export type ProductionIssueResolution = {
   reason: string
   evidenceReference: string
   maintenanceCorrectiveAction?: ProductionMaintenanceCorrectiveAction
+  qualityCorrectiveAction?: ProductionQualityCorrectiveAction
+}
+
+export type ProductionQualityCorrectiveAction = {
+  contract: typeof PRODUCTION_QUALITY_CAPA_SCHEMA
+  failureMode: string
+  causeCategory: ProductionQualityCauseCategory
+  rootCause: string
+  correctiveAction: string
+  verificationResult: string
+  effectivenessOwner: string
+  recurrenceKey: string
+  priorIssueIds: string[]
 }
 
 export type ProductionMaintenanceCorrectiveAction = {
@@ -211,6 +226,7 @@ export type ProductionEvent = {
   maintenanceReturnToService?: ProductionMaintenanceReturnToService
   maintenanceFindingSource?: ProductionMaintenanceFindingSource
   maintenanceCorrectiveAction?: ProductionMaintenanceCorrectiveAction
+  qualityCorrectiveAction?: ProductionQualityCorrectiveAction
   equipmentIds?: string[]
   installedAt?: string
   workCentreId?: string
@@ -456,6 +472,7 @@ export const productionIssueSeverities: ProductionIssueSeverity[] = ['critical',
 export const productionJobPriorities: ProductionJobPriority[] = ['urgent', 'normal', 'low']
 export const productionMachineStates: ProductionMachineState[] = ['running', 'attention', 'stopped']
 export const productionMaterialUnits: ProductionMaterialUnit[] = ['kg', 'g', 'l', 'ml', 'pcs', 'pack', 'bag', 'roll', 'sheet', 'm', 'cm']
+export const productionQualityCauseCategories: ProductionQualityCauseCategory[] = ['material', 'method', 'machine', 'measurement', 'people', 'environment']
 const eventKinds: ProductionEventKind[] = ['job_created', 'job_schedule_updated', 'job_closed', 'output_recorded', 'material_consumed', 'issue_opened', 'issue_resolved', 'quality_hold_placed', 'quality_hold_released', 'machine_state_changed', 'equipment_master_imported', 'equipment_commissioned', 'equipment_maintenance_strategy_saved', 'downtime_started', 'downtime_ended', 'maintenance_started', 'maintenance_completed', 'shift_closed']
 const baseEventFields = ['id', 'actionId', 'createdAt', 'actor', 'reason', 'evidenceReference', 'kind', 'subjectId', 'summary']
 const jobCreatedEventFields = [...baseEventFields, 'jobPriority', 'jobDueAt', 'jobOwner']
@@ -482,7 +499,8 @@ const productionShopDemandSnapshotFields = ['schema', 'operatingUnitLocationId',
 const productionIssueFields = ['id', 'createdAt', 'area', 'kind', 'summary', 'status', 'severity', 'owner', 'dueAt', 'containment', 'maintenanceFindingSource', 'resolution']
 const productionMaintenanceFindingSourceFields = ['contract', 'equipmentId', 'equipmentName', 'maintenanceOwner', 'completionActionId', 'completedAt', 'strategyActionId', 'strategyRevision', 'returnToService', 'findings', 'evidenceReference']
 const productionMaintenanceCorrectiveActionFields = ['contract', 'correctiveAction', 'verificationResult', 'finalDisposition']
-const productionIssueResolutionFields = ['actionId', 'resolvedAt', 'resolvedBy', 'reason', 'evidenceReference', 'maintenanceCorrectiveAction']
+const productionQualityCorrectiveActionFields = ['contract', 'failureMode', 'causeCategory', 'rootCause', 'correctiveAction', 'verificationResult', 'effectivenessOwner', 'recurrenceKey', 'priorIssueIds']
+const productionIssueResolutionFields = ['actionId', 'resolvedAt', 'resolvedBy', 'reason', 'evidenceReference', 'maintenanceCorrectiveAction', 'qualityCorrectiveAction']
 const productionMachineFields = ['id', 'name', 'state']
 const productionEquipmentMasterFields = ['contract', 'assets']
 const productionEquipmentAssetFields = ['id', 'name', 'workCentreId', 'criticality', 'owner', 'commissioningStatus', 'sourceActionId', 'sourcePackageDigest', 'importedAt']
@@ -498,7 +516,7 @@ const eventFieldsByKind: Record<ProductionEventKind, string[]> = {
   output_recorded: [...baseEventFields, 'quantity', 'shiftRef', 'outputKind'],
   material_consumed: [...materialEventFields, ...materialOptionalEventFields],
   issue_opened: [...baseEventFields, 'issueSeverity', 'issueOwner', 'issueDueAt', 'issueContainment', 'maintenanceFindingSource'],
-  issue_resolved: [...baseEventFields, 'maintenanceCorrectiveAction'],
+  issue_resolved: [...baseEventFields, 'maintenanceCorrectiveAction', 'qualityCorrectiveAction'],
   quality_hold_placed: qualityHoldEventFields,
   quality_hold_released: qualityHoldEventFields,
   machine_state_changed: [...baseEventFields, 'fromState', 'toState'],
@@ -672,6 +690,77 @@ function validateProductionMaintenanceCorrectiveAction(value: unknown, field: st
   canonicalText(value.verificationResult, `${field}.verificationResult`, 360)
   if (!productionMaintenanceReturnToServiceValues.includes(value.finalDisposition as ProductionMaintenanceReturnToService)) throw new Error(`${field}.finalDisposition is invalid.`)
   return value as unknown as ProductionMaintenanceCorrectiveAction
+}
+
+function productionQualityRecurrenceToken(value: string) {
+  return value
+    .normalize('NFKC')
+    .toLocaleLowerCase('en-US')
+    .replace(/[^\p{L}\p{M}\p{N}]+/gu, '-')
+    .replace(/^-+|-+$/g, '')
+}
+
+function productionQualityRecurrenceKey(failureMode: string, causeCategory: ProductionQualityCauseCategory) {
+  return `${causeCategory}:${productionQualityRecurrenceToken(failureMode)}`
+}
+
+function validateProductionQualityCorrectiveAction(value: unknown, field: string): ProductionQualityCorrectiveAction {
+  if (!isRecord(value)) throw new Error(`${field} is invalid.`)
+  if (JSON.stringify(Object.keys(value).sort()) !== JSON.stringify([...productionQualityCorrectiveActionFields].sort())) throw new Error(`${field} fields are invalid.`)
+  if (value.contract !== PRODUCTION_QUALITY_CAPA_SCHEMA) throw new Error(`${field}.contract is invalid.`)
+  const failureMode = canonicalText(value.failureMode, `${field}.failureMode`, 120)
+  if (!productionQualityCauseCategories.includes(value.causeCategory as ProductionQualityCauseCategory)) throw new Error(`${field}.causeCategory is invalid.`)
+  canonicalText(value.rootCause, `${field}.rootCause`, 360)
+  canonicalText(value.correctiveAction, `${field}.correctiveAction`, 360)
+  canonicalText(value.verificationResult, `${field}.verificationResult`, 360)
+  canonicalText(value.effectivenessOwner, `${field}.effectivenessOwner`, 120)
+  const recurrenceKey = canonicalText(value.recurrenceKey, `${field}.recurrenceKey`, 160)
+  if (!productionQualityRecurrenceToken(failureMode) || recurrenceKey !== productionQualityRecurrenceKey(failureMode, value.causeCategory as ProductionQualityCauseCategory)) throw new Error(`${field}.recurrenceKey is invalid.`)
+  if (!Array.isArray(value.priorIssueIds) || value.priorIssueIds.length > 500) throw new Error(`${field}.priorIssueIds is invalid.`)
+  const priorIssueIds = value.priorIssueIds.map((issueId, index) => canonicalText(issueId, `${field}.priorIssueIds[${index}]`, 80))
+  assertUnique(priorIssueIds, `${field}.priorIssueIds`)
+  return value as unknown as ProductionQualityCorrectiveAction
+}
+
+function productionQualityPriorIssueIds(issues: ProductionIssue[], issueId: string, recurrenceKey: string, resolvedBefore?: string) {
+  return issues
+    .filter((candidate) => candidate.id !== issueId
+      && candidate.kind === 'quality'
+      && candidate.status === 'resolved'
+      && candidate.resolution?.qualityCorrectiveAction?.recurrenceKey === recurrenceKey
+      && (!resolvedBefore || timestampBefore(candidate.resolution.resolvedAt, resolvedBefore)))
+    .sort((left, right) => compareTimestamps(left.resolution?.resolvedAt ?? left.createdAt, right.resolution?.resolvedAt ?? right.createdAt)
+      || (left.id < right.id ? -1 : left.id > right.id ? 1 : 0))
+    .map((candidate) => candidate.id)
+}
+
+export function buildProductionQualityCorrectiveAction(state: ProductionState, issueId: string, input: {
+  failureMode: string
+  causeCategory: ProductionQualityCauseCategory
+  rootCause: string
+  correctiveAction: string
+  verificationResult: string
+  effectivenessOwner: string
+}) {
+  const issue = state.issues.find((candidate) => candidate.id === issueId)
+  if (!issue || issue.kind !== 'quality' || issue.status !== 'open'
+    || !validCanonicalText(input.failureMode, 120)
+    || !productionQualityCauseCategories.includes(input.causeCategory)
+    || !validCanonicalText(input.rootCause, 360)
+    || !validCanonicalText(input.correctiveAction, 360)
+    || !validCanonicalText(input.verificationResult, 360)
+    || !validCanonicalText(input.effectivenessOwner, 120)) return null
+  const recurrenceToken = productionQualityRecurrenceToken(input.failureMode)
+  if (!recurrenceToken) return null
+  const recurrenceKey = `${input.causeCategory}:${recurrenceToken}`
+  if (recurrenceKey.length > 160) return null
+  const result: ProductionQualityCorrectiveAction = {
+    contract: PRODUCTION_QUALITY_CAPA_SCHEMA,
+    ...input,
+    recurrenceKey,
+    priorIssueIds: productionQualityPriorIssueIds(state.issues, issueId, recurrenceKey),
+  }
+  try { return validateProductionQualityCorrectiveAction(result, 'qualityCorrectiveAction') } catch { return null }
 }
 
 function validateProductionShopDemandSource(value: unknown, field: string): ProductionShopDemandSource {
@@ -915,7 +1004,11 @@ export function validateProductionState(value: unknown): ProductionState {
       canonicalText(resolution.reason, `issues[${index}].resolution.reason`)
       canonicalText(resolution.evidenceReference, `issues[${index}].resolution.evidenceReference`)
       const correctiveAction = resolution.maintenanceCorrectiveAction === undefined ? undefined : validateProductionMaintenanceCorrectiveAction(resolution.maintenanceCorrectiveAction, `issues[${index}].resolution.maintenanceCorrectiveAction`)
+      const qualityCorrectiveAction = resolution.qualityCorrectiveAction === undefined ? undefined : validateProductionQualityCorrectiveAction(resolution.qualityCorrectiveAction, `issues[${index}].resolution.qualityCorrectiveAction`)
       if (Boolean(candidate.maintenanceFindingSource) !== Boolean(correctiveAction)) throw new Error(`issues[${index}] maintenance finding resolution requires one structured corrective action only.`)
+      if (candidate.kind === 'quality' && candidate.status === 'resolved' && actionFieldCount === actionFields.length && !qualityCorrectiveAction) throw new Error(`issues[${index}] actionable quality resolution requires structured CAPA evidence.`)
+      if (qualityCorrectiveAction && candidate.kind !== 'quality') throw new Error(`issues[${index}] quality corrective action requires a quality issue.`)
+      if (correctiveAction && qualityCorrectiveAction) throw new Error(`issues[${index}] cannot carry maintenance and quality corrective actions together.`)
     }
   }
   assertUnique(issueIds, 'Production issue ID')
@@ -1209,6 +1302,8 @@ export function validateProductionState(value: unknown): ProductionState {
       if (!issueIds.includes(candidate.subjectId as string)) throw new Error(`events[${index}] references an unknown issue.`)
       if (candidate.quantity !== undefined || candidate.remainingQuantity !== undefined || candidate.shiftRef !== undefined || candidate.outputKind !== undefined || materialFieldCount || issueSnapshotFieldCount || maintenanceFieldCount || candidate.fromState !== undefined || candidate.toState !== undefined || candidate.downtimeStartActionId !== undefined) throw new Error(`events[${index}] issue event has unrelated fields.`)
       if (candidate.maintenanceCorrectiveAction !== undefined) validateProductionMaintenanceCorrectiveAction(candidate.maintenanceCorrectiveAction, `events[${index}].maintenanceCorrectiveAction`)
+      if (candidate.qualityCorrectiveAction !== undefined) validateProductionQualityCorrectiveAction(candidate.qualityCorrectiveAction, `events[${index}].qualityCorrectiveAction`)
+      if (candidate.maintenanceCorrectiveAction !== undefined && candidate.qualityCorrectiveAction !== undefined) throw new Error(`events[${index}] cannot carry maintenance and quality corrective actions together.`)
     }
   }
   assertUnique(eventIds, 'Production event ID')
@@ -1475,8 +1570,14 @@ export function validateProductionState(value: unknown): ProductionState {
       || resolutionEvent.actor !== resolution.resolvedBy
       || resolutionEvent.reason !== resolution.reason
       || resolutionEvent.evidenceReference !== resolution.evidenceReference
-      || JSON.stringify(resolutionEvent.maintenanceCorrectiveAction) !== JSON.stringify(resolution.maintenanceCorrectiveAction)) {
+      || JSON.stringify(resolutionEvent.maintenanceCorrectiveAction) !== JSON.stringify(resolution.maintenanceCorrectiveAction)
+      || JSON.stringify(resolutionEvent.qualityCorrectiveAction) !== JSON.stringify(resolution.qualityCorrectiveAction)) {
       throw new Error(`issues[${index}] resolution proof does not match its immutable event.`)
+    }
+    const qualityCorrectiveAction = resolution.qualityCorrectiveAction === undefined ? undefined : validateProductionQualityCorrectiveAction(resolution.qualityCorrectiveAction, `issues[${index}].resolution.qualityCorrectiveAction`)
+    if (qualityCorrectiveAction) {
+      const expectedPriorIssueIds = productionQualityPriorIssueIds(issues as ProductionIssue[], candidate.id as string, qualityCorrectiveAction.recurrenceKey, resolution.resolvedAt as string)
+      if (JSON.stringify(qualityCorrectiveAction.priorIssueIds) !== JSON.stringify(expectedPriorIssueIds)) throw new Error(`issues[${index}] quality recurrence links do not match prior CAPA evidence.`)
     }
     if (openingEvent && events.indexOf(resolutionEvent) >= events.indexOf(openingEvent)) {
       throw new Error(`issues[${index}] resolution must follow its opening event.`)
@@ -3083,10 +3184,20 @@ export function openProductionIssue(state: ProductionState, issue: ProductionIss
   return validateProductionState({ ...state, revision: state.revision + 1, issues: [issue, ...state.issues], events: [event, ...state.events] })
 }
 
-export function resolveProductionIssue(state: ProductionState, issueId: string, proof: ProductionActionProof, maintenanceCorrectiveAction?: ProductionMaintenanceCorrectiveAction) {
+export function resolveProductionIssue(
+  state: ProductionState,
+  issueId: string,
+  proof: ProductionActionProof,
+  maintenanceCorrectiveAction?: ProductionMaintenanceCorrectiveAction,
+  qualityCorrectiveAction?: ProductionQualityCorrectiveAction,
+) {
   if (!validProof(proof)) return null
+  if (maintenanceCorrectiveAction !== undefined && qualityCorrectiveAction !== undefined) return null
   if (maintenanceCorrectiveAction !== undefined) {
     try { validateProductionMaintenanceCorrectiveAction(maintenanceCorrectiveAction, 'maintenanceCorrectiveAction') } catch { return null }
+  }
+  if (qualityCorrectiveAction !== undefined) {
+    try { validateProductionQualityCorrectiveAction(qualityCorrectiveAction, 'qualityCorrectiveAction') } catch { return null }
   }
   const existing = state.events.find((event) => event.actionId === proof.actionId)
   if (existing) {
@@ -3101,12 +3212,17 @@ export function resolveProductionIssue(state: ProductionState, issueId: string, 
       && issue.resolution.reason === proof.reason
       && issue.resolution.evidenceReference === proof.evidenceReference
       && JSON.stringify(issue.resolution.maintenanceCorrectiveAction) === JSON.stringify(maintenanceCorrectiveAction)
-      && JSON.stringify(existing.maintenanceCorrectiveAction) === JSON.stringify(maintenanceCorrectiveAction) ? state : null
+      && JSON.stringify(existing.maintenanceCorrectiveAction) === JSON.stringify(maintenanceCorrectiveAction)
+      && JSON.stringify(issue.resolution.qualityCorrectiveAction) === JSON.stringify(qualityCorrectiveAction)
+      && JSON.stringify(existing.qualityCorrectiveAction) === JSON.stringify(qualityCorrectiveAction) ? state : null
   }
   if (actionIdIsUsed(state, proof.actionId)) return null
   const issue = state.issues.find((candidate) => candidate.id === issueId)
   if (!issue || issue.status !== 'open'
     || Boolean(issue.maintenanceFindingSource) !== Boolean(maintenanceCorrectiveAction)
+    || (issue.kind === 'quality' && Boolean(issue.severity && issue.owner && issue.dueAt && issue.containment) && qualityCorrectiveAction === undefined)
+    || (issue.kind !== 'quality' && qualityCorrectiveAction !== undefined)
+    || (qualityCorrectiveAction !== undefined && JSON.stringify(qualityCorrectiveAction.priorIssueIds) !== JSON.stringify(productionQualityPriorIssueIds(state.issues, issueId, qualityCorrectiveAction.recurrenceKey)))
     || state.revision >= Number.MAX_SAFE_INTEGER) return null
   const resolution: ProductionIssueResolution = {
     actionId: proof.actionId,
@@ -3115,8 +3231,15 @@ export function resolveProductionIssue(state: ProductionState, issueId: string, 
     reason: proof.reason,
     evidenceReference: proof.evidenceReference,
     ...(maintenanceCorrectiveAction === undefined ? {} : { maintenanceCorrectiveAction }),
+    ...(qualityCorrectiveAction === undefined ? {} : { qualityCorrectiveAction }),
   }
-  const event = eventFor(proof, { kind: 'issue_resolved', subjectId: issueId, summary: `Resolved ${issue.kind} issue for ${issue.area}`, ...(maintenanceCorrectiveAction === undefined ? {} : { maintenanceCorrectiveAction }) })
+  const event = eventFor(proof, {
+    kind: 'issue_resolved',
+    subjectId: issueId,
+    summary: `Resolved ${issue.kind} issue for ${issue.area}`,
+    ...(maintenanceCorrectiveAction === undefined ? {} : { maintenanceCorrectiveAction }),
+    ...(qualityCorrectiveAction === undefined ? {} : { qualityCorrectiveAction }),
+  })
   return validateProductionState({
     ...state,
     revision: state.revision + 1,

--- a/supermega_runtime/production_runtime.py
+++ b/supermega_runtime/production_runtime.py
@@ -9,6 +9,7 @@ from datetime import datetime, timedelta, timezone
 import hashlib
 import json
 import re
+import unicodedata
 from typing import Any, Callable
 
 from supermega_runtime.commerce_runtime import validate_commerce_state
@@ -51,6 +52,9 @@ PRODUCTION_HUMAN_EVENTS = PRODUCTION_EVENTS
 
 _ISSUE_KINDS = frozenset({"quality", "maintenance", "materials", "operations"})
 _ISSUE_SEVERITIES = frozenset({"critical", "high", "medium", "low"})
+_QUALITY_CAUSE_CATEGORIES = frozenset(
+    {"material", "method", "machine", "measurement", "people", "environment"}
+)
 _JOB_PRIORITIES = frozenset({"urgent", "normal", "low"})
 _MACHINE_STATES = frozenset({"running", "attention", "stopped"})
 _OUTPUT_KINDS = frozenset({"good", "scrap"})
@@ -217,9 +221,24 @@ _EQUIPMENT_CRITICALITIES = frozenset({"critical", "high", "medium", "low"})
 _EQUIPMENT_ID_PATTERN = re.compile(r"^[A-Z0-9][A-Z0-9._/-]{0,79}$")
 _EVIDENCE_FIELDS = frozenset({"actionId", "capturedAt", "actor", "reason", "evidenceReference"})
 _RESOLUTION_FIELDS = frozenset({"actionId", "resolvedAt", "resolvedBy", "reason", "evidenceReference"})
-_RESOLUTION_OPTIONAL_FIELDS = frozenset({"maintenanceCorrectiveAction"})
+_RESOLUTION_OPTIONAL_FIELDS = frozenset(
+    {"maintenanceCorrectiveAction", "qualityCorrectiveAction"}
+)
 _MAINTENANCE_CORRECTIVE_ACTION_FIELDS = frozenset(
     {"contract", "correctiveAction", "verificationResult", "finalDisposition"}
+)
+_QUALITY_CORRECTIVE_ACTION_FIELDS = frozenset(
+    {
+        "contract",
+        "failureMode",
+        "causeCategory",
+        "rootCause",
+        "correctiveAction",
+        "verificationResult",
+        "effectivenessOwner",
+        "recurrenceKey",
+        "priorIssueIds",
+    }
 )
 _EVENT_FIELDS = frozenset(
     {
@@ -288,7 +307,9 @@ _ISSUE_EVENT_FIELDS = frozenset(
     {"issueSeverity", "issueOwner", "issueDueAt", "issueContainment"}
 )
 _ISSUE_EVENT_OPTIONAL_FIELDS = _ISSUE_EVENT_FIELDS | {"maintenanceFindingSource"}
-_ISSUE_RESOLVED_EVENT_OPTIONAL_FIELDS = frozenset({"maintenanceCorrectiveAction"})
+_ISSUE_RESOLVED_EVENT_OPTIONAL_FIELDS = frozenset(
+    {"maintenanceCorrectiveAction", "qualityCorrectiveAction"}
+)
 _EQUIPMENT_COMMISSION_EVENT_FIELDS = frozenset(
     {"installedAt", "toState", "workCentreId"}
 )
@@ -480,6 +501,50 @@ def _maintenance_corrective_action(candidate: object, field: str) -> dict[str, A
     return action
 
 
+def _quality_recurrence_token(value: str) -> str:
+    normalized = unicodedata.normalize("NFKC", value).lower()
+    token: list[str] = []
+    separator_pending = False
+    for character in normalized:
+        if unicodedata.category(character)[0] in {"L", "M", "N"}:
+            if separator_pending and token:
+                token.append("-")
+            token.append(character)
+            separator_pending = False
+        else:
+            separator_pending = True
+    return "".join(token)
+
+
+def _quality_corrective_action(candidate: object, field: str) -> dict[str, Any]:
+    action = _object(candidate, field)
+    _exact_fields(action, field, required=_QUALITY_CORRECTIVE_ACTION_FIELDS)
+    if action["contract"] != "supermega.production.quality-capa.v1":
+        raise TrialValidationError(f"{field}.contract is unsupported.")
+    failure_mode = _text(action["failureMode"], f"{field}.failureMode", maximum=120)
+    cause_category = action["causeCategory"]
+    if cause_category not in _QUALITY_CAUSE_CATEGORIES:
+        raise TrialValidationError(f"{field}.causeCategory is unsupported.")
+    _text(action["rootCause"], f"{field}.rootCause", maximum=360)
+    _text(action["correctiveAction"], f"{field}.correctiveAction", maximum=360)
+    _text(action["verificationResult"], f"{field}.verificationResult", maximum=360)
+    _text(action["effectivenessOwner"], f"{field}.effectivenessOwner", maximum=120)
+    recurrence_key = _text(action["recurrenceKey"], f"{field}.recurrenceKey", maximum=160)
+    recurrence_token = _quality_recurrence_token(failure_mode)
+    if not recurrence_token or recurrence_key != f"{cause_category}:{recurrence_token}":
+        raise TrialValidationError(f"{field}.recurrenceKey is invalid.")
+    prior_issue_ids = action["priorIssueIds"]
+    if not isinstance(prior_issue_ids, list) or len(prior_issue_ids) > _MAX_ISSUES:
+        raise TrialValidationError(f"{field}.priorIssueIds is invalid.")
+    normalized_issue_ids = [
+        _text(issue_id, f"{field}.priorIssueIds[{index}]", maximum=80)
+        for index, issue_id in enumerate(prior_issue_ids)
+    ]
+    if len(set(normalized_issue_ids)) != len(normalized_issue_ids):
+        raise TrialValidationError(f"{field}.priorIssueIds must be unique.")
+    return action
+
+
 def _resolution(value: object, field: str) -> dict[str, Any]:
     resolution = _object(value, field)
     _exact_fields(
@@ -497,6 +562,18 @@ def _resolution(value: object, field: str) -> dict[str, Any]:
         _maintenance_corrective_action(
             resolution["maintenanceCorrectiveAction"],
             f"{field}.maintenanceCorrectiveAction",
+        )
+    if "qualityCorrectiveAction" in resolution:
+        _quality_corrective_action(
+            resolution["qualityCorrectiveAction"],
+            f"{field}.qualityCorrectiveAction",
+        )
+    if {
+        "maintenanceCorrectiveAction",
+        "qualityCorrectiveAction",
+    }.issubset(resolution):
+        raise TrialValidationError(
+            f"{field} cannot carry maintenance and quality corrective actions together."
         )
     return resolution
 
@@ -730,6 +807,18 @@ def _validate_issue(candidate: object, index: int) -> dict[str, Any]:
         ):
             raise TrialValidationError(
                 f"{field} maintenance finding resolution requires one structured corrective action only."
+            )
+        if (
+            issue["kind"] == "quality"
+            and _ISSUE_ACTION_FIELDS.issubset(issue)
+            and "qualityCorrectiveAction" not in resolution
+        ):
+            raise TrialValidationError(
+                f"{field} actionable quality resolution requires structured CAPA evidence."
+            )
+        if "qualityCorrectiveAction" in resolution and issue["kind"] != "quality":
+            raise TrialValidationError(
+                f"{field} quality corrective action requires a quality issue."
             )
     return issue
 
@@ -1519,9 +1608,58 @@ def _validate_event(
                 event["maintenanceCorrectiveAction"],
                 f"{field}.maintenanceCorrectiveAction",
             )
+        if "qualityCorrectiveAction" in event:
+            _quality_corrective_action(
+                event["qualityCorrectiveAction"],
+                f"{field}.qualityCorrectiveAction",
+            )
+        if {
+            "maintenanceCorrectiveAction",
+            "qualityCorrectiveAction",
+        }.issubset(event):
+            raise TrialValidationError(
+                f"{field} cannot carry maintenance and quality corrective actions together."
+            )
     elif subject_id not in issue_ids:
         raise TrialValidationError(f"{field} references an unknown issue.")
     return event
+
+
+def _quality_prior_issue_ids(
+    issues: Sequence[dict[str, Any]],
+    issue_id: str,
+    recurrence_key: str,
+    *,
+    resolved_before: str | None = None,
+) -> list[str]:
+    before_time = (
+        _parsed_timestamp(resolved_before, "quality CAPA resolvedAt")[1]
+        if resolved_before is not None
+        else None
+    )
+    matches: list[tuple[datetime, str]] = []
+    for candidate in issues:
+        if candidate["id"] == issue_id or candidate["status"] != "resolved":
+            continue
+        resolution = candidate.get("resolution")
+        quality_action = (
+            resolution.get("qualityCorrectiveAction")
+            if isinstance(resolution, Mapping)
+            else None
+        )
+        if (
+            not isinstance(quality_action, Mapping)
+            or quality_action.get("recurrenceKey") != recurrence_key
+        ):
+            continue
+        resolved_at = _parsed_timestamp(
+            resolution["resolvedAt"],
+            f"quality CAPA {candidate['id']} resolvedAt",
+        )[1]
+        if before_time is None or resolved_at < before_time:
+            matches.append((resolved_at, candidate["id"]))
+    matches.sort(key=lambda item: (item[0], item[1]))
+    return [issue_id for _, issue_id in matches]
 
 
 def _validate_issue_history(
@@ -1674,10 +1812,24 @@ def _validate_issue_history(
             or event["evidenceReference"] != resolution["evidenceReference"]
             or event.get("maintenanceCorrectiveAction")
             != resolution.get("maintenanceCorrectiveAction")
+            or event.get("qualityCorrectiveAction")
+            != resolution.get("qualityCorrectiveAction")
         ):
             raise TrialValidationError(
                 f"issues[{index}] resolution does not match its immutable event."
             )
+        quality_action = resolution.get("qualityCorrectiveAction")
+        if quality_action is not None:
+            expected_prior_issue_ids = _quality_prior_issue_ids(
+                issues,
+                issue["id"],
+                quality_action["recurrenceKey"],
+                resolved_before=resolution["resolvedAt"],
+            )
+            if quality_action["priorIssueIds"] != expected_prior_issue_ids:
+                raise TrialValidationError(
+                    f"issues[{index}] quality recurrence links do not match prior CAPA evidence."
+                )
         if events.index(event) >= events.index(opened[0]):
             raise TrialValidationError(
                 f"issues[{index}] resolution must follow its opening event."
@@ -3310,6 +3462,11 @@ def _validate_issue_resolved(
             if "maintenanceCorrectiveAction" in event
             else {}
         ),
+        **(
+            {"qualityCorrectiveAction": event["qualityCorrectiveAction"]}
+            if "qualityCorrectiveAction" in event
+            else {}
+        ),
     }
     if ("maintenanceFindingSource" in before) != (
         "maintenanceCorrectiveAction" in event
@@ -3317,6 +3474,32 @@ def _validate_issue_resolved(
         raise TrialValidationError(
             "maintenance finding resolution requires one structured corrective action only."
         )
+    if (
+        before["kind"] == "quality"
+        and _ISSUE_ACTION_FIELDS.issubset(before)
+        and "qualityCorrectiveAction" not in event
+    ):
+        raise TrialValidationError(
+            "an actionable quality issue requires structured CAPA evidence before resolution."
+        )
+    if before["kind"] != "quality" and "qualityCorrectiveAction" in event:
+        raise TrialValidationError(
+            "quality corrective action can resolve only a quality issue."
+        )
+    if "qualityCorrectiveAction" in event:
+        quality_action = _quality_corrective_action(
+            event["qualityCorrectiveAction"],
+            "event.qualityCorrectiveAction",
+        )
+        expected_prior_issue_ids = _quality_prior_issue_ids(
+            current["issues"],
+            before["id"],
+            quality_action["recurrenceKey"],
+        )
+        if quality_action["priorIssueIds"] != expected_prior_issue_ids:
+            raise TrialValidationError(
+                "quality CAPA recurrence links must match prior resolved evidence."
+            )
     if after != {**before, "status": "resolved", "resolution": resolution}:
         raise TrialValidationError(
             "issue resolution may change only status and exact command evidence."

--- a/tests/test_production_runtime.py
+++ b/tests/test_production_runtime.py
@@ -630,6 +630,40 @@ def opened_issue_state(
     return state
 
 
+def quality_corrective_action(
+    current: dict[str, object],
+    *,
+    issue_id: str,
+    failure_mode: str = "Seal temperature drift",
+    cause_category: str = "machine",
+) -> dict[str, object]:
+    recurrence_key = f"{cause_category}:{failure_mode.lower().replace(' ', '-')}"
+    prior = sorted(
+        (
+            issue
+            for issue in current["issues"]
+            if issue["id"] != issue_id
+            and issue["status"] == "resolved"
+            and issue.get("resolution", {})
+            .get("qualityCorrectiveAction", {})
+            .get("recurrenceKey")
+            == recurrence_key
+        ),
+        key=lambda issue: (issue["resolution"]["resolvedAt"], issue["id"]),
+    )
+    return {
+        "contract": "supermega.production.quality-capa.v1",
+        "failureMode": failure_mode,
+        "causeCategory": cause_category,
+        "rootCause": "Heater feedback drifted outside the reviewed control range.",
+        "correctiveAction": "Recalibrated the feedback loop and updated the first-piece check.",
+        "verificationResult": "Three consecutive samples remained inside the approved range.",
+        "effectivenessOwner": "Quality supervisor",
+        "recurrenceKey": recurrence_key,
+        "priorIssueIds": [issue["id"] for issue in prior],
+    }
+
+
 def resolved_issue_state(
     current: dict[str, object],
     evidence: dict[str, str],
@@ -643,6 +677,11 @@ def resolved_issue_state(
         if issue["id"] == issue_id
     )
     issue = state["issues"][index]
+    quality_action = (
+        quality_corrective_action(current, issue_id=issue_id)
+        if issue["kind"] == "quality" and {"severity", "owner", "dueAt", "containment"}.issubset(issue)
+        else None
+    )
     state["issues"][index] = {
         **issue,
         "status": "resolved",
@@ -652,6 +691,11 @@ def resolved_issue_state(
             "resolvedBy": evidence["actor"],
             "reason": evidence["reason"],
             "evidenceReference": evidence["evidenceReference"],
+            **(
+                {"qualityCorrectiveAction": deepcopy(quality_action)}
+                if quality_action is not None
+                else {}
+            ),
         },
     }
     state["revision"] += 1
@@ -661,6 +705,11 @@ def resolved_issue_state(
             kind="issue_resolved",
             subject_id=issue_id,
             summary=f"Resolved {issue['kind']} issue for {issue['area']}",
+            **(
+                {"qualityCorrectiveAction": deepcopy(quality_action)}
+                if quality_action is not None
+                else {}
+            ),
         ),
         *state["events"],
     ]
@@ -3142,6 +3191,95 @@ class ProductionRuntimeTests(unittest.TestCase):
             resolved["issues"][1]["resolution"]["resolvedBy"],
             ACTOR,
         )
+        first_capa = resolved["issues"][1]["resolution"]["qualityCorrectiveAction"]
+        self.assertEqual(first_capa["contract"], "supermega.production.quality-capa.v1")
+        self.assertEqual(first_capa["priorIssueIds"], [])
+
+        myanmar_capa = quality_corrective_action(
+            two_open,
+            issue_id="ISSUE-REAL-001",
+            failure_mode="အပူချိန် လွဲ",
+        )
+        self.assertEqual(
+            myanmar_capa["recurrenceKey"],
+            "machine:အပူချိန်-လွဲ",
+        )
+        myanmar_state = resolved_issue_state(two_open, resolve_evidence)
+        myanmar_state["issues"][1]["resolution"]["qualityCorrectiveAction"] = deepcopy(
+            myanmar_capa
+        )
+        myanmar_state["events"][0]["qualityCorrectiveAction"] = deepcopy(
+            myanmar_capa
+        )
+        self.assertEqual(validate_production_state(myanmar_state), myanmar_state)
+
+        repeat_open_evidence = action_evidence(
+            "ACT-ISSUE-OPEN-003",
+            captured_at="2026-07-24T09:40:00.000Z",
+        )
+        repeat_open = apply_event(
+            resolved,
+            "production.issue.opened",
+            opened_issue_state(
+                resolved,
+                repeat_open_evidence,
+                issue_id="ISSUE-REAL-003",
+            ),
+            repeat_open_evidence,
+        )
+        repeat_resolve_evidence = action_evidence(
+            "ACT-ISSUE-RESOLVE-003",
+            captured_at="2026-07-24T09:45:00.000Z",
+        )
+        recurring = apply_event(
+            repeat_open,
+            "production.issue.resolved",
+            resolved_issue_state(
+                repeat_open,
+                repeat_resolve_evidence,
+                issue_id="ISSUE-REAL-003",
+            ),
+            repeat_resolve_evidence,
+        )
+        repeat_capa = recurring["issues"][0]["resolution"]["qualityCorrectiveAction"]
+        self.assertEqual(repeat_capa["priorIssueIds"], ["ISSUE-REAL-001"])
+
+        missing_capa = resolved_issue_state(two_open, resolve_evidence)
+        missing_capa["issues"][1]["resolution"].pop("qualityCorrectiveAction")
+        missing_capa["events"][0].pop("qualityCorrectiveAction")
+        with self.assertRaisesRegex(
+            TrialValidationError,
+            "requires structured CAPA evidence",
+        ):
+            validate_production_state(missing_capa)
+        with self.assertRaisesRegex(
+            TrialValidationError,
+            "requires structured CAPA evidence",
+        ):
+            apply_event(
+                two_open,
+                "production.issue.resolved",
+                missing_capa,
+                resolve_evidence,
+            )
+
+        forged_recurrence = resolved_issue_state(
+            repeat_open,
+            repeat_resolve_evidence,
+            issue_id="ISSUE-REAL-003",
+        )
+        forged_recurrence["issues"][0]["resolution"]["qualityCorrectiveAction"]["priorIssueIds"] = []
+        forged_recurrence["events"][0]["qualityCorrectiveAction"]["priorIssueIds"] = []
+        with self.assertRaisesRegex(
+            TrialValidationError,
+            "recurrence links",
+        ):
+            apply_event(
+                repeat_open,
+                "production.issue.resolved",
+                forged_recurrence,
+                repeat_resolve_evidence,
+            )
 
         repeat_evidence = action_evidence(
             "ACT-ISSUE-RESOLVE-AGAIN",

--- a/tools/verify_app_build.mjs
+++ b/tools/verify_app_build.mjs
@@ -2105,6 +2105,17 @@ if (!coreSource.includes('const plantTodayMetrics = [')
   || !coreSource.includes('Keep sampling, NCR containment, corrective action, evidence, and release review in one quality queue.')
   || coreSource.includes('AI turns sampling, NCR containment, corrective action, evidence, and release review into one quality queue.')
   || !coreSource.includes('No certificate, CAPA closure, customer claim, inventory block, costing, or production write runs from this panel.')
+  || !productionSource.includes("PRODUCTION_QUALITY_CAPA_SCHEMA = 'supermega.production.quality-capa.v1'")
+  || !productionSource.includes('export function buildProductionQualityCorrectiveAction')
+  || !productionSource.includes('actionable quality resolution requires structured CAPA evidence')
+  || !productionSource.includes('quality recurrence links do not match prior CAPA evidence')
+  || !managedProductionRuntime.includes('supermega.production.quality-capa.v1')
+  || !managedProductionRuntime.includes('an actionable quality issue requires structured CAPA evidence before resolution.')
+  || !managedProductionRuntime.includes('quality CAPA recurrence links must match prior resolved evidence.')
+  || !coreSource.includes('Verify corrective action')
+  || !coreSource.includes('Review CAPA closeout')
+  || !coreSource.includes('Matching prior CAPA records are linked automatically from the failure mode and cause category.')
+  || !coreSource.includes("issue.kind === 'quality' ? 'Review CAPA' : 'Review close'")
   || !coreSource.includes("'Restore inspection readiness'")
   || !coreSource.includes("'Assign NCR containment'")
   || !coreSource.includes("'Close CAPA evidence'")
@@ -5632,6 +5643,9 @@ const productionEquipmentPosition = productionControlContract.indexOf('<h2>Recor
 if (productionProblemsPosition < 0
   || productionEquipmentPosition < 0
   || productionProblemsPosition > productionEquipmentPosition
+  || !productionControlContract.includes('className="operation-module production-operation-module"')
+  || !coreCssSource.includes('.production-operation-module > .control-workspace { min-height: clamp(420px,62vh,620px); flex: 0 0 auto; }')
+  || !coreCssSource.includes('.production-operation-module > .control-workspace { min-height: 0; flex: none; }')
   || !productionControlContract.includes('>Record problem</button>')
   || productionControlContract.includes('>Open problem form</button>')) fail('production_problems_not_task_first')
 if (!productionJobsContract.includes('This shift:')
@@ -16327,10 +16341,38 @@ async function verifyProductionRuntime() {
       issues: [{ ...opened.issues[0], status: 'resolved' }],
     }), 'production_new_issue_resolved_without_proof')
     const resolutionProof = proof('ACT-ISSUE-RESOLVE', 2_000)
-    const resolved = model.resolveProductionIssue(opened, issue.id, resolutionProof)
-    assert(resolved?.issues[0].status === 'resolved' && resolved.issues[0].resolution?.resolvedBy === resolutionProof.actor && resolved.issues[0].resolution?.evidenceReference === resolutionProof.evidenceReference && resolved.events[0].kind === 'issue_resolved', 'production_issue_resolution_lost_proof')
-    assert(model.resolveProductionIssue(resolved, issue.id, resolutionProof) === resolved, 'production_resolution_retry_not_idempotent')
-    assert(model.resolveProductionIssue(resolved, issue.id, { ...resolutionProof, reason: 'Changed' }) === null, 'production_resolution_conflicting_retry_succeeded')
+    assert(model.resolveProductionIssue(opened, issue.id, resolutionProof) === null, 'production_actionable_quality_issue_closed_without_capa')
+    const qualityCorrectiveAction = model.buildProductionQualityCorrectiveAction(opened, issue.id, {
+      failureMode: 'Temperature drift',
+      causeCategory: 'machine',
+      rootCause: 'Heater feedback drifted outside the reviewed control range.',
+      correctiveAction: 'Recalibrated the feedback loop and added a first-piece check.',
+      verificationResult: 'Three consecutive samples remained inside the approved range.',
+      effectivenessOwner: 'Quality supervisor',
+    })
+    assert(qualityCorrectiveAction?.contract === 'supermega.production.quality-capa.v1'
+      && qualityCorrectiveAction.recurrenceKey === 'machine:temperature-drift'
+      && qualityCorrectiveAction.priorIssueIds.length === 0,
+    'production_first_quality_capa_not_built')
+    const myanmarQualityCorrectiveAction = model.buildProductionQualityCorrectiveAction(opened, issue.id, {
+      failureMode: 'အပူချိန် လွဲ',
+      causeCategory: 'machine',
+      rootCause: 'Heater feedback drifted outside the reviewed control range.',
+      correctiveAction: 'Recalibrated the feedback loop and added a first-piece check.',
+      verificationResult: 'Three consecutive samples remained inside the approved range.',
+      effectivenessOwner: 'Quality supervisor',
+    })
+    assert(myanmarQualityCorrectiveAction?.recurrenceKey === 'machine:အပူချိန်-လွဲ', 'production_myanmar_quality_capa_token_lost_marks')
+    const resolved = model.resolveProductionIssue(opened, issue.id, resolutionProof, undefined, qualityCorrectiveAction)
+    assert(resolved?.issues[0].status === 'resolved'
+      && resolved.issues[0].resolution?.resolvedBy === resolutionProof.actor
+      && resolved.issues[0].resolution?.evidenceReference === resolutionProof.evidenceReference
+      && resolved.issues[0].resolution?.qualityCorrectiveAction?.recurrenceKey === 'machine:temperature-drift'
+      && resolved.events[0].kind === 'issue_resolved'
+      && resolved.events[0].qualityCorrectiveAction?.priorIssueIds.length === 0,
+    'production_issue_resolution_lost_capa_or_proof')
+    assert(model.resolveProductionIssue(resolved, issue.id, resolutionProof, undefined, qualityCorrectiveAction) === resolved, 'production_resolution_retry_not_idempotent')
+    assert(model.resolveProductionIssue(resolved, issue.id, { ...resolutionProof, reason: 'Changed' }, undefined, qualityCorrectiveAction) === null, 'production_resolution_conflicting_retry_succeeded')
     assert(model.resolveProductionIssue(resolved, issue.id, proof('ACT-RESOLVE-AGAIN')) === null, 'production_second_resolution_succeeded')
     assert(model.resolveProductionIssue(resolved, 'ISS-MISSING', proof('ACT-RESOLVE-MISSING')) === null, 'production_missing_issue_resolution_succeeded')
     const changedResolutionProof = {
@@ -16341,7 +16383,16 @@ async function verifyProductionRuntime() {
       }],
     }
     assertThrows(() => model.validateProductionState(changedResolutionProof), 'production_changed_resolution_proof_validated')
-    assert(model.resolveProductionIssue(changedResolutionProof, issue.id, resolutionProof) === null, 'production_changed_resolution_proof_replayed')
+    assert(model.resolveProductionIssue(changedResolutionProof, issue.id, resolutionProof, undefined, qualityCorrectiveAction) === null, 'production_changed_resolution_proof_replayed')
+    const capaRemovedResolution = { ...resolved.issues[0].resolution }
+    const capaRemovedEvent = { ...resolved.events[0] }
+    delete capaRemovedResolution.qualityCorrectiveAction
+    delete capaRemovedEvent.qualityCorrectiveAction
+    assertThrows(() => model.validateProductionState({
+      ...resolved,
+      issues: [{ ...resolved.issues[0], resolution: capaRemovedResolution }],
+      events: [capaRemovedEvent, ...resolved.events.slice(1)],
+    }), 'production_stored_quality_capa_was_removable')
     const legacyIssueState = model.validateProductionState({ ...base, issues: [duplicateIssue] })
     const legacyResolutionProof = proof('ACT-LEGACY-ISSUE-RESOLVE', 2_500)
     const resolvedLegacyIssue = model.resolveProductionIssue(legacyIssueState, duplicateIssue.id, legacyResolutionProof)
@@ -16349,6 +16400,35 @@ async function verifyProductionRuntime() {
       && resolvedLegacyIssue.issues[0].severity === undefined
       && resolvedLegacyIssue.issues[0].resolution?.resolvedBy === legacyResolutionProof.actor,
     'production_legacy_issue_not_readable_or_resolvable')
+
+    const recurringIssue = {
+      ...issue,
+      id: 'ISS-RECURRING',
+      createdAt: '2026-07-23T10:00:03.000Z',
+      dueAt: '2026-07-23T14:00:03.000Z',
+      summary: 'Temperature drift returned on the next controlled batch',
+    }
+    const recurringOpenProof = proof('ACT-ISSUE-RECURRING-OPEN', 3_000)
+    const recurringOpen = model.openProductionIssue(resolved, recurringIssue, recurringOpenProof)
+    const recurringCapa = model.buildProductionQualityCorrectiveAction(recurringOpen, recurringIssue.id, {
+      failureMode: 'Temperature drift',
+      causeCategory: 'machine',
+      rootCause: 'The original calibration fixture was not retained at the station.',
+      correctiveAction: 'Added the controlled fixture to the station release checklist.',
+      verificationResult: 'The next three controlled batches passed the same sample check.',
+      effectivenessOwner: 'Quality supervisor',
+    })
+    assert(recurringCapa?.priorIssueIds.join(',') === issue.id, 'production_recurrence_did_not_link_prior_capa')
+    const recurringResolutionProof = proof('ACT-ISSUE-RECURRING-RESOLVE', 4_000)
+    const recurringResolved = model.resolveProductionIssue(recurringOpen, recurringIssue.id, recurringResolutionProof, undefined, recurringCapa)
+    assert(recurringResolved?.issues[0].resolution?.qualityCorrectiveAction?.priorIssueIds.join(',') === issue.id, 'production_recurrence_resolution_lost_prior_link')
+    const forgedRecurringCapa = { ...recurringCapa, priorIssueIds: [] }
+    assert(model.resolveProductionIssue(recurringOpen, recurringIssue.id, recurringResolutionProof, undefined, forgedRecurringCapa) === null, 'production_forged_recurrence_links_succeeded')
+    assertThrows(() => model.validateProductionState({
+      ...recurringResolved,
+      issues: recurringResolved.issues.map((candidate) => candidate.id === recurringIssue.id ? { ...candidate, resolution: { ...candidate.resolution, qualityCorrectiveAction: forgedRecurringCapa } } : candidate),
+      events: recurringResolved.events.map((event) => event.actionId === recurringResolutionProof.actionId ? { ...event, qualityCorrectiveAction: forgedRecurringCapa } : event),
+    }), 'production_stored_recurrence_links_were_mutable')
 
     const holdProof = proof('ACT-QUALITY-HOLD', 2_600)
     const held = model.placeProductionQualityHold(base, 'JOB-1', holdProof)


### PR DESCRIPTION
## Outcome

Plant quality problems now require structured CAPA before closure, automatically link matching prior CAPA records, and preserve Myanmar failure-mode text in deterministic recurrence keys.

## Product behavior

- keeps CAPA inside the existing Plant Problems workflow; no new page
- records failure mode, controlled cause category, root cause, corrective action, verification result, and effectiveness owner
- derives recurrence links from immutable prior resolved CAPA evidence
- rejects missing, forged, mixed, or post-resolution CAPA evidence in browser and managed runtimes
- makes the desktop Problems action reachable while preserving the mobile layout reset
- keeps batch release, inventory blocks, customer contact, certificates, and machine control outside this action

## Verification

- `python -m unittest discover -s tests` ? 479 passed
- focused ESLint ? passed
- production Vite build ? passed, 223 modules
- `npm run app:verify` ? passed; 321 Plant production runtime checks, 95 security checks
- desktop in-app browser QA ? CAPA review, accountable confirmation, persistence, and resolved history passed; no console errors or overlay

## Activation boundary

No hosted database mutation is included. Managed activation remains fail-closed in isolated-demo mode with writes disabled and seven explicit owner gates.
