### PR TITLE
Fix Shop empty-catalog first use

### DIFF
--- a/showroom/src/core/CoreApp.tsx
+++ b/showroom/src/core/CoreApp.tsx
@@ -247,6 +247,7 @@ import { projectPlantOrder } from './plant-order-foundation'
 import { productionOrderPortfolioEntries } from './production-order-portfolio'
 import { projectShopDemandIntelligence } from './shop-demand-intelligence'
 import { projectShopProcurementDecision, projectShopReplenishment } from './shop-replenishment'
+import { decideShopNextAction } from './shop-next-action'
 
 const ChannelOrderIntake = lazy(() => import('./ChannelOrderIntake').then((module) => ({ default: module.ChannelOrderIntake })))
 const ShopInventoryFoundation = lazy(() => import('./ShopInventoryFoundation').then((module) => ({ default: module.ShopInventoryFoundation })))
@@ -1791,7 +1792,9 @@ function ShopCounter({ disabled, items, lowStockCount, onReview, openOrderCount 
               {quantity ? <span className="shop-product-quantity" aria-label={`${quantity} in sale`}>{quantity}</span> : <span aria-hidden="true" className="shop-product-add">+</span>}
             </button>
           })}
-        </div> : <Empty>No matching item. Search by name or SKU.</Empty>}
+        </div> : <Empty>{items.length
+          ? 'No matching item. Search by name or SKU.'
+          : <>Your catalog is empty. <Link className="text-link" to="/shop/?tab=inventory#shop-catalog-import">Add or import products</Link> before the first sale.</>}</Empty>}
       </section>
 
       <button aria-label="Close current sale" className={`shop-cart-backdrop${cartOpen ? ' is-open' : ''}`} onClick={() => setCartOpen(false)} type="button" />
@@ -2494,12 +2497,20 @@ function CommercePage({ ecommerceCancellationNavigationIntent, ecommerceCorrecti
   ), [commerce, correctionDraft])
 
   useEffect(() => {
-    if (tab !== 'inventory' || commerceLocation.hash !== '#purchase-orders') return
+    if (tab !== 'inventory') return
     const frame = window.requestAnimationFrame(() => {
-      const history = purchaseOrderHistoryRef.current
-      if (history) history.open = true
-      history?.scrollIntoView({ block: 'center' })
-      history?.querySelector('summary')?.focus({ preventScroll: true })
+      if (commerceLocation.hash === '#purchase-orders') {
+        const history = purchaseOrderHistoryRef.current
+        if (history) history.open = true
+        history?.scrollIntoView({ block: 'center' })
+        history?.querySelector('summary')?.focus({ preventScroll: true })
+        return
+      }
+      if (commerceLocation.hash === '#shop-catalog-import') {
+        const target = document.getElementById('shop-catalog-import')
+        target?.scrollIntoView({ block: 'start' })
+        target?.focus({ preventScroll: true })
+      }
     })
     return () => window.cancelAnimationFrame(frame)
   }, [commerceLocation.hash, tab])
