### PR TITLE
Fix Ecommerce completion proof and status

### DIFF
--- a/showroom/src/core/SettingsPage.tsx
+++ b/showroom/src/core/SettingsPage.tsx
@@ -11,6 +11,7 @@ import { ManagedContextConsent } from './ManagedContextConsent'
 import { buildManagedAiContextExport, buildManagedContextProfileRequest, managedContextProductLabel } from './managed-context'
 import { operatingChangeCopy } from './operating-baseline'
 import { getCurrentPublish, loadWebsiteWorkspace } from '../products/website/website-model'
+import { LOCAL_STOREFRONT_DRAFT_SCOPE, readStorefrontDraft } from '../products/ecommerce/storefront-draft'
 import {
   PageHeading,
   RuntimeBadge,
@@ -532,6 +533,21 @@ export function SettingsPage() {
     const loaded = loadWebsiteWorkspace(window.localStorage)
     return loaded.ok ? getCurrentPublish(loaded.workspace) : null
   })()
+  const ecommerceDemoEvidence = useMemo(() => {
+    const localEcommerceStorefront = managedIdentity ? null : readStorefrontDraft(LOCAL_STOREFRONT_DRAFT_SCOPE)
+    const currentEcommerceStorefrontAt = managedIdentity
+      ? commerce.storefrontConfiguration?.saved.capturedAt ?? null
+      : localEcommerceStorefront?.status === 'ready'
+        ? localEcommerceStorefront.draft?.savedAt ?? null
+        : null
+    const reviewedEcommerceOrders = commerce.orders.filter((order) => order.sourceRecordId?.startsWith('ECR-'))
+    return {
+      savedStorefronts: currentEcommerceStorefrontAt ? 1 : 0,
+      reviewedRequests: reviewedEcommerceOrders.length,
+      latestSavedStorefrontAt: currentEcommerceStorefrontAt,
+      latestReviewedRequestAt: latestIsoTimestamp(reviewedEcommerceOrders.map((order) => order.createdAt)),
+    }
+  }, [commerce, managedIdentity])
   const demoRunbook = demoWorkspace ? buildClientDemoRunbook(demoWorkspace, {
     commerce: {
       completedOrders: commerce.orders.filter((order) => order.status === 'completed').length,
@@ -546,12 +562,7 @@ export function SettingsPage() {
       approvedReleases: currentWebsitePublish ? 1 : 0,
       latestApprovedAt: currentWebsitePublish?.recordedAt ?? null,
     },
-    ecommerce: {
-      savedStorefronts: commerce.storefrontConfiguration ? 1 : 0,
-      reviewedRequests: commerce.storefrontRequests?.length ?? 0,
-      latestSavedStorefrontAt: commerce.storefrontConfiguration?.saved.capturedAt ?? null,
-      latestReviewedRequestAt: latestIsoTimestamp(commerce.storefrontRequests?.map((request) => request.createdAt) ?? []),
-    },
+    ecommerce: ecommerceDemoEvidence,
   }) : null
   const nextDemoMission = demoRunbook?.products.find((product) => product.product === demoRunbook.nextProduct) ?? null
   const demoLaunchPath = nextDemoMission?.startPath ?? demoRunbook?.products[0]?.startPath ?? '/'

--- a/showroom/src/core/client-onboarding.ts
+++ b/showroom/src/core/client-onboarding.ts
@@ -631,7 +631,7 @@ const clientDemoRunbookContracts: Record<ClientSolutionId, {
   ecommerce: {
     scenario: 'Turn one storefront visit into a Shop-reviewed request.',
     steps: ['Save the Shop-backed storefront', 'Build and review one customer quote', 'Send the request to Shop for confirmation'],
-    evidenceRequirement: 'A saved storefront configuration and at least one reviewed request in Shop.',
+    evidenceRequirement: 'A saved storefront configuration and at least one request confirmed into a Shop order.',
   },
 }
 
@@ -1886,7 +1886,7 @@ export function buildClientDemoRunbook(workspaceValue: unknown, evidenceValue: u
         && evidence.ecommerce.reviewedRequests > 0
         && evidenceFollowsBaseline(evidence.ecommerce.latestSavedStorefrontAt, workspace.proofBaselineAt)
         && evidenceFollowsBaseline(evidence.ecommerce.latestReviewedRequestAt, workspace.proofBaselineAt),
-      observed: `${evidence.ecommerce.savedStorefronts} saved storefront · ${evidence.ecommerce.reviewedRequests} Shop request${evidence.ecommerce.reviewedRequests === 1 ? '' : 's'}`,
+      observed: `${evidence.ecommerce.savedStorefronts} saved storefront · ${evidence.ecommerce.reviewedRequests} Shop-confirmed request${evidence.ecommerce.reviewedRequests === 1 ? '' : 's'}`,
     },
   }
   const products = workspace.blueprint.products.map((product) => {

--- a/showroom/src/products/ecommerce/EcommerceProduct.tsx
+++ b/showroom/src/products/ecommerce/EcommerceProduct.tsx
@@ -1146,6 +1146,27 @@ export function EcommerceProduct() {
   const lifecyclePaymentAttention = managedOrderTimeline.filter((entry) => entry.nextAction === 'confirm_payment')
   const lifecycleRefundAttention = managedOrderTimeline.filter((entry) => entry.nextAction === 'settle_refund')
   const managedReturnedUnits = managedOrderTimeline.reduce((total, entry) => total + entry.returnedQuantity, 0)
+  const localEcommerceOrders = managedIdentity
+    ? []
+    : (activeCommerceState?.orders ?? []).filter((order) => order.sourceRecordId?.startsWith('ECR-'))
+  const ecommerceActiveOrderCount = managedIdentity
+    ? activeManagedOrders.length
+    : localEcommerceOrders.filter((order) => order.status !== 'completed' && order.status !== 'cancelled').length
+  const ecommerceCompletedOrderCount = managedIdentity
+    ? completedManagedOrders.length
+    : localEcommerceOrders.filter((order) => order.status === 'completed').length
+  const ecommerceCancelledOrderCount = managedIdentity
+    ? cancelledManagedOrders.length
+    : localEcommerceOrders.filter((order) => order.status === 'cancelled').length
+  const ecommercePaymentAttentionCount = managedIdentity
+    ? lifecyclePaymentAttention.length
+    : localEcommerceOrders.filter((order) => order.status === 'ready' && order.paymentStatus !== 'reconciled').length
+  const ecommerceRefundAttentionCount = managedIdentity
+    ? lifecycleRefundAttention.length
+    : localEcommerceOrders.filter((order) => order.refundStatus === 'due').length
+  const ecommerceReturnedUnits = managedIdentity
+    ? managedReturnedUnits
+    : localEcommerceOrders.reduce((total, order) => total + (order.returns ?? []).reduce((returned, record) => returned + record.quantity, 0), 0)
   const importNeeded = catalog.source === 'sample' || catalog.source === 'unavailable' || catalog.items.length === 0
   const orderOpsNow = Date.now()
   const orderOpsAgingCount = pendingManagedRequests.filter((request) => Date.parse(request.createdAt) <= orderOpsNow - 30 * 60 * 1000).length
@@ -1170,9 +1191,9 @@ export function EcommerceProduct() {
         : buyingCart.length
           ? 'Quote payment and delivery'
           : 'Checkout controls ready'
-  const orderOpsPriority = lifecycleRefundAttention.length
+  const orderOpsPriority = ecommerceRefundAttentionCount
     ? 'Settle refund evidence'
-    : lifecyclePaymentAttention.length
+    : ecommercePaymentAttentionCount
       ? 'Confirm payment before completion'
       : orderOpsStockRiskCount
         ? 'Resolve stock risk'
@@ -1182,7 +1203,7 @@ export function EcommerceProduct() {
             ? 'Clear aged requests'
             : pendingManagedRequests.length
               ? 'Review next request'
-              : activeManagedOrders.length
+              : ecommerceActiveOrderCount
                 ? 'Continue fulfilment'
                 : importNeeded
                   ? 'Import sellable catalog'
@@ -1191,11 +1212,11 @@ export function EcommerceProduct() {
                     : 'Save store'
   const orderOpsRows = [
     ['Review', pendingManagedRequests.length ? `${pendingManagedRequests.length} waiting` : 'Clear'],
-    ['Fulfil', activeManagedOrders.length ? `${activeManagedOrders.length} active` : 'Clear'],
-    ['Payment', lifecyclePaymentAttention.length ? `${lifecyclePaymentAttention.length} blocking` : 'Clear'],
-    ['Refund', lifecycleRefundAttention.length ? `${lifecycleRefundAttention.length} due` : 'Clear'],
-    ['Done', `${completedManagedOrders.length} completed · ${cancelledManagedOrders.length} cancelled`],
-    ['Returns', managedReturnedUnits ? `${managedReturnedUnits} units recorded` : 'None'],
+    ['Fulfil', ecommerceActiveOrderCount ? `${ecommerceActiveOrderCount} active` : 'Clear'],
+    ['Payment', ecommercePaymentAttentionCount ? `${ecommercePaymentAttentionCount} blocking` : 'Clear'],
+    ['Refund', ecommerceRefundAttentionCount ? `${ecommerceRefundAttentionCount} due` : 'Clear'],
+    ['Done', `${ecommerceCompletedOrderCount} completed · ${ecommerceCancelledOrderCount} cancelled`],
+    ['Returns', ecommerceReturnedUnits ? `${ecommerceReturnedUnits} units recorded` : 'None'],
   ] as const
   const orderImportStage = importNeeded
     ? 'Upload catalog first'
@@ -1526,6 +1547,8 @@ export function EcommerceProduct() {
   ] as const
   const aiAgentJob = pendingManagedRequests.length
     ? 'Review Ecommerce requests in Shop'
+    : ecommerceActiveOrderCount
+      ? 'Continue Ecommerce order in Shop'
     : importNeeded
       ? 'Prepare catalog import'
       : !savedDraftIsCurrent
@@ -1535,6 +1558,8 @@ export function EcommerceProduct() {
           : 'Open store for ordering'
   const aiAgentReason = pendingManagedRequests.length
     ? `${pendingManagedRequests.length} request${pendingManagedRequests.length === 1 ? '' : 's'} waiting for accountable Shop review.`
+    : ecommerceActiveOrderCount
+      ? `${ecommerceActiveOrderCount} Ecommerce order${ecommerceActiveOrderCount === 1 ? '' : 's'} now use the Shop-owned fulfilment record.`
     : importNeeded
       ? 'The order desk needs a real Shop catalog before the store can sell.'
       : !savedDraftIsCurrent
@@ -1544,6 +1569,8 @@ export function EcommerceProduct() {
           : 'The store is saved and ready for a customer request.'
   const aiOwnerGate = pendingManagedRequests.length
     ? 'Shop confirms stock, delivery, payment, and customer contact.'
+    : ecommerceActiveOrderCount
+      ? 'Shop remains authoritative for fulfilment, payment, cancellation, and returns.'
     : importNeeded
       ? 'Review the imported catalog before going live.'
       : !savedDraftIsCurrent
@@ -1566,32 +1593,36 @@ export function EcommerceProduct() {
           ? 'Repair order batch'
           : pendingManagedRequests.length
             ? 'Open Shop review'
+            : ecommerceActiveOrderCount
+              ? 'Continue fulfilment'
             : buyingReady
               ? 'Ready for customer orders'
               : 'Check setup'
   const ecommerceTodayCustomerCount = new Set(
-    managedOrderTimeline
-      .map((entry) => entry.request.customerReference.trim())
+    (managedIdentity
+      ? managedOrderTimeline.map((entry) => entry.request.customerReference)
+      : localEcommerceOrders.map((order) => order.customer))
+      .map((customer) => customer.trim())
       .filter(Boolean),
   ).size
   const ecommerceTodayCartUnits = buyingCart.reduce((total, line) => total + line.quantity, 0)
   const ecommerceTodayState = importNeeded || !savedDraftIsCurrent
     ? 'setup'
-    : lifecycleRefundAttention.length || lifecyclePaymentAttention.length || orderOpsStockRiskCount || pendingManagedRequests.length
+    : ecommerceRefundAttentionCount || ecommercePaymentAttentionCount || orderOpsStockRiskCount || pendingManagedRequests.length
       ? 'attention'
       : 'ready'
   const ecommerceTodayHeadline = importNeeded
     ? 'Connect your products to start selling'
     : !savedDraftIsCurrent
       ? 'Finish the store customers will see'
-      : lifecycleRefundAttention.length
-        ? `${lifecycleRefundAttention.length} refund${lifecycleRefundAttention.length === 1 ? '' : 's'} need evidence`
-        : lifecyclePaymentAttention.length
-          ? `${lifecyclePaymentAttention.length} payment${lifecyclePaymentAttention.length === 1 ? '' : 's'} need confirmation`
+      : ecommerceRefundAttentionCount
+        ? `${ecommerceRefundAttentionCount} refund${ecommerceRefundAttentionCount === 1 ? '' : 's'} need evidence`
+        : ecommercePaymentAttentionCount
+          ? `${ecommercePaymentAttentionCount} payment${ecommercePaymentAttentionCount === 1 ? '' : 's'} need confirmation`
           : pendingManagedRequests.length
             ? `${pendingManagedRequests.length} order request${pendingManagedRequests.length === 1 ? '' : 's'} need review`
-            : activeManagedOrders.length
-              ? `${activeManagedOrders.length} order${activeManagedOrders.length === 1 ? '' : 's'} in progress`
+            : ecommerceActiveOrderCount
+              ? `${ecommerceActiveOrderCount} order${ecommerceActiveOrderCount === 1 ? '' : 's'} in progress`
               : ecommerceTodayCartUnits
                 ? `${ecommerceTodayCartUnits} item${ecommerceTodayCartUnits === 1 ? '' : 's'} ready for checkout`
                 : 'Your store is ready for the next order'
@@ -1601,7 +1632,7 @@ export function EcommerceProduct() {
       ? 'Review the customer view once, then save the exact products, prices, and page customers will see.'
       : pendingManagedRequests.length
         ? 'Shop keeps the accountable order record. Review stock, payment, and delivery before customer contact.'
-        : activeManagedOrders.length
+        : ecommerceActiveOrderCount
           ? 'Continue fulfilment from the Shop-owned order record; no duplicate order ledger is created here.'
           : 'Customers can browse and build a cart. Shop remains in control of payment, stock, delivery, and returns.'
   const ecommerceTodayAction = importNeeded
@@ -1614,15 +1645,17 @@ export function EcommerceProduct() {
           ? 'Fix order import'
           : pendingManagedRequests.length
             ? 'Review orders in Shop'
+            : ecommerceActiveOrderCount
+              ? 'Continue in Shop'
             : ecommerceTodayCartUnits
               ? 'Review checkout'
               : 'Prepare next order'
   const ecommerceTodayMetrics = [
     ['Storefront', savedDraftIsCurrent ? 'Ready' : catalogHydrating ? 'Checking' : 'Needs setup'],
     ['Shop requests', pendingManagedRequests.length ? `${pendingManagedRequests.length} to review` : 'Clear'],
-    ['Cart & checkout', ecommerceTodayCartUnits ? `${ecommerceTodayCartUnits} item${ecommerceTodayCartUnits === 1 ? '' : 's'}` : buyingReady ? 'Ready' : 'Locked'],
+    ['Cart & checkout', ecommerceActiveOrderCount && ecommerceTodayCartUnits ? 'Order confirmed' : ecommerceTodayCartUnits ? `${ecommerceTodayCartUnits} item${ecommerceTodayCartUnits === 1 ? '' : 's'}` : buyingReady ? 'Ready' : 'Locked'],
     ['Customers', ecommerceTodayCustomerCount ? `${ecommerceTodayCustomerCount} known` : 'No orders yet'],
-    ['Returns', managedReturnedUnits ? `${managedReturnedUnits} unit${managedReturnedUnits === 1 ? '' : 's'}` : 'Clear'],
+    ['Returns', ecommerceReturnedUnits ? `${ecommerceReturnedUnits} unit${ecommerceReturnedUnits === 1 ? '' : 's'}` : 'Clear'],
   ] as const
   const ecommerceGuidedJobs = [
     ['1', 'Browse demo', 'See the customer store first.', '#ecommerce-preview-panel'],
@@ -1651,6 +1684,10 @@ export function EcommerceProduct() {
     }
     if (pendingManagedRequests.length) {
       navigate('/shop/?tab=orders&source=ecommerce')
+      return
+    }
+    if (ecommerceActiveOrderCount) {
+      navigate('/shop/?tab=orders')
       return
     }
     prepareQuoteRecovery()

--- a/tools/verify_app_build.mjs
+++ b/tools/verify_app_build.mjs
@@ -461,11 +461,13 @@ for (const required of ['SUPERMEGA', 'Shop', 'Plant', 'Website', 'Ecommerce', 'S
 if (!ecommerceSource.includes('const ecommerceTodayMetrics = [')
   || !ecommerceSource.includes('const ecommerceTodayHeadline =')
   || !ecommerceSource.includes('const ecommerceTodayCustomerCount = new Set(')
+  || !ecommerceSource.includes("order.sourceRecordId?.startsWith('ECR-')")
+  || !ecommerceSource.includes('const ecommerceActiveOrderCount = managedIdentity')
   || !ecommerceSource.includes("['Storefront', savedDraftIsCurrent ? 'Ready'")
   || !ecommerceSource.includes("['Shop requests', pendingManagedRequests.length ? `${pendingManagedRequests.length} to review` : 'Clear']")
-  || !ecommerceSource.includes("['Cart & checkout', ecommerceTodayCartUnits")
+  || !ecommerceSource.includes("['Cart & checkout', ecommerceActiveOrderCount && ecommerceTodayCartUnits ? 'Order confirmed'")
   || !ecommerceSource.includes("['Customers', ecommerceTodayCustomerCount")
-  || !ecommerceSource.includes("['Returns', managedReturnedUnits")
+  || !ecommerceSource.includes("['Returns', ecommerceReturnedUnits")
   || !ecommerceSource.includes('aria-labelledby="ecommerce-today-title"')
   || !ecommerceSource.includes('aria-label="Ecommerce today status"')
   || !ecommerceSource.includes('className="ecommerce-today-metrics" role="group"')
@@ -490,6 +492,7 @@ if (!ecommerceSource.includes('const aiDeskRows = [')
   || !ecommerceSource.includes('aria-label="Ecommerce next step"')
   || ecommerceSource.includes('aria-label="Recommended Ecommerce next step"')
   || !ecommerceSource.includes("'Review Ecommerce requests in Shop'")
+  || !ecommerceSource.includes("'Continue Ecommerce order in Shop'")
   || !ecommerceSource.includes("'Prepare catalog import'")
   || !ecommerceSource.includes("'Finish store'")
   || !ecommerceSource.includes("'Review cart quote'")
@@ -505,6 +508,7 @@ if (!ecommerceSource.includes('const orderAutopilotStage =')
   || !ecommerceSource.includes("'Connect products'")
   || !ecommerceSource.includes("'Package order batch'")
   || !ecommerceSource.includes("'Open Shop review'")
+  || !ecommerceSource.includes("'Continue fulfilment'")
   || !ecommerceSource.includes("'Ready for customer orders'")
   || !ecommerceSource.includes('detail: `Order autopilot: ${orderAutopilotStage}`')
   || !ecommerceSource.includes('downloadOrderImportReviewPacket()')
@@ -531,9 +535,9 @@ if (!ecommerceSource.includes('const orderOpsRows = [')
   || !ecommerceSource.includes('aria-label="Order lifecycle queue"')
   || !ecommerceSource.includes('One Shop-owned record now follows each Ecommerce request through review, fulfilment, payment, cancellation, refund, and return.')
   || !ecommerceSource.includes("['Review', pendingManagedRequests.length ? `${pendingManagedRequests.length} waiting` : 'Clear']")
-  || !ecommerceSource.includes("['Fulfil', activeManagedOrders.length ? `${activeManagedOrders.length} active` : 'Clear']")
-  || !ecommerceSource.includes("['Payment', lifecyclePaymentAttention.length ? `${lifecyclePaymentAttention.length} blocking` : 'Clear']")
-  || !ecommerceSource.includes("['Refund', lifecycleRefundAttention.length ? `${lifecycleRefundAttention.length} due` : 'Clear']")
+  || !ecommerceSource.includes("['Fulfil', ecommerceActiveOrderCount ? `${ecommerceActiveOrderCount} active` : 'Clear']")
+  || !ecommerceSource.includes("['Payment', ecommercePaymentAttentionCount ? `${ecommercePaymentAttentionCount} blocking` : 'Clear']")
+  || !ecommerceSource.includes("['Refund', ecommerceRefundAttentionCount ? `${ecommerceRefundAttentionCount} due` : 'Clear']")
   || !ecommerceSource.includes('Open Shop order queue')
   || !ecommerceSource.includes('const orderImportStage =')
   || !ecommerceSource.includes('const orderImportRows = [')
@@ -4868,6 +4872,11 @@ if (!productSetupSource.includes('templateId: string')
   || settingsPageSource.indexOf('className="compact-disclosure client-system-details"') > settingsPageSource.indexOf('className="compact-disclosure client-preparation-handoff"')
   || !settingsPageSource.includes('Required proof')
   || !settingsPageSource.includes('Observed: {mission.evidenceObserved}')
+  || !settingsPageSource.includes('readStorefrontDraft(LOCAL_STOREFRONT_DRAFT_SCOPE)')
+  || !settingsPageSource.includes("order.sourceRecordId?.startsWith('ECR-')")
+  || !settingsPageSource.includes('latestIsoTimestamp(reviewedEcommerceOrders.map((order) => order.createdAt))')
+  || !clientOnboardingSource.includes('request confirmed into a Shop order')
+  || !clientOnboardingSource.includes('Shop-confirmed request')
   || !settingsPageSource.includes('onProgress={recordDemoProductProgress}')
   || !settingsPageSource.includes("not_started: 'Not started'")
   || !settingsPageSource.includes('Create client demo')
@@ -8140,6 +8149,26 @@ async function verifyClientOnboardingRuntime() {
       commerce: { completedOrders: 1, reconciledOrders: 1, latestAccountableSaleAt: '2026-07-28T08:06:00.000Z' },
     })
     assert(shopProvenRunbook.provenCount === 1 && shopProvenRunbook.nextProduct === 'production' && shopProvenRunbook.products[0].status === 'proven', 'client_demo_runbook_shop_proof_not_derived')
+    const ecommerceStorefrontOnlyRunbook = model.buildClientDemoRunbook(shopReady, {
+      ...noOperationalEvidence,
+      ecommerce: { savedStorefronts: 1, reviewedRequests: 0, latestSavedStorefrontAt: '2026-07-28T08:09:00.000Z', latestReviewedRequestAt: null },
+    })
+    assert(ecommerceStorefrontOnlyRunbook.products[3].status !== 'proven', 'client_demo_saved_storefront_claimed_shop_review')
+    const ecommerceOrderOnlyRunbook = model.buildClientDemoRunbook(shopReady, {
+      ...noOperationalEvidence,
+      ecommerce: { savedStorefronts: 0, reviewedRequests: 1, latestSavedStorefrontAt: null, latestReviewedRequestAt: '2026-07-28T08:10:00.000Z' },
+    })
+    assert(ecommerceOrderOnlyRunbook.products[3].status !== 'proven', 'client_demo_shop_order_claimed_unsaved_storefront')
+    const seededEcommerceRunbook = model.buildClientDemoRunbook(shopReady, {
+      ...noOperationalEvidence,
+      ecommerce: { savedStorefronts: 1, reviewedRequests: 1, latestSavedStorefrontAt: '2026-07-28T07:58:00.000Z', latestReviewedRequestAt: '2026-07-28T08:10:00.000Z' },
+    })
+    assert(seededEcommerceRunbook.products[3].status !== 'proven', 'client_demo_seeded_storefront_claimed_current_ecommerce_proof')
+    const ecommerceProvenRunbook = model.buildClientDemoRunbook(shopReady, {
+      ...noOperationalEvidence,
+      ecommerce: { savedStorefronts: 1, reviewedRequests: 1, latestSavedStorefrontAt: '2026-07-28T08:09:00.000Z', latestReviewedRequestAt: '2026-07-28T08:10:00.000Z' },
+    })
+    assert(ecommerceProvenRunbook.products[3].status === 'proven' && ecommerceProvenRunbook.provenCount === 1, 'client_demo_shop_confirmed_ecommerce_proof_not_derived')
     const allProvenRunbook = model.buildClientDemoRunbook(shopReady, {
       commerce: { completedOrders: 1, reconciledOrders: 1, latestAccountableSaleAt: '2026-07-28T08:06:00.000Z' },
       production: { releasedBatches: 1, latestReleasedAt: '2026-07-28T08:07:00.000Z' },


### PR DESCRIPTION
## Outcome
- bind browser-local Ecommerce proof to the saved storefront and resulting ECR Shop order
- show confirmed local Ecommerce orders in Today, customer, cart, fulfilment, payment, refund, return, and next-action states
- reject storefront-only, order-only, and pre-baseline proof

## Verification
- focused ESLint
- production showroom build
- npm run app:verify
- local browser mission: storefront -> quote -> Shop confirmation -> Ecommerce status -> Setup proof -> reload
- zero local console errors