### PR TITLE
Fix guided sample release verification

### DIFF
--- a/tools/verify_public_deploy_guard.mjs
+++ b/tools/verify_public_deploy_guard.mjs
@@ -10,6 +10,7 @@ const releaseWorkflow = read('.github/workflows/supermega-public-release.yml')
 const ciWorkflow = read('.github/workflows/showroom-ci.yml')
 const healthWorkflow = read('.github/workflows/supermega-public-live-health.yml')
 const previewVerifier = read('tools/verify_public_preview_live.mjs')
+const liveVerifier = read('tools/verify_public_release_live.mjs')
 const rollbackResolver = read('tools/resolve_vercel_rollback_target.mjs')
 const firewallVerifier = read('tools/verify_public_firewall_state.mjs')
 const publicGenerator = read('tools/create_public_vercel_output.mjs')
@@ -43,6 +44,11 @@ if (vercelConfig.git?.deploymentEnabled !== false) failures.push('native_git_dep
 if (!previewVerifier.includes('preview_contact_not_accepting')) failures.push('preview_contact_readiness_not_verified')
 if (!previewVerifier.includes('deployment_function_surface_wrong')) failures.push('preview_function_inventory_not_verified')
 if (!previewVerifier.includes('const maxAttempts = 6') || !previewVerifier.includes('protected_preview_retry:')) failures.push('preview_propagation_retry_missing')
+for (const [label, verifier] of Object.entries({ previewVerifier, liveVerifier })) {
+  if (!verifier.includes('guided_product_route_missing') || !verifier.includes('direct_product_route_remains_primary')) {
+    failures.push(`guided_product_route_contract_missing:${label}`)
+  }
+}
 if (previewVerifier.includes("'--silent'") || previewVerifier.includes("'--show-error'") || previewVerifier.includes("'--location'")) failures.push('preview_verifier_uses_platform_specific_curl_flags')
 if (previewVerifier.includes("'--token'") || !previewVerifier.includes('protected_preview_inspect_failed:') || !previewVerifier.includes('process.env.VERCEL_TOKEN')) failures.push('preview_verifier_credential_handling_unsafe')
 if (!rollbackResolver.includes("mode === 'alias'") || !rollbackResolver.includes("mode === 'deployment'") || !rollbackResolver.includes("state.projectId !== expectedProjectId") || !rollbackResolver.includes("nestedDeploymentId !== deploymentId") || !rollbackResolver.includes("state.id !== expectedDeploymentId") || !rollbackResolver.includes("state.target !== 'production'") || !rollbackResolver.includes("state.readyState !== 'READY'")) failures.push('rollback_alias_resolver_incomplete')

--- a/tools/verify_public_preview_live.mjs
+++ b/tools/verify_public_preview_live.mjs
@@ -61,6 +61,13 @@ for (const page of manifest.pages) {
   }
 }
 
+const homepage = get('/')
+for (const product of manifest.customerProducts) {
+  const guidedSampleRoute = `https://app.supermega.dev/settings/?product=${encodeURIComponent(product.id)}`
+  if (!homepage.includes(`href="${guidedSampleRoute}"`)) throw new Error(`preview_guided_product_route_missing:${product.id}`)
+  if (homepage.includes(`href="${product.appRoute}"`)) throw new Error(`preview_direct_product_route_remains_primary:${product.id}`)
+}
+
 const release = JSON.parse(get(manifest.release.releaseEndpoint))
 if (release.brandVersion !== manifest.brand.version) throw new Error('preview_brand_version_wrong')
 if (release.contextVersion !== manifest.contextVersion) throw new Error('preview_context_version_wrong')

--- a/tools/verify_public_release_live.mjs
+++ b/tools/verify_public_release_live.mjs
@@ -110,9 +110,9 @@ async function verifyOnce() {
   assert(pages.get('/')?.includes('id="products"'), 'product_portfolio_missing')
   const homepage = pages.get('/') || ''
   for (const product of manifest.customerProducts) {
-    const legacyTrialRoute = `https://app.supermega.dev/settings/?product=${encodeURIComponent(product.id)}`
-    assert(homepage.includes(`href="${product.appRoute}"`), 'direct_product_route_wrong', { product: product.id, appRoute: product.appRoute })
-    assert(!homepage.includes(legacyTrialRoute), 'template_first_route_exposed', { product: product.id })
+    const guidedSampleRoute = `https://app.supermega.dev/settings/?product=${encodeURIComponent(product.id)}`
+    assert(homepage.includes(`href="${guidedSampleRoute}"`), 'guided_product_route_missing', { product: product.id, guidedSampleRoute })
+    assert(!homepage.includes(`href="${product.appRoute}"`), 'direct_product_route_remains_primary', { product: product.id, appRoute: product.appRoute })
     for (const template of product.templates) assert(!homepage.includes(template.name), 'template_catalog_exposed', { template: template.id })
   }
   for (const internalLabel of ['SuperMega HQ', 'One next action for the company', 'Gated R&amp;D']) assert(!pages.get('/')?.includes(internalLabel), 'internal_system_exposed', { internalLabel })


### PR DESCRIPTION
## Why\nThe first guarded release of #379 correctly rolled back after the post-promotion public verifier still required raw product routes, even though the rendered marketing cards now start guided samples.\n\n## Change\n- verify guided sample links and reject raw product links in the production live verifier\n- enforce the same contract against protected candidates before promotion\n- make the public release guard reject drift between those verifiers\n\n## Validation\n- 
ode tools/verify_public_deploy_guard.mjs\n- 
pm run public:prebuilt\n- git diff --check\n\nNo customer data, managed writes, payments, messages, or runtime mode changed.