### PR TITLE
Fix Plant order execution persistence

### DIFF
--- a/showroom/src/core/PlantOrderFoundation.tsx
+++ b/showroom/src/core/PlantOrderFoundation.tsx
@@ -7,6 +7,7 @@ import {
   PLANT_ORDER_EFFECTIVE_PLAN_CONTRACT,
   PLANT_ORDER_EXECUTION_PLAN_CONTRACT,
   PLANT_ORDER_PLAN_REVISION_MAX,
+  PLANT_ORDER_WORKSPACE_UPDATED_EVENT,
   applyPlantOrderPlan,
   approvePlantOrderMaterialSubstitution,
   buildPlantOrderCostReviewPacket,
@@ -474,6 +475,11 @@ export function PlantOrderFoundation({ actor, commerceState, disabled, industryP
     }
     if (!review && dialog.open) dialog.close()
   }, [review])
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    window.dispatchEvent(new CustomEvent(PLANT_ORDER_WORKSPACE_UPDATED_EVENT, { detail: { scope } }))
+  }, [scope, state.headDigest])
 
   function selectOrder(jobId: string) {
     const retained = productionOrderExecutionForJob(productionState, jobId)

--- a/showroom/src/core/production-workspace.ts
+++ b/showroom/src/core/production-workspace.ts
@@ -1,5 +1,5 @@
 import { sha256Hex } from './managed-trial-proof.ts'
-import { plantOrderEvidenceDigest, projectPlantOrder, type PlantOrderState } from './plant-order-foundation.ts'
+import { createEmptyPlantOrderState, plantOrderEvidenceDigest, projectPlantOrder, type PlantOrderState } from './plant-order-foundation.ts'
 import { plantIndustryPack, type PlantIndustryPackId } from './plant-industry-packs.ts'
 import { productionOrderPortfolioEntries, validateProductionOrderPortfolio, type ProductionOrderPortfolio } from './production-order-portfolio.ts'
 import type { ShopProductionDemandSourceSnapshot } from './shop-production-demand.ts'
@@ -276,6 +276,8 @@ export type ProductionWorkspaceSnapshot = {
 export type ProductionMutationResult =
   | { ok: true; state: ProductionState; replayed: boolean }
   | { ok: false; error: string }
+
+export type ProductionWorkspaceMutationKind = 'operating-event' | 'order-execution'
 
 export type ProductionShiftOutput = {
   goodUnits: number
@@ -1971,10 +1973,56 @@ export function productionWorkspaceCanWrite(
   }
 }
 
+function productionOrderExecutionAppendIsExact(current: ProductionState, candidate: ProductionState) {
+  if (candidate.schema !== current.schema
+    || candidate.revision !== current.revision
+    || JSON.stringify(candidate.jobs) !== JSON.stringify(current.jobs)
+    || JSON.stringify(candidate.issues) !== JSON.stringify(current.issues)
+    || JSON.stringify(candidate.machines) !== JSON.stringify(current.machines)
+    || JSON.stringify(candidate.events) !== JSON.stringify(current.events)
+    || JSON.stringify(candidate.openingPlan) !== JSON.stringify(current.openingPlan)
+    || JSON.stringify(candidate.equipmentMaster) !== JSON.stringify(current.equipmentMaster)) return false
+
+  const beforeEntries = new Map(productionOrderPortfolioEntries(current).map((entry) => [entry.jobId, entry.execution]))
+  const afterEntries = new Map(productionOrderPortfolioEntries(candidate).map((entry) => [entry.jobId, entry.execution]))
+  const changedJobIds = [...new Set([...beforeEntries.keys(), ...afterEntries.keys()])]
+    .filter((jobId) => JSON.stringify(beforeEntries.get(jobId)) !== JSON.stringify(afterEntries.get(jobId)))
+  if (changedJobIds.length !== 1) return false
+
+  const changedJobId = changedJobIds[0]
+  const before = beforeEntries.get(changedJobId) ?? createEmptyPlantOrderState()
+  const after = afterEntries.get(changedJobId)
+  const command = after?.commands.at(-1)
+  if (!after
+    || !command
+    || after.revision !== before.revision + 1
+    || after.commands.length !== before.commands.length + 1
+    || JSON.stringify(after.commands.slice(0, -1)) !== JSON.stringify(before.commands)
+    || command.previousDigest !== before.headDigest
+    || command.digest !== after.headDigest) return false
+
+  const projection = projectPlantOrder(after)
+  const job = current.jobs.find((candidateJob) => candidateJob.id === changedJobId)
+  const remaining = job ? job.target - job.output - (job.scrap ?? 0) : 0
+  if (!projection.plan
+    || !job
+    || job.closure
+    || job.qualityHold
+    || remaining < 1
+    || projection.plan.job.jobId !== changedJobId
+    || projection.plan.job.product !== job.product
+    || projection.plan.job.targetQuantity !== remaining) return false
+
+  const commandAt = Date.parse(command.payload.proof.capturedAt)
+  const latestOperatingAt = current.events[0] ? Date.parse(current.events[0].createdAt) : Number.NEGATIVE_INFINITY
+  return Number.isFinite(commandAt) && commandAt >= latestOperatingAt
+}
+
 export async function mutateProductionWorkspace(
   transition: (state: ProductionState) => ProductionState | null,
   storage = browserStorage(),
   lockManager = globalThis.navigator?.locks as unknown as ProductionLockManager | undefined,
+  mutationKind: ProductionWorkspaceMutationKind = 'operating-event',
 ): Promise<ProductionMutationResult> {
   if (!storage) return { ok: false, error: 'Production storage is unavailable; the change was not applied.' }
   if (!lockManager?.request) return { ok: false, error: 'This browser cannot lock Production writes; the change was not applied.' }
@@ -1989,17 +2037,30 @@ export async function mutateProductionWorkspace(
       try { next = transition(current) } catch { return { ok: false, error: 'The Production transition failed integrity checks. Nothing was written.' } as const }
       if (!next) return { ok: false, error: 'The Production state changed or the requested transition is not valid. Nothing was written.' } as const
       if (next === current) return { ok: true, state: current, replayed: true } as const
-      const revisionDelta = next.revision - current.revision
-      const eventDelta = next.events.length - current.events.length
-      if (!Number.isSafeInteger(revisionDelta)
-        || revisionDelta < 1
-        || revisionDelta > 100
-        || eventDelta !== revisionDelta
-        || JSON.stringify(next.events.slice(eventDelta)) !== JSON.stringify(current.events)) {
-        return { ok: false, error: 'Production changes must append one event per revision, with at most 100 events in one locked transaction. Nothing was written.' } as const
+      let candidate: ProductionState
+      try { candidate = validateProductionState(next) } catch { return { ok: false, error: 'The proposed Production state failed integrity checks. Nothing was written.' } as const }
+      if (mutationKind === 'order-execution') {
+        if (!productionOrderExecutionAppendIsExact(current, candidate)) {
+          return { ok: false, error: 'Production order execution must append exactly one chained command without changing operating history. Nothing was written.' } as const
+        }
+      } else if (mutationKind === 'operating-event') {
+        const revisionDelta = candidate.revision - current.revision
+        const eventDelta = candidate.events.length - current.events.length
+        if (JSON.stringify(productionOrderPortfolioEntries(candidate)) !== JSON.stringify(productionOrderPortfolioEntries(current))) {
+          return { ok: false, error: 'Production order execution can change only through its dedicated write boundary. Nothing was written.' } as const
+        }
+        if (!Number.isSafeInteger(revisionDelta)
+          || revisionDelta < 1
+          || revisionDelta > 100
+          || eventDelta !== revisionDelta
+          || JSON.stringify(candidate.events.slice(eventDelta)) !== JSON.stringify(current.events)) {
+          return { ok: false, error: 'Production changes must append one event per revision, with at most 100 events in one locked transaction. Nothing was written.' } as const
+        }
+      } else {
+        return { ok: false, error: 'Production write boundary is invalid. Nothing was written.' } as const
       }
       let serialized: string
-      try { serialized = JSON.stringify(validateProductionState(next)) } catch { return { ok: false, error: 'The proposed Production state failed integrity checks. Nothing was written.' } as const }
+      try { serialized = JSON.stringify(candidate) } catch { return { ok: false, error: 'The proposed Production state could not be serialized. Nothing was written.' } as const }
       try {
         storage.setItem(PRODUCTION_KEY, serialized)
         if (storage.getItem(PRODUCTION_KEY) !== serialized) return { ok: false, error: 'Production storage did not confirm the write.' } as const

--- a/showroom/src/core/workspace-runtime.ts
+++ b/showroom/src/core/workspace-runtime.ts
@@ -701,7 +701,12 @@ export function useProductionWorkspace(managedIdentity: ManagedIdentity | null =
   ) {
     if (!managedIdentity) {
       if (eventType === 'production.workspace.initialized') throw new Error('Browser demo Plant is already initialized.')
-      const result = await mutateProductionWorkspace(transition)
+      const result = await mutateProductionWorkspace(
+        transition,
+        undefined,
+        undefined,
+        eventType === 'production.order_execution.recorded' ? 'order-execution' : 'operating-event',
+      )
       if (!result.ok) {
         if (result.error === 'The Production state changed or the requested transition is not valid. Nothing was written.') {
           const latest = loadProductionWorkspace()

--- a/tools/verify_app_build.mjs
+++ b/tools/verify_app_build.mjs
@@ -4443,6 +4443,11 @@ if (!plantOrderUiSource.includes('productionState: ProductionState')
   || !managedTrialStoreRuntime.includes('production.order_execution.recorded')
   || !plantOrderUiSource.includes("'production.order_execution.recorded'")
   || !plantOrderUiSource.includes('productionOrderExecutionForJob(current, selectedOrderJobId)')
+  || !plantOrderUiSource.includes('window.dispatchEvent(new CustomEvent(PLANT_ORDER_WORKSPACE_UPDATED_EVENT, { detail: { scope } }))')
+  || !productionSource.includes("export type ProductionWorkspaceMutationKind = 'operating-event' | 'order-execution'")
+  || !productionSource.includes('productionOrderExecutionAppendIsExact')
+  || !productionSource.includes('Production order execution can change only through its dedicated write boundary')
+  || !workspaceRuntimeSource.includes("eventType === 'production.order_execution.recorded' ? 'order-execution' : 'operating-event'")
   || !coreSource.includes('onProductionCommand={mutateProduction}')
   || !coreSource.includes('productionState={production}')) fail('managed_plant_order_execution_contract_missing')
 if (!commerceSource.includes("'production_issue'")
@@ -15704,6 +15709,7 @@ async function verifyProductionRuntime() {
   try {
     const model = await import(`${pathToFileURL(resolve(root, 'showroom', 'src', 'core', 'production-workspace.ts')).href}?verify=${Date.now()}`)
     const plantModel = await import(`${pathToFileURL(resolve(root, 'showroom', 'src', 'core', 'plant-order-foundation.ts')).href}?production-embedding-verify=${Date.now()}`)
+    const portfolioModel = await import(`${pathToFileURL(resolve(root, 'showroom', 'src', 'core', 'production-order-portfolio.ts')).href}?production-persistence-verify=${Date.now()}`)
     const emptyExecution = plantModel.createEmptyPlantOrderState()
     const executionProof = proof('ACT-MANAGED-EXECUTION')
     const executionPlan = plantModel.buildPlantOrderPlan({
@@ -17000,6 +17006,74 @@ async function verifyProductionRuntime() {
     values.set(model.LEGACY_PRODUCTION_KEYS[1], JSON.stringify(legacy))
     const staleLegacyFallback = model.loadProductionWorkspace(storage)
     assert(staleLegacyFallback.source === 'recovery' && !values.has(model.PRODUCTION_KEY), 'production_malformed_newer_legacy_restored_stale_data')
+
+    values.clear()
+    values.set(model.PRODUCTION_KEY, JSON.stringify(base))
+    const localOrderBase = {
+      ...model.createEmptyProduction(),
+      jobs: [{ id: 'JOB-1', line: 'Line 01', product: 'Test batch', target: 100, output: 0 }],
+    }
+    const applyLocalOrderPlan = (state) => {
+      const currentExecution = portfolioModel.productionOrderExecutionForJob(state, 'JOB-1') ?? plantModel.createEmptyPlantOrderState()
+      const applied = plantModel.applyPlantOrderPlan(currentExecution, executionPlan, executionProof, currentExecution.headDigest)
+      if (applied.replayed) return state
+      return model.validateProductionState(portfolioModel.upsertProductionOrderExecution(state, applied.state))
+    }
+    values.set(model.PRODUCTION_KEY, JSON.stringify(localOrderBase))
+    const rejectedOrderWithoutBoundary = await model.mutateProductionWorkspace(applyLocalOrderPlan, storage, locks)
+    assert(!rejectedOrderWithoutBoundary.ok
+      && rejectedOrderWithoutBoundary.error.includes('dedicated write boundary')
+      && values.get(model.PRODUCTION_KEY) === JSON.stringify(localOrderBase),
+    'production_local_order_command_bypassed_dedicated_boundary')
+    const persistedLocalOrder = await model.mutateProductionWorkspace(applyLocalOrderPlan, storage, locks, 'order-execution')
+    const persistedLocalOrderState = JSON.parse(values.get(model.PRODUCTION_KEY))
+    assert(persistedLocalOrder.ok
+      && persistedLocalOrderState.revision === 0
+      && persistedLocalOrderState.events.length === 0
+      && persistedLocalOrderState.orderPortfolio.entries[0].execution.revision === 1,
+    'production_local_order_command_not_persisted_without_forged_operating_event')
+    const availabilityProof = proof('ACT-LOCAL-AVAILABILITY', 1_000)
+    const applyLocalAvailability = (state) => {
+      const currentExecution = portfolioModel.productionOrderExecutionForJob(state, 'JOB-1')
+      if (!currentExecution) return null
+      const applied = plantModel.checkPlantOrderAvailability(currentExecution, {
+        checkId: 'CHK-LOCAL-001',
+        sourceDigest: plantModel.plantOrderEvidenceDigest({ check: 'CHK-LOCAL-001' }),
+        materials: [{ materialId: 'MAT-MANAGED-001', inputLotId: 'LOT-LOCAL-001', availableQuantityMilli: 100_000 }],
+        workCentres: [{ workCentreId: 'WC-MANAGED-001', availableMinutes: 100 }],
+        proof: availabilityProof,
+        expectedHeadDigest: currentExecution.headDigest,
+      })
+      if (applied.replayed) return state
+      return model.validateProductionState(portfolioModel.upsertProductionOrderExecution(state, applied.state))
+    }
+    const persistedLocalAvailability = await model.mutateProductionWorkspace(applyLocalAvailability, storage, locks, 'order-execution')
+    const persistedLocalAvailabilityState = JSON.parse(values.get(model.PRODUCTION_KEY))
+    assert(persistedLocalAvailability.ok
+      && persistedLocalAvailabilityState.revision === 0
+      && persistedLocalAvailabilityState.events.length === 0
+      && persistedLocalAvailabilityState.orderPortfolio.entries[0].execution.revision === 2,
+    'production_second_local_order_command_not_persisted')
+    const replayedLocalAvailability = await model.mutateProductionWorkspace(applyLocalAvailability, storage, locks, 'order-execution')
+    assert(replayedLocalAvailability.ok && replayedLocalAvailability.replayed === true
+      && values.get(model.PRODUCTION_KEY) === JSON.stringify(persistedLocalAvailabilityState),
+    'production_local_order_command_replay_changed_state')
+    values.set(model.PRODUCTION_KEY, JSON.stringify(localOrderBase))
+    const rejectedOperatingEventAtOrderBoundary = await model.mutateProductionWorkspace(
+      (state) => model.recordProductionOutput(state, 'JOB-1', 1, '2026-07-24 Day', proof('ACT-WRONG-BOUNDARY')),
+      storage,
+      locks,
+      'order-execution',
+    )
+    assert(!rejectedOperatingEventAtOrderBoundary.ok
+      && values.get(model.PRODUCTION_KEY) === JSON.stringify(localOrderBase),
+    'production_operating_event_crossed_order_boundary')
+    const laterOperatingState = model.openProductionIssue(localOrderBase, { id: 'ISS-LATER', createdAt: proof('ACT-LATER-ISSUE', 2_000).capturedAt, area: 'Line 01', kind: 'operations', summary: 'Later operating evidence', status: 'open', severity: 'low', owner: 'Plant owner', dueAt: proof('ACT-LATER-ISSUE', 86_402_000).capturedAt, containment: 'Retain the reviewed record.' }, proof('ACT-LATER-ISSUE', 2_000))
+    values.set(model.PRODUCTION_KEY, JSON.stringify(laterOperatingState))
+    const rejectedPredatedOrder = await model.mutateProductionWorkspace(applyLocalOrderPlan, storage, locks, 'order-execution')
+    assert(!rejectedPredatedOrder.ok
+      && values.get(model.PRODUCTION_KEY) === JSON.stringify(laterOperatingState),
+    'production_local_order_command_predated_operating_history')
 
     values.clear()
     values.set(model.PRODUCTION_KEY, JSON.stringify(base))


### PR DESCRIPTION
## What changed

- add an explicit local Plant order-execution write boundary
- preserve the outer Production revision and event chain while requiring exactly one valid nested order command
- prevent ordinary Production events from mutating the embedded order portfolio
- notify the mounted Shop handoff when Plant order evidence changes
- add adversarial runtime coverage for boundary bypass, replay, wrong-boundary writes, and stale command timestamps

## Root cause

The browser-local Production store required every state change to append an outer Production event. Controlled batch execution intentionally appends a nested `production.order_execution.recorded` command without changing the outer revision, matching the managed runtime contract. The local store therefore rejected valid controlled-batch changes and paused writes.

## User impact

Plant can now complete a real controlled batch across Plant and Shop: plan, calibration, availability, release, material issue, routing, output, inspection, and final human release. The workflow remains fail-closed and evidence-bound.

## Validation

- focused ESLint passed
- `node tools/verify_app_build.mjs` passed with 327 Production checks
- 32 managed Production/material handoff Python tests passed
- full `npm run app:verify` passed
- rendered local browser mission completed and survived reload
- synthetic workspace reset and recreated clean at 0 proven / 0 data-ready