### PR TITLE
fix(database): ignore rehearsal secrets

### DIFF
--- a/.github/workflows/showroom-ci.yml
+++ b/.github/workflows/showroom-ci.yml
@@ -23,6 +23,8 @@ on:
       - 'tools/verify_app_deploy_workflow.mjs'
       - 'tools/verify_app_security_contract.mjs'
       - 'tools/verify_private_trial_migrations.mjs'
+      - 'tools/prepare_supabase_rehearsal_packet.mjs'
+      - 'tools/prepare_supabase_rehearsal_packet.test.mjs'
       - 'tools/verify_app_release_live.mjs'
       - 'tools/verify_coordinated_release_live.mjs'
       - 'tools/verify_public_deploy_guard.mjs'

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ swan-intelligence-hub/
 .vercel
 .vercel_python_packages/
 .codex
+.tmp/
 node_modules/
 api-static/
 api-static-staging-*/

--- a/tools/prepare_supabase_rehearsal_packet.mjs
+++ b/tools/prepare_supabase_rehearsal_packet.mjs
@@ -179,11 +179,22 @@ function resolveOutput(repositoryRoot, output) {
   return destination
 }
 
+function requireIgnoredOutput(repositoryRoot, destination) {
+  const candidate = relative(repositoryRoot, destination)
+  try {
+    execFileSync('git', ['-C', repositoryRoot, 'check-ignore', '--quiet', '--', candidate])
+  }
+  catch {
+    fail('supabase_rehearsal_output_must_be_gitignored')
+  }
+}
+
 async function main() {
   const command = parseArguments(process.argv.slice(2))
   const releaseCommit = reviewedMainCommit(root)
   if (command.mode === 'verify') {
     const input = resolveOutput(root, command.input)
+    requireIgnoredOutput(root, input)
     const packet = await validateSupabaseRehearsalPacket(JSON.parse(await readFile(input, 'utf8')), {
       expectedReleaseCommit: releaseCommit,
     })
@@ -201,6 +212,7 @@ async function main() {
   }
 
   const destination = resolveOutput(root, command.output)
+  requireIgnoredOutput(root, destination)
   const packet = await buildSupabaseRehearsalPacket({
     targetProjectRef: command.targetProjectRef,
     releaseCommit,

--- a/tools/prepare_supabase_rehearsal_packet.test.mjs
+++ b/tools/prepare_supabase_rehearsal_packet.test.mjs
@@ -15,6 +15,7 @@ const generatedAt = '2026-08-03T00:00:00.000Z'
 
 test('builds an exact non-mutating v9 rehearsal packet', async () => {
   const manifest = JSON.parse(await readFile(resolve(repositoryRoot, 'package.json'), 'utf8'))
+  const ignoreRules = await readFile(resolve(repositoryRoot, '.gitignore'), 'utf8')
   const runbook = await readFile(resolve(repositoryRoot, 'docs', 'supermega-enterprise-activation.md'), 'utf8')
   const packet = await buildSupabaseRehearsalPacket({
     repositoryRoot,
@@ -35,6 +36,7 @@ test('builds an exact non-mutating v9 rehearsal packet', async () => {
   assert.match(packet.packetDigest, /^sha256:[0-9a-f]{64}$/)
   assert.doesNotMatch(JSON.stringify(packet), /postgres(?:ql)?:\/\//i)
   assert.equal(manifest.scripts['database:supabase:packet'], 'node tools/prepare_supabase_rehearsal_packet.mjs')
+  assert.match(ignoreRules, /^\.tmp\/$/m)
   assert.match(runbook, /all ten migrations/)
   assert.match(runbook, /Runtime readiness requires schema version 9/)
   assert.match(runbook, /database:supabase:packet:verify/)


### PR DESCRIPTION
## Outcome

Fix the post-merge CLI exercise discovered immediately after #374: generation wrote the packet into an unignored `.tmp` directory, so the subsequent clean-checkout verifier rejected its own output.

## Change

- ignore the documented `.tmp/` secret and evidence directory
- require every packet output to pass `git check-ignore` before generation or verification
- retain the clean-checkout and exact-`origin/main` authority checks
- add packet source and tests to the app-CI path filter so future changes cannot bypass verification
- bind the ignore rule in the packet self-test

## Verification

- exact head: `97656d34e228913a2cc9be2f831f02b34e93bf92`
- packet tests — 3/3
- coordinated-workflow contract — 80 checks
- `git check-ignore` proves the generated packet is ignored
- no provider, Vercel, production, or credential mutation

## Boundary

Code only. The existing placeholder packet is sanitized and non-authoritative. This PR does not create a Supabase branch, apply migrations, deploy, or enable writes.