### PR TITLE
Plant: close shifts by controlled-order exception

### DIFF
--- a/showroom/src/core/CoreApp.tsx
+++ b/showroom/src/core/CoreApp.tsx
@@ -186,7 +186,7 @@ import {
   closeProductionJob,
   compareProductionJobSchedule,
   completeProductionMaintenance,
-  currentProductionShiftClose,
+  currentProductionShiftCloseEvidence,
   endProductionDowntime,
   formatProductionShiftHandoff,
   formatProductionBatchGenealogy,
@@ -7552,6 +7552,7 @@ function ProductionPage({ managedIdentity, tab }: { managedIdentity: ManagedIden
   const plantOrderScopeWorkspaceId = managedIdentity
     ? managedWorkspaceId || managedIdentity.workspaceId
     : 'local-sample'
+  const plantOrderScope = `plant:${plantOrderScopeWorkspaceId}`
   const latestRecordedShiftRef = production.events.find((event) => Boolean(event.shiftRef?.trim()))?.shiftRef?.trim() ?? ''
   const [, setActions] = useStoredState<AccountableAction[]>(ACTION_KEY, [], normalizeActions)
   const [pendingAction, setPendingAction] = useState<PendingAccountableAction | null>(null)
@@ -7704,12 +7705,15 @@ function ProductionPage({ managedIdentity, tab }: { managedIdentity: ManagedIden
   const shiftHandoffIsCurrent = Boolean(shiftHandoff
     && shiftHandoff.sourceRevision === production.revision
     && shiftHandoff.sourceCanonical === currentProductionCanonical
+    && shiftHandoff.plantOrderScope === plantOrderScope
     && shiftHandoff.shiftRef === handoffShiftRef.trim())
-  const currentShiftClose = currentProductionShiftClose(production)
-  const plantHandoffReady = shiftHandoffIsCurrent || Boolean(currentShiftClose)
+  const currentShiftCloseEvidence = currentProductionShiftCloseEvidence(production, undefined, plantOrderScope)
+  const currentShiftClose = currentShiftCloseEvidence?.event ?? null
+  const controlledOrderBlockerCount = shiftHandoff?.controlledOrders.filter((order) => order.blockingReasons.length > 0).length ?? 0
   const shiftCloseRows = shiftHandoff ? [
     ['Output', shiftHandoff.shiftOutput.goodUnits > 0 && shiftHandoff.shiftOutput.entryCount > 0 ? `${shiftHandoff.shiftOutput.goodUnits} good / ${shiftHandoff.shiftOutput.entryCount} entries` : 'Need good output'],
     ['Material', shiftHandoff.materialEntries.length > 0 ? `${shiftHandoff.materialEntries.length} traced` : 'Need same-shift trace'],
+    ['Orders', shiftHandoff.controlledOrders.length ? controlledOrderBlockerCount ? `${controlledOrderBlockerCount} blocked` : `${shiftHandoff.controlledOrders.length} classified` : 'No controlled batch'],
     ['Quality', shiftHandoff.activeHolds.length + shiftHandoff.openQualityIssues.length === 0 ? 'Clear' : `${shiftHandoff.activeHolds.length + shiftHandoff.openQualityIssues.length} blockers`],
     ['Urgent', shiftHandoff.priorityProblems.length === 0 ? 'Clear' : `${shiftHandoff.priorityProblems.length} open`],
     ['Maintenance', shiftHandoff.activeDowntime.length + shiftHandoff.activeMaintenance.length === 0 ? 'Clear' : `${shiftHandoff.activeDowntime.length + shiftHandoff.activeMaintenance.length} open`],
@@ -7723,7 +7727,9 @@ function ProductionPage({ managedIdentity, tab }: { managedIdentity: ManagedIden
     && shiftHandoff.openQualityIssues.length === 0
     && shiftHandoff.priorityProblems.length === 0
     && shiftHandoff.activeDowntime.length === 0
-    && shiftHandoff.activeMaintenance.length === 0)
+    && shiftHandoff.activeMaintenance.length === 0
+    && controlledOrderBlockerCount === 0)
+  const plantHandoffReady = shiftCloseReady || Boolean(currentShiftClose)
   const selectedGenealogyJobId = production.jobs.some((job) => job.id === genealogyJobId)
     ? genealogyJobId
     : production.jobs[0]?.id ?? ''
@@ -9024,7 +9030,7 @@ function ProductionPage({ managedIdentity, tab }: { managedIdentity: ManagedIden
     event.preventDefault()
     const canonicalHandoffShiftRef = handoffShiftRef.trim() || shiftRef.trim()
     if (currentShiftClose?.shiftRef === canonicalHandoffShiftRef) return setNotice(`${canonicalHandoffShiftRef} is already closed by ${currentShiftClose.actor}. Record new Plant evidence before closing another shift packet.`)
-    const draft = buildProductionShiftHandoff(production, canonicalHandoffShiftRef)
+    const draft = buildProductionShiftHandoff(production, canonicalHandoffShiftRef, plantOrderScope)
     if (!draft) return setNotice('Enter one named shift reference of at most 80 characters.')
     setHandoffShiftRef(canonicalHandoffShiftRef)
     setShiftHandoff(draft)
@@ -9035,6 +9041,7 @@ function ProductionPage({ managedIdentity, tab }: { managedIdentity: ManagedIden
       + draft.priorityProblems.length
       + draft.activeDowntime.length
       + draft.activeMaintenance.length
+      + draft.controlledOrders.filter((order) => order.blockingReasons.length > 0).length
     setNotice(blockers
       ? `Shift packet prepared from Plant revision ${draft.sourceRevision} with ${blockers} close blocker${blockers === 1 ? '' : 's'}. No Plant record changed.`
       : `Shift packet prepared from Plant revision ${draft.sourceRevision}. It is ready for accountable owner close review.`)
@@ -9043,17 +9050,17 @@ function ProductionPage({ managedIdentity, tab }: { managedIdentity: ManagedIden
   function reviewShiftClose(trigger: HTMLButtonElement) {
     if (currentShiftClose) return setNotice(`${currentShiftClose.shiftRef} is already closed by ${currentShiftClose.actor}. Any later Plant event will require a new close packet.`)
     if (!shiftHandoff || !shiftHandoffIsCurrent) return setNotice('Build a current shift packet before owner close review.')
-    if (!shiftCloseReady) return setNotice('Close blockers remain. Record good output and same-shift material trace, then clear quality and WCM work.')
+    if (!shiftCloseReady) return setNotice('Close blockers remain. Record good output and same-shift material trace, classify controlled work, then clear quality and WCM exceptions.')
     const reviewedHandoff = shiftHandoff
     const expectedRevision = production.revision
     queueAction({
       kind: 'production_shift_close',
       subjectId: reviewedHandoff.shiftRef,
       summary: `Close shift ${reviewedHandoff.shiftRef}`,
-      before: `Revision ${reviewedHandoff.sourceRevision} | ${reviewedHandoff.shiftOutput.goodUnits} good | ${reviewedHandoff.materialEntries.length} material entries | quality clear | WCM clear`,
+      before: `Revision ${reviewedHandoff.sourceRevision} | ${reviewedHandoff.shiftOutput.goodUnits} good | ${reviewedHandoff.materialEntries.length} material entries | ${reviewedHandoff.controlledOrders.length} controlled orders | quality clear | WCM clear`,
       after: 'Append one owner-attributed shift-close event bound to this exact Plant revision and evidence packet',
       actorSuggestion: managedIdentity ? undefined : 'Shift supervisor',
-      reasonSuggestion: `Output, material trace, quality, and maintenance checks reviewed for ${reviewedHandoff.shiftRef}.`,
+      reasonSuggestion: `Output, controlled orders, material trace, quality, and maintenance checks reviewed for ${reviewedHandoff.shiftRef}.`,
       evidenceReferenceSuggestion: `Shift close ${reviewedHandoff.shiftRef} · revision ${reviewedHandoff.sourceRevision}`,
       evidenceReferenceLocked: true,
       apply: async (record) => {
@@ -9070,6 +9077,17 @@ function ProductionPage({ managedIdentity, tab }: { managedIdentity: ManagedIden
     try {
       await navigator.clipboard.writeText(formatProductionShiftHandoff(shiftHandoff))
       setNotice('Shift close file copied. No Plant record changed.')
+    } catch {
+      setNotice('Clipboard copy was not permitted. No Plant record changed.')
+    }
+  }
+
+  async function copyClosedShiftHandoff() {
+    if (!currentShiftCloseEvidence) return setNotice('The verified closed-shift evidence is unavailable.')
+    if (!navigator.clipboard?.writeText) return setNotice('Clipboard copy is unavailable in this browser. No Plant record changed.')
+    try {
+      await navigator.clipboard.writeText(formatProductionShiftHandoff(currentShiftCloseEvidence.handoff))
+      setNotice('Verified closed-shift evidence copied. No Plant record changed.')
     } catch {
       setNotice('Clipboard copy was not permitted. No Plant record changed.')
     }
@@ -9454,7 +9472,7 @@ function ProductionPage({ managedIdentity, tab }: { managedIdentity: ManagedIden
     <details className="plant-batch-disclosure" onToggle={(event) => setPlantBatchOpen(event.currentTarget.open)} open={plantBatchOpen}>
       <summary><span>Controlled batch execution</span><small>BOM, routing, material, quality, and release</small></summary>
       <div className="plant-batch-content">
-        {plantBatchOpen ? <Suspense fallback={<p className="form-notice" role="status">Loading batch execution…</p>}><PlantOrderFoundation actor={managedIdentity?.userId ?? 'Local Plant supervisor'} commerceState={relatedCommerce} disabled={!productionCanWrite || Boolean(pendingAction)} industryPackId={plantIndustryPackId} jobs={production.jobs} key={`plant-order:${plantOrderScopeWorkspaceId}:${plantIndustryPackId}`} onProductionCommand={mutateProduction} productionState={production} scope={`plant:${plantOrderScopeWorkspaceId}`} /></Suspense> : null}
+        {plantBatchOpen ? <Suspense fallback={<p className="form-notice" role="status">Loading batch execution…</p>}><PlantOrderFoundation actor={managedIdentity?.userId ?? 'Local Plant supervisor'} commerceState={relatedCommerce} disabled={!productionCanWrite || Boolean(pendingAction)} industryPackId={plantIndustryPackId} jobs={production.jobs} key={`plant-order:${plantOrderScopeWorkspaceId}:${plantIndustryPackId}`} onProductionCommand={mutateProduction} productionState={production} scope={plantOrderScope} /></Suspense> : null}
       </div>
     </details>
     {plantBusinessControls}
@@ -9522,12 +9540,12 @@ function ProductionPage({ managedIdentity, tab }: { managedIdentity: ManagedIden
               <button className="core-button" disabled={!handoffShiftRef.trim() && !shiftRef.trim()} type="submit">Prepare shift close file</button>
               <p className="panel-copy">Review current output, material, quality, WCM, maintenance, and carry-forward work. Preparing changes nothing; closing requires a named owner, reason, and evidence.</p>
             </form>
-            {shiftCloseRows.length ? <div aria-label="Shift close checklist" className="plant-command-center-rows">{shiftCloseRows.map(([label, value]) => <span key={label}><small>{label}</small><strong>{value}</strong></span>)}</div> : null}
-            {currentShiftClose ? <div className="form-notice" role="status"><strong>Shift closed by {currentShiftClose.actor}</strong><br />{currentShiftClose.shiftRef} | revision {currentShiftClose.sourceRevision} | {currentShiftClose.goodUnits} good | {currentShiftClose.materialEntryCount} material entries | quality clear | WCM clear<br />Evidence: {currentShiftClose.evidenceReference}</div> : null}
+            {shiftCloseRows.length ? <div aria-label="Shift close checklist" className="plant-shift-close-grid">{shiftCloseRows.map(([label, value]) => <span key={label}><small>{label}</small><strong>{value}</strong></span>)}</div> : null}
+            {currentShiftClose ? <div className="form-notice" role="status"><strong>Shift closed by {currentShiftClose.actor}</strong><br />{currentShiftClose.shiftRef} | revision {currentShiftClose.sourceRevision} | {currentShiftClose.goodUnits} good | {currentShiftClose.materialEntryCount} material entries | {currentShiftCloseEvidence?.handoff.controlledOrders.length ?? 0} controlled orders | quality clear | WCM clear<br />Evidence: {currentShiftClose.evidenceReference}</div> : null}
             {shiftHandoff && !shiftHandoffIsCurrent && !currentShiftClose ? <p className="form-notice" role="alert">Plant records or the shift reference changed after this close file was prepared. Prepare it again before use.</p> : null}
-            {shiftHandoff && shiftHandoffIsCurrent ? <ShiftHandoffView handoff={shiftHandoff} onCopy={copyShiftHandoff} /> : null}
-            {shiftHandoff && shiftHandoffIsCurrent ? <button className="core-button primary" disabled={!productionCanWrite || Boolean(pendingAction) || !shiftCloseReady} onClick={(event) => reviewShiftClose(event.currentTarget)} type="button">Review shift close</button> : null}
-            {shiftHandoff && shiftHandoffIsCurrent && !shiftCloseReady ? <p className="panel-copy">The owner close remains locked until this exact shift has good output and material trace and the current Plant record has no quality or WCM blocker.</p> : null}
+            {currentShiftCloseEvidence ? <ShiftHandoffView handoff={currentShiftCloseEvidence.handoff} onCopy={copyClosedShiftHandoff} /> : shiftHandoff && shiftHandoffIsCurrent ? <ShiftHandoffView handoff={shiftHandoff} onCopy={copyShiftHandoff} /> : null}
+            {!currentShiftClose && shiftHandoff && shiftHandoffIsCurrent ? <button className="core-button primary" disabled={!productionCanWrite || Boolean(pendingAction) || !shiftCloseReady} onClick={(event) => reviewShiftClose(event.currentTarget)} type="button">Review shift close</button> : null}
+            {!currentShiftClose && shiftHandoff && shiftHandoffIsCurrent && !shiftCloseReady ? <p className="panel-copy">The owner close remains locked until this exact shift has good output and material trace, every controlled order is released or safely owned forward, and the current Plant record has no quality or WCM blocker.</p> : null}
           </details>
         </section>
         <section className="core-panel" style={{ overflowY: 'auto' }}>
@@ -9716,9 +9734,10 @@ function QualityHoldList({ disabled, jobs, onRelease }: { disabled: boolean; job
 
 function ShiftHandoffView({ handoff, onCopy }: { handoff: ProductionShiftHandoff; onCopy: () => void }) {
   const visibleMaterialEntries = handoff.materialEntries.slice(0, 8)
+  const controlledOrderBlockers = handoff.controlledOrders.filter((order) => order.blockingReasons.length > 0)
   return <div>
-    <p className="panel-copy"><strong>Close gate</strong> | {handoff.openQualityIssues.length} open quality | {handoff.activeDowntime.length} downtime open | {handoff.activeMaintenance.length} maintenance open.</p>
-    <p className="form-notice" role="status">{handoff.shiftRef} · revision {handoff.sourceRevision} · {handoff.shiftOutput.goodUnits.toLocaleString()} good · {handoff.shiftOutput.scrapUnits.toLocaleString()} scrap · {handoff.materialTotals.length} material totals · {handoff.shortCloses.length} closed short · {handoff.unfinishedJobs.length} unfinished · {handoff.activeHolds.length} held · {handoff.priorityProblems.length} critical/high · {handoff.activeMaintenance.length} maintenance open.</p>
+    <p className="panel-copy"><strong>Close gate</strong> | {controlledOrderBlockers.length} controlled-order blockers | {handoff.openQualityIssues.length} open quality | {handoff.activeDowntime.length} downtime open | {handoff.activeMaintenance.length} maintenance open.</p>
+    <p className="form-notice" role="status">{handoff.shiftRef} · revision {handoff.sourceRevision} · {handoff.shiftOutput.goodUnits.toLocaleString()} good · {handoff.shiftOutput.scrapUnits.toLocaleString()} scrap · {handoff.materialTotals.length} material totals · {handoff.controlledOrders.length} controlled orders · {handoff.shortCloses.length} closed short · {handoff.unfinishedJobs.length} unfinished · {handoff.activeHolds.length} held · {handoff.priorityProblems.length} critical/high · {handoff.activeMaintenance.length} maintenance open.</p>
     <details className="compact-disclosure production-history">
       <summary>Shift entries <span>{handoff.shiftEntries.length}</span></summary>
       <div className="issue-list">
@@ -9744,6 +9763,16 @@ function ShiftHandoffView({ handoff, onCopy }: { handoff: ProductionShiftHandoff
         <div><strong>{entry.quantity.toLocaleString(undefined, { maximumFractionDigits: 3 })} {entry.materialUnit} · {entry.materialRef}{entry.materialLot ? ` · lot ${entry.materialLot}` : ''}</strong><small style={wrappedIssueDetail}>{entry.jobId} · {entry.product} · {formatIssueDue(entry.recordedAt)} · {entry.recordedBy}</small><small style={wrappedIssueDetail}>Reason: {entry.reason}</small><small style={wrappedIssueDetail}>Evidence: {entry.evidenceReference} · Action: {entry.actionId}</small></div>
       </article>)}</div></> : null}
       {handoff.materialEntries.length > visibleMaterialEntries.length ? <p className="panel-copy">Showing the latest {visibleMaterialEntries.length} of {handoff.materialEntries.length} entries. Copy keeps every attributed entry.</p> : null}
+    </details>
+    <details className="compact-disclosure production-history" open={Boolean(controlledOrderBlockers.length)}>
+      <summary>Controlled orders <span>{handoff.controlledOrders.length}</span></summary>
+      <div className="issue-list">
+        {handoff.controlledOrders.map((order) => <article key={order.jobId}>
+          <span className={`issue-mark ${order.blockingReasons.length ? 'open' : 'resolved'}`}>{order.disposition === 'released' ? 'R' : order.disposition === 'carry_forward' ? 'C' : 'Q'}</span>
+          <div><strong>{order.product} · {order.jobId}</strong><small style={wrappedIssueDetail}>{order.disposition.replaceAll('_', ' ')} · {order.status.replaceAll('_', ' ')} · Binding {order.bindingCurrent ? 'current' : 'stale'} · Plan {order.planId}</small><small style={wrappedIssueDetail}>Operations {order.completedOperationCount}/{order.operationCount} · Output {order.outputUnits.toLocaleString()}/{order.targetUnits.toLocaleString()} · Accepted {order.acceptedUnits.toLocaleString()} · Trace links {order.genealogyLinkCount}</small>{order.owner || order.dueAt ? <small style={wrappedIssueDetail}>{order.owner ? `Owner ${order.owner}` : 'Owner missing'} · {order.dueAt ? `Due ${formatIssueDue(order.dueAt)}` : 'Due time missing'}</small> : null}{order.nextOperation ? <small style={wrappedIssueDetail}>Next: {order.nextOperation.operationId} · {order.nextOperation.name} · {order.nextOperation.remainingUnits.toLocaleString()} remaining</small> : null}{order.inspection ? <small style={wrappedIssueDetail}>Inspection {order.inspection.inspectionId} · {order.inspection.result} · {order.inspection.acceptedUnits.toLocaleString()} accepted · {order.inspection.rejectedUnits.toLocaleString()} rejected · Evidence {order.inspection.evidenceReference}</small> : null}{order.batchRelease ? <small style={wrappedIssueDetail}>Release {order.batchRelease.releaseId} · {formatIssueDue(order.batchRelease.releasedAt)} · {order.batchRelease.releasedBy} · Evidence {order.batchRelease.evidenceReference}</small> : null}{order.exceptions.map((exception) => <small key={exception} style={wrappedIssueDetail}>Exception: {exception}</small>)}{order.blockingReasons.map((reason) => <small key={reason} style={wrappedIssueDetail}>BLOCKED: {reason}</small>)}<small style={wrappedIssueDetail}>Plan digest: {order.planDigest}</small></div>
+        </article>)}
+        {!handoff.controlledOrders.length ? <Empty>No controlled order exists in this Plant workspace.</Empty> : null}
+      </div>
     </details>
     <details className="compact-disclosure production-history">
       <summary>Closed short <span>{handoff.shortCloses.length}</span></summary>

--- a/showroom/src/core/PlantOrderFoundation.tsx
+++ b/showroom/src/core/PlantOrderFoundation.tsx
@@ -46,7 +46,7 @@ import {
 } from './plant-order-foundation'
 import type { CommerceState } from './commerce-workspace'
 import { pendingProductionMaterialHandoffs, projectProductionMaterialRequirements, projectProductionPortfolioMrp } from './production-material-handoff'
-import { validateProductionState, type ProductionJob, type ProductionState } from './production-workspace'
+import { productionJobPlanSourceDigest, validateProductionState, type ProductionJob, type ProductionState } from './production-workspace'
 import {
   productionOrderExecutionForJob,
   productionOrderPortfolioEntries,
@@ -147,21 +147,6 @@ function proof(actor: string, label: string): PlantOrderProof {
     actor: actor.trim() || 'Local Plant supervisor',
     reason: `Review and record ${label}.`,
     evidenceReference: `PLANT-EXECUTION:${actionId}`,
-  }
-}
-
-function jobSnapshot(scope: string, job: ProductionJob) {
-  return {
-    scope,
-    job: {
-      id: job.id,
-      product: job.product,
-      target: job.target,
-      output: job.output,
-      scrap: job.scrap ?? 0,
-      qualityHoldActionId: job.qualityHold?.actionId ?? null,
-      closureActionId: job.closure?.actionId ?? null,
-    },
   }
 }
 
@@ -375,7 +360,7 @@ export function PlantOrderFoundation({ actor, commerceState, disabled, industryP
     : { ...reworkDraft, operationId: projection.routing.at(-1)?.operationId ?? '' }
   const selectedSetupJob = activeJobs.find((job) => job.id === setupDraft.jobId) ?? activeJobs[0]
   const boundJob = projection.plan ? jobs.find((job) => job.id === projection.plan?.job.jobId) : undefined
-  const bindingCurrent = Boolean(!projection.plan || (boundJob && plantOrderEvidenceDigest(jobSnapshot(scope, boundJob)) === projection.plan.sourceDigest))
+  const bindingCurrent = Boolean(!projection.plan || (boundJob && productionJobPlanSourceDigest(scope, boundJob) === projection.plan.sourceDigest))
   const controlsDisabled = disabled || busy || Boolean(review) || (!bindingCurrent && projection.status !== 'released_to_stock')
   const nextMaterial = projection.materials.find((material) => material.remainingToIssueMilli > 0)
   const nextMaterialSubstitution = nextMaterial ? projection.materialSubstitutions.find((approval) => approval.materialId === nextMaterial.materialId) : undefined
@@ -598,7 +583,7 @@ export function PlantOrderFoundation({ actor, commerceState, disabled, industryP
       const workCentres = [...workCentreNames].map(([workCentreId, name]) => ({ workCentreId, name }))
         .sort((left, right) => left.workCentreId < right.workCentreId ? -1 : left.workCentreId > right.workCentreId ? 1 : 0)
       const targetQuantity = remaining(selectedSetupJob); const expectedHeadDigest = state.headDigest
-      const sourceDigest = plantOrderEvidenceDigest(jobSnapshot(scope, selectedSetupJob))
+      const sourceDigest = productionJobPlanSourceDigest(scope, selectedSetupJob)
       const effectiveFrom = explicitOffsetTimestamp(setupDraft.effectiveFrom, 'the plan effective date')
       const effectiveUntil = explicitOffsetTimestamp(setupDraft.effectiveUntil, 'the plan expiry date')
       if (Date.parse(effectiveUntil) <= Date.parse(effectiveFrom)) throw new Error('Plan expiry must follow its effective date.')

--- a/showroom/src/core/core-app.css
+++ b/showroom/src/core/core-app.css
@@ -637,6 +637,12 @@ textarea { min-height: 72px; resize: vertical; }
 .plant-control-rows span:last-child { border-right: 0; }
 .plant-control-rows small { overflow: hidden; color: var(--core-quiet); font-family: var(--core-mono); font-size: 8px; text-overflow: ellipsis; text-transform: uppercase; white-space: nowrap; }
 .plant-control-rows b { overflow: hidden; color: var(--core-ink); font-size: 10px; text-overflow: ellipsis; white-space: nowrap; }
+.plant-shift-close-grid { min-width: 0; display: grid; grid-template-columns: repeat(3,minmax(0,1fr)); overflow: hidden; border: 1px solid var(--core-line); border-radius: 8px; background: var(--core-panel); }
+.plant-shift-close-grid span { min-width: 0; min-height: 50px; display: grid; align-content: center; gap: 3px; border-right: 1px solid var(--core-line); border-bottom: 1px solid var(--core-line); padding: 7px 8px; }
+.plant-shift-close-grid span:nth-child(3n) { border-right: 0; }
+.plant-shift-close-grid span:nth-last-child(-n+3) { border-bottom: 0; }
+.plant-shift-close-grid small { overflow: hidden; color: var(--core-quiet); font-family: var(--core-mono); font-size: 8px; text-overflow: ellipsis; text-transform: uppercase; white-space: nowrap; }
+.plant-shift-close-grid strong { color: var(--core-ink); font-size: 10px; line-height: 1.25; overflow-wrap: anywhere; }
 .order-draft-recovery, .order-draft-status { min-width: 0; display: flex; align-items: center; justify-content: space-between; gap: 12px; border: 1px solid rgba(11,116,94,.2); border-radius: 10px; padding: 10px 12px; background: rgba(11,116,94,.05); }
 .order-draft-recovery.is-blocked, .order-draft-status.needs-review { border-color: rgba(150,94,31,.28); background: rgba(150,94,31,.06); }
 .order-draft-recovery > div:first-child, .order-draft-status > div:first-child { min-width: 0; display: grid; gap: 3px; }
@@ -2151,6 +2157,10 @@ textarea { min-height: 72px; resize: vertical; }
   .plant-control-rows span { border-right: 1px solid var(--core-line); border-bottom: 1px solid var(--core-line); }
   .plant-control-rows span:nth-child(2n) { border-right: 0; }
   .plant-control-rows span:nth-last-child(-n+2) { border-bottom: 0; }
+  .plant-shift-close-grid { grid-template-columns: repeat(2,minmax(0,1fr)); }
+  .plant-shift-close-grid span:nth-child(n) { border-right: 1px solid var(--core-line); border-bottom: 1px solid var(--core-line); }
+  .plant-shift-close-grid span:nth-child(2n) { border-right: 0; }
+  .plant-shift-close-grid span:nth-last-child(-n+2) { border-bottom: 0; }
   .order-archive-list article { grid-template-columns: 1fr; }
   .order-archive-actions { display: flex; align-items: center; justify-content: space-between; }
   .production-mode-banner { grid-template-columns: auto minmax(0,1fr); }

--- a/showroom/src/core/production-workspace.ts
+++ b/showroom/src/core/production-workspace.ts
@@ -60,6 +60,21 @@ export type ProductionJob = {
   shopDemandSource?: ProductionShopDemandSource
 }
 
+export function productionJobPlanSourceDigest(scope: string, job: ProductionJob) {
+  return plantOrderEvidenceDigest({
+    scope,
+    job: {
+      id: job.id,
+      product: job.product,
+      target: job.target,
+      output: job.output,
+      scrap: job.scrap ?? 0,
+      qualityHoldActionId: job.qualityHold?.actionId ?? null,
+      closureActionId: job.closure?.actionId ?? null,
+    },
+  })
+}
+
 export type ProductionIssueResolution = {
   actionId: string
   resolvedAt: string
@@ -287,6 +302,7 @@ export type ProductionShiftOutput = {
 
 export type ProductionShiftHandoff = {
   shiftRef: string
+  plantOrderScope: string
   sourceRevision: number
   sourceCanonical: string
   shiftOutput: ProductionShiftOutput
@@ -332,6 +348,47 @@ export type ProductionShiftHandoff = {
     recordedBy: string
     reason: string
     evidenceReference: string
+  }>
+  controlledOrders: Array<{
+    jobId: string
+    product: string
+    planId: string
+    planDigest: string
+    bindingCurrent: boolean
+    status: 'planned' | 'shortfall' | 'ready' | 'released' | 'in_process' | 'inspection_due' | 'quality_hold' | 'ready_to_release' | 'released_to_stock'
+    disposition: 'released' | 'complete_not_released' | 'carry_forward'
+    targetUnits: number
+    outputUnits: number
+    acceptedUnits: number
+    completedOperationCount: number
+    operationCount: number
+    genealogyLinkCount: number
+    owner?: string
+    dueAt?: string
+    nextOperation?: {
+      operationId: string
+      name: string
+      status: 'blocked' | 'ready' | 'in_progress'
+      remainingUnits: number
+    }
+    inspection?: {
+      inspectionId: string
+      result: 'pass' | 'fail'
+      inspectedUnits: number
+      acceptedUnits: number
+      rejectedUnits: number
+      actionId: string
+      evidenceReference: string
+    }
+    batchRelease?: {
+      releaseId: string
+      actionId: string
+      releasedAt: string
+      releasedBy: string
+      evidenceReference: string
+    }
+    exceptions: string[]
+    blockingReasons: string[]
   }>
   unfinishedJobs: Array<{
     id: string
@@ -2189,8 +2246,9 @@ export function productionMaintenanceDueQueue(
   return { contract: 'supermega.production.maintenance-due-queue.v1', asOf, items }
 }
 
-export function buildProductionShiftHandoff(state: ProductionState, shiftRef: string): ProductionShiftHandoff | null {
+export function buildProductionShiftHandoff(state: ProductionState, shiftRef: string, plantOrderScope = 'plant:local-sample'): ProductionShiftHandoff | null {
   if (!validCanonicalText(shiftRef, 80)) return null
+  if (!validCanonicalText(plantOrderScope, 160)) return null
   const current = validateProductionState(state)
   const shiftEntries = current.events
     .filter((event) => event.kind === 'output_recorded' && event.shiftRef === shiftRef)
@@ -2255,6 +2313,78 @@ export function buildProductionShiftHandoff(state: ProductionState, shiftRef: st
         evidenceReference: event.evidenceReference,
       }
     })
+  const controlledOrders: ProductionShiftHandoff['controlledOrders'] = productionOrderPortfolioEntries(current).flatMap(({ jobId, execution }) => {
+    const projection = projectPlantOrder(execution)
+    const plan = projection.plan
+    const job = current.jobs.find((candidate) => candidate.id === jobId)
+    if (!plan || !job || projection.status === 'unplanned') throw new Error(`Controlled shift order ${jobId} is missing its reviewed plan or Production job.`)
+    const nextOperation = projection.operations.find((operation) => operation.status !== 'complete')
+    const bindingCurrent = productionJobPlanSourceDigest(plantOrderScope, job) === plan.sourceDigest
+      && job.product === plan.job.product
+      && job.target - job.output - (job.scrap ?? 0) === plan.job.targetQuantity
+      && !job.qualityHold
+      && !job.closure
+    const disposition = projection.status === 'released_to_stock'
+      ? 'released' as const
+      : projection.status === 'inspection_due' || projection.status === 'quality_hold' || projection.status === 'ready_to_release'
+        ? 'complete_not_released' as const
+        : 'carry_forward' as const
+    const exceptions: string[] = []
+    const blockingReasons: string[] = []
+    if (!bindingCurrent) exceptions.push('The Plant job changed after this controlled plan was reviewed.')
+    if (nextOperation) exceptions.push(`Next operation ${nextOperation.operationId} has ${nextOperation.remainingQuantity} units remaining.`)
+    if (projection.totalOutput > 0 && !projection.latestInspection) exceptions.push('Current controlled output has no inspection.')
+    if (projection.qualityHold) exceptions.push(`Inspection ${projection.qualityHold.inspectionId} retains a quality hold.`)
+    if (projection.status === 'ready_to_release') exceptions.push('Accepted output is waiting for accountable batch release.')
+    if (projection.materialIssues.length > projection.genealogy.length) exceptions.push('Issued material is missing an exact input-lot to output-batch link.')
+    if (projection.status === 'inspection_due') blockingReasons.push('Complete output needs a current inspection before shift close.')
+    if (projection.status === 'quality_hold') blockingReasons.push('A controlled batch quality hold must be resolved before shift close.')
+    if (projection.status === 'ready_to_release') blockingReasons.push('Accepted output needs accountable batch release before shift close.')
+    if (!bindingCurrent) blockingReasons.push('The controlled plan must be reconciled to the current Plant job before shift close.')
+    if (disposition === 'carry_forward' && !job.owner) blockingReasons.push('Carry-forward work needs a responsible owner.')
+    if (disposition === 'carry_forward' && !job.dueAt) blockingReasons.push('Carry-forward work needs a due time.')
+    return [{
+      jobId,
+      product: job.product,
+      planId: plan.planId,
+      planDigest: plan.packageDigest,
+      bindingCurrent,
+      status: projection.status,
+      disposition,
+      targetUnits: plan.job.targetQuantity,
+      outputUnits: projection.totalOutput,
+      acceptedUnits: projection.metrics.acceptedQuantity,
+      completedOperationCount: projection.metrics.completedOperationCount,
+      operationCount: projection.operations.length,
+      genealogyLinkCount: projection.genealogy.length,
+      ...(job.owner ? { owner: job.owner } : {}),
+      ...(job.dueAt ? { dueAt: job.dueAt } : {}),
+      ...(nextOperation ? { nextOperation: {
+        operationId: nextOperation.operationId,
+        name: nextOperation.name,
+        status: nextOperation.status as 'blocked' | 'ready' | 'in_progress',
+        remainingUnits: nextOperation.remainingQuantity,
+      } } : {}),
+      ...(projection.latestInspection ? { inspection: {
+        inspectionId: projection.latestInspection.id,
+        result: projection.latestInspection.result,
+        inspectedUnits: projection.latestInspection.inspectedQuantity,
+        acceptedUnits: projection.latestInspection.acceptedQuantity,
+        rejectedUnits: projection.latestInspection.rejectedQuantity,
+        actionId: projection.latestInspection.proof.actionId,
+        evidenceReference: projection.latestInspection.proof.evidenceReference,
+      } } : {}),
+      ...(projection.batchRelease ? { batchRelease: {
+        releaseId: projection.batchRelease.id,
+        actionId: projection.batchRelease.proof.actionId,
+        releasedAt: projection.batchRelease.proof.capturedAt,
+        releasedBy: projection.batchRelease.proof.actor,
+        evidenceReference: projection.batchRelease.proof.evidenceReference,
+      } } : {}),
+      exceptions,
+      blockingReasons,
+    }]
+  })
   const unfinishedJobs = current.jobs
     .filter((job) => !job.closure && job.output + (job.scrap ?? 0) < job.target)
     .sort(compareProductionJobSchedule)
@@ -2356,6 +2486,7 @@ export function buildProductionShiftHandoff(state: ProductionState, shiftRef: st
   })
   return {
     shiftRef,
+    plantOrderScope,
     sourceRevision: current.revision,
     sourceCanonical: productionCanonical(current),
     shiftOutput: productionShiftOutput(current, shiftRef),
@@ -2363,6 +2494,7 @@ export function buildProductionShiftHandoff(state: ProductionState, shiftRef: st
     materialEntries,
     materialTotals,
     shortCloses,
+    controlledOrders,
     unfinishedJobs,
     activeHolds,
     priorityProblems,
@@ -2403,6 +2535,19 @@ export function formatProductionShiftHandoff(handoff: ProductionShiftHandoff) {
   if (!handoff.shortCloses.length) lines.push('- None')
   for (const entry of handoff.shortCloses) {
     lines.push(`- ${handoffLine(entry.jobId)} · ${handoffLine(entry.product)} · ${entry.goodUnits} good · ${entry.scrapUnits} scrap · ${entry.remainingUnits} not produced · closed ${entry.recordedAt} by ${handoffLine(entry.recordedBy)} · ${handoffLine(entry.reason)} · evidence ${handoffLine(entry.evidenceReference)} · action ${handoffLine(entry.actionId)}`)
+  }
+  lines.push('', `Controlled orders (${handoff.controlledOrders.length})`)
+  if (!handoff.controlledOrders.length) lines.push('- None touched by this shift')
+  for (const order of handoff.controlledOrders) {
+    const owner = order.owner ? `owner ${handoffLine(order.owner)}` : 'owner missing'
+    const due = order.dueAt ? `due ${order.dueAt}` : 'due time missing'
+    lines.push(`- ${handoffLine(order.jobId)} | ${handoffLine(order.product)} | ${order.disposition} | ${order.status} | binding ${order.bindingCurrent ? 'current' : 'stale'} | ${owner} | ${due} | plan ${handoffLine(order.planId)} | digest ${order.planDigest}`)
+    lines.push(`  Operations ${order.completedOperationCount}/${order.operationCount} | output ${order.outputUnits}/${order.targetUnits} | accepted ${order.acceptedUnits} | genealogy ${order.genealogyLinkCount}`)
+    if (order.nextOperation) lines.push(`  Next ${handoffLine(order.nextOperation.operationId)} | ${handoffLine(order.nextOperation.name)} | ${order.nextOperation.status} | ${order.nextOperation.remainingUnits} remaining`)
+    if (order.inspection) lines.push(`  Inspection ${handoffLine(order.inspection.inspectionId)} | ${order.inspection.result} | ${order.inspection.acceptedUnits} accepted | ${order.inspection.rejectedUnits} rejected | evidence ${handoffLine(order.inspection.evidenceReference)} | action ${handoffLine(order.inspection.actionId)}`)
+    if (order.batchRelease) lines.push(`  Release ${handoffLine(order.batchRelease.releaseId)} | ${order.batchRelease.releasedAt} by ${handoffLine(order.batchRelease.releasedBy)} | evidence ${handoffLine(order.batchRelease.evidenceReference)} | action ${handoffLine(order.batchRelease.actionId)}`)
+    for (const exception of order.exceptions) lines.push(`  Exception: ${handoffLine(exception)}`)
+    for (const blocker of order.blockingReasons) lines.push(`  BLOCKED: ${handoffLine(blocker)}`)
   }
   lines.push(
     '',
@@ -2465,7 +2610,7 @@ function shiftCloseSummary(
   return `Closed shift ${shiftRef} with ${goodUnits} good, ${scrapUnits} scrap, ${outputEntryCount} output entries, ${materialEntryCount} material entries`
 }
 
-export function currentProductionShiftClose(state: ProductionState, shiftRef?: string) {
+export function currentProductionShiftCloseEvidence(state: ProductionState, shiftRef?: string, plantOrderScope = 'plant:local-sample') {
   const current = validateProductionState(state)
   const event = current.events[0]
   const closeShiftRef = event?.shiftRef
@@ -2480,7 +2625,7 @@ export function currentProductionShiftClose(state: ProductionState, shiftRef?: s
     events: current.events.slice(1),
   })
   if (`sha256:${sha256Hex(productionCanonical(sourceState))}` !== event.sourceDigest) return null
-  const handoff = buildProductionShiftHandoff(sourceState, closeShiftRef)
+  const handoff = buildProductionShiftHandoff(sourceState, closeShiftRef, plantOrderScope)
   if (!handoff
     || handoff.sourceRevision !== event.sourceRevision
     || handoff.shiftOutput.goodUnits !== event.goodUnits
@@ -2494,8 +2639,13 @@ export function currentProductionShiftClose(state: ProductionState, shiftRef?: s
     || handoff.openQualityIssues.length > 0
     || handoff.priorityProblems.length > 0
     || handoff.activeDowntime.length > 0
-    || handoff.activeMaintenance.length > 0) return null
-  return event
+    || handoff.activeMaintenance.length > 0
+    || handoff.controlledOrders.some((order) => order.blockingReasons.length > 0)) return null
+  return { event, handoff }
+}
+
+export function currentProductionShiftClose(state: ProductionState, shiftRef?: string, plantOrderScope = 'plant:local-sample') {
+  return currentProductionShiftCloseEvidence(state, shiftRef, plantOrderScope)?.event ?? null
 }
 
 export function recordProductionShiftClose(
@@ -2503,7 +2653,7 @@ export function recordProductionShiftClose(
   handoff: ProductionShiftHandoff,
   proof: ProductionActionProof,
 ) {
-  if (!validProof(proof) || !handoff || !validCanonicalText(handoff.shiftRef, 80)) return null
+  if (!validProof(proof) || !handoff || !validCanonicalText(handoff.shiftRef, 80) || !validCanonicalText(handoff.plantOrderScope, 160)) return null
   const current = validateProductionState(state)
   const sourceDigest = productionShiftCloseSourceDigest(handoff)
   const goodUnits = handoff.shiftOutput.goodUnits
@@ -2521,12 +2671,12 @@ export function recordProductionShiftClose(
     && existing.outputEntryCount === outputEntryCount
     && existing.materialEntryCount === materialEntryCount
     && sameProof(existing, proof) ? current : null
-  const expectedHandoff = buildProductionShiftHandoff(current, handoff.shiftRef)
+  const expectedHandoff = buildProductionShiftHandoff(current, handoff.shiftRef, handoff.plantOrderScope)
   if (!expectedHandoff || JSON.stringify(expectedHandoff) !== JSON.stringify(handoff)) return null
   const latestEvent = current.events[0]
   if (actionIdIsUsed(current, proof.actionId)
     || current.revision >= Number.MAX_SAFE_INTEGER
-    || currentProductionShiftClose(current) !== null
+    || currentProductionShiftClose(current, undefined, handoff.plantOrderScope) !== null
     || (latestEvent && timestampBefore(proof.capturedAt, latestEvent.createdAt))
     || (current.orderExecution?.commands.length
       && timestampBefore(proof.capturedAt, current.orderExecution.commands[current.orderExecution.commands.length - 1].payload.proof.capturedAt))
@@ -2539,7 +2689,8 @@ export function recordProductionShiftClose(
     || handoff.openQualityIssues.length > 0
     || handoff.priorityProblems.length > 0
     || handoff.activeDowntime.length > 0
-    || handoff.activeMaintenance.length > 0) return null
+    || handoff.activeMaintenance.length > 0
+    || handoff.controlledOrders.some((order) => order.blockingReasons.length > 0)) return null
   const event = eventFor(proof, {
     kind: 'shift_closed',
     subjectId: handoff.shiftRef,

--- a/tools/verify_app_build.mjs
+++ b/tools/verify_app_build.mjs
@@ -4625,7 +4625,8 @@ if (!shopInventoryUiSource.includes("import { ShopProductionHandoff } from './Sh
   || !coreSource.includes('onIssue={mutateCommerce}')
   || !coreSource.includes('commerceState={relatedCommerce}')
   || !coreSource.includes('const plantOrderScopeWorkspaceId = managedIdentity')
-  || !coreSource.includes('scope={`plant:${plantOrderScopeWorkspaceId}`}')
+  || !coreSource.includes('const plantOrderScope = `plant:${plantOrderScopeWorkspaceId}`')
+  || !coreSource.includes('scope={plantOrderScope}')
   || coreSource.includes("scope={`plant:${managedWorkspaceId ?? managedIdentity?.workspaceId ?? 'local-sample'}`}")
   || !shopProductionHandoffUiSource.includes('Shop remains the only stock authority.')
   || !shopProductionHandoffUiSource.includes('Review the exact stock decrement. Nothing has been written yet.')
@@ -5612,6 +5613,18 @@ if (!productionSource.includes('buildProductionShiftHandoff')
   || !productionSource.includes('openQualityIssues')
   || !productionSource.includes('materialEntries')
   || !productionSource.includes('shortCloses')
+  || !productionSource.includes('controlledOrders')
+  || !productionSource.includes('productionOrderPortfolioEntries(current)')
+  || !productionSource.includes('productionJobPlanSourceDigest(plantOrderScope, job) === plan.sourceDigest')
+  || !productionSource.includes("buildProductionShiftHandoff(state: ProductionState, shiftRef: string, plantOrderScope = 'plant:local-sample')")
+  || !productionSource.includes('currentProductionShiftCloseEvidence')
+  || !productionSource.includes("disposition: 'released' | 'complete_not_released' | 'carry_forward'")
+  || !productionSource.includes('Complete output needs a current inspection before shift close.')
+  || !productionSource.includes('Accepted output needs accountable batch release before shift close.')
+  || !productionSource.includes('The controlled plan must be reconciled to the current Plant job before shift close.')
+  || !productionSource.includes("binding ${order.bindingCurrent ? 'current' : 'stale'}")
+  || !productionSource.includes('Carry-forward work needs a responsible owner.')
+  || !productionSource.includes('handoff.controlledOrders.some((order) => order.blockingReasons.length > 0)')
   || !productionSource.includes('activeDowntime')
   || !productionSource.includes('activeMaintenance')
   || !productionSource.includes("kind: 'shift_closed'")
@@ -5629,11 +5642,19 @@ if (!productionSource.includes('buildProductionShiftHandoff')
   || !coreSource.includes('Prepare shift close file')
   || coreSource.includes('Prepare shift packet')
   || !coreSource.includes('Shift close checklist')
+  || !coreSource.includes('className="plant-shift-close-grid"')
+  || !coreCssSource.includes('.plant-shift-close-grid { min-width: 0; display: grid; grid-template-columns: repeat(3,minmax(0,1fr));')
   || coreSource.includes('AI shift close checklist')
   || !coreSource.includes('Review shift close')
   || !coreSource.includes('Shift closed by')
+  || !coreSource.includes('controlled-order blockers')
+  || !coreSource.includes('<summary>Controlled orders <span>{handoff.controlledOrders.length}</span></summary>')
+  || !coreSource.includes("Binding {order.bindingCurrent ? 'current' : 'stale'}")
+  || !coreSource.includes('every controlled order is released or safely owned forward')
+  || !coreSource.includes('const plantHandoffReady = shiftCloseReady || Boolean(currentShiftClose)')
+  || !coreSource.includes('currentShiftCloseEvidence?.handoff.controlledOrders.length')
   || !coreSource.includes("actorSuggestion: managedIdentity ? undefined : 'Shift supervisor'")
-  || !coreSource.includes('reasonSuggestion: `Output, material trace, quality, and maintenance checks reviewed for ${reviewedHandoff.shiftRef}.`')
+  || !coreSource.includes('reasonSuggestion: `Output, controlled orders, material trace, quality, and maintenance checks reviewed for ${reviewedHandoff.shiftRef}.`')
   || !coreSource.includes('evidenceReferenceSuggestion: `Shift close ${reviewedHandoff.shiftRef} · revision ${reviewedHandoff.sourceRevision}`')
   || !coreSource.includes('reasonSuggestion: `Material use reviewed for ${recordedJobId} during ${recordedShiftRef}.`')
   || !coreSource.includes('evidenceReferenceSuggestion: `Plant shift ${recordedShiftRef} · ${recordedJobId} · ${materialRef}')
@@ -5644,6 +5665,7 @@ if (!productionSource.includes('buildProductionShiftHandoff')
   || !coreSource.includes('Copy close file')
   || coreSource.includes('Copy handoff')
   || !coreSource.includes('shiftHandoff.sourceCanonical === currentProductionCanonical')
+  || !coreSource.includes('shiftHandoff.plantOrderScope === plantOrderScope')
   || !coreSource.includes('shiftHandoff.shiftRef === handoffShiftRef.trim()')
   || !coreSource.includes('Active quality holds')
   || !coreSource.includes('Open quality problems')
@@ -16899,6 +16921,78 @@ async function verifyProductionRuntime() {
     assert(model.recordProductionShiftClose(shiftCloseOutput, outputOnlyHandoff, prematureCloseProof) === null, 'production_shift_close_without_material_succeeded')
     const shiftCloseMaterialProof = proof('ACT-SHIFT-CLOSE-MATERIAL', 3_320)
     const shiftCloseMaterial = model.recordProductionMaterialConsumption(shiftCloseOutput, 'JOB-1', 'RM-CLOSE-01', 'LOT-CLOSE-01', 1, 'kg', shiftRef, shiftCloseMaterialProof)
+    const closeExecutionPlan = plantModel.buildPlantOrderPlan({
+      planId: 'PLN-SHIFT-CLOSE-001', sourceDigest: model.productionJobPlanSourceDigest('plant:local-sample', shiftCloseMaterial.jobs[0]),
+      job: { jobId: 'JOB-1', product: 'Test batch', targetQuantity: 9, outputBatchId: 'BATCH-SHIFT-CLOSE-001' },
+      materials: [{ materialId: 'MAT-CLOSE-001', name: 'Close material', unit: 'kg', quantityPerUnitMilli: 1_000 }],
+      workCentres: [{ workCentreId: 'WC-CLOSE-001', name: 'Close line' }],
+      routing: [{ operationId: 'OP-CLOSE-10', sequence: 1, name: 'Close operation', workCentreId: 'WC-CLOSE-001', minutesPerUnitMilli: 1_000 }],
+    })
+    const closeEmptyExecution = plantModel.createEmptyPlantOrderState()
+    const closeOrderExecution = plantModel.applyPlantOrderPlan(closeEmptyExecution, closeExecutionPlan, proof('ACT-SHIFT-CLOSE-PLAN', 3_321), closeEmptyExecution.headDigest).state
+    const controlledUnownedState = model.validateProductionState({ ...shiftCloseMaterial, orderExecution: closeOrderExecution })
+    const controlledUnownedHandoff = model.buildProductionShiftHandoff(controlledUnownedState, shiftRef)
+    assert(controlledUnownedHandoff?.controlledOrders.length === 1
+      && controlledUnownedHandoff.controlledOrders[0].jobId === 'JOB-1'
+      && controlledUnownedHandoff.controlledOrders[0].planId === closeExecutionPlan.planId
+      && controlledUnownedHandoff.controlledOrders[0].planDigest === closeExecutionPlan.packageDigest
+      && controlledUnownedHandoff.controlledOrders[0].bindingCurrent === true
+      && controlledUnownedHandoff.controlledOrders[0].disposition === 'carry_forward'
+      && controlledUnownedHandoff.controlledOrders[0].nextOperation?.operationId === 'OP-CLOSE-10'
+      && controlledUnownedHandoff.controlledOrders[0].blockingReasons.includes('Carry-forward work needs a responsible owner.')
+      && controlledUnownedHandoff.controlledOrders[0].blockingReasons.includes('Carry-forward work needs a due time.'),
+    'production_shift_close_controlled_order_evidence_missing')
+    const wrongScopeHandoff = model.buildProductionShiftHandoff(controlledUnownedState, shiftRef, 'plant:wrong-workspace')
+    assert(wrongScopeHandoff?.controlledOrders[0].bindingCurrent === false
+      && wrongScopeHandoff.controlledOrders[0].blockingReasons.includes('The controlled plan must be reconciled to the current Plant job before shift close.'),
+    'production_shift_close_wrong_scope_plan_binding_succeeded')
+    assert(model.recordProductionShiftClose(controlledUnownedState, controlledUnownedHandoff, proof('ACT-SHIFT-CLOSE-UNOWNED-CONTROLLED', 3_325)) === null, 'production_shift_close_unowned_controlled_carry_forward_succeeded')
+    const controlledOwnedState = model.validateProductionState({
+      ...controlledUnownedState,
+      jobs: controlledUnownedState.jobs.map((job) => job.id === 'JOB-1' ? { ...job, owner: 'Incoming shift lead', priority: 'urgent', dueAt: '2026-07-24T10:00:00.000Z' } : job),
+    })
+    const controlledOwnedHandoff = model.buildProductionShiftHandoff(controlledOwnedState, shiftRef)
+    assert(controlledOwnedHandoff?.controlledOrders[0].blockingReasons.length === 0
+      && controlledOwnedHandoff.controlledOrders[0].owner === 'Incoming shift lead'
+      && controlledOwnedHandoff.controlledOrders[0].dueAt === '2026-07-24T10:00:00.000Z'
+      && model.formatProductionShiftHandoff(controlledOwnedHandoff).includes(`plan ${closeExecutionPlan.planId}`)
+      && model.formatProductionShiftHandoff(controlledOwnedHandoff).includes(closeExecutionPlan.packageDigest),
+    'production_shift_close_owned_controlled_carry_forward_not_ready')
+    assert(model.recordProductionShiftClose(controlledOwnedState, { ...controlledOwnedHandoff, controlledOrders: [] }, proof('ACT-SHIFT-CLOSE-TAMPERED-CONTROLLED', 3_328)) === null, 'production_shift_close_tampered_controlled_evidence_succeeded')
+    assert(model.recordProductionShiftClose(controlledOwnedState, {
+      ...controlledOwnedHandoff,
+      controlledOrders: controlledOwnedHandoff.controlledOrders.map((order) => ({ ...order, planId: 'PLN-FORGED-FIELD' })),
+    }, proof('ACT-SHIFT-CLOSE-TAMPERED-CONTROLLED-FIELD', 3_328)) === null, 'production_shift_close_tampered_controlled_field_succeeded')
+    const controlledClosed = model.recordProductionShiftClose(controlledOwnedState, controlledOwnedHandoff, proof('ACT-SHIFT-CLOSE-OWNED-CONTROLLED', 3_329))
+    assert(controlledClosed?.events[0].kind === 'shift_closed'
+      && model.currentProductionShiftClose(controlledClosed, shiftRef)?.actionId === 'ACT-SHIFT-CLOSE-OWNED-CONTROLLED',
+    'production_shift_close_owned_controlled_carry_forward_failed')
+    const closedControlledEvidence = model.currentProductionShiftCloseEvidence(controlledClosed, shiftRef)
+    assert(closedControlledEvidence?.handoff.controlledOrders.length === 1
+      && closedControlledEvidence.handoff.controlledOrders[0].planId === closeExecutionPlan.planId
+      && closedControlledEvidence.handoff.controlledOrders[0].planDigest === closeExecutionPlan.packageDigest,
+    'production_shift_close_reload_lost_controlled_evidence')
+    const untouchedControlledJob = { id: 'JOB-2', line: 'Line 02', product: 'Second controlled batch', target: 4, output: 0, owner: 'Line 02 lead', priority: 'normal', dueAt: '2026-07-24T12:00:00.000Z' }
+    const untouchedControlledPlan = plantModel.buildPlantOrderPlan({
+      planId: 'PLN-SHIFT-CLOSE-002', sourceDigest: model.productionJobPlanSourceDigest('plant:local-sample', untouchedControlledJob),
+      job: { jobId: untouchedControlledJob.id, product: untouchedControlledJob.product, targetQuantity: 4, outputBatchId: 'BATCH-SHIFT-CLOSE-002' },
+      materials: [{ materialId: 'MAT-CLOSE-002', name: 'Second material', unit: 'kg', quantityPerUnitMilli: 1_000 }],
+      workCentres: [{ workCentreId: 'WC-CLOSE-002', name: 'Second line' }],
+      routing: [{ operationId: 'OP-CLOSE-20', sequence: 1, name: 'Second operation', workCentreId: 'WC-CLOSE-002', minutesPerUnitMilli: 1_000 }],
+    })
+    const untouchedControlledExecution = plantModel.applyPlantOrderPlan(plantModel.createEmptyPlantOrderState(), untouchedControlledPlan, proof('ACT-SHIFT-CLOSE-PLAN-002', 3_322), plantModel.createEmptyPlantOrderState().headDigest).state
+    const untouchedControlledState = model.validateProductionState({ ...shiftCloseMaterial, jobs: [...shiftCloseMaterial.jobs, untouchedControlledJob], orderExecution: untouchedControlledExecution })
+    const untouchedControlledHandoff = model.buildProductionShiftHandoff(untouchedControlledState, shiftRef)
+    assert(untouchedControlledHandoff?.controlledOrders.some((order) => order.jobId === untouchedControlledJob.id)
+      && !untouchedControlledHandoff.shiftEntries.some((entry) => entry.jobId === untouchedControlledJob.id)
+      && !untouchedControlledHandoff.materialEntries.some((entry) => entry.jobId === untouchedControlledJob.id),
+    'production_shift_close_omitted_controlled_execution_without_top_level_shift_event')
+    const staleControlledState = model.validateProductionState({ ...shiftCloseMaterial, orderExecution })
+    const staleControlledHandoff = model.buildProductionShiftHandoff(staleControlledState, shiftRef)
+    assert(staleControlledHandoff?.controlledOrders[0].bindingCurrent === false
+      && staleControlledHandoff.controlledOrders[0].blockingReasons.includes('The controlled plan must be reconciled to the current Plant job before shift close.')
+      && model.recordProductionShiftClose(staleControlledState, staleControlledHandoff, proof('ACT-SHIFT-CLOSE-STALE-CONTROLLED', 3_329)) === null,
+    'production_shift_close_stale_controlled_binding_succeeded')
     const closeHandoff = model.buildProductionShiftHandoff(shiftCloseMaterial, shiftRef)
     const shiftCloseProof = proof('ACT-SHIFT-CLOSE', 3_330)
     const closedShift = model.recordProductionShiftClose(shiftCloseMaterial, closeHandoff, shiftCloseProof)
@@ -16951,7 +17045,7 @@ async function verifyProductionRuntime() {
     assert(model.currentProductionShiftClose(forgedHeldClose, shiftRef) === null, 'production_shift_close_forged_blocked_source_remained_current')
     const shiftCloseDowntime = model.startProductionDowntime(shiftCloseMaterial, 'MC-1', proof('ACT-SHIFT-CLOSE-DOWNTIME', 3_350))
     assert(model.recordProductionShiftClose(shiftCloseDowntime, model.buildProductionShiftHandoff(shiftCloseDowntime, shiftRef), proof('ACT-SHIFT-CLOSE-WCM', 3_360)) === null, 'production_shift_close_with_open_wcm_succeeded')
-    productionRuntimeChecks += 18
+    productionRuntimeChecks += 28
 
     let machineState = resolved
     const observedStates = ['attention', 'stopped', 'attention', 'running', 'stopped', 'running']


### PR DESCRIPTION
Implements a bounded Plant product workflow: shift close now classifies every controlled order, validates the exact reviewed job snapshot and workspace scope, exposes operation/inspection/release/genealogy evidence, blocks stale or unowned work, keeps cost and release readiness consistent, and reconstructs the evidence after reload.\n\nVerification: npm run app:verify; desktop/mobile Playwright QA at 1365x900 and 390x844 with zero overflow and zero console warnings/errors.\n\nNo deploy, pricing, DNS, database, managed activation, customer data, equipment command, inventory posting, or external business action.