### PR TITLE
HQ: bind the next managed pilot decision

### DIFF
--- a/hq/readiness/managed-pilot-readiness.json
+++ b/hq/readiness/managed-pilot-readiness.json
@@ -1,13 +1,57 @@
 {
-  "contract": "supermega.managed-pilot-readiness.v1",
+  "contract": "supermega.managed-pilot-readiness.v2",
   "asOf": "2026-08-03T07:01:07.469Z",
-  "sourceDigest": "sha256:c7efc16922bacff44aae694f230ca2b8dd111f8b7435bbc45b828d3eda18c886",
+  "sourceDigest": "sha256:850060ffd433ac659489eade428de80c77a3e62b102ff3f06c2c5d547edbda60",
   "overall": {
     "status": "blocked",
     "localDatabaseProofReady": true,
     "hostedActivationReady": false,
     "blockingGateCount": 7,
-    "nextAction": "Obtain founder approval for one isolated non-production Supabase target and one named Shop pilot operator."
+    "nextAction": "Approve one 24-hour, data-less Supabase preview branch and name one Shop pilot operator."
+  },
+  "founderDecision": {
+    "status": "required",
+    "authority": "proposal_only",
+    "createsAuthority": false,
+    "approvalReceipt": null,
+    "decision": "Approve one bounded managed-pilot rehearsal.",
+    "target": {
+      "provider": "supabase",
+      "environment": "preview_branch",
+      "production": false,
+      "startsWithProductionData": false,
+      "requiredServices": [
+        "database",
+        "auth",
+        "storage"
+      ],
+      "maximumLifetimeHours": 24,
+      "deleteAfterEvidence": true,
+      "providerUsageChargesAcknowledged": false
+    },
+    "operator": {
+      "productId": "shop",
+      "namedBusinessRequired": true,
+      "namedOperatorRequired": true,
+      "measuredBaselineRequired": true,
+      "acceptanceEvidenceRequired": true
+    },
+    "proposedActions": [
+      "create_one_preview_branch",
+      "apply_reviewed_migrations_to_preview",
+      "create_one_named_preview_operator",
+      "run_hosted_isolation_storage_recovery_proof",
+      "delete_preview_branch_after_evidence"
+    ],
+    "doesNotAuthorize": [
+      "production_database_change",
+      "production_deploy",
+      "customer_message",
+      "payment",
+      "stock_move",
+      "managed_product_activation",
+      "hosted_scheduler_activation"
+    ]
   },
   "gates": [
     {
@@ -144,7 +188,7 @@
     },
     {
       "path": "kernel/managed-pilot-readiness.mjs",
-      "digest": "sha256:62a11077c9d6f89d5353771acd148612af3a461120d71e5369a0bf05bce527b5"
+      "digest": "sha256:e197ab508eb90837f0a5aca6efca6aa6a2a4f6a65ab4de5b48f3fd1a0fd3cc85"
     }
   ]
 }

--- a/kernel/managed-pilot-readiness.mjs
+++ b/kernel/managed-pilot-readiness.mjs
@@ -1,6 +1,6 @@
 import { createHash } from 'node:crypto'
 
