### PR TITLE
fix(website): show a real client sample

### DIFF
--- a/showroom/src/products/website/website-model.ts
+++ b/showroom/src/products/website/website-model.ts
@@ -290,7 +290,7 @@ export function createInitialWorkspace(): WebsiteWorkspace {
     version: 2,
     revision: 0,
     contentRevision: 0,
-    siteName: 'SuperMega',
+    siteName: 'Mingalar Fresh Mart',
     selectedPageId: 'page-home',
     evidence: [],
     approvals: [],
@@ -304,56 +304,56 @@ export function createInitialWorkspace(): WebsiteWorkspace {
         stage: 'ready',
         navigation: { label: 'Home', visible: true },
         hero: {
-          eyebrow: 'Company operating system',
-          headline: 'Turn accountable work into visible progress.',
-          summary: 'SuperMega gives teams one compact place to operate, review evidence, and keep consequential actions under human control.',
-          ctaLabel: 'Explore products',
-          ctaHref: '/products',
+          eyebrow: 'Groceries in Yangon',
+          headline: 'Fresh everyday groceries without the extra trip.',
+          summary: 'Shop pantry staples, drinks, household refills, and ready-made family packs for pickup or local delivery.',
+          ctaLabel: 'Browse the catalog',
+          ctaHref: '/catalog',
         },
         sections: [
           {
             id: 'section-home-control',
-            eyebrow: 'Control',
-            title: 'Software that shows its work.',
-            body: 'Every important change keeps its owner, source, current state, and approval boundary close to the record.',
+            eyebrow: 'Clear ordering',
+            title: 'See the product, price, and fulfilment choice.',
+            body: 'Choose a practical pack, then confirm quantity, pickup or delivery, and timing before the order is accepted.',
           },
           {
             id: 'section-home-local',
-            eyebrow: 'Local first',
-            title: 'Useful before it is connected.',
-            body: 'Start with a bounded browser workspace, then connect identity, data, and deployment only when those controls are ready.',
+            eyebrow: 'Local service',
+            title: 'A simple order from request to handoff.',
+            body: 'The store checks current stock and delivery details before confirming what is available.',
           },
         ],
         seo: {
-          title: 'SuperMega | Accountable company software',
-          description: 'Compact operating software for teams that need evidence, clear ownership, and human approval.',
+          title: 'Mingalar Fresh Mart | Groceries in Yangon',
+          description: 'Everyday groceries, pantry packs, pickup, and local delivery in Yangon.',
         },
         updatedAt: INITIAL_CREATED_AT,
       },
       {
         id: 'page-products',
-        internalName: 'Products',
-        slug: '/products',
+        internalName: 'Catalog',
+        slug: '/catalog',
         stage: 'ready',
-        navigation: { label: 'Products', visible: true },
+        navigation: { label: 'Catalog', visible: true },
         hero: {
-          eyebrow: 'Products',
-          headline: 'Focused workspaces for the work that matters.',
-          summary: 'Run commerce, production, team delivery, and publishing from compact tools with explicit operational boundaries.',
-          ctaLabel: 'Talk to us',
+          eyebrow: 'Everyday essentials',
+          headline: 'Stock the week in one simple order.',
+          summary: 'Start with daily essentials, cold drinks, household refills, and personal care packs. Current availability is confirmed before purchase.',
+          ctaLabel: 'Ask about availability',
           ctaHref: '/contact',
         },
         sections: [
           {
             id: 'section-products-workspaces',
-            eyebrow: 'Workspaces',
-            title: 'Purpose-built, not page-built.',
-            body: 'Each product starts with the records, decisions, and evidence its operators actually need.',
+            eyebrow: 'Popular choices',
+            title: 'Practical packs for home and office.',
+            body: 'Choose the products and quantities you need. The store reviews stock, fulfilment, and final total before confirmation.',
           },
         ],
         seo: {
-          title: 'Products | SuperMega',
-          description: 'Explore SuperMega workspaces for accountable commerce, production, team delivery, and websites.',
+          title: 'Catalog | Mingalar Fresh Mart',
+          description: 'Browse practical grocery and household packs for pickup or local delivery in Yangon.',
         },
         updatedAt: INITIAL_CREATED_AT,
       },
@@ -364,23 +364,23 @@ export function createInitialWorkspace(): WebsiteWorkspace {
         stage: 'ready',
         navigation: { label: 'Contact', visible: true },
         hero: {
-          eyebrow: 'Start a conversation',
-          headline: 'Bring one real workflow.',
-          summary: 'We will map the record, the accountable owner, the evidence needed, and the actions that must remain human-controlled.',
-          ctaLabel: 'Email SuperMega',
-          ctaHref: 'https://supermega.dev',
+          eyebrow: 'Order help',
+          headline: 'Tell us what you need today.',
+          summary: 'Share the item, quantity, township, and preferred pickup or delivery time. We will review availability before confirming.',
+          ctaLabel: 'Browse products',
+          ctaHref: '/catalog',
         },
         sections: [
           {
             id: 'section-contact-scope',
-            eyebrow: 'First step',
-            title: 'Begin with a bounded outcome.',
-            body: 'A useful pilot has one owner, one operating surface, a measurable acceptance condition, and no hidden production access.',
+            eyebrow: 'What to include',
+            title: 'One message is enough to start.',
+            body: 'Include product names, quantities, location, and timing so the store can answer with a clear next step.',
           },
         ],
         seo: {
-          title: 'Contact | SuperMega',
-          description: 'Start a bounded SuperMega pilot with a real workflow, evidence requirements, and clear authority.',
+          title: 'Contact | Mingalar Fresh Mart',
+          description: 'Ask Mingalar Fresh Mart about current stock, pickup, or local delivery in Yangon.',
         },
         updatedAt: INITIAL_CREATED_AT,
       },
@@ -1344,8 +1344,28 @@ function migrateLegacyWorkspace(legacy: LegacyWebsiteWorkspace): WebsiteWorkspac
   }
 }
 
