### PR TITLE
fix: align workspace reset with restore scope

### DIFF
--- a/showroom/src/core/SettingsPage.tsx
+++ b/showroom/src/core/SettingsPage.tsx
@@ -86,7 +86,6 @@ import {
   type PilotOutcomeReview,
 } from './pilot-outcome'
 import { useLocalPilotOutcome } from './useLocalPilotOutcome'
-import { listResettableCompanyStorageKeys } from './company-backup'
 import { buildClientCapabilityPlan } from './client-capability-plan'
 import {
   buildClientCsvStarterPack,
@@ -139,6 +138,7 @@ import {
   LOCAL_WORKSPACE_RESTORE_POINT_KEY,
   applyLocalWorkspaceBackup,
   collectLocalWorkspaceBackup,
+  listLocalWorkspaceStorageKeys,
   restoreLocalWorkspaceBackup,
   restoreLocalWorkspaceBackupFromEvidence,
   type LocalWorkspaceBackup,
@@ -1870,7 +1870,7 @@ export function SettingsPage() {
       }
       const { resetCommerceOrderDraftRecovery } = await import('./commerce-order-draft')
       await resetCommerceOrderDraftRecovery()
-      const resettableKeys = listResettableCompanyStorageKeys(window.localStorage)
+      const resettableKeys = listLocalWorkspaceStorageKeys(window.localStorage)
       resettableKeys.forEach((key) => window.localStorage.removeItem(key))
       window.location.assign('/')
     } catch (error) {
@@ -2252,7 +2252,6 @@ export function SettingsPage() {
                 <button className="core-button" onClick={saveLocalRestorePoint} type="button">Save restore point</button>
                 <a className="core-button" download={evidenceFilename} href={evidenceHref}>Export full evidence</a>
                 <label className="core-button">Load evidence backup<input accept=".json,application/json" className="sr-only" onChange={(event) => { const file = event.currentTarget.files?.[0] ?? null; event.currentTarget.value = ''; void loadEvidenceRestorePoint(file) }} type="file" /></label>
-                {restorePoint ? <button className="core-button" disabled={restoreBusy} onClick={restoreSavedLocalWorkspace} type="button">{restoreBusy ? 'Restoring...' : 'Restore previous workspace'}</button> : null}
                 {resetArmed ? <><button className="text-link" disabled={resetBusy} onClick={() => setResetArmed(false)} type="button">Cancel</button><button className="core-button danger" disabled={resetBusy} onClick={() => void resetDemoWorkspace()} type="button">{resetBusy ? 'Resetting...' : 'Confirm reset'}</button></> : <button className="text-link danger-text" onClick={() => setResetArmed(true)} type="button">Reset local trial</button>}
               </div>
             </section>

--- a/showroom/src/core/company-backup.ts
+++ b/showroom/src/core/company-backup.ts
@@ -1,3 +1,5 @@
+import { isLocalWorkspaceKey } from './local-workspace-storage.ts'
+
 export const COMPANY_BACKUP_CONTRACT = 'supermega.company_backup.v1'
 export const COMPANY_SNAPSHOT_CONTRACT = 'supermega.local_company_snapshot.v1'
 export const COMPANY_BACKUP_KDF_ITERATIONS = 600_000
@@ -32,25 +34,6 @@ const portablePrefixes = [
   'supermega.website.release-foundation.v1:',
   'supermega.ecommerce.storefront_draft.v2.',
   'supermega.ecommerce.buying_lifecycle.v1.',
-]
-
-const resetOnlyExactKeys = new Set([
-  'supermega.shop.order_draft_reset.v1',
-  'supermega.ecommerce.storefront_draft_reset.v1',
-  'supermega.website.workspace.v1',
-  'supermega.commerce.workspace.v1',
-  'supermega.shop.workspace.v2',
-  'supermega.production.workspace.v1',
-  'supermega.plant.workspace.v2',
-  'supermega.approvals.v2',
-  'supermega.setup.v2',
-  'supermega.team.workspace.v3',
-  'supermega.team.workspace.v2',
-])
-
-const resetOnlyPrefixes = [
-  'supermega.website.workspace.recovery.v1.',
-  'supermega.ecommerce.storefront_draft.v1.',
 ]
 
 const categoryMatchers: Array<[string, (key: string) => boolean]> = [
@@ -200,9 +183,7 @@ export function isPortableCompanyStorageKey(key: string): boolean {
 }
 
 export function isResettableCompanyStorageKey(key: string): boolean {
-  return isPortableCompanyStorageKey(key)
-    || resetOnlyExactKeys.has(key)
-    || resetOnlyPrefixes.some((prefix) => key.startsWith(prefix))
+  return isLocalWorkspaceKey(key)
 }
 
 export function listPortableCompanyStorageKeys(storage: CompanyStorage): string[] {

--- a/showroom/src/core/local-workspace-backup.ts
+++ b/showroom/src/core/local-workspace-backup.ts
@@ -1,30 +1,6 @@
-import {
-  LEGACY_WEBSITE_STORAGE_KEY,
-  WEBSITE_ECOMMERCE_HANDOFF_KEY,
-  WEBSITE_STORAGE_KEY,
-} from '../products/product-handoff'
-import { WEBSITE_LEAD_LEDGER_KEY } from '../products/website/website-leads'
-import { BEHAVIOR_TRAIL_KEY } from './behavior-trail'
-import { COMMERCE_KEY, LEGACY_COMMERCE_KEYS } from './commerce-workspace'
-import { CLIENT_DEMO_WORKSPACE_STORAGE_KEY } from './client-onboarding'
-import { PLANT_INDUSTRY_PACK_STORAGE_KEY } from './plant-industry-packs'
-import { PLANT_ORDER_STORAGE_PREFIX } from './plant-order-foundation'
-import {
-  ACTION_KEY,
-  APPROVAL_KEY,
-  LEGACY_APPROVAL_KEYS,
-  LEGACY_SETUP_KEYS,
-  LEGACY_STOREFRONT_DRAFT_RESET_KEY,
-  LEGACY_STOREFRONT_DRAFT_RESET_PREFIX,
-  SETUP_KEY,
-  SHOP_ORDER_DRAFT_RESET_EPOCH_KEY,
-  SHOP_ORDER_DRAFT_RESET_PREFIX,
-  STOREFRONT_DRAFT_RESET_PREFIX,
-  WEBSITE_RECOVERY_EXPORT_PREFIX,
-} from './product-setup'
-import { LEGACY_PRODUCTION_KEYS, PRODUCTION_KEY } from './production-workspace'
-import { SHOP_SERVICE_SCHEDULE_STORAGE_KEY } from './shop-service-scheduling'
-import { LEGACY_TEAM_WORK_KEYS, TEAM_WORK_KEY } from './team-work'
+import { isLocalWorkspaceKey, listLocalWorkspaceStorageKeys } from './local-workspace-storage.ts'
+
+export { isLocalWorkspaceKey, listLocalWorkspaceStorageKeys }
 
 export const LOCAL_WORKSPACE_BACKUP_CONTRACT = 'supermega.local_workspace_backup.v1'
 export const LOCAL_WORKSPACE_BACKUP_MAX_BYTES = 5 * 1024 * 1024
@@ -39,39 +15,6 @@ export type LocalWorkspaceBackup = {
 
 type StorageReader = Pick<Storage, 'getItem' | 'key' | 'length'>
 type StorageWriter = StorageReader & Pick<Storage, 'removeItem' | 'setItem'>
-
-const exactWorkspaceKeys = new Set([
-  COMMERCE_KEY,
-  PRODUCTION_KEY,
-  APPROVAL_KEY,
-  SETUP_KEY,
-  ACTION_KEY,
-  BEHAVIOR_TRAIL_KEY,
-  SHOP_ORDER_DRAFT_RESET_EPOCH_KEY,
-  TEAM_WORK_KEY,
-  WEBSITE_STORAGE_KEY,
-  LEGACY_WEBSITE_STORAGE_KEY,
-  WEBSITE_LEAD_LEDGER_KEY,
-  WEBSITE_ECOMMERCE_HANDOFF_KEY,
-  CLIENT_DEMO_WORKSPACE_STORAGE_KEY,
-  LEGACY_STOREFRONT_DRAFT_RESET_KEY,
-  SHOP_SERVICE_SCHEDULE_STORAGE_KEY,
-  PLANT_INDUSTRY_PACK_STORAGE_KEY,
-  ...LEGACY_TEAM_WORK_KEYS,
-  ...LEGACY_COMMERCE_KEYS,
-  ...LEGACY_PRODUCTION_KEYS,
-  ...LEGACY_APPROVAL_KEYS,
-  ...LEGACY_SETUP_KEYS,
-])
-
-export function isLocalWorkspaceKey(key: string) {
-  return exactWorkspaceKeys.has(key)
-    || key.startsWith(PLANT_ORDER_STORAGE_PREFIX)
-    || key.startsWith(STOREFRONT_DRAFT_RESET_PREFIX)
-    || key.startsWith(LEGACY_STOREFRONT_DRAFT_RESET_PREFIX)
-    || key.startsWith(SHOP_ORDER_DRAFT_RESET_PREFIX)
-    || key.startsWith(WEBSITE_RECOVERY_EXPORT_PREFIX)
-}
 
 function checkedBackup(value: unknown): LocalWorkspaceBackup | null {
   if (!value || typeof value !== 'object') return null
@@ -101,9 +44,7 @@ function checkedBackup(value: unknown): LocalWorkspaceBackup | null {
 
 export function collectLocalWorkspaceBackup(storage: StorageReader, createdAt = new Date().toISOString()) {
   const records: Record<string, string> = {}
-  for (let index = 0; index < storage.length; index += 1) {
-    const key = storage.key(index)
-    if (!key || !isLocalWorkspaceKey(key)) continue
+  for (const key of listLocalWorkspaceStorageKeys(storage)) {
     const value = storage.getItem(key)
     if (value !== null) records[key] = value
   }
@@ -124,9 +65,7 @@ export function restoreLocalWorkspaceBackupFromEvidence(value: unknown) {
 }
 
 function removeLocalWorkspaceRecords(storage: StorageWriter) {
-  const keys = Array.from({ length: storage.length }, (_, index) => storage.key(index))
-    .filter((key): key is string => Boolean(key && isLocalWorkspaceKey(key)))
-  keys.forEach((key) => storage.removeItem(key))
+  listLocalWorkspaceStorageKeys(storage).forEach((key) => storage.removeItem(key))
 }
 
 export function applyLocalWorkspaceBackup(storage: StorageWriter, value: LocalWorkspaceBackup) {

--- a/showroom/src/core/local-workspace-storage.ts
+++ b/showroom/src/core/local-workspace-storage.ts
@@ -1,0 +1,54 @@
+const exactWorkspaceKeys = new Set([
+  'supermega.commerce.workspace.v2',
+  'supermega.production.workspace.v2',
+  'supermega.approvals.v3',
+  'supermega.setup.v3',
+  'supermega.accountable.actions.v1',
+  'supermega.behavior-trail.v1',
+  'supermega.shop.order_draft_reset.v1',
+  'supermega.ecommerce.storefront_draft_reset.v1',
+  'supermega.team.workspace.v4',
+  'supermega.website.workspace.v2',
+  'supermega.website.workspace.v1',
+  'supermega.website.leads.v1',
+  'supermega.website-ecommerce-handoff.v1',
+  'supermega.client-demo-workspace.v1',
+  'supermega.ecommerce.storefront_draft.v1',
+  'supermega.shop.service-schedule.v1',
+  'supermega.plant.industry-pack.v1',
+  'supermega.pilot-outcome.v1',
+  'supermega.owner-control-acknowledgements.v1',
+  'supermega.team.workspace.v3',
+  'supermega.team.workspace.v2',
+  'supermega.commerce.workspace.v1',
+  'supermega.shop.workspace.v2',
+  'supermega.production.workspace.v1',
+  'supermega.plant.workspace.v2',
+  'supermega.approvals.v2',
+  'supermega.setup.v2',
+])
+
+const workspaceKeyPrefixes = [
+  'supermega.plant.order-foundation.v1:',
+  'supermega.ecommerce.storefront_draft.v2.',
+  'supermega.ecommerce.storefront_draft.v1.',
+  'supermega.shop.order_draft.v1.',
+  'supermega.website.workspace.recovery.v1.',
+  'supermega.website.release-foundation.v1:',
+  'supermega.ecommerce.buying_lifecycle.v1.',
+]
+
+type WorkspaceStorageReader = Pick<Storage, 'key' | 'length'>
+
+export function isLocalWorkspaceKey(key: string) {
+  return exactWorkspaceKeys.has(key) || workspaceKeyPrefixes.some((prefix) => key.startsWith(prefix))
+}
+
+export function listLocalWorkspaceStorageKeys(storage: WorkspaceStorageReader) {
+  const keys = new Set<string>()
+  for (let index = 0; index < storage.length; index += 1) {
+    const key = storage.key(index)
+    if (key && isLocalWorkspaceKey(key)) keys.add(key)
+  }
+  return [...keys].sort()
+}

--- a/tools/verify_app_build.mjs
+++ b/tools/verify_app_build.mjs
@@ -128,6 +128,7 @@ const managedAccountPageSource = await readFile(resolve(root, 'showroom', 'src',
 const managedTrialProofSource = await readFile(resolve(root, 'showroom', 'src', 'core', 'managed-trial-proof.ts'), 'utf8')
 const operationsPageRouteSource = await readFile(resolve(root, 'showroom', 'src', 'core', 'OperationsPageRoute.tsx'), 'utf8')
 const localWorkspaceBackupSource = await readFile(resolve(root, 'showroom', 'src', 'core', 'local-workspace-backup.ts'), 'utf8')
+const localWorkspaceStorageSource = await readFile(resolve(root, 'showroom', 'src', 'core', 'local-workspace-storage.ts'), 'utf8')
 const productSetupSource = await readFile(resolve(root, 'showroom', 'src', 'core', 'product-setup.ts'), 'utf8')
 const workspaceRuntimeSource = await readFile(resolve(root, 'showroom', 'src', 'core', 'workspace-runtime.ts'), 'utf8')
 const operationalReportSource = await readFile(resolve(root, 'showroom', 'src', 'core', 'operational-report.ts'), 'utf8')
@@ -264,8 +265,8 @@ if (coreSource.includes('const productStartActions =')
 if (!coreSource.includes("'Use Shop demand'")
   || !coreSource.includes('className="workspace-toolbar view-tabs product-task-tabs"')) fail('product_task_navigation_missing')
 if (!coreCssSource.includes('.production-operation-module > .plant-batch-disclosure { flex: 0 0 auto; }')) fail('plant_execution_panel_can_shrink_out_of_view')
-if (!localWorkspaceBackupSource.includes("key.startsWith(PLANT_ORDER_STORAGE_PREFIX)")
-  || !settingsPageSource.includes('listResettableCompanyStorageKeys(window.localStorage)')) fail('plant_execution_evidence_not_reset_or_restored_with_workspace')
+if (!localWorkspaceStorageSource.includes("'supermega.plant.order-foundation.v1:'")
+  || !settingsPageSource.includes('listLocalWorkspaceStorageKeys(window.localStorage)')) fail('plant_execution_evidence_not_reset_or_restored_with_workspace')
 if (!plantOrderUiSource.includes('<details className="compact-disclosure production-history" open>')) fail('plant_required_batch_fields_hidden_by_default')
 if (!websiteSource.includes("const managedReleaseRequired = storageMode === 'managed'")
   || !websiteSource.includes("['Review', hasUnsavedChanges ? 'Blocked by draft' : managedReleaseRequired ? approvalIsCurrent ? 'Recorded' : 'Needed' : 'Not required']")
@@ -2452,7 +2453,8 @@ if (!shopReplenishmentSource.includes("SHOP_REPLENISHMENT_PLAN_CONTRACT = 'super
   || !coreCssSource.includes('.shop-order-control.supplier-control')
   || !coreCssSource.includes('.shop-replenishment-list')) fail('shop_replenishment_plan_missing')
 if (['fetch(', 'localStorage', 'sessionStorage', 'supabase', 'openai', 'anthropic'].some((marker) => shopReplenishmentSource.toLowerCase().includes(marker.toLowerCase()))) fail('shop_replenishment_side_effect_added')
-if (!localWorkspaceBackupSource.includes('LEGACY_TEAM_WORK_KEYS') || !localWorkspaceBackupSource.includes('LEGACY_COMMERCE_KEYS') || !localWorkspaceBackupSource.includes('LEGACY_PRODUCTION_KEYS') || !localWorkspaceBackupSource.includes('LEGACY_APPROVAL_KEYS') || !localWorkspaceBackupSource.includes('LEGACY_SETUP_KEYS')) fail('legacy_local_workspace_not_migrated')
+if (!['supermega.team.workspace.v3', 'supermega.team.workspace.v2', 'supermega.commerce.workspace.v1', 'supermega.shop.workspace.v2', 'supermega.production.workspace.v1', 'supermega.plant.workspace.v2', 'supermega.approvals.v2', 'supermega.setup.v2']
+  .every((key) => localWorkspaceStorageSource.includes(`'${key}'`))) fail('legacy_local_workspace_not_migrated')
 if (!workspaceRuntimeSource.includes('decisionPacketFingerprint') || !coreSource.includes("status: 'superseded' as const")) fail('stale_approval_packet_not_superseded')
 if (!workspaceRuntimeSource.includes('toManagedDecisionPacket') || !settingsPageSource.includes('managedApprovalRequests')) fail('managed_decision_packet_serializer_missing')
 if (!teamSource.includes('Accept and record') || !teamSource.includes("acceptedActorKind: 'human'") || !teamModel.includes('acceptanceEvidenceReference')) fail('product_decision_not_human_attributed')
@@ -2718,18 +2720,20 @@ if (!storefrontDraftStoragePrefix
   || !localProductExportBlock.includes('key.startsWith(SHOP_ORDER_DRAFT_RESET_PREFIX)')
   || !localProductResetBlock.includes("const { resetCommerceOrderDraftRecovery } = await import('./commerce-order-draft')")
   || !localProductResetBlock.includes('await resetCommerceOrderDraftRecovery()')
-  || !localProductResetBlock.includes('listResettableCompanyStorageKeys(window.localStorage)')
+  || !localProductResetBlock.includes('listLocalWorkspaceStorageKeys(window.localStorage)')
   || !localProductResetBlock.includes('resettableKeys.forEach')
-  || !companyBackupSource.includes("'supermega.shop.order_draft.v1.'")
-  || !companyBackupSource.includes("'supermega.ecommerce.storefront_draft.v2.'")
-  || !companyBackupSource.includes("'supermega.ecommerce.storefront_draft.v1.'")
-  || !companyBackupSource.includes("'supermega.shop.order_draft_reset.v1'")
+  || !localWorkspaceStorageSource.includes("'supermega.shop.order_draft.v1.'")
+  || !localWorkspaceStorageSource.includes("'supermega.ecommerce.storefront_draft.v2.'")
+  || !localWorkspaceStorageSource.includes("'supermega.ecommerce.storefront_draft.v1.'")
+  || !localWorkspaceStorageSource.includes("'supermega.shop.order_draft_reset.v1'")
   || !settingsPageSource.includes('owner-control, outcome, setup, unfinished order drafts, and local AI-memory records')
   || coreSource.includes("from '../products/ecommerce/storefront-draft'")) fail('ecommerce_storefront_draft_not_in_deliberate_reset_or_broke_lazy_boundary')
 if (!localWorkspaceBackupSource.includes("LOCAL_WORKSPACE_BACKUP_CONTRACT = 'supermega.local_workspace_backup.v1'")
   || !localWorkspaceBackupSource.includes('LOCAL_WORKSPACE_BACKUP_MAX_BYTES = 5 * 1024 * 1024')
-  || !localWorkspaceBackupSource.includes('export function isLocalWorkspaceKey(')
+  || !localWorkspaceBackupSource.includes("from './local-workspace-storage.ts'")
   || !localWorkspaceBackupSource.includes('export function collectLocalWorkspaceBackup(')
+  || !localWorkspaceStorageSource.includes('export function isLocalWorkspaceKey(')
+  || !localWorkspaceStorageSource.includes('export function listLocalWorkspaceStorageKeys(')
   || !localWorkspaceBackupSource.includes('export function restoreLocalWorkspaceBackupFromEvidence(')
   || !localWorkspaceBackupSource.includes("evidence.version !== 24")
   || !localWorkspaceBackupSource.includes('export function applyLocalWorkspaceBackup(')
@@ -17815,7 +17819,12 @@ if (!companyBackupSource.includes("COMPANY_BACKUP_CONTRACT = 'supermega.company_
   || !appLiveVerifierSource.includes('supermega.company_backup.v1')
   || !appLiveVerifierSource.includes('company_backup_chunk_missing')
   || !settingsPageSource.includes("import('./CompanyBackupPanel')")
-  || !settingsPageSource.includes('listResettableCompanyStorageKeys(window.localStorage)')
+  || !settingsPageSource.includes('listLocalWorkspaceStorageKeys(window.localStorage)')
+  || !companyBackupSource.includes('return isLocalWorkspaceKey(key)')
+  || !localWorkspaceStorageSource.includes("'supermega.client-demo-workspace.v1'")
+  || !localWorkspaceStorageSource.includes("'supermega.website.leads.v1'")
+  || !localWorkspaceStorageSource.includes("'supermega.shop.service-schedule.v1'")
+  || !localWorkspaceStorageSource.includes("'supermega.plant.industry-pack.v1'")
   || !settingsPageSource.includes('Reset clears current Shop, Plant, Website, Ecommerce, owner-control, outcome, setup, unfinished order drafts, and local AI-memory records.')
   || !coreCssSource.includes('.company-backup-panel')
   || !coreCssSource.includes('.company-backup-fields input { min-height: 44px; }')
@@ -17823,6 +17832,7 @@ if (!companyBackupSource.includes("COMPANY_BACKUP_CONTRACT = 'supermega.company_
 
 try {
   const backup = await import(`${pathToFileURL(resolve(root, 'showroom', 'src', 'core', 'company-backup.ts')).href}?company-backup=${Date.now()}`)
+  const localBackup = await import(`${pathToFileURL(resolve(root, 'showroom', 'src', 'core', 'local-workspace-backup.ts')).href}?local-workspace-backup=${Date.now()}`)
   class MemoryStorage {
     constructor(entries = []) { this.values = new Map(entries) }
     get length() { return this.values.size }
@@ -17924,6 +17934,36 @@ try {
     || legacyResetKeys.some((key) => !backup.isResettableCompanyStorageKey(key))
     || backup.isResettableCompanyStorageKey('supermega.auth.session.v1')
     || backup.isResettableCompanyStorageKey('supermega.managed.workspace.v1')) fail('company_backup_reset_classifier_invalid')
+  companyBackupRuntimeChecks += 1
+  const recoverableRows = [
+    ['supermega.client-demo-workspace.v1', JSON.stringify({ workspace: 'Demo Workspace' })],
+    ['supermega.website.leads.v1', JSON.stringify({ leads: 2 })],
+    ['supermega.shop.service-schedule.v1', JSON.stringify({ appointments: 1 })],
+    ['supermega.plant.industry-pack.v1', JSON.stringify({ pack: 'manufacturing' })],
+    ['supermega.pilot-outcome.v1', JSON.stringify({ status: 'measuring' })],
+    ['supermega.owner-control-acknowledgements.v1', JSON.stringify([{ itemId: 'shop-1' }])],
+    ['supermega.website.release-foundation.v1:main', JSON.stringify({ releases: 1 })],
+    ['supermega.ecommerce.buying_lifecycle.v1.main', JSON.stringify({ requests: 1 })],
+  ]
+  const recoveryTarget = new MemoryStorage([
+    ...recoverableRows,
+    ['supermega.auth.session.v1', 'auth-kept'],
+    ['unrelated.browser.state', 'unrelated-kept'],
+  ])
+  const recoveryPoint = localBackup.collectLocalWorkspaceBackup(recoveryTarget, new Date('2026-08-03T00:00:00.000Z').toISOString())
+  const recoveryKeys = localBackup.listLocalWorkspaceStorageKeys(recoveryTarget)
+  if (!recoveryPoint
+    || Object.keys(recoveryPoint.records).length !== recoverableRows.length
+    || recoverableRows.some(([key]) => !recoveryKeys.includes(key) || !backup.isResettableCompanyStorageKey(key))) fail('local_workspace_reset_backup_scope_drifted')
+  companyBackupRuntimeChecks += 1
+  recoveryKeys.forEach((key) => recoveryTarget.removeItem(key))
+  if (recoverableRows.some(([key]) => recoveryTarget.getItem(key) !== null)
+    || recoveryTarget.getItem('supermega.auth.session.v1') !== 'auth-kept'
+    || recoveryTarget.getItem('unrelated.browser.state') !== 'unrelated-kept') fail('local_workspace_reset_boundary_invalid')
+  localBackup.applyLocalWorkspaceBackup(recoveryTarget, recoveryPoint)
+  if (recoverableRows.some(([key, value]) => recoveryTarget.getItem(key) !== value)
+    || recoveryTarget.getItem('supermega.auth.session.v1') !== 'auth-kept'
+    || recoveryTarget.getItem('unrelated.browser.state') !== 'unrelated-kept') fail('local_workspace_restore_round_trip_invalid')
   companyBackupRuntimeChecks += 1
 } catch (error) {
   fail(`company_backup_runtime_failed:${error instanceof Error ? error.message : String(error)}`)


### PR DESCRIPTION
## Outcome
- fixes Reset local trial leaving an old client launchpad beside blank client fields
- gives reset and restore one canonical bounded browser-storage key registry
- keeps auth, managed workspace, and unrelated browser state outside the reset scope
- removes the duplicate Restore previous workspace action

## Evidence
- live release reproduced the split-brain state after visible save/reset
- corrected local journey: 11-record restore point -> blank reset state with no kit -> exact client/owner/three-product launchpad restored
- no browser errors or horizontal overflow
- in-memory regression covers client workspace, Website leads/release, Shop schedule, Plant pack, pilot outcome, owner control, and Ecommerce lifecycle plus excluded auth/unrelated state

## Verification
- focused ESLint
- production build (224 modules)
- full `npm run app:verify`: 233 onboarding, 11 company backup, 95 security checks, and all client/recovery/privacy/database/Vercel/HQ gates

## Safety
Browser-local isolated demo only. No hosted write, migration, provider, connector, model, payment, message, or credential change.