-export const MANAGED_PILOT_READINESS_CONTRACT = 'supermega.managed-pilot-readiness.v1'
+export const MANAGED_PILOT_READINESS_CONTRACT = 'supermega.managed-pilot-readiness.v2'
 
 const PRODUCT_IDS = ['shop', 'plant', 'website', 'ecommerce']
 const GATE_IDS = [
@@ -13,6 +13,22 @@ const GATE_IDS = [
   'named_pilot',
   'production_activation',
 ]
+const PROPOSED_ACTIONS = [
+  'create_one_preview_branch',
+  'apply_reviewed_migrations_to_preview',
+  'create_one_named_preview_operator',
+  'run_hosted_isolation_storage_recovery_proof',
+  'delete_preview_branch_after_evidence',
+]
+const FORBIDDEN_ACTIONS = [
+  'production_database_change',
+  'production_deploy',
+  'customer_message',
+  'payment',
+  'stock_move',
+  'managed_product_activation',
+  'hosted_scheduler_activation',
+]
 
 const isRecord = (value) => value && typeof value === 'object' && !Array.isArray(value)
 
@@ -24,6 +40,12 @@ function stableStringify(value) {
   if (value === null || typeof value !== 'object') return JSON.stringify(value)
   if (Array.isArray(value)) return `[${value.map(stableStringify).join(',')}]`
   return `{${Object.keys(value).sort().map((key) => `${JSON.stringify(key)}:${stableStringify(value[key])}`).join(',')}}`
+}
+
+function exactStringArray(value, expected) {
+  return Array.isArray(value)
+    && value.length === expected.length
+    && value.every((entry, index) => entry === expected[index])
 }
 
 export function readinessDigest(value) {
@@ -106,7 +128,33 @@ export function buildManagedPilotReadiness(input = {}) {
       localDatabaseProofReady: true,
       hostedActivationReady: false,
       blockingGateCount: gates.filter((entry) => entry.status === 'blocked').length,
-      nextAction: 'Obtain founder approval for one isolated non-production Supabase target and one named Shop pilot operator.',
+      nextAction: 'Approve one 24-hour, data-less Supabase preview branch and name one Shop pilot operator.',
+    },
+    founderDecision: {
+      status: 'required',
+      authority: 'proposal_only',
+      createsAuthority: false,
+      approvalReceipt: null,
+      decision: 'Approve one bounded managed-pilot rehearsal.',
+      target: {
+        provider: 'supabase',
+        environment: 'preview_branch',
+        production: false,
+        startsWithProductionData: false,
+        requiredServices: ['database', 'auth', 'storage'],
+        maximumLifetimeHours: 24,
+        deleteAfterEvidence: true,
+        providerUsageChargesAcknowledged: false,
+      },
+      operator: {
+        productId: 'shop',
+        namedBusinessRequired: true,
+        namedOperatorRequired: true,
+        measuredBaselineRequired: true,
+        acceptanceEvidenceRequired: true,
+      },
+      proposedActions: [...PROPOSED_ACTIONS],
+      doesNotAuthorize: [...FORBIDDEN_ACTIONS],
     },
     gates,
     products,
@@ -128,6 +176,27 @@ export function validateManagedPilotReadiness(value) {
   if (!isRecord(value) || value.contract !== MANAGED_PILOT_READINESS_CONTRACT || !Number.isFinite(Date.parse(value.asOf))) fail('managed_pilot_readiness_contract_invalid')
   if (!/^sha256:[0-9a-f]{64}$/.test(value.sourceDigest || '') || value.sourceDigest !== readinessDigest(value.sourceReceipts)) fail('managed_pilot_readiness_digest_invalid')
   if (value.overall?.status !== 'blocked' || value.overall?.hostedActivationReady !== false || value.overall?.localDatabaseProofReady !== true || value.overall?.blockingGateCount !== 7) fail('managed_pilot_readiness_overall_invalid')
+  const decision = value.founderDecision
+  if (decision?.status !== 'required'
+    || decision.authority !== 'proposal_only'
+    || decision.createsAuthority !== false
+    || decision.approvalReceipt !== null
+    || decision.target?.provider !== 'supabase'
+    || decision.target?.environment !== 'preview_branch'
+    || decision.target?.production !== false
+    || decision.target?.startsWithProductionData !== false
+    || decision.target?.maximumLifetimeHours !== 24
+    || decision.target?.deleteAfterEvidence !== true
+    || decision.target?.providerUsageChargesAcknowledged !== false
+    || decision.target?.requiredServices?.join(',') !== 'database,auth,storage'
+    || decision.operator?.productId !== 'shop'
+    || decision.operator?.namedBusinessRequired !== true
+    || decision.operator?.namedOperatorRequired !== true
+    || decision.operator?.measuredBaselineRequired !== true
+    || decision.operator?.acceptanceEvidenceRequired !== true
+    || !exactStringArray(decision.proposedActions, PROPOSED_ACTIONS)
+    || !exactStringArray(decision.doesNotAuthorize, FORBIDDEN_ACTIONS)
+    || decision.proposedActions.some((action) => decision.doesNotAuthorize.includes(action))) fail('managed_pilot_readiness_founder_decision_invalid')
   if (!Array.isArray(value.gates) || value.gates.map((entry) => entry.id).join(',') !== GATE_IDS.join(',') || value.gates[0]?.status !== 'ready-local' || value.gates.slice(1).some((entry) => entry.status !== 'blocked')) fail('managed_pilot_readiness_gates_invalid')
   if (!Array.isArray(value.products) || value.products.map((product) => product.productId).join(',') !== PRODUCT_IDS.join(',') || value.products.some((product) => product.managedPilotStatus !== 'blocked' || product.automationStatus !== 'owner-gated')) fail('managed_pilot_readiness_products_invalid')
   if (value.controls?.externalWritesPerformed !== false || value.controls?.connectorRequestsPerformed !== 0 || value.controls?.modelCallsRequiredToBuild !== 0 || value.controls?.productionWritesEnabled !== false || value.controls?.ownerApprovalRequired !== true) fail('managed_pilot_readiness_controls_invalid')

--- a/kernel/managed-pilot-readiness.test.mjs
+++ b/kernel/managed-pilot-readiness.test.mjs
@@ -43,6 +43,14 @@ test('derives one blocked four-product ledger from current bounded evidence', ()
   assert.doesNotMatch(JSON.stringify(ledger), /app_product_contract_drift/)
   assert.equal(ledger.products.length, 4)
   assert.equal(ledger.controls.modelCallsRequiredToBuild, 0)
+  assert.equal(ledger.founderDecision.target.environment, 'preview_branch')
+  assert.equal(ledger.founderDecision.target.maximumLifetimeHours, 24)
+  assert.equal(ledger.founderDecision.target.startsWithProductionData, false)
+  assert.equal(ledger.founderDecision.operator.productId, 'shop')
+  assert.equal(ledger.founderDecision.authority, 'proposal_only')
+  assert.equal(ledger.founderDecision.createsAuthority, false)
+  assert.equal(ledger.founderDecision.approvalReceipt, null)
+  assert.ok(ledger.founderDecision.doesNotAuthorize.includes('production_database_change'))
   assert.equal(validateManagedPilotReadiness(ledger), ledger)
 })
 
@@ -57,4 +65,38 @@ test('rejects hosted overclaims and product authority drift', () => {
   const ungated = structuredClone(input)
   ungated.portfolio.products[0].localAutomation.status = 'ready-local'
   assert.throws(() => buildManagedPilotReadiness(ungated), /managed_pilot_readiness_product_invalid/)
+})
+
+test('rejects a founder decision that can touch production or outlive the bounded rehearsal', () => {
+  const ledger = buildManagedPilotReadiness(input)
+  ledger.founderDecision.target.production = true
+  assert.throws(() => validateManagedPilotReadiness(ledger), /managed_pilot_readiness_founder_decision_invalid/)
+
+  const longLived = buildManagedPilotReadiness(input)
+  longLived.founderDecision.target.maximumLifetimeHours = 168
+  assert.throws(() => validateManagedPilotReadiness(longLived), /managed_pilot_readiness_founder_decision_invalid/)
+})
+
+test('rejects broadened, incomplete, or contradictory proposal authority', () => {
+  const broadened = buildManagedPilotReadiness(input)
+  broadened.founderDecision.proposedActions.push('production_deploy')
+  assert.throws(() => validateManagedPilotReadiness(broadened), /managed_pilot_readiness_founder_decision_invalid/)
+
+  const incomplete = buildManagedPilotReadiness(input)
+  incomplete.founderDecision.doesNotAuthorize.pop()
+  assert.throws(() => validateManagedPilotReadiness(incomplete), /managed_pilot_readiness_founder_decision_invalid/)
+
+  const contradictory = buildManagedPilotReadiness(input)
+  contradictory.founderDecision.doesNotAuthorize[0] = contradictory.founderDecision.proposedActions[0]
+  assert.throws(() => validateManagedPilotReadiness(contradictory), /managed_pilot_readiness_founder_decision_invalid/)
+
+  const authoritative = buildManagedPilotReadiness(input)
+  authoritative.founderDecision.createsAuthority = true
+  authoritative.founderDecision.approvalReceipt = { approvedBy: 'founder' }
+  assert.throws(() => validateManagedPilotReadiness(authoritative), /managed_pilot_readiness_founder_decision_invalid/)
+
+  const collapsed = buildManagedPilotReadiness(input)
+  collapsed.founderDecision.proposedActions = [collapsed.founderDecision.proposedActions.join(',')]
+  collapsed.founderDecision.doesNotAuthorize = [collapsed.founderDecision.doesNotAuthorize.join(',')]
+  assert.throws(() => validateManagedPilotReadiness(collapsed), /managed_pilot_readiness_founder_decision_invalid/)
 })

--- a/tools/verify_hq_contract.mjs
+++ b/tools/verify_hq_contract.mjs
@@ -24,6 +24,7 @@ import {
   COMPANY_DAILY_BUDGET_DEFAULT_UNITS,
   COMPANY_DAILY_BUDGET_HARD_MAX_UNITS,
 } from '../kernel/gateway.mjs'
+import { validateManagedPilotReadiness } from '../kernel/managed-pilot-readiness.mjs'
 
 const root = resolve(import.meta.dirname, '..')
 const [readme, now, qaBrief, workboard, current, manifestText, portfolioText, workforceText, agentWorkspaceText, research, agentSecurity, databaseRehearsalText, releaseReconciliation, allyAuditText, allyTrimText, allyCompanyCycleText, allyCeoPlannerText, allyCeoPlannerCliText, allyCeoLocalCycleText, agentJobRunnerText, packageText, storageAuditHandoff, hqLiveStateVerifier, kernelPackageText, kernelFootprintVerifier, kernelBriefText, kernelOperatorText, kernelAlertText, kernelOperationsText, kernelConsoleText, kernelAgentCompanyApiText, kernelGatewayText, kernelGatewayTestText, kernelConsoleApiText, kernelReadmeText, agentArchitectureText, agentGovernanceText] = await Promise.all([
@@ -66,7 +67,7 @@ const [readme, now, qaBrief, workboard, current, manifestText, portfolioText, wo
   readFile(resolve(root, 'supermega_runtime', 'agent_governance.py'), 'utf8'),
 ])
 const enterpriseRoadmap = await readFile(resolve(root, 'hq', 'research', 'enterprise-product-roadmap-2026-07-28.md'), 'utf8')
-const managedPilotReadiness = JSON.parse(await readFile(resolve(root, 'hq', 'readiness', 'managed-pilot-readiness.json'), 'utf8'))
+const managedPilotReadiness = validateManagedPilotReadiness(JSON.parse(await readFile(resolve(root, 'hq', 'readiness', 'managed-pilot-readiness.json'), 'utf8')))
 
 const manifest = JSON.parse(manifestText)
 const canonicalTextLength = (value) => value.replaceAll('\r\n', '\n').length
@@ -1054,13 +1055,26 @@ requireContract('local PostgreSQL rehearsal remains bounded',
   && databaseRehearsal.safety?.vercelMutated === false)
 
 requireContract('managed pilot readiness is derived and fail closed',
-  managedPilotReadiness.contract === 'supermega.managed-pilot-readiness.v1'
+  managedPilotReadiness.contract === 'supermega.managed-pilot-readiness.v2'
   && managedPilotReadiness.overall?.status === 'blocked'
   && managedPilotReadiness.overall?.localDatabaseProofReady === true
   && managedPilotReadiness.overall?.hostedActivationReady === false
   && managedPilotReadiness.overall?.blockingGateCount === 7
   && managedPilotReadiness.products?.map((product) => product.productId).join(',') === 'shop,plant,website,ecommerce'
   && managedPilotReadiness.products?.every((product) => product.managedPilotStatus === 'blocked' && product.automationStatus === 'owner-gated')
+  && managedPilotReadiness.founderDecision?.status === 'required'
+  && managedPilotReadiness.founderDecision?.authority === 'proposal_only'
+  && managedPilotReadiness.founderDecision?.createsAuthority === false
+  && managedPilotReadiness.founderDecision?.approvalReceipt === null
+  && managedPilotReadiness.founderDecision?.target?.environment === 'preview_branch'
+  && managedPilotReadiness.founderDecision?.target?.production === false
+  && managedPilotReadiness.founderDecision?.target?.startsWithProductionData === false
+  && managedPilotReadiness.founderDecision?.target?.maximumLifetimeHours === 24
+  && managedPilotReadiness.founderDecision?.target?.deleteAfterEvidence === true
+  && managedPilotReadiness.founderDecision?.operator?.productId === 'shop'
+  && managedPilotReadiness.founderDecision?.proposedActions?.includes('delete_preview_branch_after_evidence')
+  && managedPilotReadiness.founderDecision?.doesNotAuthorize?.includes('production_database_change')
+  && managedPilotReadiness.founderDecision?.doesNotAuthorize?.includes('hosted_scheduler_activation')
   && managedPilotReadiness.controls?.externalWritesPerformed === false
   && managedPilotReadiness.controls?.connectorRequestsPerformed === 0
   && managedPilotReadiness.controls?.modelCallsRequiredToBuild === 0


### PR DESCRIPTION
## Summary
- upgrade managed-pilot readiness to a proposal-only v2 founder decision
- bind the next proof to one data-less 24-hour Supabase preview branch and one named Shop operator
- reject broadened, incomplete, contradictory, production-capable, or authority-creating proposals
- make HQ use the canonical readiness validator

## Verification
- `npm run readiness:managed:self-test`
- `npm run hq:verify`
- `npm run app:verify`
- independent read-only review: no remaining P0-P2 findings
- live app/public/HQ availability and contract verification passed before this internal change

## Boundaries
No deploy, provider mutation, database write, customer message, payment, scheduler activation, pricing change, or production activation.