+function isUntouchedLegacyCorporateSample(workspace: WebsiteWorkspace) {
+  return workspace.revision === 0
+    && workspace.contentRevision === 0
+    && workspace.siteName === 'SuperMega'
+    && workspace.selectedPageId === 'page-home'
+    && workspace.pages.length === 3
+    && workspace.pages.some((page) => page.id === 'page-home' && page.slug === '/')
+    && workspace.pages.some((page) => page.id === 'page-products' && page.slug === '/products')
+    && workspace.pages.some((page) => page.id === 'page-contact' && page.slug === '/contact')
+    && workspace.evidence.length === 0
+    && workspace.approvals.length === 0
+    && workspace.localPublishes.length === 0
+    && workspace.events.length === 0
+}
+
 function parseStoredWorkspace(raw: string) {
-  try { return restoreV2(JSON.parse(raw) as unknown) } catch { return null }
+  try {
+    const restored = restoreV2(JSON.parse(raw) as unknown)
+    return restored && isUntouchedLegacyCorporateSample(restored)
+      ? createInitialWorkspace()
+      : restored
+  } catch { return null }
 }
 
 function parseLegacyWorkspace(raw: string) {

--- a/showroom/src/products/website/website-starter.ts
+++ b/showroom/src/products/website/website-starter.ts
@@ -104,7 +104,7 @@ export function applyWebsiteStarterBrief(
     || !isCanonicalTimestamp(capturedAt)) return workspace
 
   const home = workspace.pages.find((page) => page.slug.trim() === '/')
-  const secondary = workspace.pages.find((page) => page.slug.trim() === '/products')
+  const secondary = workspace.pages.find((page) => page.id === 'page-products')
   const contact = workspace.pages.find((page) => page.slug.trim() === '/contact')
   if (!home || home.sections.length < 2 || !secondary?.sections.length || !contact?.sections.length) return workspace
 

--- a/tools/verify_app_build.mjs
+++ b/tools/verify_app_build.mjs
@@ -3439,6 +3439,20 @@ if (!websiteSource.includes('starterSetupActive')
   || !websiteStarterSource.includes("stage: 'draft'")
   || !websiteStarterSource.includes('websiteStarterBriefIssues')
   || ['fetch(', 'localStorage', 'sessionStorage', 'XMLHttpRequest'].some((marker) => websiteStarterSource.includes(marker) || websiteStarterSetupSource.includes(marker))) fail('website_named_business_starter_missing_or_side_effectful')
+if (!websiteModelSource.includes("siteName: 'Mingalar Fresh Mart'")
+  || !websiteModelSource.includes("headline: 'Fresh everyday groceries without the extra trip.'")
+  || !websiteModelSource.includes("internalName: 'Catalog'")
+  || !websiteModelSource.includes("slug: '/catalog'")
+  || !websiteModelSource.includes("headline: 'Stock the week in one simple order.'")
+  || !websiteModelSource.includes("headline: 'Tell us what you need today.'")
+  || !websiteModelSource.includes('isUntouchedLegacyCorporateSample')
+  || !websiteModelSource.includes("workspace.siteName === 'SuperMega'")
+  || !websiteModelSource.includes("page.id === 'page-products' && page.slug === '/products'")
+  || !websiteModelSource.includes('restored && isUntouchedLegacyCorporateSample(restored)')
+  || !websiteStarterSource.includes("workspace.pages.find((page) => page.id === 'page-products')")
+  || websiteModelSource.includes("headline: 'Turn accountable work into visible progress.'")
+  || websiteModelSource.includes("headline: 'Focused workspaces for the work that matters.'")
+  || websiteModelSource.includes("headline: 'Bring one real workflow.'")) fail('website_real_client_sample_missing')
 if (!websiteModelSource.includes("supermega.website.workspace.v2")
   || !websiteModelSource.includes('LEGACY_WEBSITE_STORAGE_KEY')
   || !websiteModelSource.includes('mutateWebsiteWorkspace')
@@ -9685,6 +9699,29 @@ async function verifyWebsiteRuntime() {
     const starter = await import(`${pathToFileURL(resolve(root, 'showroom', 'src', 'products', 'website', 'website-starter.ts')).href}?website-starter-verify=${Date.now()}`)
     const seed = model.createInitialWorkspace()
     const fingerprint = model.workspaceFingerprint(seed)
+    assert(seed.siteName === 'Mingalar Fresh Mart'
+      && seed.pages.map((page) => page.slug).join(',') === '/,/catalog,/contact'
+      && seed.pages[0].hero.headline === 'Fresh everyday groceries without the extra trip.'
+      && seed.pages[1].hero.headline === 'Stock the week in one simple order.'
+      && seed.pages[2].hero.headline === 'Tell us what you need today.', 'website_real_client_sample_was_not_seeded')
+    const legacyCorporateSample = {
+      ...seed,
+      siteName: 'SuperMega',
+      pages: seed.pages.map((page) => page.id === 'page-products'
+        ? { ...page, internalName: 'Products', slug: '/products', navigation: { label: 'Products', visible: true } }
+        : page),
+    }
+    values.set(model.WEBSITE_STORAGE_KEY, JSON.stringify(legacyCorporateSample))
+    const upgradedLegacySample = model.loadWebsiteWorkspace(storage)
+    assert(upgradedLegacySample.ok
+      && upgradedLegacySample.workspace.siteName === seed.siteName
+      && upgradedLegacySample.workspace.pages[1].slug === '/catalog', 'website_untouched_legacy_sample_was_not_upgraded')
+    values.set(model.WEBSITE_STORAGE_KEY, JSON.stringify({ ...legacyCorporateSample, revision: 1, contentRevision: 1 }))
+    const preservedLegacyEdit = model.loadWebsiteWorkspace(storage)
+    assert(preservedLegacyEdit.ok
+      && preservedLegacyEdit.workspace.siteName === 'SuperMega'
+      && preservedLegacyEdit.workspace.pages[1].slug === '/products', 'website_edited_legacy_workspace_was_replaced')
+    values.clear()
     const starterBrief = {
       templateId: 'catalog-showcase',
       businessName: 'Shwe Family Store',
@@ -10265,7 +10302,7 @@ async function verifyWebsiteRuntime() {
     const firstDownload = exporter.createWebsiteHtmlDownload(retainedArtifact)
     const secondDownload = exporter.createWebsiteHtmlDownload(retainedArtifact)
     assert(JSON.stringify(firstDownload) === JSON.stringify(secondDownload) && firstDownload.filename.endsWith('.html'), 'website_artifact_export_not_deterministic')
-    assert(firstDownload.content.includes('Content-Security-Policy') && firstDownload.content.includes('href="#products"') && firstDownload.content.includes('https://supermega.dev/'), 'website_artifact_links_or_security_boundary_missing')
+    assert(firstDownload.content.includes('Content-Security-Policy') && firstDownload.content.includes('href="#catalog"') && firstDownload.content.includes('Mingalar Fresh Mart'), 'website_artifact_links_or_security_boundary_missing')
     assert(![fingerprint, approvalInput.actionId, firstInput.actionId, 'OP-OWNER', 'page-home'].some((value) => firstDownload.content.includes(value)), 'website_artifact_export_leaked_governance_metadata')
     const unsafeArtifact = structuredClone(retainedArtifact)
     unsafeArtifact.pages[0].hero.ctaHref = 'javascript:alert(1)'

--- a/tools/verify_app_release_live.mjs
+++ b/tools/verify_app_release_live.mjs
@@ -33,7 +33,7 @@ export function verifyCurrentReleaseAssets({
     ['module_drawer', productSystemNavigatorChunk, ['Modules', ' working / ', ' setup', 'Start with the working demo.', 'Use the sample workflow first. Setup and imports can wait.', 'Use now', 'Add data later', 'Advanced modules stay hidden until a real client needs them.']],
     ['support_helper', productHomeReadinessCorpus, ['Support helper', 'Uses Shop, Plant, Website, and Ecommerce records.', 'Readiness review status', 'Mark reviewed', 'Acknowledgement confirms review only.', 'supermega.local_business_snapshot.v1', 'supermega.local_business_answer.v1']],
     ['settings', settingsChunk, ['supermega_trial_evidence', 'Premium company learning', 'Advanced controls', 'Save, export, restore, or reset.', 'Export full evidence']],
-    ['website', websiteChunk, ['Make this website yours', 'Download site', 'Website starter brief generated', 'Not online yet']],
+    ['website', websiteChunk, ['Make this website yours', 'Download site', 'Website starter brief generated', 'Not online yet', 'Mingalar Fresh Mart', 'Fresh everyday groceries without the extra trip.', 'Stock the week in one simple order.', 'Tell us what you need today.']],
     ['ecommerce', ecommerceProductCorpus, ['Review an order batch', 'Upload CSV or paste channel orders only when needed.', 'Payment and customer messages stay locked.', 'Shop review', 'supermega.ecommerce.order_import_review_packet.v1']],
     ['data_onboarding', clientDataOnboardingChunk, ['Start with a CSV or sample so SuperMega can map columns and inspect rows locally.', 'No customer message, payment, website publish, or automation runs from this check.']],
     ['company_login', managedLoginChunk, ['Open your company.', 'Try free demo', 'Request company account']],
@@ -51,6 +51,10 @@ export function verifyCurrentReleaseAssets({
   for (const forbidden of ['Complete sale', 'Stock updated. Receipt saved.']) {
     checks += 1
     if (operationsChunk.includes(forbidden)) throw new Error(`misleading_shop_release_asset:${forbidden}`)
+  }
+  for (const forbidden of ['Turn accountable work into visible progress.', 'Focused workspaces for the work that matters.', 'Bring one real workflow.']) {
+    checks += 1
+    if (websiteChunk.includes(forbidden)) throw new Error(`generic_website_sample_release_asset:${forbidden}`)
   }
   const completeCorpus = groups.map(([, corpus]) => corpus).join('\n')
   for (const forbidden of ['pos.supermega.dev', 'ytf.supermega.dev', 'Yangon Tyre', 'ytf-plant-a']) {
@@ -89,6 +93,7 @@ if (artifactSelfTest) {
     ecommerceChunk,
     ecommercePacketChunk,
     websiteChunk,
+    websiteModelChunk,
     clientDataOnboardingChunk,
     managedLoginChunk,
     managedAccountChunk,
@@ -103,6 +108,7 @@ if (artifactSelfTest) {
     readArtifactChunk(assetsDir, assetNames, /^EcommerceProduct-[A-Za-z0-9_-]+\.js$/),
     readArtifactChunk(assetsDir, assetNames, /^ecommerce-order-review-packet-[A-Za-z0-9_-]+\.js$/),
     readArtifactChunk(assetsDir, assetNames, /^WebsiteProduct-[A-Za-z0-9_-]+\.js$/),
+    readArtifactChunk(assetsDir, assetNames, /^website-model-[A-Za-z0-9_-]+\.js$/),
     readArtifactChunk(assetsDir, assetNames, /^ClientDataOnboarding-[A-Za-z0-9_-]+\.js$/),
     readArtifactChunk(assetsDir, assetNames, /^ManagedLoginPage-[A-Za-z0-9_-]+\.js$/),
     readArtifactChunk(assetsDir, assetNames, /^ManagedAccountPage-[A-Za-z0-9_-]+\.js$/),
@@ -119,7 +125,7 @@ if (artifactSelfTest) {
     productHomeReadinessCorpus: `${productHomeReadinessChunk}\n${businessCommandChunk}`,
     settingsChunk,
     ecommerceProductCorpus: `${ecommerceChunk}\n${ecommercePacketChunk}`,
-    websiteChunk,
+    websiteChunk: `${websiteChunk}\n${websiteModelChunk}`,
     clientDataOnboardingChunk,
     managedLoginChunk,
     managedAccountChunk,
@@ -379,7 +385,11 @@ const ecommercePacketChunk = (await get(`/${ecommercePacketChunkPath}`)).body
 const ecommerceProductCorpus = `${ecommerceChunk}\n${ecommercePacketChunk}`
 const websiteChunkPath = /assets\/WebsiteProduct-[A-Za-z0-9_-]+\.js/.exec(assetCorpus)?.[0]
 if (!websiteChunkPath) throw new Error('website_chunk_missing')
-const websiteChunk = (await get(`/${websiteChunkPath}`)).body
+const websiteProductChunk = (await get(`/${websiteChunkPath}`)).body
+const websiteModelChunkPath = /assets\/website-model-[A-Za-z0-9_-]+\.js/.exec(`${assetCorpus}\n${websiteProductChunk}`)?.[0]
+if (!websiteModelChunkPath) throw new Error('website_model_chunk_missing')
+const websiteModelChunk = (await get(`/${websiteModelChunkPath}`)).body
+const websiteChunk = `${websiteProductChunk}\n${websiteModelChunk}`
 const activationRunbookChunkPath = /assets\/ManagedActivationRunbook-[A-Za-z0-9_-]+\.js/.exec(settingsChunk)?.[0]
 if (!activationRunbookChunkPath) throw new Error('managed_activation_runbook_chunk_missing')
 const activationRunbookChunk = (await get(`/${activationRunbookChunkPath}`)).body


### PR DESCRIPTION
## Outcome
- replace the generic SuperMega Website seed with a credible Mingalar Fresh Mart client sample
- keep Home, Catalog, and Contact navigation functional across desktop and mobile previews
- upgrade only the exact untouched legacy corporate sample while preserving edited workspaces
- verify the split Website/model production assets and reject retired corporate seed copy

## Verification
- focused ESLint passed
- `npm run app:build:checked` passed
- Website runtime: 109 checks
- release asset contract: 77 checks
- local browser: Home -> Catalog -> Contact, mobile preview, template preview/discard, zero console errors

## Boundary
- no managed database, DNS, customer message, payment, or provider mutation
- existing edited Website workspaces are preserved