### PR TITLE
fix(setup): require post-setup mission proof

### DIFF
--- a/showroom/src/core/SettingsPage.tsx
+++ b/showroom/src/core/SettingsPage.tsx
@@ -256,6 +256,13 @@ function safePacketFilename(value: string) {
   return value.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '').slice(0, 48) || 'store'
 }
 
+function latestIsoTimestamp(values: Array<string | null | undefined>) {
+  return values.reduce<string | null>((latest, value) => {
+    if (!value || !Number.isFinite(Date.parse(value))) return latest
+    return !latest || Date.parse(value) > Date.parse(latest) ? value : latest
+  }, null)
+}
+
 function settingsCommandUuid() {
   if (globalThis.crypto?.randomUUID) return globalThis.crypto.randomUUID()
   const bytes = globalThis.crypto.getRandomValues(new Uint8Array(16))
@@ -507,23 +514,43 @@ export function SettingsPage() {
   const preparedBlockedEntry = preparedBlockedProduct
     ? preparedArtifact?.products.find((product) => product.product === preparedBlockedProduct) ?? null
     : null
-  const plantReleasedBatches = (() => {
-    try { return productionOrderPortfolioEntries(production).filter((entry) => projectPlantOrder(entry.execution).status === 'released_to_stock').length } catch { return 0 }
+  const accountableShopSaleTimes = commerce.orders.flatMap((order) => {
+    const completedAt = order.status === 'completed' ? order.completion?.capturedAt : null
+    const reconciledAt = order.paymentStatus === 'reconciled' ? order.paymentReconciledAt : null
+    if (!completedAt || !reconciledAt || !Number.isFinite(Date.parse(completedAt)) || !Number.isFinite(Date.parse(reconciledAt))) return []
+    return [Date.parse(completedAt) < Date.parse(reconciledAt) ? completedAt : reconciledAt]
+  })
+  const releasedPlantBatchProofTimes = (() => {
+    try {
+      return productionOrderPortfolioEntries(production).flatMap((entry) => {
+        const projection = projectPlantOrder(entry.execution)
+        return projection.status === 'released_to_stock' && projection.batchRelease ? [projection.batchRelease.proof.capturedAt] : []
+      })
+    } catch { return [] }
   })()
-  const approvedWebsiteReleases = (() => {
+  const currentWebsitePublish = (() => {
     const loaded = loadWebsiteWorkspace(window.localStorage)
-    return loaded.ok && getCurrentPublish(loaded.workspace) ? 1 : 0
+    return loaded.ok ? getCurrentPublish(loaded.workspace) : null
   })()
   const demoRunbook = demoWorkspace ? buildClientDemoRunbook(demoWorkspace, {
     commerce: {
       completedOrders: commerce.orders.filter((order) => order.status === 'completed').length,
       reconciledOrders: commerce.orders.filter((order) => order.paymentStatus === 'reconciled').length,
+      latestAccountableSaleAt: latestIsoTimestamp(accountableShopSaleTimes),
     },
-    production: { releasedBatches: plantReleasedBatches },
-    website: { approvedReleases: approvedWebsiteReleases },
+    production: {
+      releasedBatches: releasedPlantBatchProofTimes.length,
+      latestReleasedAt: latestIsoTimestamp(releasedPlantBatchProofTimes),
+    },
+    website: {
+      approvedReleases: currentWebsitePublish ? 1 : 0,
+      latestApprovedAt: currentWebsitePublish?.recordedAt ?? null,
+    },
     ecommerce: {
       savedStorefronts: commerce.storefrontConfiguration ? 1 : 0,
       reviewedRequests: commerce.storefrontRequests?.length ?? 0,
+      latestSavedStorefrontAt: commerce.storefrontConfiguration?.saved.capturedAt ?? null,
+      latestReviewedRequestAt: latestIsoTimestamp(commerce.storefrontRequests?.map((request) => request.createdAt) ?? []),
     },
   }) : null
   const nextDemoMission = demoRunbook?.products.find((product) => product.product === demoRunbook.nextProduct) ?? null

--- a/showroom/src/core/client-onboarding.ts
+++ b/showroom/src/core/client-onboarding.ts
@@ -5,7 +5,7 @@ export const CLIENT_IMPORT_SCHEMA = 'supermega.client_import_preview.v1' as cons
 export const CLIENT_STAGING_SCHEMA = 'supermega.client_import_staging.v1' as const
 export const CLIENT_DEMO_BLUEPRINT_SCHEMA = 'supermega.client_demo_blueprint.v3' as const
 export const CLIENT_DEMO_KIT_SCHEMA = 'supermega.client_demo_kit.v3' as const
-export const CLIENT_DEMO_WORKSPACE_SCHEMA = 'supermega.client_demo_workspace.v3' as const
+export const CLIENT_DEMO_WORKSPACE_SCHEMA = 'supermega.client_demo_workspace.v4' as const
 export const CLIENT_DEMO_RUNBOOK_SCHEMA = 'supermega.client_demo_runbook.v1' as const
 export const CLIENT_DEMO_PREPARATION_SCHEMA = 'supermega.client_demo_preparation.v3' as const
 export const CLIENT_OPERATING_FOUNDATION_SCHEMA = 'supermega.client_operating_foundation.v1' as const
@@ -17,6 +17,7 @@ const LEGACY_CLIENT_DEMO_KIT_SCHEMA = 'supermega.client_demo_kit.v1' as const
 const LEGACY_V2_CLIENT_DEMO_KIT_SCHEMA = 'supermega.client_demo_kit.v2' as const
 const LEGACY_CLIENT_DEMO_WORKSPACE_SCHEMA = 'supermega.client_demo_workspace.v1' as const
 const LEGACY_V2_CLIENT_DEMO_WORKSPACE_SCHEMA = 'supermega.client_demo_workspace.v2' as const
+const LEGACY_V3_CLIENT_DEMO_WORKSPACE_SCHEMA = 'supermega.client_demo_workspace.v3' as const
 export const CLIENT_DEMO_WORKSPACE_STORAGE_KEY = 'supermega.client-demo-workspace.v1'
 export const CLIENT_DEMO_KIT_MAX_BYTES = 128 * 1024
 export const CLIENT_DEMO_PREPARATION_MAX_BYTES = 5 * 1024 * 1024
@@ -287,6 +288,7 @@ export type ClientDemoWorkspace = {
   schema: typeof CLIENT_DEMO_WORKSPACE_SCHEMA
   blueprint: ClientDemoBlueprint
   products: ClientDemoProductProgress[]
+  proofBaselineAt: string
   updatedAt: string
 }
 
@@ -302,10 +304,15 @@ export type ClientDemoKit = {
 }
 
 export type ClientDemoOperationalEvidence = {
-  commerce: { completedOrders: number; reconciledOrders: number }
-  production: { releasedBatches: number }
-  website: { approvedReleases: number }
-  ecommerce: { savedStorefronts: number; reviewedRequests: number }
+  commerce: { completedOrders: number; reconciledOrders: number; latestAccountableSaleAt: string | null }
+  production: { releasedBatches: number; latestReleasedAt: string | null }
+  website: { approvedReleases: number; latestApprovedAt: string | null }
+  ecommerce: {
+    savedStorefronts: number
+    reviewedRequests: number
+    latestSavedStorefrontAt: string | null
+    latestReviewedRequestAt: string | null
+  }
 }
 
 export type ClientDemoRunbookStatus = 'prepare_data' | 'needs_fix' | 'ready_to_run' | 'proven'
@@ -1739,22 +1746,31 @@ export function createClientDemoWorkspace(blueprintValue: unknown, updatedAtValu
     schema: CLIENT_DEMO_WORKSPACE_SCHEMA,
     blueprint,
     products: blueprint.products.map(({ product }) => ({ product, status: 'not_started', rows: 0, readyRows: 0, issueRows: 0, updatedAt: null })),
+    proofBaselineAt: updatedAt,
     updatedAt,
   }
 }
 
 export function restoreClientDemoWorkspace(value: unknown): ClientDemoWorkspace | null {
   if (!value || typeof value !== 'object' || Array.isArray(value)) return null
-  if (!hasExactKeys(value, ['schema', 'blueprint', 'products', 'updatedAt'])) return null
   const source = value as Partial<ClientDemoWorkspace>
+  const sourceSchema = source.schema as string | undefined
+  const currentSchema = sourceSchema === CLIENT_DEMO_WORKSPACE_SCHEMA
+  const legacySchema = sourceSchema === LEGACY_V3_CLIENT_DEMO_WORKSPACE_SCHEMA
+    || sourceSchema === LEGACY_V2_CLIENT_DEMO_WORKSPACE_SCHEMA
+    || sourceSchema === LEGACY_CLIENT_DEMO_WORKSPACE_SCHEMA
+  if ((!currentSchema && !legacySchema)
+    || !hasExactKeys(value, currentSchema
+      ? ['schema', 'blueprint', 'products', 'proofBaselineAt', 'updatedAt']
+      : ['schema', 'blueprint', 'products', 'updatedAt'])) return null
   const blueprint = canonicalClientDemoBlueprint(source.blueprint)
   const updatedAt = canonicalTimestamp(source.updatedAt)
-  const sourceSchema = source.schema as string | undefined
-  if ((sourceSchema !== CLIENT_DEMO_WORKSPACE_SCHEMA && sourceSchema !== LEGACY_V2_CLIENT_DEMO_WORKSPACE_SCHEMA && sourceSchema !== LEGACY_CLIENT_DEMO_WORKSPACE_SCHEMA) || !blueprint || !updatedAt || !Array.isArray(source.products)
+  const proofBaselineAt = currentSchema ? canonicalTimestamp(source.proofBaselineAt) : updatedAt
+  if (!blueprint || !updatedAt || !proofBaselineAt || Date.parse(proofBaselineAt) > Date.parse(updatedAt) || !Array.isArray(source.products)
     || source.products.length !== blueprint.products.length) return null
   const products = blueprint.products.map(({ product }, index) => canonicalProgress(source.products?.[index], product))
   if (products.some((product) => !product)) return null
-  return { schema: CLIENT_DEMO_WORKSPACE_SCHEMA, blueprint, products: products as ClientDemoProductProgress[], updatedAt }
+  return { schema: CLIENT_DEMO_WORKSPACE_SCHEMA, blueprint, products: products as ClientDemoProductProgress[], proofBaselineAt, updatedAt }
 }
 
 export function reconcileClientDemoWorkspace(
@@ -1797,6 +1813,13 @@ function clientDemoEvidenceCount(value: unknown, field: string) {
   return Number(value)
 }
 
+function clientDemoEvidenceTimestamp(value: unknown, field: string) {
+  if (value === null) return null
+  const timestamp = canonicalTimestamp(value)
+  if (!timestamp) throw new Error(`Client demo evidence ${field} is invalid.`)
+  return timestamp
+}
+
 function canonicalClientDemoEvidence(value: unknown): ClientDemoOperationalEvidence {
   if (!value || typeof value !== 'object' || Array.isArray(value)
     || !hasExactKeys(value, ['commerce', 'production', 'website', 'ecommerce'])) {
@@ -1804,24 +1827,37 @@ function canonicalClientDemoEvidence(value: unknown): ClientDemoOperationalEvide
   }
   const source = value as Partial<ClientDemoOperationalEvidence>
   if (!source.commerce || !source.production || !source.website || !source.ecommerce
-    || !hasExactKeys(source.commerce, ['completedOrders', 'reconciledOrders'])
-    || !hasExactKeys(source.production, ['releasedBatches'])
-    || !hasExactKeys(source.website, ['approvedReleases'])
-    || !hasExactKeys(source.ecommerce, ['savedStorefronts', 'reviewedRequests'])) {
+    || !hasExactKeys(source.commerce, ['completedOrders', 'reconciledOrders', 'latestAccountableSaleAt'])
+    || !hasExactKeys(source.production, ['releasedBatches', 'latestReleasedAt'])
+    || !hasExactKeys(source.website, ['approvedReleases', 'latestApprovedAt'])
+    || !hasExactKeys(source.ecommerce, ['savedStorefronts', 'reviewedRequests', 'latestSavedStorefrontAt', 'latestReviewedRequestAt'])) {
     throw new Error('The client demo operational evidence is invalid.')
   }
   return {
     commerce: {
       completedOrders: clientDemoEvidenceCount(source.commerce.completedOrders, 'completed orders'),
       reconciledOrders: clientDemoEvidenceCount(source.commerce.reconciledOrders, 'reconciled orders'),
+      latestAccountableSaleAt: clientDemoEvidenceTimestamp(source.commerce.latestAccountableSaleAt, 'latest accountable sale'),
     },
-    production: { releasedBatches: clientDemoEvidenceCount(source.production.releasedBatches, 'released batches') },
-    website: { approvedReleases: clientDemoEvidenceCount(source.website.approvedReleases, 'approved releases') },
+    production: {
+      releasedBatches: clientDemoEvidenceCount(source.production.releasedBatches, 'released batches'),
+      latestReleasedAt: clientDemoEvidenceTimestamp(source.production.latestReleasedAt, 'latest released batch'),
+    },
+    website: {
+      approvedReleases: clientDemoEvidenceCount(source.website.approvedReleases, 'approved releases'),
+      latestApprovedAt: clientDemoEvidenceTimestamp(source.website.latestApprovedAt, 'latest approved release'),
+    },
     ecommerce: {
       savedStorefronts: clientDemoEvidenceCount(source.ecommerce.savedStorefronts, 'saved storefronts'),
       reviewedRequests: clientDemoEvidenceCount(source.ecommerce.reviewedRequests, 'reviewed requests'),
+      latestSavedStorefrontAt: clientDemoEvidenceTimestamp(source.ecommerce.latestSavedStorefrontAt, 'latest saved storefront'),
+      latestReviewedRequestAt: clientDemoEvidenceTimestamp(source.ecommerce.latestReviewedRequestAt, 'latest reviewed request'),
     },
   }
+}
+
+function evidenceFollowsBaseline(value: string | null, baseline: string) {
+  return value !== null && Date.parse(value) > Date.parse(baseline)
 }
 
 export function buildClientDemoRunbook(workspaceValue: unknown, evidenceValue: unknown): ClientDemoRunbook {
@@ -1830,19 +1866,26 @@ export function buildClientDemoRunbook(workspaceValue: unknown, evidenceValue: u
   const evidence = canonicalClientDemoEvidence(evidenceValue)
   const proofByProduct: Record<ClientSolutionId, { ready: boolean; observed: string }> = {
     commerce: {
-      ready: evidence.commerce.completedOrders > 0 && evidence.commerce.reconciledOrders > 0,
+      ready: evidence.commerce.completedOrders > 0
+        && evidence.commerce.reconciledOrders > 0
+        && evidenceFollowsBaseline(evidence.commerce.latestAccountableSaleAt, workspace.proofBaselineAt),
       observed: `${evidence.commerce.completedOrders} completed · ${evidence.commerce.reconciledOrders} payment reconciled`,
     },
     production: {
-      ready: evidence.production.releasedBatches > 0,
+      ready: evidence.production.releasedBatches > 0
+        && evidenceFollowsBaseline(evidence.production.latestReleasedAt, workspace.proofBaselineAt),
       observed: `${evidence.production.releasedBatches} batch${evidence.production.releasedBatches === 1 ? '' : 'es'} released to stock`,
     },
     website: {
-      ready: evidence.website.approvedReleases > 0,
+      ready: evidence.website.approvedReleases > 0
+        && evidenceFollowsBaseline(evidence.website.latestApprovedAt, workspace.proofBaselineAt),
       observed: `${evidence.website.approvedReleases} approved local release${evidence.website.approvedReleases === 1 ? '' : 's'}`,
     },
     ecommerce: {
-      ready: evidence.ecommerce.savedStorefronts > 0 && evidence.ecommerce.reviewedRequests > 0,
+      ready: evidence.ecommerce.savedStorefronts > 0
+        && evidence.ecommerce.reviewedRequests > 0
+        && evidenceFollowsBaseline(evidence.ecommerce.latestSavedStorefrontAt, workspace.proofBaselineAt)
+        && evidenceFollowsBaseline(evidence.ecommerce.latestReviewedRequestAt, workspace.proofBaselineAt),
       observed: `${evidence.ecommerce.savedStorefronts} saved storefront · ${evidence.ecommerce.reviewedRequests} Shop request${evidence.ecommerce.reviewedRequests === 1 ? '' : 's'}`,
     },
   }

--- a/tools/verify_app_build.mjs
+++ b/tools/verify_app_build.mjs
@@ -4597,7 +4597,7 @@ if (!clientOnboardingSource.includes("CLIENT_IMPORT_SCHEMA = 'supermega.client_i
   || !clientOnboardingSource.includes('plantIndustryPackId: PlantIndustryPackId')
   || !clientOnboardingSource.includes("...(plantPackId ? { plantIndustryPackId: plantPackId } : {})")
   || !clientOnboardingSource.includes('export function buildClientDemoBlueprint')
-  || !clientOnboardingSource.includes("CLIENT_DEMO_WORKSPACE_SCHEMA = 'supermega.client_demo_workspace.v3'")
+  || !clientOnboardingSource.includes("CLIENT_DEMO_WORKSPACE_SCHEMA = 'supermega.client_demo_workspace.v4'")
   || !clientOnboardingSource.includes("CLIENT_DEMO_KIT_SCHEMA = 'supermega.client_demo_kit.v3'")
   || !clientOnboardingSource.includes('CLIENT_DEMO_KIT_MAX_BYTES = 128 * 1024')
   || !clientOnboardingSource.includes("CLIENT_DEMO_RUNBOOK_SCHEMA = 'supermega.client_demo_runbook.v1'")
@@ -4838,6 +4838,8 @@ if (!productSetupSource.includes('templateId: string')
   || !settingsPageSource.includes('updateClientDemoWorkspaceProgress')
   || !settingsPageSource.includes("previous.status === 'applied' && progress.status !== 'applied'")
   || !settingsPageSource.includes('buildClientDemoRunbook')
+  || !settingsPageSource.includes('latestAccountableSaleAt: latestIsoTimestamp(accountableShopSaleTimes)')
+  || !clientOnboardingSource.includes('evidenceFollowsBaseline(evidence.commerce.latestAccountableSaleAt, workspace.proofBaselineAt)')
   || !settingsPageSource.includes('aria-label="Client demo launchpad"')
   || !settingsPageSource.includes('const demoLaunchActionRef = useRef<HTMLAnchorElement>(null)')
   || !settingsPageSource.includes('const demoLaunchHandoffPendingRef = useRef(false)')
@@ -7978,7 +7980,10 @@ async function verifyClientOnboardingRuntime() {
     rejectsSync(() => model.clientImportTemplate('commerce', 'unknown', { shopIndustryPackId: 'school' }), 'client_demo_industry_template_bypassed_workflow_validation')
     const workspaceCreatedAt = '2026-07-28T08:00:00.000Z'
     const demoWorkspace = model.createClientDemoWorkspace(manufacturingBlueprint, workspaceCreatedAt)
-    assert(demoWorkspace.schema === model.CLIENT_DEMO_WORKSPACE_SCHEMA && demoWorkspace.products.length === 4 && demoWorkspace.products.every((product) => product.status === 'not_started'), 'client_demo_workspace_not_initialized')
+    assert(demoWorkspace.schema === model.CLIENT_DEMO_WORKSPACE_SCHEMA
+      && demoWorkspace.proofBaselineAt === workspaceCreatedAt
+      && demoWorkspace.products.length === 4
+      && demoWorkspace.products.every((product) => product.status === 'not_started'), 'client_demo_workspace_not_initialized')
     assert(JSON.stringify(model.restoreClientDemoWorkspace(JSON.parse(JSON.stringify(demoWorkspace)))) === JSON.stringify(demoWorkspace), 'client_demo_workspace_not_restorable')
     const demoKit = model.buildClientDemoKit(manufacturingBlueprint, workspaceCreatedAt)
     const readyDemoKit = model.clientDemoKitReadiness(manufacturingBlueprint, workspaceCreatedAt)
@@ -8089,18 +8094,27 @@ async function verifyClientOnboardingRuntime() {
     delete legacyBlueprint.client.shopIndustryPackId
     const migratedLegacyWorkspace = model.createClientDemoWorkspace(legacyBlueprint, workspaceCreatedAt)
     assert(migratedLegacyWorkspace.blueprint.client.shopIndustryPackId === 'retail', 'client_demo_legacy_shop_pack_not_migrated')
+    const legacyV3Workspace = structuredClone(demoWorkspace)
+    legacyV3Workspace.schema = 'supermega.client_demo_workspace.v3'
+    delete legacyV3Workspace.proofBaselineAt
+    assert(model.restoreClientDemoWorkspace(legacyV3Workspace)?.proofBaselineAt === workspaceCreatedAt, 'client_demo_v3_workspace_proof_baseline_not_migrated')
     const shopReadyAt = '2026-07-28T08:05:00.000Z'
     const shopReady = model.updateClientDemoWorkspaceProgress(demoWorkspace, { product: 'commerce', status: 'data_ready', rows: 2, readyRows: 2, issueRows: 0, updatedAt: null }, shopReadyAt)
-    assert(shopReady.updatedAt === shopReadyAt && shopReady.products[0].status === 'data_ready' && shopReady.products.slice(1).every((product) => product.status === 'not_started'), 'client_demo_workspace_progress_not_isolated')
+    assert(shopReady.updatedAt === shopReadyAt
+      && shopReady.proofBaselineAt === workspaceCreatedAt
+      && shopReady.products[0].status === 'data_ready'
+      && shopReady.products.slice(1).every((product) => product.status === 'not_started'), 'client_demo_workspace_progress_not_isolated')
     const reopenedShopReady = model.reconcileClientDemoWorkspace(manufacturingBlueprint, shopReady, '2026-07-28T08:10:00.000Z')
     assert(JSON.stringify(reopenedShopReady) === JSON.stringify(shopReady), 'client_demo_matching_package_erased_progress')
     const changedWorkspace = model.reconcileClientDemoWorkspace(schoolIntegratedBlueprint, shopReady, '2026-07-28T08:10:00.000Z')
-    assert(changedWorkspace.blueprint.client.workspace === 'Learning Centre' && changedWorkspace.products.every((product) => product.status === 'not_started'), 'client_demo_changed_package_preserved_wrong_progress')
+    assert(changedWorkspace.blueprint.client.workspace === 'Learning Centre'
+      && changedWorkspace.proofBaselineAt === '2026-07-28T08:10:00.000Z'
+      && changedWorkspace.products.every((product) => product.status === 'not_started'), 'client_demo_changed_package_preserved_wrong_progress')
     const noOperationalEvidence = {
-      commerce: { completedOrders: 0, reconciledOrders: 0 },
-      production: { releasedBatches: 0 },
-      website: { approvedReleases: 0 },
-      ecommerce: { savedStorefronts: 0, reviewedRequests: 0 },
+      commerce: { completedOrders: 0, reconciledOrders: 0, latestAccountableSaleAt: null },
+      production: { releasedBatches: 0, latestReleasedAt: null },
+      website: { approvedReleases: 0, latestApprovedAt: null },
+      ecommerce: { savedStorefronts: 0, reviewedRequests: 0, latestSavedStorefrontAt: null, latestReviewedRequestAt: null },
     }
     const readyRunbook = model.buildClientDemoRunbook(shopReady, noOperationalEvidence)
     assert(readyRunbook.schema === model.CLIENT_DEMO_RUNBOOK_SCHEMA
@@ -8108,26 +8122,35 @@ async function verifyClientOnboardingRuntime() {
       && readyRunbook.provenCount === 0
       && readyRunbook.products.map((product) => product.status).join(',') === 'ready_to_run,prepare_data,prepare_data,prepare_data', 'client_demo_runbook_readiness_wrong')
     assert(readyRunbook.products.every((product) => product.steps.length === 3 && product.evidenceRequirement && product.startPath.startsWith('/')), 'client_demo_runbook_scenario_contract_incomplete')
+    const seededShopRunbook = model.buildClientDemoRunbook(shopReady, {
+      ...noOperationalEvidence,
+      commerce: { completedOrders: 1, reconciledOrders: 1, latestAccountableSaleAt: '2026-07-28T07:59:00.000Z' },
+    })
+    assert(seededShopRunbook.provenCount === 0 && seededShopRunbook.products[0].status === 'ready_to_run', 'client_demo_seeded_history_claimed_current_proof')
     const shopProvenRunbook = model.buildClientDemoRunbook(shopReady, {
       ...noOperationalEvidence,
-      commerce: { completedOrders: 1, reconciledOrders: 1 },
+      commerce: { completedOrders: 1, reconciledOrders: 1, latestAccountableSaleAt: '2026-07-28T08:06:00.000Z' },
     })
     assert(shopProvenRunbook.provenCount === 1 && shopProvenRunbook.nextProduct === 'production' && shopProvenRunbook.products[0].status === 'proven', 'client_demo_runbook_shop_proof_not_derived')
     const allProvenRunbook = model.buildClientDemoRunbook(shopReady, {
-      commerce: { completedOrders: 1, reconciledOrders: 1 },
-      production: { releasedBatches: 1 },
-      website: { approvedReleases: 1 },
-      ecommerce: { savedStorefronts: 1, reviewedRequests: 1 },
+      commerce: { completedOrders: 1, reconciledOrders: 1, latestAccountableSaleAt: '2026-07-28T08:06:00.000Z' },
+      production: { releasedBatches: 1, latestReleasedAt: '2026-07-28T08:07:00.000Z' },
+      website: { approvedReleases: 1, latestApprovedAt: '2026-07-28T08:08:00.000Z' },
+      ecommerce: { savedStorefronts: 1, reviewedRequests: 1, latestSavedStorefrontAt: '2026-07-28T08:09:00.000Z', latestReviewedRequestAt: '2026-07-28T08:10:00.000Z' },
     })
     assert(allProvenRunbook.provenCount === 4 && allProvenRunbook.nextProduct === null && allProvenRunbook.products.every((product) => product.status === 'proven'), 'client_demo_runbook_complete_proof_wrong')
-    rejectsSync(() => model.buildClientDemoRunbook(shopReady, { ...noOperationalEvidence, production: { releasedBatches: -1 } }), 'client_demo_runbook_negative_evidence_accepted')
-    rejectsSync(() => model.buildClientDemoRunbook(shopReady, { ...noOperationalEvidence, website: { approvedReleases: 0, manualDone: true } }), 'client_demo_runbook_manual_completion_field_accepted')
+    rejectsSync(() => model.buildClientDemoRunbook(shopReady, { ...noOperationalEvidence, production: { releasedBatches: -1, latestReleasedAt: null } }), 'client_demo_runbook_negative_evidence_accepted')
+    rejectsSync(() => model.buildClientDemoRunbook(shopReady, { ...noOperationalEvidence, website: { approvedReleases: 0, latestApprovedAt: null, manualDone: true } }), 'client_demo_runbook_manual_completion_field_accepted')
+    rejectsSync(() => model.buildClientDemoRunbook(shopReady, { ...noOperationalEvidence, website: { approvedReleases: 1, latestApprovedAt: 'not-a-time' } }), 'client_demo_runbook_invalid_evidence_timestamp_accepted')
     const tamperedWorkspace = structuredClone(shopReady)
     tamperedWorkspace.blueprint.products[0].demoPath = 'https://attacker.example/'
     assert(model.restoreClientDemoWorkspace(tamperedWorkspace) === null, 'client_demo_workspace_blueprint_tamper_accepted')
     const rawDataWorkspace = structuredClone(shopReady)
     rawDataWorkspace.products[0].sourceText = 'customer-secret-csv'
     assert(model.restoreClientDemoWorkspace(rawDataWorkspace) === null, 'client_demo_workspace_raw_data_field_accepted')
+    const missingProofBaselineWorkspace = structuredClone(shopReady)
+    delete missingProofBaselineWorkspace.proofBaselineAt
+    assert(model.restoreClientDemoWorkspace(missingProofBaselineWorkspace) === null, 'client_demo_workspace_missing_proof_baseline_accepted')
     rejectsSync(() => model.updateClientDemoWorkspaceProgress(demoWorkspace, { product: 'production', status: 'applied', rows: 2, readyRows: 3, issueRows: 0, updatedAt: null }, shopReadyAt), 'client_demo_workspace_impossible_progress_accepted')
     rejectsSync(() => model.buildClientDemoBlueprint({ workspace: '', owner: 'Owner', presetId: 'social-seller', selections: model.clientDemoPresets[0].selections }), 'client_demo_blank_workspace_accepted')
     rejectsSync(() => model.buildClientDemoBlueprint({ workspace: 'Client', owner: 'Owner', presetId: 'social-seller', selections: [{ product: 'commerce', templateId: 'social-commerce' }, { product: 'commerce', templateId: 'retail-wholesale' }] }), 'client_demo_duplicate_product_accepted')


### PR DESCRIPTION
Stops fresh client workspaces from claiming evidence based on seeded sample history. Client workspace v4 records a setup proof baseline, migrates v1-v3 conservatively, and accepts Shop, Plant, Website, or Ecommerce proof only from accountable operational timestamps after that baseline. Rendered QA proved fresh zero, counter sale alone zero, full prepare-payment-complete lifecycle one, reload persistence, and reset back to zero. Full app verification passes; no hosted writes or provider mutations.