@@ -3202,95 +3213,29 @@ function CommercePage({ ecommerceCancellationNavigationIntent, ecommerceCorrecti
       <div className="shop-replenishment-list" role="list">{demandForecastRows.slice(0, 4).map((row) => <div data-status={row.status} key={row.sku} role="listitem"><span><strong>{row.itemName}</strong><small>{row.completedOrderCount} completed {row.completedOrderCount === 1 ? 'order' : 'orders'} · {row.confidence} evidence</small></span><span><b>{row.status === 'stockout_risk' ? 'Stockout risk' : row.status === 'reorder_soon' ? 'Reorder soon' : `${row.forecastWeeklyUnits}/week`}</b><small>{row.projectedDaysOfCover === null ? 'Cover collecting' : `${row.projectedDaysOfCover}d projected cover`} · {row.planningHorizonDays}d {row.planningHorizonSource === 'supplier_policy' ? 'supplier lead' : 'planning horizon'}{row.recommendedSafetyStockUnits === null ? '' : ` · ${row.recommendedSafetyStockUnits} safety suggested`}</small></span></div>)}</div>
     </section> : <p className="empty-state">Demand forecast starts after the first completed sale.</p>}
   </section>
-  const shopAgentJob = !commerceCanWrite
-    ? 'Restore Shop write readiness'
-    : pendingAction
-      ? 'Approve pending Shop change'
-      : pendingStorefrontRequests.length || legacyWebsiteWorkWaiting
-        ? 'Review online order requests'
-        : actionOrders.length
-          ? 'Finish fulfilment queue'
-          : activePurchaseOrders.length
-            ? 'Receive purchase orders'
-            : lowStock.length
-              ? 'Reorder low stock'
-              : !commerce.inventoryFoundation || !managedInventoryProjection
-                ? 'Set up stock locations'
-                : 'Open counter for next sale'
-  const shopAgentReason = !commerceCanWrite
-    ? 'Writes are paused until durable storage or company account readiness is confirmed.'
-    : pendingAction
-      ? 'A reviewed Shop change is waiting for a named human confirmation.'
-      : pendingStorefrontRequests.length || legacyWebsiteWorkWaiting
-        ? `${pendingStorefrontRequests.length + (legacyWebsiteWorkWaiting ? 1 : 0)} online request${pendingStorefrontRequests.length + (legacyWebsiteWorkWaiting ? 1 : 0) === 1 ? '' : 's'} need Shop review before order, stock, payment, or delivery changes.`
-        : actionOrders.length
-          ? `${actionOrders.length} order${actionOrders.length === 1 ? '' : 's'} need fulfilment or payment review.`
-          : activePurchaseOrders.length
-            ? `${activePurchaseOrders.length} purchase order${activePurchaseOrders.length === 1 ? '' : 's'} can be checked against received stock evidence.`
-            : lowStock.length
-              ? `${lowStock.length} SKU${lowStock.length === 1 ? '' : 's'} are at or below reorder level.`
-              : !commerce.inventoryFoundation || !managedInventoryProjection
-                ? 'Stock can move from simple on-hand counts to location, lot, ATP, reservation, and count evidence.'
-                : 'Orders, inventory, purchase orders, and stock foundation are ready for front-counter work.'
-  const shopOwnerGate = !commerceCanWrite
-    ? 'Open Settings before any Shop write is allowed.'
-    : pendingAction
-      ? 'Approve or cancel the pending accountable action.'
-      : pendingStorefrontRequests.length || legacyWebsiteWorkWaiting
-        ? 'Choose whether each online request becomes a Shop order.'
-        : actionOrders.length
-          ? 'Confirm fulfilment, payment, return, cancellation, or settlement.'
-          : activePurchaseOrders.length
-            ? 'Confirm received quantity, location, lot, and evidence.'
-            : lowStock.length
-              ? 'Confirm supplier reference, expected arrival, and quantity.'
-              : !commerce.inventoryFoundation || !managedInventoryProjection
-                ? 'Enable the inventory foundation before location-level stock control.'
-                : 'Confirm each sale before stock or cash records change.'
-  const shopAgentPath = !commerceCanWrite
-    ? '/settings/#controls'
-    : pendingStorefrontRequests.length || legacyWebsiteWorkWaiting || actionOrders.length || pendingAction
-      ? '/shop/?tab=orders'
-      : activePurchaseOrders.length || lowStock.length || !commerce.inventoryFoundation || !managedInventoryProjection
-        ? '/shop/?tab=inventory'
-        : '/shop/?tab=counter'
+  const shopNextAction = decideShopNextAction({
+    actionOrderCount: actionOrders.length,
+    activePurchaseOrderCount: activePurchaseOrders.length,
+    canWrite: commerceCanWrite,
+    catalogItemCount: commerce.items.length,
+    inventoryReady: Boolean(commerce.inventoryFoundation && managedInventoryProjection),
+    lowStockCount: lowStock.length,
+    pendingAction: Boolean(pendingAction),
+    pendingOnlineRequestCount: pendingStorefrontRequests.length + (legacyWebsiteWorkWaiting ? 1 : 0),
+  })
+  const shopAgentJob = shopNextAction.job
+  const shopAgentReason = shopNextAction.reason
+  const shopOwnerGate = shopNextAction.ownerGate
+  const shopAgentPath = shopNextAction.path
   const shopAgentRows = [
     ['Next step', shopAgentJob],
     ['Why', shopAgentReason],
     ['Review', shopOwnerGate],
   ]
-  const shopAutopilotStage = !commerceCanWrite
-    ? 'Restore Shop readiness'
-    : pendingAction
-      ? 'Review pending Shop change'
-      : pendingStorefrontRequests.length || legacyWebsiteWorkWaiting
-        ? 'Review online requests'
-        : actionOrders.length
-          ? 'Finish order queue'
-          : activePurchaseOrders.length
-            ? 'Receive purchase orders'
-            : lowStock.length
-              ? 'Reorder low stock'
-              : !commerce.inventoryFoundation || !managedInventoryProjection
-                ? 'Set up stock foundation'
-                : 'Open counter sales'
-  const shopAutopilotNextAction = !commerceCanWrite
-    ? 'Open setup controls'
-    : pendingAction
-      ? 'Finish review'
-      : pendingStorefrontRequests.length || legacyWebsiteWorkWaiting
-        ? 'Open online request review'
-        : actionOrders.length
-          ? 'Open fulfilment queue'
-          : activePurchaseOrders.length
-            ? 'Open receiving queue'
-            : lowStock.length
-              ? 'Open reorder queue'
-              : !commerce.inventoryFoundation || !managedInventoryProjection
-                ? 'Open inventory setup'
-                : 'Open counter'
+  const shopAutopilotStage = shopNextAction.stage
+  const shopAutopilotNextAction = shopNextAction.nextAction
   const shopAutopilotRows = [
-    ['Track', pendingAction ? 'Review' : pendingStorefrontRequests.length || legacyWebsiteWorkWaiting || actionOrders.length ? 'Orders' : activePurchaseOrders.length || lowStock.length || !commerce.inventoryFoundation || !managedInventoryProjection ? 'Inventory' : 'Counter'],
+    ['Track', shopNextAction.track],
     ['Stage', shopAutopilotStage],
     ['Next', shopAutopilotNextAction],
     ['Memory', 'Saves helpful patterns'],
@@ -3311,6 +3256,12 @@ function CommercePage({ ecommerceCancellationNavigationIntent, ecommerceCorrecti
     ['Accounting', latestCloseDownload ? 'Export ready' : 'Close later'],
     ['Boundary', 'Review before writes'],
   ] as const
+  const shopCatalogOnboarding = <section aria-label="Shop catalog import helper" className="catalog-onboarding-bridge" id="shop-catalog-import" tabIndex={-1}>
+    <div><span className="core-eyebrow">Catalog import helper</span><strong>Bring your catalog into the Shop trial.</strong><p>The assistant routes product spreadsheets through the shared mapper, checks SKU, name, stock, reorder, and price fields, then prepares one reviewed import package. No supplier message, stock move, sale, accounting post, or Shop write runs from this panel.</p></div>
+    <div className="catalog-onboarding-status">{shopCatalogUploadRows.map(([label, value]) => <span key={label}><small>{label}</small><strong>{value}</strong></span>)}</div>
+    <button className="core-button" disabled={commerceControlsDisabled} onClick={loadSampleCatalogItem} type="button">Load sample catalog item</button>
+    <Link className="core-button" to={clientSetupPath('commerce')}>Upload product data</Link>
+  </section>
   function runShopAutopilot() {
     recordBehaviorSignal(window.localStorage, {
       event: 'agent_job_chosen',
@@ -6467,7 +6418,7 @@ function CommercePage({ ecommerceCancellationNavigationIntent, ecommerceCorrecti
 
   if (tab === 'today') return <div className="operation-module shop-today-module">
     {commerceBoundary}
-    <Suspense fallback={null}><ShopToday metrics={shopTodayMetrics} modules={shopTodayModules} nextAction={shopAgentJob} nextDetail={shopAgentReason} nextTo={shopAgentPath} /></Suspense>
+    <Suspense fallback={null}><ShopToday catalogReady={commerce.items.length > 0} metrics={shopTodayMetrics} modules={shopTodayModules} nextAction={shopAgentJob} nextDetail={shopAgentReason} nextTo={shopAgentPath} /></Suspense>
     {actionGate}
   </div>
 
@@ -6913,8 +6864,9 @@ function CommercePage({ ecommerceCancellationNavigationIntent, ecommerceCorrecti
   if (tab === 'inventory') return <div className="operation-module">
     {commerceBoundary}
     {shopGuidance}
+    {!commerce.items.length ? shopCatalogOnboarding : null}
     <section className="core-panel inventory-panel">
-      <div className="panel-head"><div><span className="core-eyebrow">Stock</span><h2>Available stock</h2></div><div className="order-queue-actions"><span className="panel-note">{lowStock.length} need attention</span><button aria-controls="stock-count-editor" aria-expanded={Boolean(stockCountDraft)} className="core-button" disabled={commerceControlsDisabled} onClick={openStockCount} ref={stockCountTriggerRef} type="button">{stockCountDraft ? 'Continue count' : 'Count stock'}</button></div></div>
+      <div className="panel-head"><div><span className="core-eyebrow">Stock</span><h2>Available stock</h2></div><div className="order-queue-actions"><span className="panel-note">{lowStock.length} need attention</span><button aria-controls="stock-count-editor" aria-expanded={Boolean(stockCountDraft)} className="core-button" disabled={commerceControlsDisabled || !commerce.items.length} onClick={openStockCount} ref={stockCountTriggerRef} type="button">{stockCountDraft ? 'Continue count' : commerce.items.length ? 'Count stock' : 'Add products first'}</button></div></div>
       {stockCountDraft ? <form aria-labelledby="stock-count-title" className="stock-receipt-editor stock-count-editor" id="stock-count-editor" onSubmit={reviewStockCount} ref={stockCountEditorRef}>
         <div className="stock-receipt-copy">
           <span className="core-eyebrow">Stock check</span>
@@ -6984,7 +6936,7 @@ function CommercePage({ ecommerceCancellationNavigationIntent, ecommerceCorrecti
         <summary><span><strong>Purchasing &amp; locations</strong><small>Supplier planning, location stock, and available-to-promise</small></span><b>Open when needed</b></summary>
         <div className="inventory-tools-content">
           {supplierControl}
-          <Suspense fallback={null}><ShopInventoryFoundation actor={managedIdentity?.userId ?? 'Local Shop operator'} commerce={commerce} disabled={commerceControlsDisabled} identity={managedIdentity} key={`${orderDraftScope}:${commerce.items.map((item) => item.sku).sort().join('|')}`} onInventory={mutateCommerce} onIssue={mutateCommerce} production={relatedProduction} scope={orderDraftScope} /></Suspense>
+          {commerce.items.length ? <Suspense fallback={null}><ShopInventoryFoundation actor={managedIdentity?.userId ?? 'Local Shop operator'} commerce={commerce} disabled={commerceControlsDisabled} identity={managedIdentity} key={`${orderDraftScope}:${commerce.items.map((item) => item.sku).sort().join('|')}`} onInventory={mutateCommerce} onIssue={mutateCommerce} production={relatedProduction} scope={orderDraftScope} /></Suspense> : <p className="empty-state">Add products before enabling locations, lots, available-to-promise, or supplier policies.</p>}
         </div>
       </details>
       {supplierSourcingDraft ? <form aria-labelledby="supplier-sourcing-title" className="stock-receipt-editor purchase-order-editor" onSubmit={reviewSupplierSourcing}>
@@ -7088,12 +7040,7 @@ function CommercePage({ ecommerceCancellationNavigationIntent, ecommerceCorrecti
           </article>
         })}</div> : <p className="empty-state">No purchase orders yet. Use Order stock on an item when replenishment is needed.</p>}
       </details>
-      <section aria-label="Shop catalog import helper" className="catalog-onboarding-bridge">
-        <div><span className="core-eyebrow">Catalog import helper</span><strong>Bring your catalog into the Shop trial.</strong><p>The assistant routes product spreadsheets through the shared mapper, checks SKU, name, stock, reorder, and price fields, then prepares one reviewed import package. No supplier message, stock move, sale, accounting post, or Shop write runs from this panel.</p></div>
-        <div className="catalog-onboarding-status">{shopCatalogUploadRows.map(([label, value]) => <span key={label}><small>{label}</small><strong>{value}</strong></span>)}</div>
-        <button className="core-button" disabled={commerceControlsDisabled} onClick={loadSampleCatalogItem} type="button">Load sample catalog item</button>
-        <Link className="core-button" to={clientSetupPath('commerce')}>Upload product data</Link>
-      </section>
+      {commerce.items.length ? shopCatalogOnboarding : null}
       <details className="compact-disclosure catalog-disclosure" onToggle={(event) => setCatalogCreateOpen(event.currentTarget.open)} open={catalogCreateOpen}>
         <summary>Add catalog item</summary>
         <form className="core-form compact-form catalog-create-form" onSubmit={queueCatalogItem} ref={catalogCreateFormRef}>

--- a/showroom/src/core/ShopToday.tsx
+++ b/showroom/src/core/ShopToday.tsx
@@ -15,6 +15,7 @@ export type ShopTodayModule = {
 }
 
 type ShopTodayProps = {
+  catalogReady: boolean
   metrics: ShopTodayMetric[]
   modules: ShopTodayModule[]
   nextAction: string
@@ -31,13 +32,14 @@ const capabilityGroups = [
   ['Control', 'Daily close, settlement review, accounting export, audit'],
 ] as const
 
-const guidedJobs = [
-  ['1', 'Make a sale', 'Tap items, choose payment, and save a receipt.', '/shop/?tab=counter'],
-  ['2', 'Finish orders', 'Check online orders, payment, delivery, returns, and cancellations.', '/shop/?tab=orders'],
-  ['3', 'Check stock', 'See low stock, counts, receiving, and buying.', '/shop/?tab=inventory'],
-] as const
-
-export function ShopToday({ metrics, modules, nextAction, nextDetail, nextTo }: ShopTodayProps) {
+export function ShopToday({ catalogReady, metrics, modules, nextAction, nextDetail, nextTo }: ShopTodayProps) {
+  const guidedJobs = [
+    catalogReady
+      ? ['1', 'Make a sale', 'Tap items, choose payment, and save a receipt.', '/shop/?tab=counter']
+      : ['1', 'Add your products', 'Load a sample or map a product file before the first sale.', '/shop/?tab=inventory#shop-catalog-import'],
+    ['2', 'Finish orders', 'Check online orders, payment, delivery, returns, and cancellations.', '/shop/?tab=orders'],
+    ['3', 'Check stock', 'See low stock, counts, receiving, and buying.', '/shop/?tab=inventory'],
+  ] as const
   return <div className="shop-today">
     <section className="shop-today-mission" aria-label="Next Shop action">
       <div>
@@ -47,7 +49,7 @@ export function ShopToday({ metrics, modules, nextAction, nextDetail, nextTo }: 
       </div>
       <div className="shop-today-actions">
         <Link className="core-button primary" to={nextTo}>Open next step</Link>
-        <Link className="core-button" to="/shop/?tab=counter">New sale</Link>
+        {catalogReady ? <Link className="core-button" to="/shop/?tab=counter">New sale</Link> : null}
       </div>
     </section>
 

--- a/showroom/src/core/core-app.css
+++ b/showroom/src/core/core-app.css
@@ -1318,8 +1318,9 @@ textarea { min-height: 72px; resize: vertical; }
 .catalog-disclosure { margin-top: 12px; border-top: 1px solid var(--core-line); padding-top: 10px; }
 .catalog-create-form { max-width: none; margin-top: 10px; }
 .catalog-create-form .form-actions { justify-content: flex-start; }
-.catalog-onboarding-bridge { min-height: 72px; display: flex; align-items: center; justify-content: space-between; gap: 16px; margin-top: 12px; border: 1px solid var(--core-line); border-radius: 10px; padding: 12px 14px; background: var(--core-panel-raised); }
+.catalog-onboarding-bridge { min-height: 72px; display: flex; flex-wrap: wrap; align-items: center; justify-content: space-between; gap: 12px 16px; margin-top: 12px; border: 1px solid var(--core-line); border-radius: 10px; padding: 12px 14px; background: var(--core-panel-raised); }
 .catalog-onboarding-bridge > div { display: grid; gap: 4px; }
+.catalog-onboarding-bridge > div:first-child { min-width: min(420px,100%); flex: 1 1 520px; }
 .catalog-onboarding-bridge strong { font-size: 13px; }
 .catalog-onboarding-bridge p { margin: 0; color: var(--core-muted); font-size: 11px; line-height: 1.4; }
 .catalog-import-disclosure { margin-top: 12px; border-top: 1px solid var(--core-line); padding-top: 10px; }
@@ -1355,7 +1356,7 @@ textarea { min-height: 72px; resize: vertical; }
 .catalog-import-checklist-grid code { overflow: hidden; color: var(--core-green); font-size: 8px; text-overflow: ellipsis; white-space: nowrap; }
 .catalog-import-checklist-grid span[data-required="true"] { background: var(--core-green-soft); }
 .catalog-import-boundary { margin: 0; border-left: 2px solid var(--core-green); padding-left: 10px; color: var(--core-muted); font-size: 11px; line-height: 1.5; }
-.catalog-onboarding-status { min-width: 0; display: grid; grid-template-columns: repeat(5,minmax(0,1fr)); overflow: hidden; border: 1px solid var(--core-line); border-radius: 7px; background: #fff; }
+.catalog-onboarding-status { min-width: 0; flex: 1 0 100%; order: 2; display: grid; grid-template-columns: repeat(5,minmax(0,1fr)); overflow: hidden; border: 1px solid var(--core-line); border-radius: 7px; background: #fff; }
 .catalog-onboarding-status span { min-width: 0; min-height: 48px; display: grid; align-content: center; gap: 2px; border-right: 1px solid var(--core-line); padding: 7px 8px; }
 .catalog-onboarding-status span:last-child { border-right: 0; }
 .catalog-onboarding-status small { overflow: hidden; color: var(--core-quiet); font-family: var(--core-mono); font-size: 7px; text-overflow: ellipsis; text-transform: uppercase; white-space: nowrap; }
@@ -2050,6 +2051,8 @@ textarea { min-height: 72px; resize: vertical; }
   .settings-step-actions { align-items: stretch; flex-direction: column; }
   .settings-step-actions .core-button, .settings-step-actions .text-link { width: 100%; }
   .setup-complete, .catalog-onboarding-bridge { align-items: stretch; flex-direction: column; }
+  .catalog-onboarding-bridge > div:first-child { min-width: 0; flex: none; }
+  .catalog-onboarding-status { order: 0; }
   .setup-complete .core-button, .catalog-onboarding-bridge .core-button { width: 100%; }
   .ai-memory-preview-heading { flex-direction: column; }
   .ai-memory-preview-rows { grid-template-columns: 1fr; }

--- a/showroom/src/core/shop-next-action.ts
+++ b/showroom/src/core/shop-next-action.ts
@@ -1,0 +1,107 @@
+export type ShopNextActionInput = {
+  actionOrderCount: number
+  activePurchaseOrderCount: number
+  canWrite: boolean
+  catalogItemCount: number
+  inventoryReady: boolean
+  lowStockCount: number
+  pendingAction: boolean
+  pendingOnlineRequestCount: number
+}
+
+export type ShopNextActionDecision = {
+  job: string
+  nextAction: string
+  ownerGate: string
+  path: string
+  reason: string
+  stage: string
+  track: 'Review' | 'Orders' | 'Inventory' | 'Counter'
+}
+
+export function decideShopNextAction(input: ShopNextActionInput): ShopNextActionDecision {
+  const counts = [input.actionOrderCount, input.activePurchaseOrderCount, input.catalogItemCount, input.lowStockCount, input.pendingOnlineRequestCount]
+  if (!counts.every((count) => Number.isSafeInteger(count) && count >= 0)) throw new Error('Shop next-action counts must be non-negative safe integers.')
+
+  if (!input.canWrite) return {
+    job: 'Restore Shop write readiness',
+    nextAction: 'Open setup controls',
+    ownerGate: 'Open Settings before any Shop write is allowed.',
+    path: '/settings/#controls',
+    reason: 'Writes are paused until durable storage or company account readiness is confirmed.',
+    stage: 'Restore Shop readiness',
+    track: 'Review',
+  }
+  if (input.pendingAction) return {
+    job: 'Approve pending Shop change',
+    nextAction: 'Finish review',
+    ownerGate: 'Approve or cancel the pending accountable action.',
+    path: '/shop/?tab=orders',
+    reason: 'A reviewed Shop change is waiting for a named human confirmation.',
+    stage: 'Review pending Shop change',
+    track: 'Review',
+  }
+  if (!input.catalogItemCount) return {
+    job: 'Import your first products',
+    nextAction: 'Open catalog import',
+    ownerGate: 'Review mapped SKU, price, opening stock, and reorder fields before anything is saved.',
+    path: '/shop/?tab=inventory#shop-catalog-import',
+    reason: 'Shop needs products and opening stock before the counter or Ecommerce can take a real order.',
+    stage: 'Prepare Shop catalog',
+    track: 'Inventory',
+  }
+  if (input.pendingOnlineRequestCount) return {
+    job: 'Review online order requests',
+    nextAction: 'Open online request review',
+    ownerGate: 'Choose whether each online request becomes a Shop order.',
+    path: '/shop/?tab=orders',
+    reason: `${input.pendingOnlineRequestCount} online request${input.pendingOnlineRequestCount === 1 ? '' : 's'} need Shop review before order, stock, payment, or delivery changes.`,
+    stage: 'Review online requests',
+    track: 'Orders',
+  }
+  if (input.actionOrderCount) return {
+    job: 'Finish fulfilment queue',
+    nextAction: 'Open fulfilment queue',
+    ownerGate: 'Confirm fulfilment, payment, return, cancellation, or settlement.',
+    path: '/shop/?tab=orders',
+    reason: `${input.actionOrderCount} order${input.actionOrderCount === 1 ? '' : 's'} need fulfilment or payment review.`,
+    stage: 'Finish order queue',
+    track: 'Orders',
+  }
+  if (input.activePurchaseOrderCount) return {
+    job: 'Receive purchase orders',
+    nextAction: 'Open receiving queue',
+    ownerGate: 'Confirm received quantity, location, lot, and evidence.',
+    path: '/shop/?tab=inventory',
+    reason: `${input.activePurchaseOrderCount} purchase order${input.activePurchaseOrderCount === 1 ? '' : 's'} can be checked against received stock evidence.`,
+    stage: 'Receive purchase orders',
+    track: 'Inventory',
+  }
+  if (input.lowStockCount) return {
+    job: 'Reorder low stock',
+    nextAction: 'Open reorder queue',
+    ownerGate: 'Confirm supplier reference, expected arrival, and quantity.',
+    path: '/shop/?tab=inventory',
+    reason: `${input.lowStockCount} SKU${input.lowStockCount === 1 ? '' : 's'} are at or below reorder level.`,
+    stage: 'Reorder low stock',
+    track: 'Inventory',
+  }
+  if (!input.inventoryReady) return {
+    job: 'Set up stock locations',
+    nextAction: 'Open inventory setup',
+    ownerGate: 'Enable the inventory foundation before location-level stock control.',
+    path: '/shop/?tab=inventory',
+    reason: 'Stock can move from simple on-hand counts to location, lot, ATP, reservation, and count evidence.',
+    stage: 'Set up stock foundation',
+    track: 'Inventory',
+  }
+  return {
+    job: 'Open counter for next sale',
+    nextAction: 'Open counter',
+    ownerGate: 'Confirm each sale before stock or cash records change.',
+    path: '/shop/?tab=counter',
+    reason: 'Orders, inventory, purchase orders, and stock foundation are ready for front-counter work.',
+    stage: 'Open counter sales',
+    track: 'Counter',
+  }
+}

--- a/tools/verify_app_build.mjs
+++ b/tools/verify_app_build.mjs
@@ -37,6 +37,7 @@ let shopServiceScheduleRuntimeChecks = 0
 let plantOrderRuntimeChecks = 0
 let websiteReleaseRuntimeChecks = 0
 let shopOperatingFlowRuntimeChecks = 0
+let shopNextActionRuntimeChecks = 0
 let operationalReportRuntimeChecks = 0
 let commerceRuntimeChecks = 0
 let productionRuntimeChecks = 0
@@ -221,6 +222,7 @@ const managedEcommerceBuyingLifecycleSource = await readFile(resolve(root, 'supe
 const shopOperatingFlowSource = await readFile(resolve(root, 'showroom', 'src', 'core', 'shop-operating-flow.ts'), 'utf8')
 const shopOperatingFlowUiSource = await readFile(resolve(root, 'showroom', 'src', 'core', 'ShopOperatingFlow.tsx'), 'utf8')
 const shopTodayUiSource = await readFile(resolve(root, 'showroom', 'src', 'core', 'ShopToday.tsx'), 'utf8')
+const shopNextActionSource = await readFile(resolve(root, 'showroom', 'src', 'core', 'shop-next-action.ts'), 'utf8')
 const shopServiceScheduleSource = await readFile(resolve(root, 'showroom', 'src', 'core', 'shop-service-scheduling.ts'), 'utf8')
 const shopServiceScheduleUiSource = await readFile(resolve(root, 'showroom', 'src', 'core', 'ShopServiceSchedule.tsx'), 'utf8')
 const shopProductionDemandSource = await readFile(resolve(root, 'showroom', 'src', 'core', 'shop-production-demand.ts'), 'utf8')
@@ -239,6 +241,11 @@ if (!shopOperatingFlowSource.includes("export type ShopOperatingStageId = 'intak
 if (['fetch(', 'localStorage', 'sessionStorage', 'supabase', 'openai', 'anthropic'].some((marker) => shopOperatingFlowSource.toLowerCase().includes(marker.toLowerCase()))) fail('shop_operating_flow_side_effect_added')
 if (!shopTodayUiSource.includes('aria-label="Next Shop action"')
   || !shopTodayUiSource.includes('const guidedJobs =')
+  || !shopTodayUiSource.includes('catalogReady: boolean')
+  || !shopTodayUiSource.includes("'Add your products'")
+  || !shopTodayUiSource.includes('Load a sample or map a product file before the first sale.')
+  || !shopTodayUiSource.includes("'/shop/?tab=inventory#shop-catalog-import'")
+  || !shopTodayUiSource.includes('{catalogReady ? <Link className="core-button" to="/shop/?tab=counter">New sale</Link> : null}')
   || !shopTodayUiSource.includes('aria-label="Shop guided jobs"')
   || !shopTodayUiSource.includes('Use Shop in 3 steps.')
   || !shopTodayUiSource.includes('Check online orders, payment, delivery, returns, and cancellations.')
@@ -2325,19 +2332,44 @@ if (!coreSource.includes('const shopAgentRows = [')
   || !coreSource.includes("['Next step', shopAgentJob]")
   || !coreSource.includes("['Why', shopAgentReason]")
   || !coreSource.includes('See today’s next job and key numbers.')
-  || !coreSource.includes("need fulfilment or payment review.")
+  || !shopNextActionSource.includes('need fulfilment or payment review.')
   || !coreSource.includes("['Review', shopOwnerGate]")
   || coreSource.includes("['Owner gate', shopOwnerGate]")
   || coreSource.includes("['Agent job', shopAgentJob]")
   || coreSource.includes("['Reason', shopAgentReason]")
   || !coreSource.includes('aria-label="Next Shop step"')
   || !coreSource.includes('Next Shop step')
-  || !coreSource.includes("'Restore Shop write readiness'")
-  || !coreSource.includes("'Review online order requests'")
-  || !coreSource.includes("'Finish fulfilment queue'")
-  || !coreSource.includes("'Receive purchase orders'")
-  || !coreSource.includes("'Reorder low stock'")
-  || !coreSource.includes("'Set up stock locations'")
+  || !coreSource.includes("import { decideShopNextAction } from './shop-next-action'")
+  || !coreSource.includes('const shopNextAction = decideShopNextAction({')
+  || !coreSource.includes('const shopAgentJob = shopNextAction.job')
+  || !coreSource.includes('const shopAgentPath = shopNextAction.path')
+  || !shopNextActionSource.includes("'Restore Shop write readiness'")
+  || !shopNextActionSource.includes("'Import your first products'")
+  || !shopNextActionSource.includes('Shop needs products and opening stock before the counter or Ecommerce can take a real order.')
+  || !shopNextActionSource.includes('Review mapped SKU, price, opening stock, and reorder fields before anything is saved.')
+  || !shopNextActionSource.includes("'/shop/?tab=inventory#shop-catalog-import'")
+  || !shopNextActionSource.includes("'Prepare Shop catalog'")
+  || !shopNextActionSource.includes("'Open catalog import'")
+  || !coreSource.includes('<ShopToday catalogReady={commerce.items.length > 0}')
+  || !coreSource.includes('Your catalog is empty.')
+  || !coreSource.includes('Add or import products')
+  || !coreSource.includes('const shopCatalogOnboarding = <section')
+  || !coreSource.includes('{!commerce.items.length ? shopCatalogOnboarding : null}')
+  || !coreSource.includes("commerce.items.length ? 'Count stock' : 'Add products first'")
+  || !coreSource.includes('{commerce.items.length ? <Suspense fallback={null}><ShopInventoryFoundation')
+  || !coreSource.includes('Add products before enabling locations, lots, available-to-promise, or supplier policies.')
+  || !coreSource.includes('{commerce.items.length ? shopCatalogOnboarding : null}')
+  || !coreSource.includes("commerceLocation.hash === '#shop-catalog-import'")
+  || !coreSource.includes("document.getElementById('shop-catalog-import')")
+  || !coreSource.includes("target?.scrollIntoView({ block: 'start' })")
+  || !coreSource.includes('target?.focus({ preventScroll: true })')
+  || !coreSource.includes('tabIndex={-1}')
+  || (coreSource.match(/id="shop-catalog-import"/g) || []).length !== 1
+  || !shopNextActionSource.includes("'Review online order requests'")
+  || !shopNextActionSource.includes("'Finish fulfilment queue'")
+  || !shopNextActionSource.includes("'Receive purchase orders'")
+  || !shopNextActionSource.includes("'Reorder low stock'")
+  || !shopNextActionSource.includes("'Set up stock locations'")
   || !coreSource.includes('SuperMega chooses the best place to start. The manager reviews important changes before anything is saved.')
   || !coreSource.includes('const shopAutopilotStage =')
   || !coreSource.includes('const shopAutopilotNextAction =')
@@ -2376,6 +2408,9 @@ if (!coreSource.includes('const shopAgentRows = [')
   || !coreCssSource.includes('.shop-command-center-rows')
   || !coreCssSource.includes('.shop-order-control.shop-setup-guide')
   || !coreCssSource.includes('.shop-agent-queue')) fail('shop_agent_queue_missing')
+if (!shopNextActionSource.includes('export function decideShopNextAction')
+  || !shopNextActionSource.includes('Number.isSafeInteger(count) && count >= 0')
+  || ['fetch(', 'localStorage', 'sessionStorage', 'supabase', 'openai', 'anthropic', 'Date.now(', 'Math.random('].some((marker) => shopNextActionSource.toLowerCase().includes(marker.toLowerCase()))) fail('shop_next_action_contract_missing_or_impure')
 if (!coreSource.includes('const shopOrderLifecycleRows = [')
   || !coreSource.includes("['Capture', pendingStorefrontRequests.length || legacyWebsiteWorkWaiting")
   || !coreSource.includes("['Reserve', managedInventoryProjection ? 'ATP active' : 'Catalog stock']")
@@ -4303,6 +4338,7 @@ if (coreSource.includes("await import('./shop-catalog-import')")
   || !coreSource.includes("['Upload', 'Shared mapper']")
   || !coreSource.includes("['Safety', 'Review first']")
   || !coreSource.includes('aria-label="Shop catalog import helper"')
+  || !coreSource.includes('id="shop-catalog-import"')
   || !coreSource.includes('Catalog import helper')
   || !coreSource.includes('Bring your catalog into the Shop trial.')
   || !coreSource.includes('The assistant routes product spreadsheets through the shared mapper, checks SKU, name, stock, reorder, and price fields, then prepares one reviewed import package.')
@@ -4313,7 +4349,12 @@ if (coreSource.includes("await import('./shop-catalog-import')")
   || !coreSource.includes("to={clientSetupPath('commerce')}")
   || !coreSource.includes('Upload product data')
   || !coreCssSource.includes('.catalog-onboarding-bridge {')
+  || !coreCssSource.includes('display: flex; flex-wrap: wrap;')
+  || !coreCssSource.includes('.catalog-onboarding-bridge > div:first-child { min-width: min(420px,100%); flex: 1 1 520px; }')
   || !coreCssSource.includes('.catalog-onboarding-status {')
+  || !coreCssSource.includes('flex: 1 0 100%; order: 2; display: grid;')
+  || !coreCssSource.includes('.catalog-onboarding-bridge > div:first-child { min-width: 0; flex: none; }')
+  || !coreCssSource.includes('.catalog-onboarding-status { order: 0; }')
   || !coreCssSource.includes('.catalog-onboarding-status span:last-child { grid-column: 1 / -1; border-right: 0; border-bottom: 0; }')
   || !coreCssSource.includes('.catalog-import-table { max-height: 340px;')
   || !coreCssSource.includes('.catalog-import-mapping { display: grid;')
@@ -5335,7 +5376,7 @@ if (!commercePageContract.includes('purchaseOrderDraft')
   || !managedCommerceRuntime.includes('_PURCHASE_DISCREPANCY_FIELDS')
   || !commercePageContract.includes('Cancel remainder')
   || !commercePageContract.includes('id="purchase-orders"')
-  || !commercePageContract.includes("commerceLocation.hash !== '#purchase-orders'")
+  || !commercePageContract.includes("commerceLocation.hash === '#purchase-orders'")
   || !commercePageContract.includes('if (history) history.open = true')
   || !commercePageContract.includes("history?.scrollIntoView({ block: 'center' })")
   || !commercePageContract.includes("history?.querySelector('summary')?.focus({ preventScroll: true })")
@@ -17774,8 +17815,53 @@ async function verifyShopOperatingFlowRuntime() {
   }
 }
 
+async function verifyShopNextActionRuntime() {
+  const assert = (condition, reason) => {
+    if (!condition) throw new Error(reason)
+    shopNextActionRuntimeChecks += 1
+  }
+  const input = (patch = {}) => ({
+    actionOrderCount: 0,
+    activePurchaseOrderCount: 0,
+    canWrite: true,
+    catalogItemCount: 1,
+    inventoryReady: true,
+    lowStockCount: 0,
+    pendingAction: false,
+    pendingOnlineRequestCount: 0,
+    ...patch,
+  })
+  try {
+    const model = await import(`${pathToFileURL(resolve(root, 'showroom', 'src', 'core', 'shop-next-action.ts')).href}?shop-next-action-verify=${Date.now()}`)
+    const blocked = model.decideShopNextAction(input({ canWrite: false, pendingAction: true, catalogItemCount: 0 }))
+    assert(blocked.job === 'Restore Shop write readiness' && blocked.path === '/settings/#controls', 'shop_next_action_write_gate_priority_wrong')
+    const pending = model.decideShopNextAction(input({ pendingAction: true, catalogItemCount: 0, pendingOnlineRequestCount: 2 }))
+    assert(pending.job === 'Approve pending Shop change' && pending.track === 'Review', 'shop_next_action_pending_review_priority_wrong')
+    const empty = model.decideShopNextAction(input({ catalogItemCount: 0, pendingOnlineRequestCount: 2, actionOrderCount: 3, lowStockCount: 4, inventoryReady: false }))
+    assert(empty.job === 'Import your first products' && empty.path === '/shop/?tab=inventory#shop-catalog-import' && empty.nextAction === 'Open catalog import' && empty.track === 'Inventory', 'shop_next_action_empty_catalog_not_first_prerequisite')
+    const online = model.decideShopNextAction(input({ pendingOnlineRequestCount: 2, actionOrderCount: 3 }))
+    assert(online.job === 'Review online order requests' && online.reason.startsWith('2 online requests'), 'shop_next_action_online_request_priority_wrong')
+    const orders = model.decideShopNextAction(input({ actionOrderCount: 2, activePurchaseOrderCount: 3 }))
+    assert(orders.job === 'Finish fulfilment queue' && orders.track === 'Orders', 'shop_next_action_fulfilment_priority_wrong')
+    const receiving = model.decideShopNextAction(input({ activePurchaseOrderCount: 2, lowStockCount: 3 }))
+    assert(receiving.job === 'Receive purchase orders' && receiving.nextAction === 'Open receiving queue', 'shop_next_action_receiving_priority_wrong')
+    const reorder = model.decideShopNextAction(input({ lowStockCount: 2, inventoryReady: false }))
+    assert(reorder.job === 'Reorder low stock' && reorder.reason.startsWith('2 SKUs'), 'shop_next_action_reorder_priority_wrong')
+    const inventory = model.decideShopNextAction(input({ inventoryReady: false }))
+    assert(inventory.job === 'Set up stock locations' && inventory.path === '/shop/?tab=inventory', 'shop_next_action_inventory_setup_wrong')
+    const counter = model.decideShopNextAction(input())
+    assert(counter.job === 'Open counter for next sale' && counter.path === '/shop/?tab=counter' && counter.track === 'Counter', 'shop_next_action_counter_ready_wrong')
+    let invalidRejected = false
+    try { model.decideShopNextAction(input({ catalogItemCount: -1 })) } catch { invalidRejected = true }
+    assert(invalidRejected, 'shop_next_action_negative_count_accepted')
+  } catch (error) {
+    fail(`shop_next_action_runtime:${error instanceof Error ? error.message : 'unknown'}`)
+  }
+}
+
 await verifyOperationalReportRuntime()
 await verifyShopOperatingFlowRuntime()
+await verifyShopNextActionRuntime()
 await verifyChannelOrderRuntime()
 await verifyShopInventoryRuntime()
 await verifyShopServiceScheduleRuntime()
@@ -18251,4 +18337,4 @@ if (failures.length) {
   console.error(JSON.stringify({ ok: false, contract: 'supermega_app_build', failures }, null, 2))
   process.exit(1)
 }
-console.log(JSON.stringify({ ok: true, contract: 'supermega_app_build', customerProducts: 4, sharedCapabilities: 1, primaryRoutes: 5, operatingModules: 2, makerModules: 2, compatibilityRedirects: 5, workflowProfiles, operationalReportRuntimeChecks, shopOperatingFlowRuntimeChecks, channelOrderRuntimeChecks, shopInventoryRuntimeChecks, shopServiceScheduleRuntimeChecks, shopProductionDemandRuntimeChecks, shopDemandIntelligenceRuntimeChecks, shopReplenishmentRuntimeChecks, shopProcurementDecisionRuntimeChecks, plantOrderRuntimeChecks, websiteReleaseRuntimeChecks, catalogImportRuntimeChecks, clientOnboardingRuntimeChecks, managedClientImportRuntimeChecks, plantEquipmentImportRuntimeChecks, managedContextRuntimeChecks, operatingBaselineRuntimeChecks, websiteRuntimeChecks, orderCompletionRuntimeChecks, commerceOrderDraftRuntimeChecks, storefrontDraftRuntimeChecks, storefrontRuntimeChecks, storefrontRequestRuntimeChecks, managedWebsiteRuntimeChecks, managedStorefrontRuntimeChecks, ecommerceActivationRuntimeChecks, ecommerceHandoffRuntimeChecks, ecommerceBuyingRuntimeChecks, commerceRuntimeChecks, productionRuntimeChecks, businessCommandRuntimeChecks, ownerControlRuntimeChecks, pilotOutcomeRuntimeChecks, companyBackupRuntimeChecks, largestJavascriptBytes, bytes }, null, 2))
+console.log(JSON.stringify({ ok: true, contract: 'supermega_app_build', customerProducts: 4, sharedCapabilities: 1, primaryRoutes: 5, operatingModules: 2, makerModules: 2, compatibilityRedirects: 5, workflowProfiles, operationalReportRuntimeChecks, shopOperatingFlowRuntimeChecks, shopNextActionRuntimeChecks, channelOrderRuntimeChecks, shopInventoryRuntimeChecks, shopServiceScheduleRuntimeChecks, shopProductionDemandRuntimeChecks, shopDemandIntelligenceRuntimeChecks, shopReplenishmentRuntimeChecks, shopProcurementDecisionRuntimeChecks, plantOrderRuntimeChecks, websiteReleaseRuntimeChecks, catalogImportRuntimeChecks, clientOnboardingRuntimeChecks, managedClientImportRuntimeChecks, plantEquipmentImportRuntimeChecks, managedContextRuntimeChecks, operatingBaselineRuntimeChecks, websiteRuntimeChecks, orderCompletionRuntimeChecks, commerceOrderDraftRuntimeChecks, storefrontDraftRuntimeChecks, storefrontRuntimeChecks, storefrontRequestRuntimeChecks, managedWebsiteRuntimeChecks, managedStorefrontRuntimeChecks, ecommerceActivationRuntimeChecks, ecommerceHandoffRuntimeChecks, ecommerceBuyingRuntimeChecks, commerceRuntimeChecks, productionRuntimeChecks, businessCommandRuntimeChecks, ownerControlRuntimeChecks, pilotOutcomeRuntimeChecks, companyBackupRuntimeChecks, largestJavascriptBytes, bytes }, null, 2))


### PR DESCRIPTION
## Summary
- make an empty catalog the first Shop prerequisite instead of routing users to a dead sale or stock setup
- keep Counter and Inventory usable with direct catalog recovery, guarded enterprise inventory projection, and explicit hash focus
- centralize Shop next-action priority in a pure helper with 10 runtime boundary checks
- improve catalog-helper layout across desktop and mobile

## Verification
- npm run app:verify
- desktop 1365x900 and mobile 390x844 browser QA
- valid empty workspace: Today -> catalog helper -> accountable sample item -> sale-ready guide
- zero horizontal overflow, 44px actions, no console errors
- independent read-only review: no remaining P0-P2

## Boundaries
- no pricing, DNS, managed runtime, database, customer data, external message, payment, stock movement, or production action changed
- production remains isolated_demo with managed writes and scheduler activation off