### PR TITLE
kernel: isolate tenant cache from authority data

### DIFF
--- a/kernel/README.md
+++ b/kernel/README.md
@@ -47,6 +47,13 @@ company-wide UTC-day cost bound before provider I/O. Concurrent calls and retrie
 atomic budget; provider failures remain conservatively charged, while cache hits consume no new
 reservation. Hosted runtimes fail closed when the durable reservation store is unavailable.
 
+The response cache is not an authority store. Sign-in codes, operator sessions, missions, work
+orders, customer reviews, and internal evaluations use versioned `supermega_control_records` rows
+with tenant metadata plus append-only `supermega_control_transitions` evidence. Compatibility calls
+route only fixed control-key prefixes to that store; matching legacy rows in `supermega_ai_cache`
+are never read as authority. Apply `supabase/control-records-migration.sql` only after review. Its
+rollback fixture refuses to drop non-empty authority or transition tables.
+
 ## Workcells
 
 Workcells are the unit of recurring client value above connectors. Their tool plan is declared in
@@ -148,7 +155,7 @@ the `running` state plus the first dispatch timestamp through the same atomic tr
 cancellation, so only dispatch or cancellation can win and storage failure blocks model spend.
 A concurrent or lost-response retry hits
 the cycle runner's durable claim and either returns the saved result or reports the existing run.
-Queued evidence remains inside the service-role-only cache record until an explicit dispatch or
+Queued evidence remains inside the service-role-only control record until an explicit dispatch or
 cancel decision. Terminal dispatch and cancellation both scrub the raw input while preserving its
 fingerprints.
 Operator-recorded customer reviews are explicitly `operator_recorded_customer_review` with

--- a/kernel/agent-company-store-transition.test.mjs
+++ b/kernel/agent-company-store-transition.test.mjs
@@ -161,3 +161,114 @@ test('cache control-record listing is prefix-bounded, tenant-filtered, and repor
     restoreEnvironment(saved)
   }
 })
+
+test('authority-bearing compatibility keys use the control store and never the response cache', async () => {
+  const saved = captureEnvironment()
+  const originalFetch = globalThis.fetch
+  const planHash = 'b'.repeat(64)
+  const key = `company-work-order-record:company-order:${'1'.repeat(40)}`
+  const planned = {
+    version: 1,
+    workOrderId: `company-order:${'1'.repeat(40)}`,
+    clientId: 'client-acme',
+    status: 'planned',
+    planHash,
+    input: { private: true },
+  }
+  try {
+    for (const name of STORE_ENV) delete process.env[name]
+    const memoryStore = await import(`./store.mjs?agent-company-control-memory=${Date.now()}`)
+    assert.equal(await memoryStore.putResponseCache(key, planned), null)
+    assert.equal(await memoryStore.getResponseCache(key), null)
+    assert.equal(await memoryStore.putCachedResponse(key, planned), true)
+    assert.deepEqual(await memoryStore.getCachedResponse(key), planned)
+    assert.equal(await memoryStore.getResponseCache(key), null)
+
+    const listed = await memoryStore.listCachedResponseRecords({
+      prefix: 'company-work-order-record:',
+      clientId: 'client-acme',
+      status: 'planned',
+      limit: 10,
+    })
+    assert.equal(listed.durable, false)
+    assert.deepEqual(listed.records.map((record) => record.key), [key])
+
+    const running = { ...planned, status: 'running' }
+    assert.deepEqual(
+      await memoryStore.transitionCachedResponse(key, { status: 'planned', planHash }, running),
+      { updated: true, durable: false },
+    )
+    assert.deepEqual(await memoryStore.getControlRecord(key), running)
+    assert.deepEqual(
+      await memoryStore.transitionCachedResponse(key, { status: 'planned', planHash }, planned),
+      { updated: false, durable: false, reason: 'transition_conflict' },
+    )
+    assert.equal(await memoryStore.putCachedResponse(key, { ...running, clientId: 'client-other' }), null)
+
+    process.env.SUPABASE_URL = 'https://project.supabase.co'
+    process.env.SUPABASE_SERVICE_ROLE_KEY = 'test-service-role'
+    const requests = []
+    globalThis.fetch = async (url, init) => {
+      const request = { url: String(url), init }
+      requests.push(request)
+      if (request.url.includes('/rpc/supermega_put_control_record')) {
+        return { ok: true, status: 200, json: async () => [{ updated: true, version: 1 }], text: async () => '' }
+      }
+      if (request.url.includes('/rpc/supermega_transition_control_record')) {
+        return { ok: true, status: 200, json: async () => [{ updated: true, version: 2 }], text: async () => '' }
+      }
+      if (request.url.includes('supermega_control_records?record_key=')) {
+        return { ok: true, status: 200, json: async () => [{ payload: planned }], text: async () => '' }
+      }
+      if (request.url.includes('supermega_control_records?record_type=')) {
+        return { ok: true, status: 200, json: async () => [{ record_key: key, payload: planned }], text: async () => '' }
+      }
+      return { ok: true, status: 200, json: async () => [{ payload: { status: 'malicious-cache-row' } }], text: async () => '' }
+    }
+    const supabaseStore = await import(`./store.mjs?agent-company-control-supabase=${Date.now()}`)
+    assert.equal(await supabaseStore.putCachedResponse(key, planned), true)
+    assert.deepEqual(await supabaseStore.getCachedResponse(key), planned)
+    const remoteList = await supabaseStore.listCachedResponseRecords({
+      prefix: 'company-work-order-record:',
+      clientId: 'client-acme',
+      status: 'planned',
+      limit: 10,
+    })
+    assert.equal(remoteList.durable, true)
+    assert.equal(remoteList.records[0].key, key)
+    assert.deepEqual(
+      await supabaseStore.transitionCachedResponse(key, { status: 'planned', planHash }, running),
+      { updated: true, durable: true },
+    )
+    assert.equal(requests.some((request) => request.url.includes('supermega_ai_cache')), false)
+    assert.match(requests[0].url, /rpc\/supermega_put_control_record/)
+    assert.match(requests[1].url, /supermega_control_records\?record_key=/)
+    assert.match(requests[2].url, /supermega_control_records\?record_type=eq\.work_order/)
+    assert.match(requests[2].url, /tenant_id=eq\.client-acme/)
+    assert.match(requests[3].url, /rpc\/supermega_transition_control_record/)
+  } finally {
+    globalThis.fetch = originalFetch
+    restoreEnvironment(saved)
+  }
+})
+
+test('control-record migration is service-only, append-only, cache-inert, and rollback is fail-closed', () => {
+  const migration = readFileSync(new URL('./supabase/control-records-migration.sql', import.meta.url), 'utf8')
+  const rollback = readFileSync(new URL('./supabase/control-records-rollback.sql', import.meta.url), 'utf8')
+  const store = readFileSync(new URL('./store.mjs', import.meta.url), 'utf8')
+
+  assert.match(migration, /create table if not exists public\.supermega_control_records/)
+  assert.match(migration, /create table if not exists public\.supermega_control_transitions/)
+  assert.match(migration, /create unique index if not exists supermega_control_transitions_record_version_uidx/)
+  assert.match(migration, /before update or delete on public\.supermega_control_transitions/)
+  assert.match(migration, /security definer\s+set search_path = ''/)
+  assert.match(migration, /revoke all on public\.supermega_control_records from public, anon, authenticated, service_role/)
+  assert.match(migration, /grant select on public\.supermega_control_records to service_role/)
+  assert.match(migration, /grant execute on function public\.supermega_transition_control_record/)
+  assert.doesNotMatch(migration, /insert\s+into\s+public\.supermega_control_records[^;]*select[^;]*supermega_ai_cache/i)
+  assert.match(rollback, /control_records_require_explicit_reconciliation_before_rollback/)
+  assert.match(rollback, /control_transition_history_requires_explicit_reconciliation_before_rollback/)
+  assert.match(rollback, /drop table if exists public\.supermega_control_transitions/)
+  assert.match(store, /controlRecordType\(cacheKey\) \? getControlRecord\(cacheKey\) : getResponseCache\(cacheKey\)/)
+  assert.match(store, /old cache row with the same key is inert/)
+})

--- a/kernel/gateway.cache-isolation.test.mjs
+++ b/kernel/gateway.cache-isolation.test.mjs
@@ -1,0 +1,166 @@
+// Tenant-safe response-cache containment. Runs fully offline with the memory store and stubbed providers.
+import { test, after } from 'node:test'
+import assert from 'node:assert/strict'
+
+const DATABASE_ENV = [
+  'SUPABASE_URL',
+  'SUPABASE_SERVICE_ROLE_KEY',
+  'SUPABASE_SERVICE_KEY',
+  'POSTGRES_URL_NON_POOLING',
+  'POSTGRES_URL',
+  'DATABASE_URL_UNPOOLED',
+  'POSTGRES_PRISMA_URL',
+  'SUPERMEGA_DATABASE_URL',
+  'DATABASE_URL',
+]
+for (const key of DATABASE_ENV) delete process.env[key]
+process.env.SUPERMEGA_GATEWAY_PERSIST = '1'
+process.env.ANTHROPIC_API_KEY = 'sk-ant-test-not-a-real-key'
+delete process.env.CLAUDE_API_KEY
+delete process.env.OPENROUTER_API_KEY
+
+const { complete } = await import('./gateway.mjs')
+const store = (await import('./store.mjs')).default
+assert.equal(store.mode, 'memory', 'cache-isolation tests must never touch a real database')
+
+const realFetch = globalThis.fetch
+const wireCalls = []
+globalThis.fetch = async (url, opts = {}) => {
+  const body = JSON.parse(opts.body)
+  wireCalls.push({ url: String(url), body })
+  if (String(url).includes('openrouter.ai')) {
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({
+        choices: [{ message: body.tools
+          ? { tool_calls: [{ function: { arguments: JSON.stringify({ value: 'openrouter' }) } }] }
+          : { content: `openrouter-${wireCalls.length}` } }],
+        usage: { prompt_tokens: 7, completion_tokens: 3 },
+      }),
+      text: async () => '',
+    }
+  }
+  return {
+    ok: true,
+    status: 200,
+    json: async () => ({
+      content: body.tools
+        ? [{ type: 'tool_use', name: 'emit', input: { value: 'anthropic' } }]
+        : [{ type: 'text', text: `anthropic-${wireCalls.length}` }],
+      usage: { input_tokens: 7, output_tokens: 3 },
+    }),
+    text: async () => '',
+  }
+}
+
+after(() => { globalThis.fetch = realFetch })
+
+const ask = (content, options = {}) => complete({
+  system: 'cache-isolation-test',
+  messages: [{ role: 'user', content }],
+  ...options,
+})
+
+test('same explicit hint cannot collide across tenants', async () => {
+  const before = wireCalls.length
+  const first = await ask('same request', { clientId: 'tenant-cache-a', cacheKey: 'shared-hint' })
+  const second = await ask('same request', { clientId: 'tenant-cache-b', cacheKey: 'shared-hint' })
+
+  assert.equal(wireCalls.length - before, 2, 'each tenant must execute its own provider call')
+  assert.notEqual(first.text, second.text)
+  assert.notEqual(second.cached, true)
+})
+
+test('explicit hint cannot bypass request identity', async () => {
+  const before = wireCalls.length
+  const first = await ask('request alpha', { clientId: 'tenant-explicit-bypass', cacheKey: 'same-hint' })
+  const second = await ask('request beta', { clientId: 'tenant-explicit-bypass', cacheKey: 'same-hint' })
+
+  assert.equal(wireCalls.length - before, 2, 'different requests must not alias through one explicit hint')
+  assert.notEqual(first.text, second.text)
+  assert.notEqual(second.cached, true)
+})
+
+test('reserved control-record prefixes are rejected case-insensitively', async () => {
+  const before = wireCalls.length
+  for (const cacheKey of [
+    'company-work-order-record:customer-controlled',
+    ' AGENT-COMPANY-SIGN-IN-CODE:customer-controlled ',
+    'company-mission-record:customer-controlled',
+  ]) {
+    await assert.rejects(
+      () => ask('reserved prefix', { clientId: 'tenant-reserved-prefix', cacheKey }),
+      /gateway_reserved_cache_key/,
+    )
+  }
+  assert.equal(wireCalls.length, before, 'reserved hints must fail before provider execution')
+})
+
+test('identical same-tenant context produces a deterministic cache hit', async () => {
+  const before = wireCalls.length
+  const options = { clientId: 'tenant-deterministic-hit', cacheKey: 'stable-hint', tier: 'bulk' }
+  const first = await ask('deterministic request', options)
+  const second = await ask('deterministic request', options)
+
+  assert.equal(wireCalls.length - before, 1)
+  assert.equal(first.cached, undefined)
+  assert.equal(second.cached, true)
+  assert.equal(second.text, first.text)
+})
+
+test('persistent response-cache keys contain only a versioned SHA-256 digest', async () => {
+  const persistedKeys = []
+  const originalPut = store.putCachedResponse
+  store.putCachedResponse = async (key, payload) => {
+    persistedKeys.push(key)
+    return originalPut(key, payload)
+  }
+  try {
+    await ask('raw request material must be hashed', {
+      clientId: 'tenant-raw-material-must-not-leak',
+      cacheKey: 'raw-caller-hint-must-not-leak',
+    })
+  } finally {
+    store.putCachedResponse = originalPut
+  }
+
+  assert.equal(persistedKeys.length, 1)
+  assert.match(persistedKeys[0], /^ai-response:v2:[a-f0-9]{64}$/)
+  assert.doesNotMatch(persistedKeys[0], /tenant|caller|request/i)
+})
+
+test('full schema content participates in cache identity', async () => {
+  const before = wireCalls.length
+  const common = { clientId: 'tenant-schema-context', cacheKey: 'schema-hint' }
+  const stringSchema = { title: 'SameTitle', type: 'object', properties: { value: { type: 'string' } }, required: ['value'] }
+  const integerSchema = { title: 'SameTitle', type: 'object', properties: { value: { type: 'integer' } }, required: ['value'] }
+
+  await ask('schema request', { ...common, schema: stringSchema })
+  const second = await ask('schema request', { ...common, schema: integerSchema })
+
+  assert.equal(wireCalls.length - before, 2, 'schemas with the same title but different contracts must not collide')
+  assert.notEqual(second.cached, true)
+})
+
+test('provider and model route participate in cache identity', async () => {
+  const before = wireCalls.length
+  const options = { clientId: 'tenant-route-context', cacheKey: 'route-hint', tier: 'bulk' }
+  const anthropic = await ask('route request', options)
+
+  delete process.env.ANTHROPIC_API_KEY
+  process.env.OPENROUTER_API_KEY = 'sk-or-test-not-a-real-key'
+  try {
+    const openrouter = await ask('route request', options)
+    const openrouterHit = await ask('route request', options)
+    assert.equal(wireCalls.length - before, 2, 'changing provider/model must miss once, then hit its own cache')
+    assert.equal(anthropic.provider, 'anthropic')
+    assert.equal(openrouter.provider, 'openrouter')
+    assert.equal(openrouter.cached, undefined)
+    assert.equal(openrouterHit.cached, true)
+    assert.equal(openrouterHit.text, openrouter.text)
+  } finally {
+    process.env.ANTHROPIC_API_KEY = 'sk-ant-test-not-a-real-key'
+    delete process.env.OPENROUTER_API_KEY
+  }
+})

--- a/kernel/gateway.mjs
+++ b/kernel/gateway.mjs
@@ -5,7 +5,7 @@
 // ONE file, not every caller. Every build agent, the Deal Desk, and the per-client operator
 // call complete() — never the Anthropic SDK directly.
 
-import { randomUUID } from 'node:crypto'
+import { createHash, randomUUID } from 'node:crypto'
 
 const API_URL = 'https://api.anthropic.com/v1/messages'
 const API_VERSION = '2023-06-01'
@@ -29,8 +29,34 @@ const FALLBACK = { deep: 'reason', reason: 'bulk', bulk: null }
 // span every instance. The store is imported lazily so memory-mode/dev with no deps still works.
 const ledger = new Map() // clientId -> { inTokens, outTokens, calls } (this instance, current process life)
 const cache = new Map() // cacheKey -> { ...out, _exp }
+const localSpendReservations = new Map() // reservationId -> fail-closed dispatch state
+const localSpendCaps = new Map() // tenant::window -> immutable server-owned cap
 const CACHE_TTL_MS = Number(process.env.SUPERMEGA_AI_CACHE_TTL_MS || 3_600_000) // 1h default; keys are tenant-scoped
-const DEFAULT_CAP_TOKENS = Number(process.env.SUPERMEGA_CLIENT_TOKEN_CAP || 150_000) // P0: free-tier cap (was 2M — 2M/mo kills margin at scale)
+const SPEND_RESERVATION_TTL_MS = Math.max(60_000, Number(process.env.SUPERMEGA_SPEND_RESERVATION_TTL_MS) || 900_000)
+const MAX_PROVIDER_REQUEST_BYTES = Math.min(262_144, Math.max(4_096, Number(process.env.SUPERMEGA_MAX_PROVIDER_REQUEST_BYTES) || 131_072))
+const PROVIDER_FRAMING_TOKEN_ALLOWANCE = 4_096
+const REQUIRE_DURABLE_SPEND = process.env.SUPERMEGA_REQUIRE_DURABLE_SPEND === undefined
+  ? process.env.NODE_ENV === 'production' || Boolean(process.env.VERCEL)
+  : String(process.env.SUPERMEGA_REQUIRE_DURABLE_SPEND) === '1'
+const RESPONSE_CACHE_PREFIX = 'ai-response:v2:'
+const RESPONSE_CACHE_POLICY_VERSION = 'gateway-policy:v1'
+const RESERVED_CONTROL_CACHE_PREFIXES = [
+  'agent-company:',
+  'agent-company-sign-in-code:',
+  'agent-company-operator-session:',
+  'company-mission-record:',
+  'company-work-order-record:',
+  'company-work-order-review-record:',
+  'company-work-order-evaluation:',
+  'ceo-outcome-operation:',
+  'ceo-outcome-evaluation:',
+  'ceo-outcome-delivery:',
+  'ceo-outcome-action:',
+]
+const PLATFORM_TENANT_ID = 'supermega-platform'
+const PLATFORM_PLAN = 'platform' // server-owned internal plan: requested tier honored, cap still enforced
+const configuredDefaultCap = Number(process.env.SUPERMEGA_CLIENT_TOKEN_CAP || 150_000)
+const DEFAULT_CAP_TOKENS = Number.isSafeInteger(configuredDefaultCap) && configuredDefaultCap > 0 ? configuredDefaultCap : 150_000
 
 // Company-wide admission budget. Every provider attempt reserves a conservative upper-bound before
 // network I/O, so concurrent tenants and retries cannot race past the daily ceiling. The environment
@@ -99,16 +125,21 @@ export async function resolvePlan(clientId) {
   return plan
 }
 
-// Pure policy: the tier + cap a tenant on `plan` actually gets, given what the caller asked for.
-// Free tenants are FORCED to bulk and caller-supplied capTokens overrides are rejected (the
-// default cap stands) — otherwise any client could hand itself Sonnet and an unlimited budget.
-// Paid plans keep their requested tier and may override the cap.
+// Pure policy: the tier and server-configured cap a tenant on `plan` actually gets. Requests cannot
+// raise or replace their own budget.
+function configuredPlanCap(plan) {
+  const envName = `SUPERMEGA_PLAN_CAP_${String(plan || FREE_PLAN).toUpperCase().replace(/[^A-Z0-9]/g, '_')}`
+  const configured = Number(process.env[envName])
+  return Number.isSafeInteger(configured) && configured > 0 ? configured : DEFAULT_CAP_TOKENS
+}
+
 export function policyFor(plan, { tier, capTokens } = {}) {
   const requested = tier && TIERS[tier] ? tier : 'reason'
   if (!plan || String(plan).toLowerCase() === FREE_PLAN) {
     return { plan: FREE_PLAN, tier: 'bulk', cap: DEFAULT_CAP_TOKENS, overridesRejected: Boolean((tier && tier !== 'bulk') || capTokens) }
   }
-  return { plan: String(plan).toLowerCase(), tier: requested, cap: Number(capTokens || DEFAULT_CAP_TOKENS), overridesRejected: false }
+  const normalizedPlan = String(plan).toLowerCase()
+  return { plan: normalizedPlan, tier: requested, cap: configuredPlanCap(normalizedPlan), overridesRejected: capTokens !== undefined }
 }
 
 // Persistent ledger/cache toggle. On by default; set SUPERMEGA_GATEWAY_PERSIST=0 to force pure in-memory.
@@ -192,10 +223,175 @@ function weightedUsageUnits(usage, tier) {
   return Math.max(0, Math.ceil(((Number(usage?.input_tokens) || 0) + (Number(usage?.output_tokens) || 0)) * weight))
 }
 
-function hash(str) {
-  let h = 5381
-  for (let i = 0; i < str.length; i++) h = ((h << 5) + h + str.charCodeAt(i)) | 0
-  return (h >>> 0).toString(36)
+function canonicalJson(value) {
+  const ancestors = new Set()
+  const normalize = (item, inArray = false) => {
+    if (item === null || typeof item === 'string' || typeof item === 'boolean') return item
+    if (typeof item === 'number') return Number.isFinite(item) ? item : null
+    if (typeof item === 'bigint') throw new TypeError('gateway_cache_context_not_json')
+    if (typeof item === 'undefined' || typeof item === 'function' || typeof item === 'symbol') return inArray ? null : undefined
+    if (typeof item?.toJSON === 'function') {
+      if (ancestors.has(item)) throw new TypeError('gateway_cache_context_circular')
+      ancestors.add(item)
+      const serialized = item.toJSON()
+      if (serialized === item) throw new TypeError('gateway_cache_context_circular')
+      const out = normalize(serialized, inArray)
+      ancestors.delete(item)
+      return out
+    }
+    if (ancestors.has(item)) throw new TypeError('gateway_cache_context_circular')
+    ancestors.add(item)
+    const out = Array.isArray(item)
+      ? item.map((entry) => normalize(entry, true))
+      : Object.fromEntries(Object.keys(item).sort().flatMap((key) => {
+        const normalized = normalize(item[key], false)
+        return normalized === undefined ? [] : [[key, normalized]]
+      }))
+    ancestors.delete(item)
+    return out
+  }
+  return JSON.stringify(normalize(value))
+}
+
+function sha256(value) {
+  return createHash('sha256').update(value).digest('hex')
+}
+
+function effectiveMaxTokens(value, tier) {
+  if (value === undefined || value === null) return TIERS[tier].maxTokens
+  const tokens = Number(value)
+  if (!Number.isSafeInteger(tokens) || tokens <= 0 || tokens > TIERS[tier].maxTokens) throw new TypeError('gateway_invalid_max_tokens')
+  return tokens
+}
+
+// Bound the exact provider JSON envelope before dispatch. Twice the UTF-8 bytes plus a fixed framing
+// allowance is intentionally conservative for weighted-token budget enforcement.
+function reservationUnitsFor({ provider, system, messages, schema, tier, maxTokens }) {
+  if (!Array.isArray(messages) || messages.length > 64) throw new TypeError('gateway_invalid_messages')
+  const tierDef = TIERS[tier]
+  const tool = schema ? { name: 'emit', description: 'Return the result in this exact shape.', input_schema: schema } : null
+  const body = provider.name === 'openrouter'
+    ? {
+        model: tierDef.fallbackModel,
+        max_tokens: maxTokens,
+        messages: [...(system ? [{ role: 'system', content: system }] : []), ...messages.map((message) => ({ role: message.role, content: flattenContent(message.content) }))],
+        ...(tool ? { tools: [{ type: 'function', function: { name: 'emit', description: tool.description, parameters: tool.input_schema } }], tool_choice: { type: 'function', function: { name: 'emit' } } } : {}),
+      }
+    : {
+        model: tierDef.model,
+        max_tokens: maxTokens,
+        system,
+        messages,
+        ...(tool ? { tools: [tool], tool_choice: { type: 'tool', name: 'emit' } } : {}),
+      }
+  const requestBytes = Buffer.byteLength(canonicalJson(body), 'utf8')
+  if (requestBytes > MAX_PROVIDER_REQUEST_BYTES) throw new Error('gateway_request_too_large')
+  const inputUpperBound = requestBytes * 2 + PROVIDER_FRAMING_TOKEN_ALLOWANCE
+  const weighted = (inputUpperBound + maxTokens) * (TIER_COST_WEIGHTS[tier] || 1)
+  if (!Number.isSafeInteger(weighted) || weighted <= 0) throw new TypeError('gateway_invalid_reservation_units')
+  return weighted
+}
+
+function activeLocalReserved(clientId, window) {
+  let total = 0
+  for (const reservation of localSpendReservations.values()) {
+    if (reservation.clientId === clientId && reservation.window === window && ['reserved', 'dispatched', 'indeterminate'].includes(reservation.status)) total += reservation.reservedTokens
+  }
+  return total
+}
+
+function reserveLocalSpend({ reservationId, clientId, window, reservedTokens, cap, dispatchToken, context, expiresAt }) {
+  const capKey = `${clientId}::${window}`
+  const pinnedCap = localSpendCaps.get(capKey)
+  if (pinnedCap === undefined) localSpendCaps.set(capKey, cap)
+  else if (pinnedCap !== cap) return { accepted: false, reason: 'cap_mismatch', reservation_id: reservationId, durable: false, spend_total: usageFor(clientId).inTokens + usageFor(clientId).outTokens + activeLocalReserved(clientId, window) }
+  const existing = localSpendReservations.get(reservationId)
+  if (existing) {
+    const sameScope = existing.clientId === clientId && existing.window === window && existing.reservedTokens === reservedTokens && canonicalJson(existing.context || {}) === canonicalJson(context || {})
+    let accepted = false
+    let reason = 'reservation_exists'
+    if (sameScope && existing.status === 'reserved' && existing.dispatchToken === dispatchToken) {
+      accepted = true
+      reason = 'idempotent'
+    } else if (sameScope && existing.status === 'reserved' && Date.parse(existing.expiresAt) <= Date.now()) {
+      localSpendReservations.set(reservationId, { ...existing, dispatchToken, context, expiresAt })
+      accepted = true
+      reason = 'reservation_reclaimed'
+    } else if (sameScope && ['dispatched', 'indeterminate'].includes(existing.status)) reason = 'reconciliation_required'
+    else if (sameScope && existing.status === 'reserved') reason = 'reservation_in_progress'
+    return { accepted, reason, reservation_id: reservationId, status: existing.status, durable: false, spend_total: (usageFor(clientId).inTokens + usageFor(clientId).outTokens + activeLocalReserved(clientId, window)) }
+  }
+  const used = usageFor(clientId)
+  const spendTotal = used.inTokens + used.outTokens + activeLocalReserved(clientId, window)
+  if (cap > 0 && spendTotal + reservedTokens > cap) return { accepted: false, reason: 'cap_reached', reservation_id: reservationId, durable: false, spend_total: spendTotal, in_tokens: used.inTokens, out_tokens: used.outTokens, calls: used.calls }
+  localSpendReservations.set(reservationId, { clientId, window, reservedTokens, dispatchToken, context, expiresAt, status: 'reserved' })
+  return { accepted: true, reason: 'reserved', reservation_id: reservationId, status: 'reserved', durable: false, spend_total: spendTotal + reservedTokens, in_tokens: used.inTokens, out_tokens: used.outTokens, calls: used.calls, reserved_tokens: activeLocalReserved(clientId, window) }
+}
+
+function operationIdentity(value) {
+  if (value === undefined || value === null || value === '') return randomUUID()
+  if (typeof value !== 'string' || !value.trim() || value.trim().length > 160) throw new TypeError('gateway_invalid_operation_id')
+  return value.trim()
+}
+
+function explicitCacheHint(value) {
+  if (value === undefined || value === null || value === '') return ''
+  if (typeof value !== 'string') throw new TypeError('gateway_invalid_cache_key')
+  const hint = value.trim()
+  if (!hint) return ''
+  const normalized = hint.toLowerCase()
+  if (RESERVED_CONTROL_CACHE_PREFIXES.some((prefix) => normalized.startsWith(prefix))) {
+    throw new Error('gateway_reserved_cache_key')
+  }
+  return value
+}
+
+function tenantIdentity(value) {
+  if (value === undefined || value === null || value === '') return PLATFORM_TENANT_ID
+  if (typeof value !== 'string') throw new TypeError('gateway_invalid_client_id')
+  const tenant = value.trim()
+  if (!tenant || tenant.length > 200) throw new TypeError('gateway_invalid_client_id')
+  return tenant
+}
+
+function routeModel(provider, tier) {
+  const tierDef = TIERS[tier]
+  return provider.name === 'openrouter' ? tierDef.fallbackModel : tierDef.model
+}
+
+function responseCacheKey({
+  system,
+  messages,
+  clientId,
+  schema,
+  cacheHint,
+  maxTokens,
+  policy,
+  provider,
+  tier,
+  model,
+}) {
+  const context = {
+    version: 2,
+    tenant: clientId
+      ? { type: typeof clientId, id: clientId }
+      : { type: 'anonymous', id: '' },
+    policy: {
+      version: RESPONSE_CACHE_POLICY_VERSION,
+      plan: policy.plan,
+      requestedTier: policy.requestedTier,
+      effectiveTier: tier,
+    },
+    route: {
+      provider,
+      model,
+      maxTokens: maxTokens || TIERS[tier].maxTokens,
+    },
+    output: { schema: schema ?? null },
+    request: { system: system ?? '', messages: messages ?? [], cacheHint: cacheHint || null },
+    retention: { class: 'ephemeral-response', ttlMs: CACHE_TTL_MS },
+  }
+  return `${RESPONSE_CACHE_PREFIX}${sha256(canonicalJson(context))}`
 }
 
 // Strip assistant/system framing from client-supplied text before it reaches the model.
@@ -211,23 +407,57 @@ export function stripInjectionFrames(text) {
 
 // Ledger units are COST-WEIGHTED (bulk-equivalent) tokens: raw tokens × TIER_COST_WEIGHTS[tier].
 // This makes the monthly cap a spend ceiling — a Sonnet call burns 3x what the same Haiku call would.
-async function recordUsage(clientId, usage, tier) {
-  if (!clientId || !usage) return
+async function recordUsage(clientId, usage, tier, reservation = null) {
+  const usageComplete = usage
+    && Object.prototype.hasOwnProperty.call(usage, 'input_tokens')
+    && Object.prototype.hasOwnProperty.call(usage, 'output_tokens')
+  if (!clientId || !usageComplete) {
+    await markSpendIndeterminate(reservation)
+    return false
+  }
   const w = TIER_COST_WEIGHTS[tier] || 1
-  const inTokens = (usage.input_tokens || 0) * w
-  const outTokens = (usage.output_tokens || 0) * w
-  // Always update the fast in-memory ledger (synchronous source for usageFor()).
+  const rawIn = usage.input_tokens
+  const rawOut = usage.output_tokens
+  if (!Number.isSafeInteger(rawIn) || rawIn < 0 || !Number.isSafeInteger(rawOut) || rawOut < 0) {
+    await markSpendIndeterminate(reservation)
+    return false
+  }
+  const inTokens = rawIn * w
+  const outTokens = rawOut * w
+  if (!Number.isSafeInteger(inTokens) || !Number.isSafeInteger(outTokens)) {
+    await markSpendIndeterminate(reservation)
+    return false
+  }
+  if (reservation?.backend === 'local') {
+    const current = localSpendReservations.get(reservation.id)
+    if (!current || current.dispatchToken !== reservation.dispatchToken || !['dispatched', 'indeterminate'].includes(current.status) || inTokens + outTokens > reservation.reservedTokens) return false
+    localSpendReservations.set(reservation.id, { ...current, status: 'settled', inTokens, outTokens, calls: 1 })
+  } else {
+    // Settle the durable maximum reservation to actual usage. A failed settlement deliberately
+    // leaves the active maximum counted, so another request cannot spend the same capacity.
+    const store = await spine()
+    if (reservation?.backend === 'store' && store?.settleTokenSpend) {
+      let settled = null
+      for (let retry = 0; retry < 3; retry++) {
+        try {
+          settled = await store.settleTokenSpend(reservation.id, { inTokens, outTokens, calls: 1, dispatchToken: reservation.dispatchToken })
+          if (settled?.settled) break
+        } catch { /* retry the same idempotent settlement */ }
+        if (retry < 2) await sleep(25 * (retry + 1))
+      }
+      if (!settled?.settled) {
+        await markSpendIndeterminate(reservation)
+        return false
+      }
+    } else return false
+  }
+  // Update the fast local view only after settlement succeeds.
   const e = ledger.get(clientId) || { inTokens: 0, outTokens: 0, calls: 0 }
   e.inTokens += inTokens
   e.outTokens += outTokens
   e.calls += 1
   ledger.set(clientId, e)
-  // Best-effort persist to the spine so the cap survives cold starts / spans instances.
-  const store = await spine()
-  if (store?.addTokenUsage) {
-    try { await store.addTokenUsage(clientId, currentWindow(), { inTokens, outTokens, calls: 1 }) }
-    catch { /* never break a completed call on a ledger write */ }
-  }
+  return true
 }
 
 // Synchronous, in-memory view (this instance only). Kept for back-compat with existing callers.
@@ -250,10 +480,106 @@ export async function monthlyUsageFor(clientId) {
       const inTokens = Math.max(Number(r.in_tokens) || 0, Number(local.inTokens) || 0)
       const outTokens = Math.max(Number(r.out_tokens) || 0, Number(local.outTokens) || 0)
       const calls = Math.max(Number(r.calls) || 0, Number(local.calls) || 0)
-      return { inTokens, outTokens, calls, total: inTokens + outTokens, window, source: 'spine+local-max' }
+      const reservedTokens = Math.max(Number(r.reserved_tokens) || 0, 0)
+      return { inTokens, outTokens, calls, total: inTokens + outTokens, reservedTokens, spendTotal: inTokens + outTokens + reservedTokens, window, source: 'spine+local-max' }
     } catch { /* fall through to in-memory */ }
   }
-  return { ...local, total: local.inTokens + local.outTokens, window, source: 'memory' }
+  const reservedTokens = activeLocalReserved(clientId, window)
+  return { ...local, total: local.inTokens + local.outTokens, reservedTokens, spendTotal: local.inTokens + local.outTokens + reservedTokens, window, source: 'memory' }
+}
+
+async function reserveSpend({ reservationId, dispatchToken, context, clientId, window, reservedTokens, cap }) {
+  const store = await spine()
+  let result
+  const expiresAt = new Date(Date.now() + SPEND_RESERVATION_TTL_MS).toISOString()
+  try {
+    if (store?.reserveTokenSpend) {
+      result = await store.reserveTokenSpend(reservationId, clientId, window, {
+        reservedTokens,
+        capTokens: cap,
+        expiresAt,
+        dispatchToken,
+        context,
+      })
+    } else if (!PERSIST) {
+      result = reserveLocalSpend({ reservationId, clientId, window, reservedTokens, cap, dispatchToken, context, expiresAt })
+    } else {
+      throw new Error('reservation_store_missing')
+    }
+  } catch (cause) {
+    const error = new Error('gateway_spend_reservation_unavailable', { cause })
+    error.clientId = clientId
+    error.window = window
+    throw error
+  }
+  const reservation = { id: reservationId, dispatchToken, backend: store?.reserveTokenSpend ? 'store' : 'local', durable: Boolean(result?.durable), reservedTokens }
+  if (!result?.accepted) {
+    const message = result?.reason === 'cap_reached'
+      ? 'gateway_client_cap_reached'
+      : result?.reason === 'reconciliation_required'
+        ? 'gateway_spend_reconciliation_required'
+        : result?.reason === 'reservation_in_progress'
+          ? 'gateway_spend_reservation_in_progress'
+          : 'gateway_spend_reservation_rejected'
+    const error = new Error(message)
+    error.clientId = clientId
+    error.used = Number(result?.spend_total) || 0
+    error.cap = cap
+    error.window = window
+    error.reason = result?.reason || 'reservation_rejected'
+    throw error
+  }
+  if (REQUIRE_DURABLE_SPEND && !result.durable) {
+    await releaseSpendReservation(reservation)
+    const error = new Error('gateway_durable_spend_required')
+    error.clientId = clientId
+    error.window = window
+    throw error
+  }
+  return reservation
+}
+
+async function markSpendDispatched(reservation) {
+  if (!reservation) return false
+  if (reservation.backend === 'local') {
+    const current = localSpendReservations.get(reservation.id)
+    if (!current || current.dispatchToken !== reservation.dispatchToken || !['reserved', 'dispatched'].includes(current.status)) return false
+    if (current.status === 'reserved' && Date.parse(current.expiresAt) <= Date.now()) return false
+    if (current.status === 'reserved') localSpendReservations.set(reservation.id, { ...current, status: 'dispatched' })
+    return true
+  }
+  const store = await spine()
+  if (!store?.markTokenSpendDispatched) return false
+  try { return Boolean((await store.markTokenSpendDispatched(reservation.id, reservation.dispatchToken))?.changed) }
+  catch { return false }
+}
+
+async function markSpendIndeterminate(reservation) {
+  if (!reservation) return false
+  if (reservation.backend === 'local') {
+    const current = localSpendReservations.get(reservation.id)
+    if (!current || current.dispatchToken !== reservation.dispatchToken) return false
+    if (current.status === 'dispatched') localSpendReservations.set(reservation.id, { ...current, status: 'indeterminate' })
+    return current.status === 'dispatched' || current.status === 'indeterminate'
+  }
+  const store = await spine()
+  if (!store?.markTokenSpendIndeterminate) return false
+  try { return Boolean((await store.markTokenSpendIndeterminate(reservation.id, reservation.dispatchToken))?.changed) }
+  catch { return false }
+}
+
+async function releaseSpendReservation(reservation, { definitive = false } = {}) {
+  if (!reservation) return false
+  if (reservation.backend === 'local') {
+    const current = localSpendReservations.get(reservation.id)
+    if (!current || current.dispatchToken !== reservation.dispatchToken || current.status === 'indeterminate' || current.status === 'settled' || (current.status === 'dispatched' && !definitive)) return false
+    if (current.status !== 'released') localSpendReservations.set(reservation.id, { ...current, status: 'released' })
+    return true
+  }
+  const store = await spine()
+  if (!store?.releaseTokenSpend) return false
+  try { return Boolean((await store.releaseTokenSpend(reservation.id, { dispatchToken: reservation.dispatchToken, definitive }))?.released) }
+  catch { return false }
 }
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms))
@@ -432,8 +758,10 @@ const OPENROUTER = {
     })
     if (!res.ok) throw providerError('openrouter', res.status, await res.text().catch(() => ''))
     const json = await res.json()
-    const u = json.usage || {}
-    const usage = { input_tokens: u.prompt_tokens || 0, output_tokens: u.completion_tokens || 0 }
+    const u = json.usage
+    const usage = u && Object.prototype.hasOwnProperty.call(u, 'prompt_tokens') && Object.prototype.hasOwnProperty.call(u, 'completion_tokens')
+      ? { input_tokens: u.prompt_tokens, output_tokens: u.completion_tokens }
+      : null
     const msg = json.choices?.[0]?.message || {}
     if (tool) {
       const call = (msg.tool_calls || [])[0]
@@ -457,58 +785,73 @@ export function providerChain() {
  * @param {string}   o.system            system prompt
  * @param {Array}    o.messages          [{role, content}]
  * @param {string}   [o.tier='reason']   'bulk' | 'reason' | 'deep' — a REQUEST, not a right: free-plan tenants are forced to 'bulk' server-side
- * @param {string}   [o.clientId]        tenant id — enables server-side plan resolution + the per-tenant monthly cost cap + logging
+ * @param {string}   [o.clientId]        tenant id; omitted calls use the capped platform tenant
  * @param {object}   [o.schema]          JSON Schema -> forces validated structured output (tool-use)
- * @param {string}   [o.cacheKey]        explicit cache key; else derived from the request
+ * @param {string}   [o.cacheKey]        optional cache hint/salt; it never replaces the tenant-safe derived key
  * @param {number}   [o.maxTokens]       override the tier default
- * @param {number}   [o.capTokens]       override the monthly cap for THIS tenant (else DEFAULT_CAP_TOKENS) — REJECTED for free-plan tenants
+ * @param {number}   [o.capTokens]       deprecated caller override; always rejected
+ * @param {string}   [o.operationId]     stable caller operation id for fail-closed retry identity
  * @param {number}   [o.timeoutMs=45000]
  * @returns {Promise<{text?:string, data?:object, usage:object, model:string, tier:string}>}
  */
 export async function complete(o) {
-  const { system, messages, clientId, schema, maxTokens, timeoutMs = 45_000 } = o
+  const { system, messages, clientId: requestedClientId, schema, maxTokens, timeoutMs = 45_000 } = o
+  const clientId = tenantIdentity(requestedClientId)
+  const operationId = operationIdentity(o.operationId)
+  const operationHash = sha256(`${clientId}\0${operationId}`)
   let tier = o.tier && TIERS[o.tier] ? o.tier : 'reason'
+  let cachePolicy = { plan: 'unscoped', requestedTier: tier }
+  let spendCap = 0
+  let spendWindow = currentWindow()
 
   // Per-tenant monthly cost cap, enforced against the persisted ledger (survives cold starts /
   // spans instances). Over the hard cap → refuse. Over the soft threshold → downgrade to a cheaper
   // tier so the client stays under budget instead of being cut off mid-month.
   // The tenant's PLAN is resolved server-side first: free tenants are forced to the bulk (Haiku)
-  // tier and their capTokens override is rejected — tier/cap are never trusted from the caller.
+  // tier; spend caps come from server configuration, not the request.
   if (clientId) {
-    const plan = await resolvePlan(clientId)
+    // Internal calls without an explicit tenant are charged to the capped platform tenant. The
+    // platform tenant is server-owned: it keeps its requested tier (internal agents legitimately
+    // use reason/deep) but can never raise its server-configured cap.
+    const plan = clientId === PLATFORM_TENANT_ID ? PLATFORM_PLAN : await resolvePlan(clientId)
     const policy = policyFor(plan, { tier: o.tier, capTokens: o.capTokens })
     tier = policy.tier
-    const cap = policy.cap
+    cachePolicy = { plan: policy.plan, requestedTier: o.tier && TIERS[o.tier] ? o.tier : 'reason' }
+    spendCap = policy.cap
     const used = await monthlyUsageFor(clientId)
-    if (cap > 0 && used.total >= cap) {
-      const err = new Error('gateway_client_cap_reached')
-      err.clientId = clientId
-      err.used = used.total
-      err.cap = cap
-      err.window = used.window
-      throw err
-    }
+    spendWindow = used.window
     // Soft downgrade band (default: last 20% of the cap). One step down the tier ladder.
-    const softAt = cap > 0 ? cap * Number(process.env.SUPERMEGA_CLIENT_CAP_SOFT_RATIO || 0.8) : Infinity
-    if (used.total >= softAt && FALLBACK[tier]) tier = FALLBACK[tier]
+    const softAt = spendCap > 0 ? spendCap * Number(process.env.SUPERMEGA_CLIENT_CAP_SOFT_RATIO || 0.8) : Infinity
+    if (used.spendTotal >= softAt && FALLBACK[tier]) tier = FALLBACK[tier]
   }
 
-  // Tenant-scoped (clientId in the key) + TTL-bounded, so tenants never share a cached response and a
-  // stale entry can't live forever.
-  const key = o.cacheKey || hash(JSON.stringify({ system, messages, tier, schema: schema?.title || !!schema, clientId: clientId || '', maxTokens: boundedMaxTokens(maxTokens, tier) }))
+  const requestMaxTokens = effectiveMaxTokens(maxTokens, tier)
+
+  // A caller-supplied cacheKey is only a hashed hint. It can never become the storage key or collide
+  // with control records that currently share the backing table. The full request/schema plus the
+  // resolved tenant policy, provider/model route, and retention policy form the cache identity.
+  const cacheHint = explicitCacheHint(o.cacheKey)
+  const providers = providerChain()
+  if (!providers.length) throw new Error('gateway_missing_api_key')
   const nowMs = Date.now()
   const fresh = (v) => v && (!v._exp || nowMs < v._exp)
   const unwrap = (v) => { const { _exp, ...out } = v; return { ...out, cached: true } }
-  const memHit = cache.get(key)
-  if (fresh(memHit)) return unwrap(memHit)
-  if (memHit) cache.delete(key) // expired
-  // Shared cache: a hit on another instance still saves the spend.
   const store = await spine()
-  if (store?.getCachedResponse) {
-    try {
-      const hit = await store.getCachedResponse(key)
-      if (fresh(hit)) { cache.set(key, hit); return unwrap(hit) }
-    } catch { /* cache is best-effort; fall through to a live call */ }
+  for (const provider of providers) {
+    const key = responseCacheKey({
+      system, messages, clientId, schema, cacheHint, maxTokens: requestMaxTokens, policy: cachePolicy,
+      provider: provider.name, tier, model: routeModel(provider, tier),
+    })
+    const memHit = cache.get(key)
+    if (fresh(memHit)) return unwrap(memHit)
+    if (memHit) cache.delete(key) // expired
+    // Shared cache: a hit on another instance still saves the spend.
+    if (store?.getCachedResponse) {
+      try {
+        const hit = await store.getCachedResponse(key)
+        if (fresh(hit)) { cache.set(key, hit); return unwrap(hit) }
+      } catch { /* cache is best-effort; fall through to a live call */ }
+    }
   }
 
   // Structured output is done via forced tool-use, NOT JSON-from-text.
@@ -518,50 +861,113 @@ export async function complete(o) {
     : null
 
   const startTier = tier
-  const providers = providerChain()
-  if (!providers.length) throw new Error('gateway_missing_api_key')
 
   // Try each provider in turn (local when enabled, then paid failover). Provider-specific retry
   // ceilings apply; paid providers retain backoff and tier fallback while local inference attempts once.
   let lastErr
+  let attemptOrdinal = 0
   for (const provider of providers) {
     let curTier = startTier
     const maxAttempts = provider.maxAttempts || 4
     for (let attempt = 0; attempt < maxAttempts; attempt++) {
       const tierDef = TIERS[curTier]
-      const attemptMaxTokens = boundedMaxTokens(maxTokens, curTier)
-      const reservation = await reserveProviderBudget({
-        system,
-        messages,
-        schema,
-        tier: curTier,
-        maxTokens: attemptMaxTokens,
-        clientId,
-        provider: provider.name,
-      })
+      const attemptMaxTokens = Math.min(requestMaxTokens, tierDef.maxTokens)
+      let spendReservation = null
+      attemptOrdinal += 1
+      if (clientId) {
+        try {
+          const reservationId = `spend:${sha256(`${operationHash}\0${attemptOrdinal}`)}`
+          const dispatchToken = randomUUID()
+          spendReservation = await reserveSpend({
+            reservationId,
+            dispatchToken,
+            context: {
+              operation_hash: operationHash,
+              request_hash: sha256(canonicalJson({ system, messages, schema, maxTokens: attemptMaxTokens })),
+              attempt: attemptOrdinal,
+              provider: provider.name,
+              model: routeModel(provider, curTier),
+              tier: curTier,
+            },
+            clientId,
+            window: spendWindow,
+            reservedTokens: reservationUnitsFor({ provider, system, messages, schema, tier: curTier, maxTokens: attemptMaxTokens }),
+            cap: spendCap,
+          })
+        } catch (error) {
+          if (lastErr && error?.message === 'gateway_client_cap_reached') {
+            const blocked = new Error('gateway_retry_blocked_by_reserved_spend', { cause: lastErr })
+            blocked.clientId = clientId
+            blocked.used = error.used
+            blocked.cap = error.cap
+            blocked.window = error.window
+            throw blocked
+          }
+          throw error
+        }
+      }
+      // Company-wide daily admission budget (fail closed) — reserved AFTER the tenant spend
+      // reservation so a tenant-cap rejection never consumes company budget. If the company
+      // budget refuses this attempt, the still-undispatched tenant reservation is released.
+      let budgetReservation = null
+      try {
+        budgetReservation = await reserveProviderBudget({
+          system,
+          messages,
+          schema,
+          tier: curTier,
+          maxTokens: attemptMaxTokens,
+          clientId,
+          provider: provider.name,
+        })
+      } catch (error) {
+        await releaseSpendReservation(spendReservation, { definitive: true })
+        throw error
+      }
       const controller = new AbortController()
       const timer = setTimeout(() => controller.abort(), timeoutMs)
       try {
+        if (!(await markSpendDispatched(spendReservation))) {
+          await releaseSpendReservation(spendReservation)
+          throw new Error('gateway_dispatch_state_unavailable')
+        }
         const r = await provider.call({ tierDef, system, messages, tool, maxTokens: attemptMaxTokens }, controller.signal)
         clearTimeout(timer)
-        await settleProviderBudget(reservation, 'consumed', weightedUsageUnits(r.usage, curTier))
-        await recordUsage(clientId, r.usage, curTier)
+        await settleProviderBudget(budgetReservation, 'consumed', weightedUsageUnits(r.usage, curTier))
+        budgetReservation = null
+        const spendSettled = await recordUsage(clientId, r.usage, curTier, spendReservation)
         const out = tool
           ? { data: r.data, usage: r.usage, model: r.model, tier: curTier, provider: provider.name }
           : { text: r.text, usage: r.usage, model: r.model, tier: curTier, provider: provider.name }
+        if (!spendSettled) {
+          return { ...out, spend: { status: 'reconciliation_required', reservationId: spendReservation.id } }
+        }
         const cached = { ...out, _exp: Date.now() + CACHE_TTL_MS }
+        const key = responseCacheKey({
+          system, messages, clientId, schema, cacheHint, maxTokens: attemptMaxTokens, policy: cachePolicy,
+          provider: provider.name, tier: curTier, model: r.model,
+        })
         cache.set(key, cached)
         if (store?.putCachedResponse) { try { await store.putCachedResponse(key, cached) } catch { /* best-effort */ } }
         return out
       } catch (err) {
         clearTimeout(timer)
-        await settleProviderBudget(reservation, 'failed', reservation.reservedUnits)
+        // Failed or ambiguous provider attempts stay conservatively charged to the daily company
+        // budget; only a successful call re-prices its reservation down to actual usage.
+        if (budgetReservation) await settleProviderBudget(budgetReservation, 'failed', budgetReservation.reservedUnits)
         lastErr = err
-        if (err.providerUnavailable) break
-        if (err.noKey) break // provider unusable → next provider
-        if (err.status === 401 || err.status === 403) break // this provider's auth is broken → next provider
-        // Other 4xx (bad request) is a request problem — failing over won't help.
-        if (err.status && err.status >= 400 && err.status < 500 && err.status !== 429) throw err
+        if (err.message === 'gateway_dispatch_state_unavailable') throw err
+        if (err.providerUnavailable) { await releaseSpendReservation(spendReservation, { definitive: true }); break } // provider unreachable before acceptance → next provider
+        if (err.noKey) { await releaseSpendReservation(spendReservation, { definitive: true }); break } // no provider dispatch
+        if (err.status === 401 || err.status === 403) { await releaseSpendReservation(spendReservation, { definitive: true }); break }
+        // Only explicit request-rejection statuses release capacity; 408 and unusual 4xx responses
+        // remain indeterminate because an intermediary may already have accepted the work.
+        if ([400, 404, 405, 413, 415, 422].includes(err.status)) {
+          await releaseSpendReservation(spendReservation, { definitive: true })
+          throw err
+        }
+        if (err.status === 429) await releaseSpendReservation(spendReservation, { definitive: true })
+        else await markSpendIndeterminate(spendReservation)
         if (attempt + 1 >= maxAttempts) break
         // Retriable (429 / 5xx / timeout / network): back off with jitter, drop a tier on a later try.
         await sleep(400 * (attempt + 1) ** 2 + Math.floor(Math.random() * 250))

--- a/kernel/gateway.policy.test.mjs
+++ b/kernel/gateway.policy.test.mjs
@@ -7,6 +7,8 @@ import assert from 'node:assert/strict'
 // Force memory-mode store + deterministic cap BEFORE the modules load (both read env at import).
 for (const k of ['SUPABASE_URL', 'SUPABASE_SERVICE_ROLE_KEY', 'SUPABASE_SERVICE_KEY', 'POSTGRES_URL_NON_POOLING', 'POSTGRES_URL', 'DATABASE_URL_UNPOOLED', 'POSTGRES_PRISMA_URL', 'SUPERMEGA_DATABASE_URL', 'DATABASE_URL']) delete process.env[k]
 process.env.SUPERMEGA_CLIENT_TOKEN_CAP = '150000'
+process.env.SUPERMEGA_PLAN_CAP_PRO = '10000000'
+delete process.env.SUPERMEGA_ALLOW_TRUSTED_CAP_OVERRIDE
 process.env.ANTHROPIC_API_KEY = 'sk-ant-test-not-a-real-key'
 delete process.env.CLAUDE_API_KEY
 delete process.env.OPENROUTER_API_KEY
@@ -33,15 +35,25 @@ globalThis.fetch = async (url, opts = {}) => {
 after(() => { globalThis.fetch = realFetch })
 
 const ask = (q, opts = {}) => complete({ system: 'test', messages: [{ role: 'user', content: q }], ...opts })
+let seedCounter = 0
+async function seedCommittedUsage(tenant, amount, cap) {
+  const id = `policy-seed-${++seedCounter}`
+  const dispatchToken = `policy-dispatch-${seedCounter}`
+  await store.reserveTokenSpend(id, tenant, WINDOW, { reservedTokens: amount, capTokens: cap, dispatchToken, expiresAt: new Date(Date.now() + 60_000).toISOString(), context: { test_seed: seedCounter } })
+  await store.markTokenSpendDispatched(id, dispatchToken)
+  const settled = await store.settleTokenSpend(id, { inTokens: amount, outTokens: 0, calls: 1, dispatchToken })
+  assert.equal(settled.settled, true)
+}
 
-test('policyFor: free plan → forced bulk + default cap, overrides rejected (pure)', () => {
+test('policyFor: tier and spend caps are server-owned (pure)', () => {
   const pol = policyFor('free', { tier: 'deep', capTokens: 5_000_000 })
   assert.equal(pol.tier, 'bulk', 'free is forced to the bulk (Haiku) tier')
   assert.equal(pol.cap, CAP, 'caller capTokens is rejected — default cap stands')
   assert.equal(pol.overridesRejected, true)
   const pro = policyFor('pro', { tier: 'deep', capTokens: 5_000_000 })
   assert.equal(pro.tier, 'deep', 'paid plans keep their requested tier')
-  assert.equal(pro.cap, 5_000_000, 'paid plans may override the cap')
+  assert.equal(pro.cap, 10_000_000, 'paid plans use the configured server-side plan cap')
+  assert.equal(pro.overridesRejected, true, 'a request cannot raise or replace its own cap')
 })
 
 test('resolvePlan: unknown tenant / no row → free (fail closed)', async () => {
@@ -60,7 +72,7 @@ test('free tenant gets Haiku regardless of the tier it requests', async () => {
 })
 
 test('free tenant capTokens override is rejected — cap still enforced at the default', async () => {
-  await store.addTokenUsage('tenant-free-capped', WINDOW, { inTokens: CAP, outTokens: 1, calls: 1 })
+  await seedCommittedUsage('tenant-free-capped', CAP, CAP)
   await assert.rejects(
     () => ask('q-free-cap-override', { clientId: 'tenant-free-capped', capTokens: 99_999_999 }),
     /gateway_client_cap_reached/,
@@ -68,14 +80,14 @@ test('free tenant capTokens override is rejected — cap still enforced at the d
   )
 })
 
-test('paid tenant keeps its requested tier and its cap override is honored', async () => {
+test('paid tenant keeps its requested tier while the server plan cap remains authoritative', async () => {
   await store.createClient({ id: 'tenant-pro-a', name: 'Pro tenant A', plan: 'pro' })
   const r = await ask('q-pro-tier', { clientId: 'tenant-pro-a', tier: 'deep' })
   assert.equal(r.tier, 'deep')
   assert.equal(captured.at(-1).model, TIERS.deep.model)
   // over the default cap but under its own override → still served
   await store.createClient({ id: 'tenant-pro-b', name: 'Pro tenant B', plan: 'pro' })
-  await store.addTokenUsage('tenant-pro-b', WINDOW, { inTokens: CAP + 50_000, outTokens: 0, calls: 1 })
+  await seedCommittedUsage('tenant-pro-b', CAP + 50_000, 10_000_000)
   const r2 = await ask('q-pro-cap-override', { clientId: 'tenant-pro-b', tier: 'bulk', capTokens: 10_000_000 })
   assert.equal(r2.text, 'ok')
 })

--- a/kernel/gateway.spend-reservation.test.mjs
+++ b/kernel/gateway.spend-reservation.test.mjs
@@ -1,0 +1,528 @@
+import { test, after } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+
+for (const key of ['SUPABASE_URL', 'SUPABASE_SERVICE_ROLE_KEY', 'SUPABASE_SERVICE_KEY', 'POSTGRES_URL_NON_POOLING', 'POSTGRES_URL', 'DATABASE_URL_UNPOOLED', 'POSTGRES_PRISMA_URL', 'SUPERMEGA_DATABASE_URL', 'DATABASE_URL']) delete process.env[key]
+delete process.env.NODE_ENV
+delete process.env.VERCEL
+process.env.SUPERMEGA_GATEWAY_PERSIST = '1'
+process.env.SUPERMEGA_CLIENT_TOKEN_CAP = '150000'
+process.env.SUPERMEGA_PLAN_CAP_PRO = '8000'
+process.env.ANTHROPIC_API_KEY = 'sk-ant-test-not-real'
+delete process.env.OPENROUTER_API_KEY
+
+const gateway = await import('./gateway.mjs')
+const store = (await import('./store.mjs')).default
+assert.equal(store.mode, 'memory', 'tests must never touch an external database')
+
+const realFetch = globalThis.fetch
+const realRandom = Math.random
+after(() => {
+  globalThis.fetch = realFetch
+  Math.random = realRandom
+})
+
+const WINDOW = `${new Date().getUTCFullYear()}-${String(new Date().getUTCMonth() + 1).padStart(2, '0')}`
+const expiry = () => new Date(Date.now() + 60_000).toISOString()
+const okResponse = (usage = { input_tokens: 10, output_tokens: 5 }) => ({
+  ok: true,
+  status: 200,
+  json: async () => ({ content: [{ type: 'text', text: 'ok' }], usage }),
+  text: async () => '',
+})
+const errorResponse = (status) => ({ ok: false, status, json: async () => ({}), text: async () => `status-${status}` })
+const ask = (tenant, content, extra = {}) => gateway.complete({ clientId: tenant, tier: 'bulk', system: 'test', messages: [{ role: 'user', content }], ...extra })
+let seedCounter = 0
+async function seedCommittedUsage(tenant, amount, cap) {
+  const id = `spend-seed-${++seedCounter}`
+  const dispatchToken = `spend-seed-token-${seedCounter}`
+  await store.reserveTokenSpend(id, tenant, WINDOW, { reservedTokens: amount, capTokens: cap, expiresAt: expiry(), dispatchToken, context: { test_seed: seedCounter } })
+  await store.markTokenSpendDispatched(id, dispatchToken)
+  const settled = await store.settleTokenSpend(id, { inTokens: amount, outTokens: 0, calls: 0, dispatchToken })
+  assert.equal(settled.settled, true)
+}
+
+test('memory store admits only reservations that fit under one tenant cap', async () => {
+  const tenant = 'reservation-concurrency-store'
+  const specs = Array.from({ length: 6 }, (_, index) => ({ id: `store-concurrent-${index}`, token: `dispatch-${index}` }))
+  const attempts = await Promise.all(specs.map(({ id, token }) => store.reserveTokenSpend(
+    id,
+    tenant,
+    WINDOW,
+    { reservedTokens: 25, capTokens: 100, expiresAt: expiry(), dispatchToken: token, context: { test: true } },
+  )))
+  assert.equal(attempts.filter((row) => row.accepted).length, 4)
+  assert.equal((await store.getTokenUsage(tenant, WINDOW)).spend_total, 100)
+  await Promise.all(attempts.map((row, index) => row.accepted ? store.releaseTokenSpend(row.reservation_id, { dispatchToken: specs[index].token }) : null))
+  assert.equal((await store.getTokenUsage(tenant, WINDOW)).reserved_tokens, 0)
+  const mismatch = await store.reserveTokenSpend('store-cap-mismatch', tenant, WINDOW, { reservedTokens: 1, capTokens: 200, expiresAt: expiry(), dispatchToken: 'dispatch-mismatch' })
+  assert.equal(mismatch.reason, 'cap_mismatch', 'the first server-owned monthly cap remains authoritative')
+  assert.equal((await store.getTokenUsage(tenant, WINDOW)).cap_tokens, 100)
+})
+
+test('settlement and release are idempotent and settlement replaces the reservation with actual usage', async () => {
+  const tenant = 'reservation-lifecycle-store'
+  const id = 'store-lifecycle-1'
+  const token = 'dispatch-lifecycle-1'
+  assert.equal((await store.reserveTokenSpend(id, tenant, WINDOW, { reservedTokens: 100, capTokens: 500, expiresAt: expiry(), dispatchToken: token })).accepted, true)
+  assert.equal((await store.settleTokenSpend(id, { inTokens: 1, outTokens: 1, calls: 1, dispatchToken: token })).reason, 'reservation_not_dispatched')
+  assert.equal((await store.markTokenSpendDispatched(id, token)).changed, true)
+  const first = await store.settleTokenSpend(id, { inTokens: 20, outTokens: 5, calls: 1, dispatchToken: token })
+  const replay = await store.settleTokenSpend(id, { inTokens: 20, outTokens: 5, calls: 1, dispatchToken: token })
+  assert.equal(first.settled, true)
+  assert.equal(replay.reason, 'idempotent')
+  assert.equal((await store.settleTokenSpend(id, { inTokens: 21, outTokens: 5, calls: 1, dispatchToken: token })).reason, 'settlement_conflict')
+  const usage = await store.getTokenUsage(tenant, WINDOW)
+  assert.equal(usage.committed_tokens, 25)
+  assert.equal(usage.reserved_tokens, 0)
+  assert.equal(usage.calls, 1)
+  assert.equal((await store.releaseTokenSpend(id, { dispatchToken: token })).reason, 'reservation_settled')
+
+  const releasedId = 'store-lifecycle-release'
+  const releasedToken = 'dispatch-release'
+  await store.reserveTokenSpend(releasedId, tenant, WINDOW, { reservedTokens: 50, capTokens: 500, expiresAt: expiry(), dispatchToken: releasedToken })
+  assert.equal((await store.releaseTokenSpend(releasedId, { dispatchToken: releasedToken })).released, true)
+  assert.equal((await store.releaseTokenSpend(releasedId, { dispatchToken: releasedToken })).reason, 'idempotent')
+  assert.equal((await store.settleTokenSpend(releasedId, { inTokens: 1, outTokens: 1, calls: 1, dispatchToken: releasedToken })).reason, 'reservation_released')
+
+  const undersizedId = 'store-lifecycle-undersized'
+  const undersizedToken = 'dispatch-undersized'
+  await store.reserveTokenSpend(undersizedId, tenant, WINDOW, { reservedTokens: 10, capTokens: 500, expiresAt: expiry(), dispatchToken: undersizedToken })
+  await store.markTokenSpendDispatched(undersizedId, undersizedToken)
+  const over = await store.settleTokenSpend(undersizedId, { inTokens: 11, outTokens: 0, calls: 1, dispatchToken: undersizedToken })
+  assert.equal(over.reason, 'actual_exceeds_reservation')
+  assert.equal((await store.getTokenUsage(tenant, WINDOW)).reserved_tokens, 10, 'an undersized reservation remains fail-closed')
+  await store.markTokenSpendIndeterminate(undersizedId, undersizedToken)
+  assert.equal((await store.releaseTokenSpend(undersizedId, { dispatchToken: undersizedToken, definitive: true })).reason, 'reservation_indeterminate')
+  const releaseProof = 'a'.repeat(64)
+  assert.equal((await store.reconcileTokenSpend(undersizedId, { action: 'release', actor: 'test-operator', evidenceHash: releaseProof })).reconciled, true)
+  assert.equal((await store.reconcileTokenSpend(undersizedId, { action: 'release', actor: 'test-operator', evidenceHash: releaseProof })).reason, 'idempotent')
+  assert.equal((await store.reconcileTokenSpend(undersizedId, { action: 'release', actor: 'test-operator', evidenceHash: 'b'.repeat(64) })).reason, 'reconciliation_conflict')
+
+  const reconcileSettleId = 'store-lifecycle-reconcile-settle'
+  const reconcileSettleToken = 'dispatch-reconcile-settle'
+  await store.reserveTokenSpend(reconcileSettleId, tenant, WINDOW, { reservedTokens: 20, capTokens: 500, expiresAt: expiry(), dispatchToken: reconcileSettleToken })
+  await store.markTokenSpendDispatched(reconcileSettleId, reconcileSettleToken)
+  await store.markTokenSpendIndeterminate(reconcileSettleId, reconcileSettleToken)
+  const reconciled = await store.reconcileTokenSpend(reconcileSettleId, { action: 'settle', inTokens: 7, outTokens: 3, calls: 1, actor: 'test-operator', evidenceHash: 'c'.repeat(64) })
+  assert.equal(reconciled.reconciled, true)
+  assert.equal(reconciled.status, 'settled')
+
+  const staleId = 'store-lifecycle-stale'
+  const staleToken = 'dispatch-stale'
+  await store.reserveTokenSpend(staleId, tenant, WINDOW, { reservedTokens: 10, capTokens: 500, expiresAt: new Date(Date.now() + 20).toISOString(), dispatchToken: staleToken })
+  await store.markTokenSpendDispatched(staleId, staleToken)
+  await new Promise((resolve) => setTimeout(resolve, 30))
+  assert.equal((await store.settleTokenSpend(staleId, { inTokens: 1, outTokens: 1, calls: 1, dispatchToken: staleToken })).settled, true, 'expiry prevents late dispatch, not authenticated settlement')
+
+  const reclaimId = 'store-lifecycle-reclaim'
+  const reclaimContext = { operation_hash: 'stable-operation' }
+  await store.reserveTokenSpend(reclaimId, tenant, WINDOW, { reservedTokens: 10, capTokens: 500, expiresAt: new Date(Date.now() + 20).toISOString(), dispatchToken: 'dispatch-old', context: reclaimContext })
+  await new Promise((resolve) => setTimeout(resolve, 30))
+  assert.equal((await store.markTokenSpendDispatched(reclaimId, 'dispatch-old')).reason, 'reservation_stale')
+  const reclaimed = await store.reserveTokenSpend(reclaimId, tenant, WINDOW, { reservedTokens: 10, capTokens: 500, expiresAt: expiry(), dispatchToken: 'dispatch-new', context: reclaimContext })
+  assert.equal(reclaimed.reason, 'reservation_reclaimed')
+  assert.equal((await store.markTokenSpendDispatched(reclaimId, 'dispatch-old')).reason, 'dispatch_token_mismatch')
+  assert.equal((await store.markTokenSpendDispatched(reclaimId, 'dispatch-new')).changed, true)
+  assert.equal((await store.releaseTokenSpend(reclaimId, { dispatchToken: 'dispatch-new', definitive: true })).released, true)
+})
+
+test('concurrent gateway calls cannot dispatch beyond the cap', async () => {
+  const tenant = 'gateway-concurrent-pro'
+  await store.createClient({ id: tenant, name: tenant, plan: 'pro' })
+  let started
+  const providerStarted = new Promise((resolve) => { started = resolve })
+  let finish
+  const providerFinish = new Promise((resolve) => { finish = resolve })
+  let calls = 0
+  globalThis.fetch = async () => {
+    calls += 1
+    started()
+    await providerFinish
+    return okResponse()
+  }
+  const first = ask(tenant, 'held-first-request')
+  await providerStarted
+  await assert.rejects(() => ask(tenant, 'blocked-second-request'), /gateway_client_cap_reached/)
+  assert.equal(calls, 1, 'the rejected request never reaches a provider')
+  finish()
+  assert.equal((await first).text, 'ok')
+  assert.equal((await store.getTokenUsage(tenant, WINDOW)).reserved_tokens, 0)
+})
+
+test('a stable operation id prevents duplicate provider dispatch', async () => {
+  const tenant = 'gateway-operation-id'
+  await store.createClient({ id: tenant, name: tenant, plan: 'pro' })
+  let started
+  const providerStarted = new Promise((resolve) => { started = resolve })
+  let finish
+  const providerFinish = new Promise((resolve) => { finish = resolve })
+  let calls = 0
+  globalThis.fetch = async () => {
+    calls += 1
+    started()
+    await providerFinish
+    return okResponse()
+  }
+  const first = ask(tenant, 'same-operation', { operationId: 'work-order-42' })
+  await providerStarted
+  await assert.rejects(() => ask(tenant, 'same-operation', { operationId: 'work-order-42' }), /gateway_spend_reconciliation_required/)
+  assert.equal(calls, 1)
+  finish()
+  assert.equal((await first).text, 'ok')
+})
+
+test('definitive provider rejection releases capacity, while an ambiguous failure remains reserved', async () => {
+  Math.random = () => 0
+  const rejectedTenant = 'gateway-definite-rejection'
+  await store.createClient({ id: rejectedTenant, name: rejectedTenant, plan: 'pro' })
+  globalThis.fetch = async () => errorResponse(400)
+  await assert.rejects(() => ask(rejectedTenant, 'definite-400'), /anthropic_400/)
+  assert.equal((await store.getTokenUsage(rejectedTenant, WINDOW)).reserved_tokens, 0)
+
+  const uncertainTenant = 'gateway-ambiguous-failure'
+  await store.createClient({ id: uncertainTenant, name: uncertainTenant, plan: 'pro' })
+  let calls = 0
+  globalThis.fetch = async () => { calls += 1; return errorResponse(500) }
+  await assert.rejects(() => ask(uncertainTenant, 'ambiguous-500'), /gateway_retry_blocked_by_reserved_spend/)
+  const uncertain = await store.getTokenUsage(uncertainTenant, WINDOW)
+  assert.equal(calls, 1, 'the retained first attempt prevents an unsafe retry')
+  assert.ok(uncertain.reserved_tokens > 0)
+  assert.equal(uncertain.committed_tokens, 0)
+})
+
+test('HTTP 408 and missing provider usage remain indeterminate', async () => {
+  Math.random = () => 0
+  const timeoutTenant = 'gateway-ambiguous-408'
+  await store.createClient({ id: timeoutTenant, name: timeoutTenant, plan: 'pro' })
+  let timeoutCalls = 0
+  globalThis.fetch = async () => { timeoutCalls += 1; return errorResponse(408) }
+  await assert.rejects(() => ask(timeoutTenant, 'ambiguous-408'), /gateway_retry_blocked_by_reserved_spend/)
+  assert.equal(timeoutCalls, 1)
+  assert.ok((await store.getTokenUsage(timeoutTenant, WINDOW)).reserved_tokens > 0)
+
+  const usageTenant = 'gateway-openrouter-missing-usage'
+  await store.createClient({ id: usageTenant, name: usageTenant, plan: 'pro' })
+  process.env.SUPERMEGA_PLAN_CAP_PRO = '20000'
+  process.env.OPENROUTER_API_KEY = 'openrouter-test-key'
+  let anthropicCalls = 0
+  let openrouterCalls = 0
+  globalThis.fetch = async (url) => {
+    if (String(url).includes('openrouter.ai')) {
+      openrouterCalls += 1
+      return { ok: true, status: 200, json: async () => ({ choices: [{ message: { content: 'ok' } }] }), text: async () => '' }
+    }
+    anthropicCalls += 1
+    return errorResponse(401)
+  }
+  const pending = await ask(usageTenant, 'missing-usage')
+  assert.equal(pending.provider, 'openrouter')
+  assert.equal(pending.spend.status, 'reconciliation_required')
+  assert.equal(anthropicCalls, 1)
+  assert.equal(openrouterCalls, 1)
+  assert.ok((await store.getTokenUsage(usageTenant, WINDOW)).reserved_tokens > 0)
+  delete process.env.OPENROUTER_API_KEY
+  process.env.SUPERMEGA_PLAN_CAP_PRO = '8000'
+})
+
+test('rate-limit retries use a fresh reservation and settle only successful usage', async () => {
+  Math.random = () => 0
+  const tenant = 'gateway-rate-limit-retry'
+  await store.createClient({ id: tenant, name: tenant, plan: 'pro' })
+  let calls = 0
+  globalThis.fetch = async () => (++calls === 1 ? errorResponse(429) : okResponse({ input_tokens: 7, output_tokens: 3 }))
+  const result = await ask(tenant, 'retry-after-429')
+  assert.equal(result.text, 'ok')
+  assert.equal(calls, 2)
+  const usage = await store.getTokenUsage(tenant, WINDOW)
+  assert.equal(usage.committed_tokens, 10)
+  assert.equal(usage.reserved_tokens, 0)
+  assert.equal(usage.calls, 1)
+})
+
+test('ambiguous retry and cross-provider failover each obtain an independent reservation', async () => {
+  Math.random = () => 0
+  process.env.SUPERMEGA_PLAN_CAP_PRO = '20000'
+  const retryTenant = 'gateway-ambiguous-retry-success'
+  await store.createClient({ id: retryTenant, name: retryTenant, plan: 'pro' })
+  let retryCalls = 0
+  globalThis.fetch = async () => (++retryCalls === 1 ? errorResponse(500) : okResponse({ input_tokens: 4, output_tokens: 2 }))
+  assert.equal((await ask(retryTenant, 'ambiguous-then-success')).text, 'ok')
+  const retryUsage = await store.getTokenUsage(retryTenant, WINDOW)
+  assert.equal(retryCalls, 2)
+  assert.equal(retryUsage.committed_tokens, 6)
+  assert.ok(retryUsage.reserved_tokens > 0, 'the ambiguous first attempt remains conservatively reserved')
+
+  process.env.OPENROUTER_API_KEY = 'sk-or-test-not-real'
+  const failoverTenant = 'gateway-auth-failover-success'
+  await store.createClient({ id: failoverTenant, name: failoverTenant, plan: 'pro' })
+  const urls = []
+  globalThis.fetch = async (url) => {
+    urls.push(String(url))
+    if (String(url).includes('anthropic.com')) return errorResponse(401)
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({ choices: [{ message: { content: 'fallback-ok' } }], usage: { prompt_tokens: 3, completion_tokens: 2 } }),
+      text: async () => '',
+    }
+  }
+  const failover = await ask(failoverTenant, 'auth-failover')
+  assert.equal(failover.provider, 'openrouter')
+  assert.equal(failover.text, 'fallback-ok')
+  assert.equal(urls.length, 2)
+  assert.equal((await store.getTokenUsage(failoverTenant, WINDOW)).reserved_tokens, 0)
+  delete process.env.OPENROUTER_API_KEY
+  process.env.SUPERMEGA_PLAN_CAP_PRO = '8000'
+})
+
+test('a fresh gateway instance reads the shared cache at the hard cap before reserving', async () => {
+  const tenant = 'gateway-cache-at-cap'
+  await store.createClient({ id: tenant, name: tenant, plan: 'pro' })
+  let calls = 0
+  globalThis.fetch = async () => { calls += 1; return okResponse() }
+  await ask(tenant, 'cache-at-cap')
+  const before = await store.getTokenUsage(tenant, WINDOW)
+  await seedCommittedUsage(tenant, 8000 - before.committed_tokens, 8000)
+  const freshGateway = await import(`./gateway.mjs?shared-cache=${Date.now()}`)
+  const cappedBefore = await store.getTokenUsage(tenant, WINDOW)
+  const cached = await freshGateway.complete({ clientId: tenant, tier: 'bulk', system: 'test', messages: [{ role: 'user', content: 'cache-at-cap' }] })
+  assert.equal(cached.cached, true)
+  assert.equal(calls, 1)
+  assert.deepEqual(await store.getTokenUsage(tenant, WINDOW), cappedBefore)
+  await assert.rejects(
+    () => freshGateway.complete({ clientId: tenant, tier: 'bulk', system: 'test', messages: [{ role: 'user', content: 'cache-miss-at-cap' }], capTokens: 99_999_999 }),
+    /gateway_client_cap_reached/,
+  )
+  assert.equal(calls, 1, 'a request cannot raise its cap or dispatch on a cache miss')
+})
+
+test('an oversized or unpersisted settlement returns the response once but retains its reservation', async () => {
+  const tenant = 'gateway-settlement-fail-closed'
+  await store.createClient({ id: tenant, name: tenant, plan: 'pro' })
+  let calls = 0
+  globalThis.fetch = async () => { calls += 1; return okResponse({ input_tokens: 10000, output_tokens: 0 }) }
+  const first = await ask(tenant, 'oversized-actual')
+  assert.equal(first.text, 'ok')
+  assert.equal(first.spend.status, 'reconciliation_required')
+  const usage = await store.getTokenUsage(tenant, WINDOW)
+  assert.equal(usage.committed_tokens, 0)
+  assert.ok(usage.reserved_tokens > 0)
+  await assert.rejects(() => ask(tenant, 'oversized-actual'), /gateway_client_cap_reached/)
+  assert.equal(calls, 1)
+})
+
+test('malformed limits fail before provider execution or ledger mutation', async () => {
+  const tenant = 'gateway-malformed-limit'
+  await store.createClient({ id: tenant, name: tenant, plan: 'pro' })
+  let calls = 0
+  globalThis.fetch = async () => { calls += 1; return okResponse() }
+  await assert.rejects(() => ask(tenant, 'bad-max', { maxTokens: -1 }), /gateway_invalid_max_tokens/)
+  await assert.rejects(() => store.reserveTokenSpend('bad-reservation', tenant, WINDOW, { reservedTokens: Number.NaN, capTokens: 100, expiresAt: expiry(), dispatchToken: 'dispatch-bad' }), /invalid_reserved_tokens/)
+  assert.equal(calls, 0)
+  assert.equal((await store.getTokenUsage(tenant, WINDOW)).spend_total, 0)
+})
+
+test('an omitted client id is charged to the capped platform tenant', async () => {
+  let calls = 0
+  globalThis.fetch = async () => { calls += 1; return okResponse({ input_tokens: 2, output_tokens: 1 }) }
+  const result = await gateway.complete({ tier: 'bulk', system: 'platform', messages: [{ role: 'user', content: 'bounded internal call' }] })
+  assert.equal(result.text, 'ok')
+  assert.equal(calls, 1)
+  const usage = await store.getTokenUsage('supermega-platform', WINDOW)
+  assert.equal(usage.committed_tokens, 3)
+  assert.equal(usage.cap_tokens, 150000)
+})
+
+test('explicit no-persistence mode still enforces an in-process reservation', async () => {
+  const execFileAsync = promisify(execFile)
+  const gatewayUrl = new URL('./gateway.mjs', import.meta.url).href
+  const script = `
+    process.env.SUPERMEGA_GATEWAY_PERSIST='0';
+    process.env.ANTHROPIC_API_KEY='test';
+    delete process.env.NODE_ENV;
+    delete process.env.VERCEL;
+    process.env.SUPERMEGA_CLIENT_TOKEN_CAP='8000';
+    let calls=0, started, finish;
+    const began=new Promise(resolve=>{started=resolve});
+    const held=new Promise(resolve=>{finish=resolve});
+    globalThis.fetch=async()=>{ calls+=1; started(); await held; return {ok:true,status:200,json:async()=>({content:[{type:'text',text:'ok'}],usage:{input_tokens:1,output_tokens:1}}),text:async()=>''}; };
+    const {complete}=await import(${JSON.stringify(gatewayUrl)});
+    const first=complete({clientId:'local-only',system:'x',messages:[{role:'user',content:'first'}],tier:'bulk'});
+    await began;
+    let blocked=false;
+    try { await complete({clientId:'local-only',system:'x',messages:[{role:'user',content:'second'}],tier:'bulk'}); }
+    catch(error){ blocked=error.message==='gateway_client_cap_reached'; }
+    if(!blocked || calls!==1) throw new Error('local_cap_not_enforced');
+    finish();
+    if((await first).text!=='ok') throw new Error('unexpected_result');
+  `
+  await execFileAsync(process.execPath, ['--input-type=module', '-e', script], { windowsHide: true })
+})
+
+test('production refuses a model dispatch when only an in-process budget is available', async () => {
+  const execFileAsync = promisify(execFile)
+  const gatewayUrl = new URL('./gateway.mjs', import.meta.url).href
+  const script = `
+    process.env.SUPERMEGA_GATEWAY_PERSIST='0';
+    process.env.SUPERMEGA_REQUIRE_DURABLE_SPEND='1';
+    process.env.ANTHROPIC_API_KEY='test';
+    let calls=0;
+    globalThis.fetch=async()=>{ calls+=1; throw new Error('provider_must_not_run') };
+    const {complete}=await import(${JSON.stringify(gatewayUrl)});
+    try {
+      await complete({clientId:'production-no-store',system:'x',messages:[{role:'user',content:'y'}],tier:'bulk'});
+      throw new Error('expected_rejection');
+    } catch (error) {
+      if(error.message!=='gateway_durable_spend_required' || calls!==0) throw error;
+    }
+  `
+  await execFileAsync(process.execPath, ['--input-type=module', '-e', script], { windowsHide: true })
+})
+
+test('Supabase adapter uses one exact RPC per spend transition with no read-modify-write request', async () => {
+  const execFileAsync = promisify(execFile)
+  const storeUrl = new URL('./store.mjs', import.meta.url).href
+  const script = `
+    process.env.SUPABASE_URL='https://unit-test.supabase.co';
+    process.env.SUPABASE_SERVICE_ROLE_KEY='server-only-test-key';
+    const calls=[];
+    globalThis.fetch=async(url, options={})=>{
+      calls.push({url:String(url),method:options.method,body:JSON.parse(options.body||'null')});
+      const path=String(url);
+      if(path.endsWith('/supermega_get_token_usage')) return {ok:true,status:200,json:async()=>[{tenant_id:'tenant',window:'2026-07',in_tokens:0,out_tokens:0,calls:0,reserved_tokens:0}],text:async()=>''};
+      if(path.endsWith('/supermega_reserve_token_spend')) return {ok:true,status:200,json:async()=>[{accepted:true,reservation_id:'reservation',durable:true}],text:async()=>''};
+      if(path.endsWith('/supermega_mark_token_spend_dispatched')) return {ok:true,status:200,json:async()=>[{changed:true,reservation_id:'reservation'}],text:async()=>''};
+      if(path.endsWith('/supermega_mark_token_spend_indeterminate')) return {ok:true,status:200,json:async()=>[{changed:true,reservation_id:'reservation'}],text:async()=>''};
+      if(path.endsWith('/supermega_settle_token_spend')) return {ok:true,status:200,json:async()=>[{settled:true,reservation_id:'reservation'}],text:async()=>''};
+      if(path.endsWith('/supermega_release_token_spend')) return {ok:true,status:200,json:async()=>[{released:true,reservation_id:'reservation'}],text:async()=>''};
+      if(path.endsWith('/supermega_reconcile_token_spend')) return {ok:true,status:200,json:async()=>[{reconciled:true,reservation_id:'reservation'}],text:async()=>''};
+      throw new Error('unexpected_path:'+path);
+    };
+    const store=(await import(${JSON.stringify(storeUrl)})).default;
+    await store.getTokenUsage('tenant','2026-07');
+    await store.reserveTokenSpend('reservation','tenant','2026-07',{reservedTokens:100,capTokens:1000,expiresAt:new Date(Date.now()+60000).toISOString(),dispatchToken:'dispatch-token',context:{operation_hash:'hash'}});
+    await store.markTokenSpendDispatched('reservation','dispatch-token');
+    await store.markTokenSpendIndeterminate('reservation','dispatch-token');
+    await store.settleTokenSpend('reservation',{inTokens:1,outTokens:2,calls:1,dispatchToken:'dispatch-token'});
+    await store.releaseTokenSpend('reservation',{dispatchToken:'dispatch-token'});
+    await store.reconcileTokenSpend('reservation',{action:'release',actor:'operator',evidenceHash:'${'d'.repeat(64)}'});
+    console.log(JSON.stringify({mode:store.mode,calls}));
+  `
+  const { stdout } = await execFileAsync(process.execPath, ['--input-type=module', '-e', script], { windowsHide: true })
+  const report = JSON.parse(stdout.trim().split(/\r?\n/).at(-1))
+  assert.equal(report.mode, 'supabase')
+  assert.equal(report.calls.length, 7)
+  assert.deepEqual(report.calls.map((call) => [call.method, new URL(call.url).pathname]), [
+    ['POST', '/rest/v1/rpc/supermega_get_token_usage'],
+    ['POST', '/rest/v1/rpc/supermega_reserve_token_spend'],
+    ['POST', '/rest/v1/rpc/supermega_mark_token_spend_dispatched'],
+    ['POST', '/rest/v1/rpc/supermega_mark_token_spend_indeterminate'],
+    ['POST', '/rest/v1/rpc/supermega_settle_token_spend'],
+    ['POST', '/rest/v1/rpc/supermega_release_token_spend'],
+    ['POST', '/rest/v1/rpc/supermega_reconcile_token_spend'],
+  ])
+  assert.deepEqual(report.calls[1].body, {
+    p_reservation_id: 'reservation',
+    p_tenant_id: 'tenant',
+    p_window: '2026-07',
+    p_reserved_tokens: 100,
+    p_cap_tokens: 1000,
+    p_expires_at: report.calls[1].body.p_expires_at,
+    p_dispatch_token: 'dispatch-token',
+    p_context: { operation_hash: 'hash' },
+  })
+})
+
+test('gateway retries idempotent settlement exactly three times and exposes durable reconciliation state', async () => {
+  const execFileAsync = promisify(execFile)
+  const gatewayUrl = new URL('./gateway.mjs', import.meta.url).href
+  const script = `
+    process.env.SUPABASE_URL='https://unit-test.supabase.co';
+    process.env.SUPABASE_SERVICE_ROLE_KEY='server-only-test-key';
+    process.env.ANTHROPIC_API_KEY='provider-test-key';
+    process.env.SUPERMEGA_PLAN_CAP_PRO='50000';
+    let settleAttempts=0, providerCalls=0, cacheWrites=0, indeterminateCalls=0, failAlways=false;
+    const ok=(value)=>({ok:true,status:200,json:async()=>value,text:async()=>''});
+    globalThis.fetch=async(url, options={})=>{
+      const path=String(url);
+      if(path.startsWith('https://api.anthropic.com/')) {
+        providerCalls+=1;
+        return ok({content:[{type:'text',text:'ok'}],usage:{input_tokens:2,output_tokens:1},model:'synthetic-model'});
+      }
+      if(path.includes('/supermega_console_clients?')) return ok([{id:'tenant',plan:'pro'}]);
+      if(path.includes('/supermega_ai_cache?') && options.method==='GET') return ok([]);
+      if(path.includes('/supermega_ai_cache?') && options.method==='POST') { cacheWrites+=1; return ok([]); }
+      if(path.endsWith('/supermega_reserve_ai_budget')) return ok([{granted:true,used_units:1,cap_units:500000,reason:null}]);
+      if(path.includes('/supermega_ai_budget_reservations?')) return ok([{reservation_id:'company-budget',status:'consumed'}]);
+      if(path.endsWith('/supermega_get_token_usage')) return ok([{tenant_id:'tenant',window:'2026-07',cap_tokens:50000,in_tokens:0,out_tokens:0,calls:0,reserved_tokens:0}]);
+      if(path.endsWith('/supermega_reserve_token_spend')) return ok([{accepted:true,reservation_id:'reservation',durable:true}]);
+      if(path.endsWith('/supermega_mark_token_spend_dispatched')) return ok([{changed:true}]);
+      if(path.endsWith('/supermega_mark_token_spend_indeterminate')) { indeterminateCalls+=1; return ok([{changed:true}]); }
+      if(path.endsWith('/supermega_settle_token_spend')) {
+        settleAttempts+=1;
+        if(failAlways || settleAttempts < 3) return {ok:false,status:500,json:async()=>({}),text:async()=>'synthetic settlement response loss'};
+        return ok([{settled:true,reason:'idempotent'}]);
+      }
+      throw new Error('unexpected_path:'+path);
+    };
+    const gateway=await import(${JSON.stringify(gatewayUrl)});
+    const request=(clientId,operationId)=>gateway.complete({clientId,tier:'bulk',operationId,system:'test',messages:[{role:'user',content:operationId}]});
+    const recovered=await request('tenant-recovered','settlement-recovered');
+    failAlways=true;
+    const pending=await request('tenant-pending','settlement-pending');
+    console.log(JSON.stringify({settleAttempts,providerCalls,cacheWrites,indeterminateCalls,recovered,pending}));
+  `
+  const { stdout } = await execFileAsync(process.execPath, ['--input-type=module', '-e', script], { windowsHide: true })
+  const report = JSON.parse(stdout.trim().split(/\r?\n/).at(-1))
+  assert.equal(report.settleAttempts, 6)
+  assert.equal(report.providerCalls, 2)
+  assert.equal(report.cacheWrites, 1, 'only a durably settled response is cached')
+  assert.equal(report.indeterminateCalls, 1)
+  assert.equal(report.recovered.spend, undefined)
+  assert.equal(report.pending.spend.status, 'reconciliation_required')
+})
+
+test('Supabase schemas and adapter pin atomic RPC and least-privilege contracts', async () => {
+  const [workcell, consoleSql, storeSource] = await Promise.all([
+    readFile(new URL('./supabase/workcell-client.sql', import.meta.url), 'utf8'),
+    readFile(new URL('./supabase/console-tables.sql', import.meta.url), 'utf8'),
+    readFile(new URL('./store.mjs', import.meta.url), 'utf8'),
+  ])
+  for (const sql of [workcell, consoleSql]) {
+    assert.match(sql, /create table if not exists public\.supermega_spend_reservations/i)
+    assert.match(sql, /create or replace function public\.supermega_reserve_token_spend/i)
+    assert.match(sql, /create or replace function public\.supermega_mark_token_spend_dispatched/i)
+    assert.match(sql, /create or replace function public\.supermega_mark_token_spend_indeterminate/i)
+    assert.match(sql, /create or replace function public\.supermega_reconcile_token_spend/i)
+    assert.match(sql, /legacy_active_reservations_require_reconciliation/i)
+    assert.match(sql, /drop function if exists public\.supermega_add_token_usage/i)
+    assert.doesNotMatch(sql, /create or replace function public\.supermega_add_token_usage/i)
+    assert.doesNotMatch(sql, /grant execute on function public\.supermega_add_token_usage/i)
+    assert.match(sql, /alter table public\.supermega_spend_reservations alter column dispatch_token set not null/i)
+    assert.doesNotMatch(sql, /update public\.supermega_spend_reservations set status='reserved' where status='active'/i)
+    assert.match(sql, /for update;/i)
+    assert.match(sql, /security definer\s+set search_path = ''/i)
+    assert.match(sql, /revoke all on public\.supermega_token_ledger from public, service_role/i)
+    assert.match(sql, /revoke all on public\.supermega_spend_reservations from public, anon, authenticated, service_role/i)
+    assert.match(sql, /grant execute on function public\.supermega_reserve_token_spend[\s\S]+to service_role/i)
+  }
+  const rpcBlock = (sql) => sql.slice(sql.indexOf('create or replace function public.supermega_get_token_usage'), sql.indexOf("notify pgrst, 'reload schema';")).replace('-- Reload PostgREST schema cache', '').trim()
+  const reservationDdl = (sql) => sql
+    .slice(sql.indexOf('create table if not exists public.supermega_spend_reservations'), sql.indexOf('create table if not exists public.supermega_ai_cache'))
+    .replace(/create index if not exists supermega_spend_reservations_active_idx[\s\S]*?;\s*/i, '')
+    .trim()
+  assert.equal(reservationDdl(workcell), reservationDdl(consoleSql), 'central and workcell reservation DDL must remain byte-identical')
+  assert.equal(rpcBlock(workcell), rpcBlock(consoleSql), 'central and workcell RPC definitions must remain byte-identical')
+  assert.match(storeSource, /rpc\/supermega_reserve_token_spend/)
+  assert.match(storeSource, /supermega_mark_token_spend_dispatched/)
+  assert.match(storeSource, /supermega_mark_token_spend_indeterminate/)
+  assert.match(storeSource, /rpc\/supermega_settle_token_spend/)
+  assert.match(storeSource, /rpc\/supermega_release_token_spend/)
+  assert.match(storeSource, /rpc\/supermega_reconcile_token_spend/)
+  assert.doesNotMatch(storeSource, /rpc\/supermega_add_token_usage/)
+  await assert.rejects(() => store.addTokenUsage('tenant', WINDOW, { inTokens: 1 }), /unreserved_token_usage_disabled/)
+  assert.doesNotMatch(storeSource, /PostgREST has no native UPSERT-with-increment/)
+})

--- a/kernel/store.mjs
+++ b/kernel/store.mjs
@@ -4,7 +4,7 @@
 //  - 'memory'   : in-process maps, for dev with no credentials.
 // Reads real `supermega_leads`; pipeline lives in additive `supermega_console_*` tables. See ../PLATFORM.md.
 
-import { randomUUID } from 'node:crypto'
+import { createHash, randomUUID } from 'node:crypto'
 
 const SUPABASE_URL = String(process.env.SUPABASE_URL || '').replace(/\/$/, '')
 const SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_KEY || ''
@@ -41,6 +41,20 @@ async function pg() {
   return pool
 }
 async function q(sql, params = []) { return (await (await pg()).query(sql, params)).rows || [] }
+async function tx(run) {
+  const client = await (await pg()).connect()
+  try {
+    await client.query('begin')
+    const result = await run(async (sql, params = []) => (await client.query(sql, params)).rows || [])
+    await client.query('commit')
+    return result
+  } catch (error) {
+    await client.query('rollback').catch(() => {})
+    throw error
+  } finally {
+    client.release()
+  }
+}
 let tablesReady
 async function ensurePgTables() {
   if (!tablesReady) tablesReady = q(`
@@ -49,7 +63,8 @@ async function ensurePgTables() {
     create table if not exists supermega_console_projects (id text primary key, client_id text, lead_id text, offer text, scope_summary text, price_mmk bigint, deposit_status text default 'unpaid', deposit_method text, status text default 'scoping', live_url text, created_at timestamptz default now());
     create table if not exists supermega_console_deals (id text primary key, lead_id text, project_id text, packet jsonb, status text default 'draft', created_at timestamptz default now());
     create table if not exists supermega_console_activity (id text primary key, at timestamptz default now(), kind text, summary text, ref text);
-    create table if not exists supermega_token_ledger (tenant_id text not null, "window" text not null, in_tokens bigint default 0, out_tokens bigint default 0, calls bigint default 0, updated_at timestamptz default now(), primary key (tenant_id, "window"));
+    create table if not exists supermega_token_ledger (tenant_id text not null, "window" text not null, cap_tokens bigint, in_tokens bigint default 0, out_tokens bigint default 0, calls bigint default 0, updated_at timestamptz default now(), primary key (tenant_id, "window"));
+    alter table supermega_token_ledger add column if not exists cap_tokens bigint;
     create table if not exists supermega_ai_budget_reservations (reservation_id text primary key, "window" text not null, reserved_units bigint not null check (reserved_units > 0), actual_units bigint, status text not null default 'reserved' check (status in ('reserved','consumed','failed','released')), tenant_id text, tier text, provider text, created_at timestamptz not null default now(), settled_at timestamptz);
     create index if not exists supermega_ai_budget_window_status_idx on supermega_ai_budget_reservations ("window", status);
     create or replace function public.supermega_reserve_ai_budget(
@@ -119,7 +134,153 @@ async function ensurePgTables() {
       where r."window" = p_window and r.status <> 'released'
     $supermega$;
     revoke all on function public.supermega_get_ai_budget_usage(text) from public;
+    create table if not exists supermega_spend_reservations (reservation_id text primary key, tenant_id text not null, "window" text not null, reserved_tokens bigint not null check (reserved_tokens > 0), status text not null default 'reserved' check (status in ('reserved','dispatched','indeterminate','settled','released')), dispatch_token text not null, context jsonb not null default '{}'::jsonb, actual_in_tokens bigint not null default 0, actual_out_tokens bigint not null default 0, actual_calls bigint not null default 0, reconciled_by text, reconciliation_evidence_hash text, reconciled_at timestamptz, expires_at timestamptz not null, created_at timestamptz not null default now(), updated_at timestamptz not null default now());
+    alter table supermega_spend_reservations add column if not exists dispatch_token text;
+    alter table supermega_spend_reservations add column if not exists context jsonb not null default '{}'::jsonb;
+    alter table supermega_spend_reservations add column if not exists reconciled_by text;
+    alter table supermega_spend_reservations add column if not exists reconciliation_evidence_hash text;
+    alter table supermega_spend_reservations add column if not exists reconciled_at timestamptz;
+    do $migration$
+    begin
+      if exists (select 1 from supermega_spend_reservations where status='active') then
+        raise exception 'legacy_active_reservations_require_reconciliation';
+      end if;
+      if exists (
+        select 1 from pg_constraint
+         where conrelid='supermega_spend_reservations'::regclass
+           and conname='supermega_spend_reservations_status_check'
+           and pg_get_constraintdef(oid) not like '%indeterminate%'
+      ) then
+        alter table supermega_spend_reservations drop constraint supermega_spend_reservations_status_check;
+      end if;
+      if not exists (
+        select 1 from pg_constraint
+         where conrelid='supermega_spend_reservations'::regclass
+           and conname='supermega_spend_reservations_status_check'
+           and pg_get_constraintdef(oid) like '%indeterminate%'
+      ) then
+        alter table supermega_spend_reservations alter column status set default 'reserved';
+        alter table supermega_spend_reservations add constraint supermega_spend_reservations_status_check check (status in ('reserved','dispatched','indeterminate','settled','released'));
+      end if;
+      update supermega_spend_reservations
+         set dispatch_token='legacy-terminal:' || md5(reservation_id)
+       where dispatch_token is null and status in ('settled','released');
+      if exists (select 1 from supermega_spend_reservations where dispatch_token is null) then
+        raise exception 'reservation_dispatch_token_reconciliation_required';
+      end if;
+      alter table supermega_spend_reservations alter column dispatch_token set not null;
+      if not exists (
+        select 1 from pg_constraint
+         where conrelid='supermega_spend_reservations'::regclass
+           and conname='supermega_spend_reservations_dispatch_token_check'
+      ) then
+        alter table supermega_spend_reservations add constraint supermega_spend_reservations_dispatch_token_check check (char_length(dispatch_token) between 1 and 160);
+      end if;
+      if not exists (
+        select 1 from pg_constraint
+         where conrelid='supermega_spend_reservations'::regclass
+           and conname='supermega_spend_reservations_reconciliation_check'
+      ) then
+        alter table supermega_spend_reservations add constraint supermega_spend_reservations_reconciliation_check check (
+          (reconciled_by is null and reconciliation_evidence_hash is null and reconciled_at is null)
+          or (char_length(reconciled_by) between 1 and 80 and reconciliation_evidence_hash ~ '^[a-f0-9]{64}$' and reconciled_at is not null)
+        );
+      end if;
+    end;
+    $migration$;
+    create index if not exists supermega_spend_reservations_active_idx on supermega_spend_reservations (tenant_id, "window", status);
     create table if not exists supermega_ai_cache (cache_key text primary key, payload jsonb not null, created_at timestamptz default now());
+    create table if not exists supermega_control_records (
+      record_key text primary key,
+      record_type text not null,
+      tenant_id text not null,
+      status text not null,
+      plan_hash text not null,
+      payload jsonb not null,
+      payload_hash text not null,
+      record_version bigint not null default 1 check (record_version >= 1),
+      created_at timestamptz not null default now(),
+      updated_at timestamptz not null default now(),
+      constraint supermega_control_records_key_check check (char_length(record_key) between 1 and 240),
+      constraint supermega_control_records_type_check check (record_type in ('sign_in_code','operator_session','mission','work_order','work_order_review','work_order_evaluation','ceo_outcome_operation','ceo_outcome_evaluation','ceo_outcome_delivery','ceo_outcome_action')),
+      constraint supermega_control_records_tenant_check check (char_length(tenant_id) between 1 and 80),
+      constraint supermega_control_records_status_check check (status ~ '^[a-z][a-z_]{0,39}$'),
+      constraint supermega_control_records_plan_hash_check check (plan_hash ~ '^[a-f0-9]{64}$'),
+      constraint supermega_control_records_payload_hash_check check (payload_hash ~ '^[a-f0-9]{64}$')
+    );
+    create index if not exists supermega_control_records_tenant_type_status_idx on supermega_control_records (tenant_id, record_type, status, updated_at desc);
+    create table if not exists supermega_control_transitions (
+      transition_id bigint generated always as identity primary key,
+      record_key text not null references supermega_control_records(record_key) on delete restrict,
+      record_type text not null,
+      tenant_id text not null,
+      event_type text not null check (event_type in ('created','replaced','transitioned')),
+      from_status text,
+      to_status text not null,
+      from_record_version bigint,
+      to_record_version bigint not null,
+      prior_payload_hash text,
+      next_payload_hash text not null,
+      created_at timestamptz not null default now()
+    );
+    create unique index if not exists supermega_control_transitions_record_version_uidx on supermega_control_transitions (record_key, to_record_version);
+    create or replace function supermega_reject_control_transition_mutation()
+    returns trigger language plpgsql security definer set search_path = '' as $immutable$
+    begin raise exception 'control_transition_history_is_immutable'; end;
+    $immutable$;
+    drop trigger if exists supermega_control_transitions_immutable on supermega_control_transitions;
+    create trigger supermega_control_transitions_immutable before update or delete on supermega_control_transitions
+    for each row execute function supermega_reject_control_transition_mutation();
+    create or replace function supermega_put_control_record(
+      p_record_key text, p_record_type text, p_tenant_id text, p_status text,
+      p_plan_hash text, p_payload jsonb, p_payload_hash text
+    ) returns table (updated boolean, version bigint)
+    language plpgsql security definer set search_path = '' as $control$
+    declare existing public.supermega_control_records%rowtype; next_version bigint;
+    begin
+      select * into existing from public.supermega_control_records where record_key=p_record_key for update;
+      if not found then
+        insert into public.supermega_control_records (record_key,record_type,tenant_id,status,plan_hash,payload,payload_hash,record_version)
+        values (p_record_key,p_record_type,p_tenant_id,p_status,p_plan_hash,p_payload,p_payload_hash,1);
+        insert into public.supermega_control_transitions (record_key,record_type,tenant_id,event_type,to_status,to_record_version,next_payload_hash)
+        values (p_record_key,p_record_type,p_tenant_id,'created',p_status,1,p_payload_hash);
+        return query select true, 1::bigint;
+        return;
+      end if;
+      if existing.record_type<>p_record_type or existing.tenant_id<>p_tenant_id then
+        raise exception 'control_record_identity_conflict';
+      end if;
+      next_version := existing.record_version + 1;
+      update public.supermega_control_records set status=p_status,plan_hash=p_plan_hash,payload=p_payload,payload_hash=p_payload_hash,record_version=next_version,updated_at=now() where record_key=p_record_key;
+      insert into public.supermega_control_transitions (record_key,record_type,tenant_id,event_type,from_status,to_status,from_record_version,to_record_version,prior_payload_hash,next_payload_hash)
+      values (p_record_key,p_record_type,p_tenant_id,'replaced',existing.status,p_status,existing.record_version,next_version,existing.payload_hash,p_payload_hash);
+      return query select true, next_version;
+    end;
+    $control$;
+    create or replace function supermega_transition_control_record(
+      p_record_key text, p_expected_status text, p_expected_plan_hash text,
+      p_has_revision boolean, p_expected_revision bigint,
+      p_record_type text, p_tenant_id text, p_status text, p_plan_hash text,
+      p_payload jsonb, p_payload_hash text
+    ) returns table (updated boolean, version bigint)
+    language plpgsql security definer set search_path = '' as $control$
+    declare existing public.supermega_control_records%rowtype; next_version bigint;
+    begin
+      select * into existing from public.supermega_control_records
+       where record_key=p_record_key and status=p_expected_status and plan_hash=p_expected_plan_hash
+         and (not p_has_revision or payload->>'revision'=p_expected_revision::text)
+       for update;
+      if not found then return query select false, null::bigint; return; end if;
+      if existing.record_type<>p_record_type or existing.tenant_id<>p_tenant_id then
+        raise exception 'control_record_identity_conflict';
+      end if;
+      next_version := existing.record_version + 1;
+      update public.supermega_control_records set status=p_status,plan_hash=p_plan_hash,payload=p_payload,payload_hash=p_payload_hash,record_version=next_version,updated_at=now() where record_key=p_record_key;
+      insert into public.supermega_control_transitions (record_key,record_type,tenant_id,event_type,from_status,to_status,from_record_version,to_record_version,prior_payload_hash,next_payload_hash)
+      values (p_record_key,p_record_type,p_tenant_id,'transitioned',existing.status,p_status,existing.record_version,next_version,existing.payload_hash,p_payload_hash);
+      return query select true, next_version;
+    end;
+    $control$;
     create table if not exists supermega_action_queue (id text primary key, client_id text not null, action_type text not null, title text not null, payload jsonb not null, payload_hash text not null, source jsonb not null default '{}'::jsonb, status text not null default 'draft', version int not null default 0, approved_by text, approved_at timestamptz, rejected_by text, rejected_at timestamptz, executing_at timestamptz, lease_expires_at timestamptz, attempts int not null default 0, provider_ref text, result jsonb, last_error text, executed_at timestamptz, created_at timestamptz not null default now(), updated_at timestamptz not null default now(), constraint supermega_action_queue_status check (status in ('draft','approved','executing','succeeded','failed','rejected')));
     create table if not exists supermega_graduation (signature text primary key, label text, count int not null default 1, sources jsonb default '[]'::jsonb, modules jsonb default '[]'::jsonb, productized boolean not null default false, graduated_at timestamptz, updated_at timestamptz default now());
     create table if not exists supermega_build_modules (id text primary key, project_id text, signature text, modules jsonb default '[]'::jsonb, shipped_at timestamptz default now());
@@ -129,7 +290,7 @@ async function ensurePgTables() {
 }
 
 // ---------- in-memory fallback ----------
-const mem = { lead: new Map(), client: new Map(), project: new Map(), deal: new Map(), activity: new Map(), tokenLedger: new Map(), aiBudgetReservations: new Map(), aiCache: new Map(), approval: new Map(), graduation: new Map(), buildModules: new Map(), paymentEvents: new Set() }
+const mem = { lead: new Map(), client: new Map(), project: new Map(), deal: new Map(), activity: new Map(), tokenLedger: new Map(), spendReservation: new Map(), aiBudgetReservations: new Map(), aiCache: new Map(), controlRecords: new Map(), controlTransitions: [], approval: new Map(), graduation: new Map(), buildModules: new Map(), paymentEvents: new Set() }
 const memSort = (rows) => rows.sort((a, b) => String(b.created_at).localeCompare(String(a.created_at)))
 
 // ---------- leads (real supermega_leads) ----------
@@ -468,52 +629,97 @@ export async function listActivity(limit = 30, filter = {}) {
 // Backs gateway.mjs so per-client spend caps + caching survive cold starts / multiple instances.
 // memory mode keeps the same shape so nothing breaks locally without credentials.
 
-// Read one tenant's usage for a window (e.g. '2026-06'). Always returns a row shape.
-export async function getTokenUsage(tenantId, window) {
-  const empty = { tenant_id: tenantId, window, in_tokens: 0, out_tokens: 0, calls: 0 }
-  if (!tenantId || !window) return empty
-  if (mode === 'supabase') {
-    const r = await rest('GET', `supermega_token_ledger?tenant_id=eq.${encodeURIComponent(tenantId)}&window=eq.${encodeURIComponent(window)}&limit=1`)
-    return r[0] ? { ...empty, ...r[0] } : empty
+function spendSnapshot(row, reservedTokens = 0) {
+  const inTokens = Number(row?.in_tokens) || 0
+  const outTokens = Number(row?.out_tokens) || 0
+  const calls = Number(row?.calls) || 0
+  const reserved = Number(reservedTokens) || 0
+  return {
+    ...row,
+    cap_tokens: row?.cap_tokens === null || row?.cap_tokens === undefined ? null : Number(row.cap_tokens),
+    in_tokens: inTokens,
+    out_tokens: outTokens,
+    calls,
+    reserved_tokens: reserved,
+    committed_tokens: inTokens + outTokens,
+    spend_total: inTokens + outTokens + reserved,
   }
-  if (mode === 'postgres') {
-    await ensurePgTables()
-    const r = await q('select tenant_id, "window", in_tokens, out_tokens, calls from supermega_token_ledger where tenant_id=$1 and "window"=$2 limit 1', [tenantId, window])
-    return r[0] ? { ...empty, ...r[0] } : empty
-  }
-  return mem.tokenLedger.get(`${tenantId}::${window}`) || empty
 }
 
-// Atomically add spend to a tenant's window and return the new running totals.
-export async function addTokenUsage(tenantId, window, { inTokens = 0, outTokens = 0, calls = 1 } = {}) {
-  if (!tenantId || !window) return null
+function counter(value, name, { positive = false } = {}) {
+  const n = Number(value)
+  if (!Number.isSafeInteger(n) || n < (positive ? 1 : 0)) throw new TypeError(`invalid_${name}`)
+  return n
+}
+
+function reservationIdentity(reservationId, tenantId, window) {
+  const id = String(reservationId || '').trim()
+  const tenant = String(tenantId || '').trim()
+  const month = String(window || '').trim()
+  if (!id || id.length > 120) throw new TypeError('invalid_reservation_id')
+  if (!tenant || tenant.length > 200) throw new TypeError('invalid_tenant_id')
+  if (!/^\d{4}-\d{2}$/.test(month)) throw new TypeError('invalid_usage_window')
+  return { id, tenant, month }
+}
+
+const ACTIVE_SPEND_STATUSES = new Set(['reserved', 'dispatched', 'indeterminate'])
+const ACTIVE_SPEND_SQL = "('reserved','dispatched','indeterminate')"
+
+function dispatchCredential(value) {
+  const token = String(value || '').trim()
+  if (!token || token.length > 160) throw new TypeError('invalid_dispatch_token')
+  return token
+}
+
+function safeReservationContext(value) {
+  if (value === undefined) return {}
+  if (!value || typeof value !== 'object' || Array.isArray(value)) throw new TypeError('invalid_reservation_context')
+  const encoded = JSON.stringify(value)
+  if (encoded.length > 4096) throw new TypeError('invalid_reservation_context')
+  return JSON.parse(encoded)
+}
+
+function sameReservationContext(left, right) {
+  return JSON.stringify(left || {}) === JSON.stringify(right || {})
+}
+
+function memoryActiveReserved(tenantId, window) {
+  let total = 0
+  for (const row of mem.spendReservation.values()) {
+    if (row.tenant_id === tenantId && row.window === window && ACTIVE_SPEND_STATUSES.has(row.status)) total += row.reserved_tokens
+  }
+  return total
+}
+
+async function pgActiveReserved(query, tenantId, window) {
+  const rows = await query(`select coalesce(sum(reserved_tokens),0) as reserved_tokens from supermega_spend_reservations where tenant_id=$1 and "window"=$2 and status in ${ACTIVE_SPEND_SQL}`, [tenantId, window])
+  return Number(rows[0]?.reserved_tokens) || 0
+}
+
+// Read one tenant's committed and in-flight usage for a window (e.g. '2026-06').
+// spend_total is the cap-safe value: committed usage plus every active reservation.
+export async function getTokenUsage(tenantId, window) {
+  const empty = spendSnapshot({ tenant_id: tenantId, window, in_tokens: 0, out_tokens: 0, calls: 0 })
+  if (!tenantId || !window) return empty
   if (mode === 'supabase') {
-    // PostgREST has no native UPSERT-with-increment; read-modify-write (best-effort, monthly granularity).
-    const cur = await getTokenUsage(tenantId, window)
-    const row = { tenant_id: tenantId, window, in_tokens: Number(cur.in_tokens) + inTokens, out_tokens: Number(cur.out_tokens) + outTokens, calls: Number(cur.calls) + calls, updated_at: new Date().toISOString() }
-    const r = await rest('POST', 'supermega_token_ledger?on_conflict=tenant_id,window', row).catch(async () => rest('PATCH', `supermega_token_ledger?tenant_id=eq.${encodeURIComponent(tenantId)}&window=eq.${encodeURIComponent(window)}`, row))
-    return r?.[0] ? r[0] : row
+    const rows = await rest('POST', 'rpc/supermega_get_token_usage', { p_tenant_id: tenantId, p_window: window })
+    return rows?.[0] ? spendSnapshot({ ...empty, ...rows[0] }, rows[0].reserved_tokens) : empty
   }
   if (mode === 'postgres') {
     await ensurePgTables()
     const r = await q(
-      `insert into supermega_token_ledger (tenant_id, "window", in_tokens, out_tokens, calls, updated_at)
-       values ($1,$2,$3,$4,$5, now())
-       on conflict (tenant_id, "window") do update set
-         in_tokens = supermega_token_ledger.in_tokens + excluded.in_tokens,
-         out_tokens = supermega_token_ledger.out_tokens + excluded.out_tokens,
-         calls = supermega_token_ledger.calls + excluded.calls,
-         updated_at = now()
-       returning tenant_id, "window", in_tokens, out_tokens, calls`,
-      [tenantId, window, inTokens, outTokens, calls],
+      `select l.tenant_id, l."window", l.cap_tokens, l.in_tokens, l.out_tokens, l.calls,
+              coalesce(sum(r.reserved_tokens) filter (where r.status in ('reserved','dispatched','indeterminate')), 0) as reserved_tokens
+         from supermega_token_ledger l
+         left join supermega_spend_reservations r on r.tenant_id=l.tenant_id and r."window"=l."window"
+        where l.tenant_id=$1 and l."window"=$2
+        group by l.tenant_id, l."window", l.cap_tokens, l.in_tokens, l.out_tokens, l.calls
+        limit 1`,
+      [tenantId, window],
     )
-    return r[0] || null
+    return r[0] ? spendSnapshot({ ...empty, ...r[0] }, r[0].reserved_tokens) : empty
   }
-  const key = `${tenantId}::${window}`
-  const cur = mem.tokenLedger.get(key) || { tenant_id: tenantId, window, in_tokens: 0, out_tokens: 0, calls: 0 }
-  const next = { ...cur, in_tokens: cur.in_tokens + inTokens, out_tokens: cur.out_tokens + outTokens, calls: cur.calls + calls }
-  mem.tokenLedger.set(key, next)
-  return next
+  return spendSnapshot(mem.tokenLedger.get(`${tenantId}::${window}`) || empty, memoryActiveReserved(tenantId, window))
 }
 
 // ---------- company-wide daily AI admission budget ----------
@@ -703,9 +909,386 @@ export async function settleAiBudgetReservation(reservationIdInput, statusInput,
   }
 }
 
-// AI response cache (optional). Returns the stored payload or null.
-export async function getCachedResponse(cacheKey) {
+// Legacy post-dispatch increments bypass atomic admission and are intentionally disabled.
+export async function addTokenUsage() {
+  throw new Error('unreserved_token_usage_disabled')
+}
+
+// Reserve the maximum weighted units a model call can consume before any provider is contacted.
+// Every durable implementation serializes on the tenant/window ledger row. Active reservations are
+// deliberately not auto-expired: a crashed process must fail closed until an operator reconciles it.
+export async function reserveTokenSpend(reservationId, tenantId, window, { reservedTokens, capTokens, expiresAt, dispatchToken, context } = {}) {
+  const { id, tenant, month } = reservationIdentity(reservationId, tenantId, window)
+  const requested = counter(reservedTokens, 'reserved_tokens', { positive: true })
+  const cap = counter(capTokens, 'cap_tokens', { positive: true })
+  const token = dispatchCredential(dispatchToken)
+  const safeContext = safeReservationContext(context)
+  const expiry = new Date(expiresAt)
+  if (!Number.isFinite(expiry.getTime()) || expiry.getTime() <= Date.now()) throw new TypeError('invalid_reservation_expiry')
+
+  if (mode === 'supabase') {
+    const rows = await rest('POST', 'rpc/supermega_reserve_token_spend', {
+      p_reservation_id: id,
+      p_tenant_id: tenant,
+      p_window: month,
+      p_reserved_tokens: requested,
+      p_cap_tokens: cap,
+      p_expires_at: expiry.toISOString(),
+      p_dispatch_token: token,
+      p_context: safeContext,
+    })
+    return { ...(rows?.[0] || { accepted: false, reason: 'reservation_store_empty' }), durable: true }
+  }
+
+  if (mode === 'postgres') {
+    await ensurePgTables()
+    return tx(async (query) => {
+      await query('insert into supermega_token_ledger (tenant_id, "window", cap_tokens) values ($1,$2,$3) on conflict do nothing', [tenant, month, cap])
+      let ledgerRow = (await query('select tenant_id, "window", cap_tokens, in_tokens, out_tokens, calls from supermega_token_ledger where tenant_id=$1 and "window"=$2 for update', [tenant, month]))[0]
+      if (ledgerRow.cap_tokens === null) ledgerRow = (await query('update supermega_token_ledger set cap_tokens=$3,updated_at=now() where tenant_id=$1 and "window"=$2 returning tenant_id,"window",cap_tokens,in_tokens,out_tokens,calls', [tenant, month, cap]))[0]
+      const existingRows = await query('select * from supermega_spend_reservations where reservation_id=$1', [id])
+      const existing = existingRows[0]
+      const active = await pgActiveReserved(query, tenant, month)
+      const snapshot = spendSnapshot(ledgerRow, active)
+      if (Number(ledgerRow.cap_tokens) !== cap) return { accepted: false, reason: 'cap_mismatch', reservation_id: id, status: 'rejected', ...snapshot, durable: true }
+      if (existing) {
+        const sameScope = existing.tenant_id === tenant && existing.window === month && Number(existing.reserved_tokens) === requested && sameReservationContext(existing.context, safeContext)
+        if (sameScope && existing.status === 'reserved' && existing.dispatch_token === token) return { accepted: true, reason: 'idempotent', reservation_id: id, status: existing.status, ...snapshot, durable: true }
+        if (sameScope && existing.status === 'reserved' && Date.parse(existing.expires_at) <= Date.now()) {
+          await query('update supermega_spend_reservations set dispatch_token=$2,context=$3::jsonb,expires_at=$4,updated_at=now() where reservation_id=$1', [id, token, JSON.stringify(safeContext), expiry.toISOString()])
+          return { accepted: true, reason: 'reservation_reclaimed', reservation_id: id, status: 'reserved', ...snapshot, durable: true }
+        }
+        const reason = sameScope && ['dispatched', 'indeterminate'].includes(existing.status)
+          ? 'reconciliation_required'
+          : sameScope && existing.status === 'reserved'
+            ? 'reservation_in_progress'
+            : 'reservation_exists'
+        return { accepted: false, reason, reservation_id: id, status: existing.status, ...snapshot, durable: true }
+      }
+      if (snapshot.spend_total + requested > cap) return { accepted: false, reason: 'cap_reached', reservation_id: id, status: 'rejected', ...snapshot, durable: true }
+      await query(
+        `insert into supermega_spend_reservations (reservation_id,tenant_id,"window",reserved_tokens,status,expires_at,dispatch_token,context) values ($1,$2,$3,$4,'reserved',$5,$6,$7::jsonb)`,
+        [id, tenant, month, requested, expiry.toISOString(), token, JSON.stringify(safeContext)],
+      )
+      return { accepted: true, reason: 'reserved', reservation_id: id, status: 'reserved', ...spendSnapshot(ledgerRow, active + requested), durable: true }
+    })
+  }
+
+  const ledgerKey = `${tenant}::${month}`
+  let ledgerRow = mem.tokenLedger.get(ledgerKey) || { tenant_id: tenant, window: month, cap_tokens: cap, in_tokens: 0, out_tokens: 0, calls: 0 }
+  if (ledgerRow.cap_tokens === null || ledgerRow.cap_tokens === undefined) ledgerRow = { ...ledgerRow, cap_tokens: cap }
+  mem.tokenLedger.set(ledgerKey, ledgerRow)
+  const existing = mem.spendReservation.get(id)
+  const active = memoryActiveReserved(tenant, month)
+  const snapshot = spendSnapshot(ledgerRow, active)
+  if (Number(ledgerRow.cap_tokens) !== cap) return { accepted: false, reason: 'cap_mismatch', reservation_id: id, status: 'rejected', ...snapshot, durable: false }
+  if (existing) {
+    const sameScope = existing.tenant_id === tenant && existing.window === month && existing.reserved_tokens === requested && sameReservationContext(existing.context, safeContext)
+    if (sameScope && existing.status === 'reserved' && existing.dispatch_token === token) return { accepted: true, reason: 'idempotent', reservation_id: id, status: existing.status, ...snapshot, durable: false }
+    if (sameScope && existing.status === 'reserved' && Date.parse(existing.expires_at) <= Date.now()) {
+      mem.spendReservation.set(id, { ...existing, dispatch_token: token, context: safeContext, expires_at: expiry.toISOString(), updated_at: new Date().toISOString() })
+      return { accepted: true, reason: 'reservation_reclaimed', reservation_id: id, status: 'reserved', ...snapshot, durable: false }
+    }
+    const reason = sameScope && ['dispatched', 'indeterminate'].includes(existing.status)
+      ? 'reconciliation_required'
+      : sameScope && existing.status === 'reserved'
+        ? 'reservation_in_progress'
+        : 'reservation_exists'
+    return { accepted: false, reason, reservation_id: id, status: existing.status, ...snapshot, durable: false }
+  }
+  if (snapshot.spend_total + requested > cap) return { accepted: false, reason: 'cap_reached', reservation_id: id, status: 'rejected', ...snapshot, durable: false }
+  mem.spendReservation.set(id, { reservation_id: id, tenant_id: tenant, window: month, reserved_tokens: requested, status: 'reserved', dispatch_token: token, context: safeContext, actual_in_tokens: 0, actual_out_tokens: 0, actual_calls: 0, expires_at: expiry.toISOString() })
+  return { accepted: true, reason: 'reserved', reservation_id: id, status: 'reserved', ...spendSnapshot(ledgerRow, active + requested), durable: false }
+}
+
+async function transitionTokenSpend(reservationId, dispatchToken, target) {
+  const id = String(reservationId || '').trim()
+  if (!id || id.length > 120) throw new TypeError('invalid_reservation_id')
+  const token = dispatchCredential(dispatchToken)
+  const rpc = target === 'dispatched' ? 'supermega_mark_token_spend_dispatched' : 'supermega_mark_token_spend_indeterminate'
+  if (mode === 'supabase') {
+    const rows = await rest('POST', `rpc/${rpc}`, { p_reservation_id: id, p_dispatch_token: token })
+    return { ...(rows?.[0] || { changed: false, reason: 'reservation_store_empty' }), durable: true }
+  }
+  const from = target === 'dispatched' ? 'reserved' : 'dispatched'
+  if (mode === 'postgres') {
+    await ensurePgTables()
+    return tx(async (query) => {
+      const reservation = (await query('select * from supermega_spend_reservations where reservation_id=$1 for update', [id]))[0]
+      if (!reservation) return { changed: false, reason: 'reservation_not_found', reservation_id: id, durable: true }
+      if (reservation.dispatch_token !== token) return { changed: false, reason: 'dispatch_token_mismatch', reservation_id: id, status: reservation.status, durable: true }
+      if (reservation.status === target) return { changed: true, reason: 'idempotent', reservation_id: id, status: target, durable: true }
+      if (reservation.status !== from) return { changed: false, reason: 'invalid_reservation_state', reservation_id: id, status: reservation.status, durable: true }
+      if (target === 'dispatched' && Date.parse(reservation.expires_at) <= Date.now()) return { changed: false, reason: 'reservation_stale', reservation_id: id, status: reservation.status, durable: true }
+      await query('update supermega_spend_reservations set status=$2,updated_at=now() where reservation_id=$1', [id, target])
+      return { changed: true, reason: target, reservation_id: id, status: target, durable: true }
+    })
+  }
+  const reservation = mem.spendReservation.get(id)
+  if (!reservation) return { changed: false, reason: 'reservation_not_found', reservation_id: id, durable: false }
+  if (reservation.dispatch_token !== token) return { changed: false, reason: 'dispatch_token_mismatch', reservation_id: id, status: reservation.status, durable: false }
+  if (reservation.status === target) return { changed: true, reason: 'idempotent', reservation_id: id, status: target, durable: false }
+  if (reservation.status !== from) return { changed: false, reason: 'invalid_reservation_state', reservation_id: id, status: reservation.status, durable: false }
+  if (target === 'dispatched' && Date.parse(reservation.expires_at) <= Date.now()) return { changed: false, reason: 'reservation_stale', reservation_id: id, status: reservation.status, durable: false }
+  mem.spendReservation.set(id, { ...reservation, status: target, updated_at: new Date().toISOString() })
+  return { changed: true, reason: target, reservation_id: id, status: target, durable: false }
+}
+
+export async function markTokenSpendDispatched(reservationId, dispatchToken) {
+  return transitionTokenSpend(reservationId, dispatchToken, 'dispatched')
+}
+
+export async function markTokenSpendIndeterminate(reservationId, dispatchToken) {
+  return transitionTokenSpend(reservationId, dispatchToken, 'indeterminate')
+}
+
+// Settle exactly once. If the durable write fails, the active maximum reservation remains counted,
+// which over-counts safely instead of allowing a second request to spend the same budget.
+export async function settleTokenSpend(reservationId, { inTokens = 0, outTokens = 0, calls = 1, dispatchToken } = {}) {
+  const id = String(reservationId || '').trim()
+  if (!id || id.length > 120) throw new TypeError('invalid_reservation_id')
+  const token = dispatchCredential(dispatchToken)
+  const input = counter(inTokens, 'input_tokens')
+  const output = counter(outTokens, 'output_tokens')
+  const callCount = counter(calls, 'calls')
+
+  if (mode === 'supabase') {
+    const rows = await rest('POST', 'rpc/supermega_settle_token_spend', { p_reservation_id: id, p_dispatch_token: token, p_in_tokens: input, p_out_tokens: output, p_calls: callCount })
+    return { ...(rows?.[0] || { settled: false, reason: 'reservation_store_empty' }), durable: true }
+  }
+  if (mode === 'postgres') {
+    await ensurePgTables()
+    return tx(async (query) => {
+      const identities = await query('select tenant_id, "window" from supermega_spend_reservations where reservation_id=$1', [id])
+      if (!identities[0]) return { settled: false, reason: 'reservation_not_found', reservation_id: id, durable: true }
+      const { tenant_id: tenant, window: month } = identities[0]
+      await query('insert into supermega_token_ledger (tenant_id, "window") values ($1,$2) on conflict do nothing', [tenant, month])
+      let ledgerRow = (await query('select tenant_id, "window", cap_tokens, in_tokens, out_tokens, calls from supermega_token_ledger where tenant_id=$1 and "window"=$2 for update', [tenant, month]))[0]
+      const reservation = (await query('select * from supermega_spend_reservations where reservation_id=$1 for update', [id]))[0]
+      const snapshot = async () => spendSnapshot(ledgerRow, await pgActiveReserved(query, tenant, month))
+      if (reservation.dispatch_token !== token) return { settled: false, reason: 'dispatch_token_mismatch', reservation_id: id, status: reservation.status, ...(await snapshot()), durable: true }
+      if (reservation.status === 'released') {
+        return { settled: false, reason: 'reservation_released', reservation_id: id, status: reservation.status, ...(await snapshot()), durable: true }
+      }
+      if (reservation.status === 'settled' && (Number(reservation.actual_in_tokens) !== input || Number(reservation.actual_out_tokens) !== output || Number(reservation.actual_calls) !== callCount)) {
+        return { settled: false, reason: 'settlement_conflict', reservation_id: id, status: reservation.status, ...(await snapshot()), durable: true }
+      }
+      if (reservation.status === 'reserved') return { settled: false, reason: 'reservation_not_dispatched', reservation_id: id, status: reservation.status, ...(await snapshot()), durable: true }
+      if (ACTIVE_SPEND_STATUSES.has(reservation.status) && input + output > Number(reservation.reserved_tokens)) {
+        return { settled: false, reason: 'actual_exceeds_reservation', reservation_id: id, status: reservation.status, ...(await snapshot()), durable: true }
+      }
+      const settleable = reservation.status === 'dispatched' || reservation.status === 'indeterminate'
+      if (settleable) {
+        ledgerRow = (await query(
+          `update supermega_token_ledger set in_tokens=in_tokens+$3, out_tokens=out_tokens+$4, calls=calls+$5, updated_at=now() where tenant_id=$1 and "window"=$2 returning tenant_id,"window",cap_tokens,in_tokens,out_tokens,calls`,
+          [tenant, month, input, output, callCount],
+        ))[0]
+        await query(`update supermega_spend_reservations set status='settled',actual_in_tokens=$2,actual_out_tokens=$3,actual_calls=$4,updated_at=now() where reservation_id=$1`, [id, input, output, callCount])
+      }
+      return { settled: reservation.status === 'settled' || settleable, reason: settleable ? 'settled' : 'idempotent', reservation_id: id, status: 'settled', ...(await snapshot()), durable: true }
+    })
+  }
+
+  const reservation = mem.spendReservation.get(id)
+  if (!reservation) return { settled: false, reason: 'reservation_not_found', reservation_id: id, durable: false }
+  const ledgerKey = `${reservation.tenant_id}::${reservation.window}`
+  let ledgerRow = mem.tokenLedger.get(ledgerKey) || { tenant_id: reservation.tenant_id, window: reservation.window, in_tokens: 0, out_tokens: 0, calls: 0 }
+  if (reservation.dispatch_token !== token) return { settled: false, reason: 'dispatch_token_mismatch', reservation_id: id, status: reservation.status, ...spendSnapshot(ledgerRow, memoryActiveReserved(reservation.tenant_id, reservation.window)), durable: false }
+  if (reservation.status === 'released') return { settled: false, reason: 'reservation_released', reservation_id: id, status: reservation.status, ...spendSnapshot(ledgerRow, memoryActiveReserved(reservation.tenant_id, reservation.window)), durable: false }
+  if (reservation.status === 'settled' && (reservation.actual_in_tokens !== input || reservation.actual_out_tokens !== output || reservation.actual_calls !== callCount)) return { settled: false, reason: 'settlement_conflict', reservation_id: id, status: reservation.status, ...spendSnapshot(ledgerRow, memoryActiveReserved(reservation.tenant_id, reservation.window)), durable: false }
+  if (reservation.status === 'reserved') return { settled: false, reason: 'reservation_not_dispatched', reservation_id: id, status: reservation.status, ...spendSnapshot(ledgerRow, memoryActiveReserved(reservation.tenant_id, reservation.window)), durable: false }
+  if (ACTIVE_SPEND_STATUSES.has(reservation.status) && input + output > reservation.reserved_tokens) return { settled: false, reason: 'actual_exceeds_reservation', reservation_id: id, status: reservation.status, ...spendSnapshot(ledgerRow, memoryActiveReserved(reservation.tenant_id, reservation.window)), durable: false }
+  const settleable = reservation.status === 'dispatched' || reservation.status === 'indeterminate'
+  if (settleable) {
+    ledgerRow = { ...ledgerRow, in_tokens: ledgerRow.in_tokens + input, out_tokens: ledgerRow.out_tokens + output, calls: ledgerRow.calls + callCount }
+    mem.tokenLedger.set(ledgerKey, ledgerRow)
+    mem.spendReservation.set(id, { ...reservation, status: 'settled', actual_in_tokens: input, actual_out_tokens: output, actual_calls: callCount })
+  }
+  return { settled: reservation.status === 'settled' || settleable, reason: settleable ? 'settled' : 'idempotent', reservation_id: id, status: 'settled', ...spendSnapshot(ledgerRow, memoryActiveReserved(reservation.tenant_id, reservation.window)), durable: false }
+}
+
+export async function releaseTokenSpend(reservationId, { dispatchToken, definitive = false } = {}) {
+  const id = String(reservationId || '').trim()
+  if (!id || id.length > 120) throw new TypeError('invalid_reservation_id')
+  const token = dispatchCredential(dispatchToken)
+  if (mode === 'supabase') {
+    const rows = await rest('POST', 'rpc/supermega_release_token_spend', { p_reservation_id: id, p_dispatch_token: token, p_definitive: Boolean(definitive) })
+    return { ...(rows?.[0] || { released: false, reason: 'reservation_store_empty' }), durable: true }
+  }
+  if (mode === 'postgres') {
+    await ensurePgTables()
+    return tx(async (query) => {
+      const identities = await query('select tenant_id, "window" from supermega_spend_reservations where reservation_id=$1', [id])
+      if (!identities[0]) return { released: false, reason: 'reservation_not_found', reservation_id: id, durable: true }
+      const { tenant_id: tenant, window: month } = identities[0]
+      await query('insert into supermega_token_ledger (tenant_id, "window") values ($1,$2) on conflict do nothing', [tenant, month])
+      const ledgerRow = (await query('select tenant_id, "window", cap_tokens, in_tokens, out_tokens, calls from supermega_token_ledger where tenant_id=$1 and "window"=$2 for update', [tenant, month]))[0]
+      const reservation = (await query('select * from supermega_spend_reservations where reservation_id=$1 for update', [id]))[0]
+      const snapshot = async () => spendSnapshot(ledgerRow, await pgActiveReserved(query, tenant, month))
+      if (reservation.dispatch_token !== token) return { released: false, reason: 'dispatch_token_mismatch', reservation_id: id, status: reservation.status, ...(await snapshot()), durable: true }
+      if (reservation.status === 'settled') {
+        return { released: false, reason: 'reservation_settled', reservation_id: id, status: reservation.status, ...(await snapshot()), durable: true }
+      }
+      if (reservation.status === 'indeterminate') return { released: false, reason: 'reservation_indeterminate', reservation_id: id, status: reservation.status, ...(await snapshot()), durable: true }
+      if (reservation.status === 'dispatched' && !definitive) return { released: false, reason: 'dispatch_not_definitive', reservation_id: id, status: reservation.status, ...(await snapshot()), durable: true }
+      const releasable = reservation.status === 'reserved' || reservation.status === 'dispatched'
+      if (releasable) await query(`update supermega_spend_reservations set status='released',updated_at=now() where reservation_id=$1`, [id])
+      return { released: reservation.status === 'released' || releasable, reason: releasable ? 'released' : 'idempotent', reservation_id: id, status: 'released', ...(await snapshot()), durable: true }
+    })
+  }
+  const reservation = mem.spendReservation.get(id)
+  if (!reservation) return { released: false, reason: 'reservation_not_found', reservation_id: id, durable: false }
+  const ledgerRow = mem.tokenLedger.get(`${reservation.tenant_id}::${reservation.window}`) || { tenant_id: reservation.tenant_id, window: reservation.window, in_tokens: 0, out_tokens: 0, calls: 0 }
+  if (reservation.dispatch_token !== token) return { released: false, reason: 'dispatch_token_mismatch', reservation_id: id, status: reservation.status, ...spendSnapshot(ledgerRow, memoryActiveReserved(reservation.tenant_id, reservation.window)), durable: false }
+  if (reservation.status === 'settled') return { released: false, reason: 'reservation_settled', reservation_id: id, status: reservation.status, ...spendSnapshot(ledgerRow, memoryActiveReserved(reservation.tenant_id, reservation.window)), durable: false }
+  if (reservation.status === 'indeterminate') return { released: false, reason: 'reservation_indeterminate', reservation_id: id, status: reservation.status, ...spendSnapshot(ledgerRow, memoryActiveReserved(reservation.tenant_id, reservation.window)), durable: false }
+  if (reservation.status === 'dispatched' && !definitive) return { released: false, reason: 'dispatch_not_definitive', reservation_id: id, status: reservation.status, ...spendSnapshot(ledgerRow, memoryActiveReserved(reservation.tenant_id, reservation.window)), durable: false }
+  const releasable = reservation.status === 'reserved' || reservation.status === 'dispatched'
+  if (releasable) mem.spendReservation.set(id, { ...reservation, status: 'released' })
+  return { released: reservation.status === 'released' || releasable, reason: releasable ? 'released' : 'idempotent', reservation_id: id, status: 'released', ...spendSnapshot(ledgerRow, memoryActiveReserved(reservation.tenant_id, reservation.window)), durable: false }
+}
+
+// Privileged operator recovery for a provider outcome proven outside the request process. This is
+// intentionally separate from dispatch credentials and requires a hash of reviewed evidence.
+export async function reconcileTokenSpend(reservationId, { action, inTokens = 0, outTokens = 0, calls = 0, actor, evidenceHash } = {}) {
+  const id = String(reservationId || '').trim()
+  if (!id || id.length > 120) throw new TypeError('invalid_reservation_id')
+  const resolution = String(action || '').trim().toLowerCase()
+  if (!['settle', 'release'].includes(resolution)) throw new TypeError('invalid_reconciliation_action')
+  const reconciledBy = String(actor || '').trim()
+  if (!reconciledBy || reconciledBy.length > 80) throw new TypeError('invalid_reconciliation_actor')
+  const proof = String(evidenceHash || '').trim().toLowerCase()
+  if (!/^[a-f0-9]{64}$/.test(proof)) throw new TypeError('invalid_reconciliation_evidence_hash')
+  const input = counter(inTokens, 'input_tokens')
+  const output = counter(outTokens, 'output_tokens')
+  const callCount = counter(calls, 'calls')
+  if (resolution === 'release' && (input !== 0 || output !== 0 || callCount !== 0)) throw new TypeError('invalid_release_reconciliation_usage')
+
+  if (mode === 'supabase') {
+    const rows = await rest('POST', 'rpc/supermega_reconcile_token_spend', {
+      p_reservation_id: id,
+      p_action: resolution,
+      p_in_tokens: input,
+      p_out_tokens: output,
+      p_calls: callCount,
+      p_actor: reconciledBy,
+      p_evidence_hash: proof,
+    })
+    return { ...(rows?.[0] || { reconciled: false, reason: 'reservation_store_empty' }), durable: true }
+  }
+
+  if (mode === 'postgres') {
+    await ensurePgTables()
+    return tx(async (query) => {
+      const identity = (await query('select tenant_id,"window" from supermega_spend_reservations where reservation_id=$1', [id]))[0]
+      if (!identity) return { reconciled: false, reason: 'reservation_not_found', reservation_id: id, durable: true }
+      const { tenant_id: tenant, window: month } = identity
+      const ledgerRow = (await query('select tenant_id,"window",cap_tokens,in_tokens,out_tokens,calls from supermega_token_ledger where tenant_id=$1 and "window"=$2 for update', [tenant, month]))[0]
+      const reservation = (await query('select * from supermega_spend_reservations where reservation_id=$1 for update', [id]))[0]
+      const terminalStatus = resolution === 'settle' ? 'settled' : 'released'
+      const sameTerminal = reservation.status === terminalStatus
+        && reservation.reconciled_by === reconciledBy
+        && reservation.reconciliation_evidence_hash === proof
+        && (resolution === 'release' || (Number(reservation.actual_in_tokens) === input && Number(reservation.actual_out_tokens) === output && Number(reservation.actual_calls) === callCount))
+      if (sameTerminal) return { reconciled: true, reason: 'idempotent', reservation_id: id, status: terminalStatus, ...spendSnapshot(ledgerRow, await pgActiveReserved(query, tenant, month)), durable: true }
+      if (['settled', 'released'].includes(reservation.status)) return { reconciled: false, reason: 'reconciliation_conflict', reservation_id: id, status: reservation.status, ...spendSnapshot(ledgerRow, await pgActiveReserved(query, tenant, month)), durable: true }
+      if (!['dispatched', 'indeterminate'].includes(reservation.status)) return { reconciled: false, reason: 'invalid_reservation_state', reservation_id: id, status: reservation.status, ...spendSnapshot(ledgerRow, await pgActiveReserved(query, tenant, month)), durable: true }
+      if (resolution === 'settle' && input + output > Number(reservation.reserved_tokens)) return { reconciled: false, reason: 'actual_exceeds_reservation', reservation_id: id, status: reservation.status, ...spendSnapshot(ledgerRow, await pgActiveReserved(query, tenant, month)), durable: true }
+      let nextLedger = ledgerRow
+      if (resolution === 'settle') {
+        nextLedger = (await query('update supermega_token_ledger set in_tokens=in_tokens+$3,out_tokens=out_tokens+$4,calls=calls+$5,updated_at=now() where tenant_id=$1 and "window"=$2 returning tenant_id,"window",cap_tokens,in_tokens,out_tokens,calls', [tenant, month, input, output, callCount]))[0]
+      }
+      await query(`update supermega_spend_reservations set status=$2,actual_in_tokens=$3,actual_out_tokens=$4,actual_calls=$5,reconciled_by=$6,reconciliation_evidence_hash=$7,reconciled_at=now(),updated_at=now() where reservation_id=$1`, [id, terminalStatus, input, output, callCount, reconciledBy, proof])
+      return { reconciled: true, reason: 'reconciled', reservation_id: id, status: terminalStatus, ...spendSnapshot(nextLedger, await pgActiveReserved(query, tenant, month)), durable: true }
+    })
+  }
+
+  const reservation = mem.spendReservation.get(id)
+  if (!reservation) return { reconciled: false, reason: 'reservation_not_found', reservation_id: id, durable: false }
+  const ledgerKey = `${reservation.tenant_id}::${reservation.window}`
+  let ledgerRow = mem.tokenLedger.get(ledgerKey) || { tenant_id: reservation.tenant_id, window: reservation.window, in_tokens: 0, out_tokens: 0, calls: 0 }
+  const terminalStatus = resolution === 'settle' ? 'settled' : 'released'
+  const sameTerminal = reservation.status === terminalStatus
+    && reservation.reconciled_by === reconciledBy
+    && reservation.reconciliation_evidence_hash === proof
+    && (resolution === 'release' || (reservation.actual_in_tokens === input && reservation.actual_out_tokens === output && reservation.actual_calls === callCount))
+  if (sameTerminal) return { reconciled: true, reason: 'idempotent', reservation_id: id, status: terminalStatus, ...spendSnapshot(ledgerRow, memoryActiveReserved(reservation.tenant_id, reservation.window)), durable: false }
+  if (['settled', 'released'].includes(reservation.status)) return { reconciled: false, reason: 'reconciliation_conflict', reservation_id: id, status: reservation.status, ...spendSnapshot(ledgerRow, memoryActiveReserved(reservation.tenant_id, reservation.window)), durable: false }
+  if (!['dispatched', 'indeterminate'].includes(reservation.status)) return { reconciled: false, reason: 'invalid_reservation_state', reservation_id: id, status: reservation.status, ...spendSnapshot(ledgerRow, memoryActiveReserved(reservation.tenant_id, reservation.window)), durable: false }
+  if (resolution === 'settle' && input + output > reservation.reserved_tokens) return { reconciled: false, reason: 'actual_exceeds_reservation', reservation_id: id, status: reservation.status, ...spendSnapshot(ledgerRow, memoryActiveReserved(reservation.tenant_id, reservation.window)), durable: false }
+  if (resolution === 'settle') {
+    ledgerRow = { ...ledgerRow, in_tokens: ledgerRow.in_tokens + input, out_tokens: ledgerRow.out_tokens + output, calls: ledgerRow.calls + callCount }
+    mem.tokenLedger.set(ledgerKey, ledgerRow)
+  }
+  mem.spendReservation.set(id, { ...reservation, status: terminalStatus, actual_in_tokens: input, actual_out_tokens: output, actual_calls: callCount, reconciled_by: reconciledBy, reconciliation_evidence_hash: proof, reconciled_at: new Date().toISOString() })
+  return { reconciled: true, reason: 'reconciled', reservation_id: id, status: terminalStatus, ...spendSnapshot(ledgerRow, memoryActiveReserved(reservation.tenant_id, reservation.window)), durable: false }
+}
+
+const CONTROL_RECORD_PREFIXES = Object.freeze([
+  ['agent-company-sign-in-code:', 'sign_in_code'],
+  ['agent-company-operator-session:', 'operator_session'],
+  ['company-mission-record:', 'mission'],
+  ['company-work-order-record:', 'work_order'],
+  ['company-work-order-review-record:', 'work_order_review'],
+  ['company-work-order-evaluation:', 'work_order_evaluation'],
+  // CEO outcome records are execution authority (completions, evaluations, deliveries, follow-up
+  // actions) recorded by agent-company-operations.mjs. They must never live in the response cache.
+  ['ceo-outcome-operation:', 'ceo_outcome_operation'],
+  ['ceo-outcome-evaluation:', 'ceo_outcome_evaluation'],
+  ['ceo-outcome-delivery:', 'ceo_outcome_delivery'],
+  ['ceo-outcome-action:', 'ceo_outcome_action'],
+])
+const CONTROL_ID_RE = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,79}$/
+const CONTROL_STATUS_RE = /^[a-z][a-z_]{0,39}$/
+const CONTROL_HASH_RE = /^[a-f0-9]{64}$/
+
+function controlRecordType(key) {
+  const normalized = String(key || '')
+  return CONTROL_RECORD_PREFIXES.find(([prefix]) => normalized.startsWith(prefix))?.[1] || ''
+}
+
+function controlRecordTypeForPrefix(prefix) {
+  const normalized = String(prefix || '')
+  return CONTROL_RECORD_PREFIXES.find(([candidate]) => normalized === candidate)?.[1] || ''
+}
+
+function stableJson(value) {
+  if (value === null || typeof value !== 'object') return JSON.stringify(value ?? null)
+  if (Array.isArray(value)) return `[${value.map(stableJson).join(',')}]`
+  return `{${Object.keys(value).sort().map((key) => `${JSON.stringify(key)}:${stableJson(value[key])}`).join(',')}}`
+}
+
+function controlEnvelope(recordKey, payload) {
+  const key = String(recordKey || '').trim()
+  const recordType = controlRecordType(key)
+  if (!recordType || key.length > 240 || !payload || typeof payload !== 'object' || Array.isArray(payload)) return null
+  const tenantId = String(payload.clientId || payload.tenantId || '').trim()
+  const status = String(payload.status || 'recorded').trim()
+  const planHash = String(payload.planHash || payload.reviewHash || payload.recordHash || payload.deliveryHash || payload.actionHash || payload.evaluationHash || '').trim()
+  const revision = Number.isInteger(payload.revision) && payload.revision >= 1 ? payload.revision : 1
+  if (!CONTROL_ID_RE.test(tenantId) || !CONTROL_STATUS_RE.test(status) || !CONTROL_HASH_RE.test(planHash)) return null
+  let serialized
+  try { serialized = stableJson(payload) } catch { return null }
+  return {
+    record_key: key,
+    record_type: recordType,
+    tenant_id: tenantId,
+    status,
+    plan_hash: planHash,
+    payload,
+    payload_hash: createHash('sha256').update(serialized).digest('hex'),
+    revision,
+  }
+}
+
+function rpcRow(result) {
+  return Array.isArray(result) ? result[0] : result
+}
+
+// AI response cache (optional). Control-plane keys are never accepted by these explicit APIs.
+export async function getResponseCache(cacheKey) {
   if (!cacheKey) return null
+  if (controlRecordType(cacheKey)) return null
   if (mode === 'supabase') {
     const r = await rest('GET', `supermega_ai_cache?cache_key=eq.${encodeURIComponent(cacheKey)}&select=payload&limit=1`)
     return r[0]?.payload || null
@@ -718,8 +1301,9 @@ export async function getCachedResponse(cacheKey) {
   return mem.aiCache.get(cacheKey) || null
 }
 
-export async function putCachedResponse(cacheKey, payload) {
+export async function putResponseCache(cacheKey, payload) {
   if (!cacheKey) return null
+  if (controlRecordType(cacheKey)) return null
   if (mode === 'supabase') {
     return rest('POST', 'supermega_ai_cache?on_conflict=cache_key', { cache_key: cacheKey, payload }).catch(() => null)
   }
@@ -733,7 +1317,7 @@ export async function putCachedResponse(cacheKey, payload) {
 
 // Bounded internal index for cache-backed control records. Callers must still validate every
 // payload before using it; this only narrows the durable read by key prefix and tenant metadata.
-export async function listCachedResponseRecords({
+async function listResponseCacheRecords({
   prefix,
   clientId = '',
   status = '',
@@ -804,7 +1388,7 @@ export async function listCachedResponseRecords({
 // Atomically replace one cached payload only while its status, plan hash, and optional revision
 // still match. Work orders use status + planHash; staged missions also bind every transition to a
 // monotonically increasing revision so concurrent operators cannot both advance the same stage.
-export async function transitionCachedResponse(cacheKey, expected, payload) {
+async function transitionResponseCache(cacheKey, expected, payload) {
   const key = String(cacheKey || '').trim()
   const status = String(expected?.status || '').trim()
   const planHash = String(expected?.planHash || '').trim()
@@ -870,6 +1454,239 @@ export async function transitionCachedResponse(cacheKey, expected, payload) {
   }
   mem.aiCache.set(key, payload)
   return { updated: true, durable: false }
+}
+
+// ---------- versioned Agent Company control records ----------
+// These records are physically separate from model-response cache entries. The compatibility
+// exports below route only a fixed set of authority-bearing key prefixes into this store, so an
+// old cache row with the same key is inert and can never be read as current authority.
+export async function getControlRecord(recordKey) {
+  const key = String(recordKey || '').trim()
+  if (!controlRecordType(key)) return null
+  if (mode === 'supabase') {
+    const rows = await rest('GET', `supermega_control_records?record_key=eq.${encodeURIComponent(key)}&select=payload&limit=1`)
+    return rows[0]?.payload || null
+  }
+  if (mode === 'postgres') {
+    await ensurePgTables()
+    const rows = await q('select payload from supermega_control_records where record_key=$1 limit 1', [key])
+    return rows[0]?.payload || null
+  }
+  return mem.controlRecords.get(key)?.payload || null
+}
+
+export async function putControlRecord(recordKey, payload) {
+  const envelope = controlEnvelope(recordKey, payload)
+  if (!envelope) return null
+  const params = [
+    envelope.record_key,
+    envelope.record_type,
+    envelope.tenant_id,
+    envelope.status,
+    envelope.plan_hash,
+    JSON.stringify(envelope.payload),
+    envelope.payload_hash,
+  ]
+  if (mode === 'supabase') {
+    const row = rpcRow(await rest('POST', 'rpc/supermega_put_control_record', {
+      p_record_key: envelope.record_key,
+      p_record_type: envelope.record_type,
+      p_tenant_id: envelope.tenant_id,
+      p_status: envelope.status,
+      p_plan_hash: envelope.plan_hash,
+      p_payload: envelope.payload,
+      p_payload_hash: envelope.payload_hash,
+    }))
+    return row?.updated === true
+  }
+  if (mode === 'postgres') {
+    await ensurePgTables()
+    const row = (await q('select * from supermega_put_control_record($1,$2,$3,$4,$5,$6::jsonb,$7)', params))[0]
+    return row?.updated === true
+  }
+  const current = mem.controlRecords.get(envelope.record_key)
+  if (current && (current.record_type !== envelope.record_type || current.tenant_id !== envelope.tenant_id)) return null
+  const version = Number(current?.record_version || 0) + 1
+  const now = new Date().toISOString()
+  mem.controlRecords.set(envelope.record_key, {
+    ...envelope,
+    record_version: version,
+    created_at: current?.created_at || now,
+    updated_at: now,
+  })
+  mem.controlTransitions.push({
+    record_key: envelope.record_key,
+    record_type: envelope.record_type,
+    tenant_id: envelope.tenant_id,
+    event_type: current ? 'replaced' : 'created',
+    from_status: current?.status || null,
+    to_status: envelope.status,
+    from_record_version: current?.record_version || null,
+    to_record_version: version,
+    prior_payload_hash: current?.payload_hash || null,
+    next_payload_hash: envelope.payload_hash,
+    created_at: now,
+  })
+  return true
+}
+
+export async function listControlRecords({
+  prefix,
+  clientId = '',
+  status = '',
+  expiresAfter = '',
+  limit = 200,
+} = {}) {
+  const normalizedPrefix = String(prefix || '').trim()
+  const recordType = controlRecordTypeForPrefix(normalizedPrefix)
+  const normalizedClientId = String(clientId || '').trim()
+  const normalizedStatus = String(status || '').trim()
+  const normalizedExpiry = String(expiresAfter || '').trim()
+  const boundedLimit = Number(limit)
+  const validExpiry = !normalizedExpiry
+    || (Number.isFinite(new Date(normalizedExpiry).getTime()) && new Date(normalizedExpiry).toISOString() === normalizedExpiry)
+  if (!recordType
+    || (normalizedClientId && !CONTROL_ID_RE.test(normalizedClientId))
+    || (normalizedStatus && !CONTROL_STATUS_RE.test(normalizedStatus))
+    || !validExpiry
+    || !Number.isInteger(boundedLimit)
+    || boundedLimit < 1
+    || boundedLimit > 250) {
+    throw new Error('invalid_control_record_list_query')
+  }
+  if (mode === 'supabase') {
+    const query = [
+      `record_type=eq.${encodeURIComponent(recordType)}`,
+      normalizedClientId ? `tenant_id=eq.${encodeURIComponent(normalizedClientId)}` : '',
+      normalizedStatus ? `status=eq.${encodeURIComponent(normalizedStatus)}` : '',
+      normalizedExpiry ? `payload->>expiresAt=gt.${encodeURIComponent(normalizedExpiry)}` : '',
+      'select=record_key,payload',
+      'order=updated_at.desc',
+      `limit=${boundedLimit}`,
+    ].filter(Boolean).join('&')
+    const rows = await rest('GET', `supermega_control_records?${query}`)
+    return { durable: true, records: rows.map((row) => ({ key: row.record_key, payload: row.payload })) }
+  }
+  if (mode === 'postgres') {
+    await ensurePgTables()
+    const clauses = ['record_type=$1']
+    const values = [recordType]
+    if (normalizedClientId) { values.push(normalizedClientId); clauses.push(`tenant_id=$${values.length}`) }
+    if (normalizedStatus) { values.push(normalizedStatus); clauses.push(`status=$${values.length}`) }
+    if (normalizedExpiry) { values.push(normalizedExpiry); clauses.push(`payload->>'expiresAt'>$${values.length}`) }
+    values.push(boundedLimit)
+    const rows = await q(
+      `select record_key, payload from supermega_control_records where ${clauses.join(' and ')} order by updated_at desc limit $${values.length}`,
+      values,
+    )
+    return { durable: true, records: rows.map((row) => ({ key: row.record_key, payload: row.payload })) }
+  }
+  let records = [...mem.controlRecords.values()]
+    .filter((record) => record.record_type === recordType)
+  if (normalizedClientId) records = records.filter((record) => record.tenant_id === normalizedClientId)
+  if (normalizedStatus) records = records.filter((record) => record.status === normalizedStatus)
+  if (normalizedExpiry) records = records.filter((record) => String(record.payload?.expiresAt || '') > normalizedExpiry)
+  records.sort((left, right) => String(right.updated_at).localeCompare(String(left.updated_at)))
+  return { durable: false, records: records.slice(0, boundedLimit).map((record) => ({ key: record.record_key, payload: record.payload })) }
+}
+
+export async function transitionControlRecord(recordKey, expected, payload) {
+  const key = String(recordKey || '').trim()
+  const envelope = controlEnvelope(key, payload)
+  const status = String(expected?.status || '').trim()
+  const planHash = String(expected?.planHash || '').trim()
+  const hasRevision = expected?.revision !== undefined
+  const revision = Number(expected?.revision)
+  if (!envelope
+    || !CONTROL_STATUS_RE.test(status)
+    || !CONTROL_HASH_RE.test(planHash)
+    || (hasRevision && (!Number.isInteger(revision) || revision < 1))) {
+    return { updated: false, durable: mode !== 'memory', reason: 'invalid_transition' }
+  }
+  if (mode === 'supabase') {
+    try {
+      const row = rpcRow(await rest('POST', 'rpc/supermega_transition_control_record', {
+        p_record_key: key,
+        p_expected_status: status,
+        p_expected_plan_hash: planHash,
+        p_has_revision: hasRevision,
+        p_expected_revision: hasRevision ? revision : null,
+        p_record_type: envelope.record_type,
+        p_tenant_id: envelope.tenant_id,
+        p_status: envelope.status,
+        p_plan_hash: envelope.plan_hash,
+        p_payload: envelope.payload,
+        p_payload_hash: envelope.payload_hash,
+      }))
+      return row?.updated === true
+        ? { updated: true, durable: true }
+        : { updated: false, durable: true, reason: 'transition_conflict' }
+    } catch {
+      return { updated: false, durable: false, reason: 'store_unavailable' }
+    }
+  }
+  if (mode === 'postgres') {
+    try {
+      await ensurePgTables()
+      const row = (await q(
+        'select * from supermega_transition_control_record($1,$2,$3,$4,$5,$6,$7,$8,$9,$10::jsonb,$11)',
+        [key, status, planHash, hasRevision, hasRevision ? revision : null, envelope.record_type, envelope.tenant_id, envelope.status, envelope.plan_hash, JSON.stringify(envelope.payload), envelope.payload_hash],
+      ))[0]
+      return row?.updated === true
+        ? { updated: true, durable: true }
+        : { updated: false, durable: true, reason: 'transition_conflict' }
+    } catch {
+      return { updated: false, durable: false, reason: 'store_unavailable' }
+    }
+  }
+  const current = mem.controlRecords.get(key)
+  if (!current
+    || current.status !== status
+    || current.plan_hash !== planHash
+    || current.record_type !== envelope.record_type
+    || current.tenant_id !== envelope.tenant_id
+    || (hasRevision && current.payload?.revision !== revision)) {
+    return { updated: false, durable: false, reason: 'transition_conflict' }
+  }
+  const version = current.record_version + 1
+  const now = new Date().toISOString()
+  mem.controlRecords.set(key, { ...envelope, record_version: version, created_at: current.created_at, updated_at: now })
+  mem.controlTransitions.push({
+    record_key: key,
+    record_type: envelope.record_type,
+    tenant_id: envelope.tenant_id,
+    event_type: 'transitioned',
+    from_status: current.status,
+    to_status: envelope.status,
+    from_record_version: current.record_version,
+    to_record_version: version,
+    prior_payload_hash: current.payload_hash,
+    next_payload_hash: envelope.payload_hash,
+    created_at: now,
+  })
+  return { updated: true, durable: false }
+}
+
+// Compatibility adapter for existing Agent Company modules. Non-control keys retain response-cache
+// behavior; recognized authority keys are never read from or written to supermega_ai_cache.
+export async function getCachedResponse(cacheKey) {
+  return controlRecordType(cacheKey) ? getControlRecord(cacheKey) : getResponseCache(cacheKey)
+}
+
+export async function putCachedResponse(cacheKey, payload) {
+  return controlRecordType(cacheKey) ? putControlRecord(cacheKey, payload) : putResponseCache(cacheKey, payload)
+}
+
+export async function listCachedResponseRecords(query = {}) {
+  return controlRecordTypeForPrefix(String(query.prefix || '').trim())
+    ? listControlRecords(query)
+    : listResponseCacheRecords(query)
+}
+
+export async function transitionCachedResponse(cacheKey, expected, payload) {
+  return controlRecordType(cacheKey)
+    ? transitionControlRecord(cacheKey, expected, payload)
+    : transitionResponseCache(cacheKey, expected, payload)
 }
 
 // ---------- approval queue ----------
@@ -1112,4 +1929,4 @@ export async function ping() {
   return { ok: false, mode, detail: 'unknown_mode' }
 }
 
-export default { mode, listLeads, getLead, insertLead, updateLead, listClients, listProjects, createClient, getClient, createProject, updateProject, getProject, markDepositPaid, convertedLeadIds, saveDeal, listDeals, updateDeal, logActivity, claimActivity, releaseActivityClaim, getActivityClaim, transitionActivityClaim, listActivity, getTokenUsage, addTokenUsage, reserveAiBudget, getAiBudgetUsage, settleAiBudgetReservation, getCachedResponse, putCachedResponse, listCachedResponseRecords, transitionCachedResponse, createApprovalRecord, getApprovalRecord, listApprovalRecords, transitionApprovalRecord, recordPaymentEvent, ping, bumpGraduation, recordBuildModules, listGraduation }
+export default { mode, listLeads, getLead, insertLead, updateLead, listClients, listProjects, createClient, getClient, createProject, updateProject, getProject, markDepositPaid, convertedLeadIds, saveDeal, listDeals, updateDeal, logActivity, claimActivity, releaseActivityClaim, getActivityClaim, transitionActivityClaim, listActivity, getTokenUsage, addTokenUsage, reserveAiBudget, getAiBudgetUsage, settleAiBudgetReservation, reserveTokenSpend, markTokenSpendDispatched, markTokenSpendIndeterminate, settleTokenSpend, releaseTokenSpend, reconcileTokenSpend, getResponseCache, putResponseCache, getControlRecord, putControlRecord, listControlRecords, transitionControlRecord, getCachedResponse, putCachedResponse, listCachedResponseRecords, transitionCachedResponse, createApprovalRecord, getApprovalRecord, listApprovalRecords, transitionApprovalRecord, recordPaymentEvent, ping, bumpGraduation, recordBuildModules, listGraduation }

--- a/kernel/supabase/console-tables.sql
+++ b/kernel/supabase/console-tables.sql
@@ -64,6 +64,7 @@ create table if not exists public.supermega_graduation (
 create table if not exists public.supermega_token_ledger (
   tenant_id  text not null,
   "window"   text not null,   -- quoted: `window` is a reserved keyword in Postgres
+  cap_tokens bigint check (cap_tokens is null or cap_tokens > 0),
   in_tokens  bigint default 0,
   out_tokens bigint default 0,
   calls      bigint default 0,
@@ -158,6 +159,91 @@ as $supermega$
   where r."window" = p_window and r.status <> 'released'
 $supermega$;
 
+alter table public.supermega_token_ledger add column if not exists cap_tokens bigint;
+do $migration$
+begin
+  if not exists (select 1 from pg_constraint where conname='supermega_token_ledger_cap_positive') then
+    alter table public.supermega_token_ledger add constraint supermega_token_ledger_cap_positive check (cap_tokens is null or cap_tokens > 0);
+  end if;
+end;
+$migration$;
+
+create table if not exists public.supermega_spend_reservations (
+  reservation_id text primary key check (char_length(reservation_id) between 1 and 120),
+  tenant_id text not null check (char_length(tenant_id) between 1 and 200),
+  "window" text not null check ("window" ~ '^\d{4}-\d{2}$'),
+  reserved_tokens bigint not null check (reserved_tokens > 0),
+  status text not null default 'reserved' check (status in ('reserved', 'dispatched', 'indeterminate', 'settled', 'released')),
+  dispatch_token text not null check (char_length(dispatch_token) between 1 and 160),
+  context jsonb not null default '{}'::jsonb,
+  actual_in_tokens bigint not null default 0 check (actual_in_tokens >= 0),
+  actual_out_tokens bigint not null default 0 check (actual_out_tokens >= 0),
+  actual_calls bigint not null default 0 check (actual_calls >= 0),
+  reconciled_by text,
+  reconciliation_evidence_hash text,
+  reconciled_at timestamptz,
+  expires_at timestamptz not null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+alter table public.supermega_spend_reservations add column if not exists dispatch_token text;
+alter table public.supermega_spend_reservations add column if not exists context jsonb not null default '{}'::jsonb;
+alter table public.supermega_spend_reservations add column if not exists reconciled_by text;
+alter table public.supermega_spend_reservations add column if not exists reconciliation_evidence_hash text;
+alter table public.supermega_spend_reservations add column if not exists reconciled_at timestamptz;
+do $migration$
+begin
+  if exists (select 1 from public.supermega_spend_reservations where status='active') then
+    raise exception 'legacy_active_reservations_require_reconciliation';
+  end if;
+  if exists (
+    select 1 from pg_constraint
+     where conrelid='public.supermega_spend_reservations'::regclass
+       and conname='supermega_spend_reservations_status_check'
+       and pg_get_constraintdef(oid) not like '%indeterminate%'
+  ) then
+    alter table public.supermega_spend_reservations drop constraint supermega_spend_reservations_status_check;
+  end if;
+  if not exists (
+    select 1 from pg_constraint
+     where conrelid='public.supermega_spend_reservations'::regclass
+       and conname='supermega_spend_reservations_status_check'
+       and pg_get_constraintdef(oid) like '%indeterminate%'
+  ) then
+    alter table public.supermega_spend_reservations alter column status set default 'reserved';
+    alter table public.supermega_spend_reservations add constraint supermega_spend_reservations_status_check check (status in ('reserved', 'dispatched', 'indeterminate', 'settled', 'released'));
+  end if;
+  update public.supermega_spend_reservations
+     set dispatch_token='legacy-terminal:' || md5(reservation_id)
+   where dispatch_token is null and status in ('settled','released');
+  if exists (select 1 from public.supermega_spend_reservations where dispatch_token is null) then
+    raise exception 'reservation_dispatch_token_reconciliation_required';
+  end if;
+  alter table public.supermega_spend_reservations alter column dispatch_token set not null;
+  if not exists (
+    select 1 from pg_constraint
+     where conrelid='public.supermega_spend_reservations'::regclass
+       and conname='supermega_spend_reservations_dispatch_token_check'
+  ) then
+    alter table public.supermega_spend_reservations add constraint supermega_spend_reservations_dispatch_token_check check (char_length(dispatch_token) between 1 and 160);
+  end if;
+  if not exists (
+    select 1 from pg_constraint
+     where conrelid='public.supermega_spend_reservations'::regclass
+       and conname='supermega_spend_reservations_reconciliation_check'
+  ) then
+    alter table public.supermega_spend_reservations add constraint supermega_spend_reservations_reconciliation_check check (
+      (reconciled_by is null and reconciliation_evidence_hash is null and reconciled_at is null)
+      or (char_length(reconciled_by) between 1 and 80 and reconciliation_evidence_hash ~ '^[a-f0-9]{64}$' and reconciled_at is not null)
+    );
+  end if;
+end;
+$migration$;
+
+create index if not exists supermega_spend_reservations_active_idx
+  on public.supermega_spend_reservations (tenant_id, "window", status);
+
 create table if not exists public.supermega_ai_cache (
   cache_key  text primary key,
   payload    jsonb not null,
@@ -200,11 +286,15 @@ alter table public.supermega_console_deals    enable row level security;
 alter table public.supermega_console_activity enable row level security;
 alter table public.supermega_token_ledger     enable row level security;
 alter table public.supermega_ai_budget_reservations enable row level security;
+alter table public.supermega_spend_reservations enable row level security;
 alter table public.supermega_ai_cache         enable row level security;
 alter table public.supermega_graduation       enable row level security;
 alter table public.supermega_action_queue     enable row level security;
 
 revoke all on public.supermega_action_queue from anon, authenticated;
+revoke all on public.supermega_token_ledger from anon, authenticated;
+revoke all on public.supermega_token_ledger from public, service_role;
+revoke all on public.supermega_spend_reservations from public, anon, authenticated, service_role;
 grant select, insert, update, delete on public.supermega_action_queue to service_role;
 revoke all on public.supermega_ai_budget_reservations from anon, authenticated;
 grant select, insert, update, delete on public.supermega_ai_budget_reservations to service_role;
@@ -212,6 +302,641 @@ revoke all on function public.supermega_reserve_ai_budget(text,text,bigint,bigin
 grant execute on function public.supermega_reserve_ai_budget(text,text,bigint,bigint,text,text,text) to service_role;
 revoke all on function public.supermega_get_ai_budget_usage(text) from public, anon, authenticated;
 grant execute on function public.supermega_get_ai_budget_usage(text) to service_role;
+
+create or replace function public.supermega_get_token_usage(p_tenant_id text, p_window text)
+returns table (
+  tenant_id text,
+  "window" text,
+  cap_tokens bigint,
+  in_tokens bigint,
+  out_tokens bigint,
+  calls bigint,
+  reserved_tokens bigint,
+  committed_tokens bigint,
+  spend_total bigint
+)
+language sql
+stable
+security definer
+set search_path = ''
+as $$
+  select
+    p_tenant_id,
+    p_window,
+    ledger.cap_tokens,
+    coalesce(ledger.in_tokens, 0),
+    coalesce(ledger.out_tokens, 0),
+    coalesce(ledger.calls, 0),
+    coalesce((select sum(r.reserved_tokens) from public.supermega_spend_reservations as r where r.tenant_id=p_tenant_id and r."window"=p_window and r.status in ('reserved','dispatched','indeterminate')), 0),
+    coalesce(ledger.in_tokens, 0) + coalesce(ledger.out_tokens, 0),
+    coalesce(ledger.in_tokens, 0) + coalesce(ledger.out_tokens, 0)
+      + coalesce((select sum(r.reserved_tokens) from public.supermega_spend_reservations as r where r.tenant_id=p_tenant_id and r."window"=p_window and r.status in ('reserved','dispatched','indeterminate')), 0)
+  from (values (1)) as seed(n)
+  left join public.supermega_token_ledger as ledger
+    on ledger.tenant_id=p_tenant_id and ledger."window"=p_window
+  where p_tenant_id is not null and p_tenant_id <> '' and p_window ~ '^\d{4}-\d{2}$';
+$$;
+
+drop function if exists public.supermega_add_token_usage(text, text, bigint, bigint, bigint);
+
+drop function if exists public.supermega_reserve_token_spend(text, text, text, bigint, bigint, timestamptz);
+drop function if exists public.supermega_settle_token_spend(text, bigint, bigint, bigint);
+drop function if exists public.supermega_release_token_spend(text);
+
+create or replace function public.supermega_reserve_token_spend(
+  p_reservation_id text,
+  p_tenant_id text,
+  p_window text,
+  p_reserved_tokens bigint,
+  p_cap_tokens bigint,
+  p_expires_at timestamptz,
+  p_dispatch_token text,
+  p_context jsonb
+)
+returns table (
+  accepted boolean,
+  reason text,
+  reservation_id text,
+  status text,
+  in_tokens bigint,
+  out_tokens bigint,
+  calls bigint,
+  reserved_tokens bigint,
+  committed_tokens bigint,
+  spend_total bigint
+)
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_in bigint;
+  v_out bigint;
+  v_calls bigint;
+  v_cap bigint;
+  v_reserved bigint;
+  v_existing_tenant text;
+  v_existing_window text;
+  v_existing_reserved bigint;
+  v_existing_status text;
+  v_existing_dispatch_token text;
+  v_existing_context jsonb;
+  v_existing_expires_at timestamptz;
+  v_same_scope boolean;
+begin
+  if p_reservation_id is null or char_length(p_reservation_id) not between 1 and 120
+     or p_tenant_id is null or char_length(p_tenant_id) not between 1 and 200
+     or p_window !~ '^\d{4}-\d{2}$' or p_reserved_tokens <= 0 or p_cap_tokens <= 0
+     or p_expires_at is null or p_expires_at <= now()
+     or p_dispatch_token is null or char_length(p_dispatch_token) not between 1 and 160
+     or p_context is null or jsonb_typeof(p_context) <> 'object' or pg_column_size(p_context) > 4096 then
+    raise exception 'invalid_spend_reservation';
+  end if;
+
+  insert into public.supermega_token_ledger (tenant_id, "window", cap_tokens)
+  values (p_tenant_id, p_window, p_cap_tokens)
+  on conflict do nothing;
+
+  select ledger.cap_tokens, ledger.in_tokens, ledger.out_tokens, ledger.calls
+    into v_cap, v_in, v_out, v_calls
+    from public.supermega_token_ledger as ledger
+   where ledger.tenant_id = p_tenant_id and ledger."window" = p_window
+   for update;
+
+  if v_cap is null then
+    update public.supermega_token_ledger as ledger
+       set cap_tokens=p_cap_tokens, updated_at=now()
+     where ledger.tenant_id=p_tenant_id and ledger."window"=p_window
+     returning ledger.cap_tokens, ledger.in_tokens, ledger.out_tokens, ledger.calls into v_cap, v_in, v_out, v_calls;
+  end if;
+
+  select r.tenant_id, r."window", r.reserved_tokens, r.status, r.dispatch_token, r.context, r.expires_at
+    into v_existing_tenant, v_existing_window, v_existing_reserved, v_existing_status, v_existing_dispatch_token, v_existing_context, v_existing_expires_at
+    from public.supermega_spend_reservations as r
+   where r.reservation_id = p_reservation_id;
+
+  select coalesce(sum(r.reserved_tokens), 0)
+    into v_reserved
+    from public.supermega_spend_reservations as r
+   where r.tenant_id = p_tenant_id and r."window" = p_window and r.status in ('reserved','dispatched','indeterminate');
+
+  if v_cap <> p_cap_tokens then
+    accepted := false;
+    reason := 'cap_mismatch';
+    reservation_id := p_reservation_id;
+    status := 'rejected';
+    in_tokens := v_in;
+    out_tokens := v_out;
+    calls := v_calls;
+    reserved_tokens := v_reserved;
+    committed_tokens := v_in + v_out;
+    spend_total := v_in + v_out + v_reserved;
+    return next;
+    return;
+  end if;
+
+  if v_existing_status is not null then
+    v_same_scope := v_existing_tenant = p_tenant_id
+      and v_existing_window = p_window
+      and v_existing_reserved = p_reserved_tokens
+      and v_existing_context = p_context;
+    if v_same_scope and v_existing_status = 'reserved' and v_existing_dispatch_token = p_dispatch_token then
+      accepted := true;
+      reason := 'idempotent';
+    elsif v_same_scope and v_existing_status = 'reserved' and v_existing_expires_at <= now() then
+      update public.supermega_spend_reservations as r
+         set dispatch_token=p_dispatch_token, context=p_context, expires_at=p_expires_at, updated_at=now()
+       where r.reservation_id=p_reservation_id;
+      accepted := true;
+      reason := 'reservation_reclaimed';
+    else
+      accepted := false;
+      reason := case
+        when v_same_scope and v_existing_status in ('dispatched','indeterminate') then 'reconciliation_required'
+        when v_same_scope and v_existing_status = 'reserved' then 'reservation_in_progress'
+        else 'reservation_exists'
+      end;
+    end if;
+    reservation_id := p_reservation_id;
+    status := v_existing_status;
+    in_tokens := v_in;
+    out_tokens := v_out;
+    calls := v_calls;
+    reserved_tokens := v_reserved;
+    committed_tokens := v_in + v_out;
+    spend_total := v_in + v_out + v_reserved;
+    return next;
+    return;
+  end if;
+
+  if v_in + v_out + v_reserved + p_reserved_tokens > v_cap then
+    accepted := false;
+    reason := 'cap_reached';
+    reservation_id := p_reservation_id;
+    status := 'rejected';
+    in_tokens := v_in;
+    out_tokens := v_out;
+    calls := v_calls;
+    reserved_tokens := v_reserved;
+    committed_tokens := v_in + v_out;
+    spend_total := v_in + v_out + v_reserved;
+    return next;
+    return;
+  end if;
+
+  insert into public.supermega_spend_reservations (reservation_id, tenant_id, "window", reserved_tokens, status, expires_at, dispatch_token, context)
+  values (p_reservation_id, p_tenant_id, p_window, p_reserved_tokens, 'reserved', p_expires_at, p_dispatch_token, p_context);
+
+  accepted := true;
+  reason := 'reserved';
+  reservation_id := p_reservation_id;
+  status := 'reserved';
+  in_tokens := v_in;
+  out_tokens := v_out;
+  calls := v_calls;
+  reserved_tokens := v_reserved + p_reserved_tokens;
+  committed_tokens := v_in + v_out;
+  spend_total := v_in + v_out + v_reserved + p_reserved_tokens;
+  return next;
+end;
+$$;
+
+create or replace function public.supermega_mark_token_spend_dispatched(
+  p_reservation_id text,
+  p_dispatch_token text
+)
+returns table (changed boolean, reason text, reservation_id text, status text)
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_status text;
+  v_dispatch_token text;
+  v_expires_at timestamptz;
+begin
+  if p_reservation_id is null or p_reservation_id = ''
+     or p_dispatch_token is null or p_dispatch_token = '' then
+    raise exception 'invalid_spend_dispatch';
+  end if;
+  select r.status, r.dispatch_token, r.expires_at
+    into v_status, v_dispatch_token, v_expires_at
+    from public.supermega_spend_reservations as r
+   where r.reservation_id=p_reservation_id
+   for update;
+  if not found then
+    changed := false; reason := 'reservation_not_found'; reservation_id := p_reservation_id; return next; return;
+  end if;
+  if v_dispatch_token is distinct from p_dispatch_token then
+    changed := false; reason := 'dispatch_token_mismatch';
+  elsif v_status = 'dispatched' then
+    changed := true; reason := 'idempotent';
+  elsif v_status <> 'reserved' then
+    changed := false; reason := 'invalid_reservation_state';
+  elsif v_expires_at <= now() then
+    changed := false; reason := 'reservation_stale';
+  else
+    update public.supermega_spend_reservations as r
+       set status='dispatched', updated_at=now()
+     where r.reservation_id=p_reservation_id;
+    changed := true; reason := 'dispatched'; v_status := 'dispatched';
+  end if;
+  reservation_id := p_reservation_id; status := v_status; return next;
+end;
+$$;
+
+create or replace function public.supermega_mark_token_spend_indeterminate(
+  p_reservation_id text,
+  p_dispatch_token text
+)
+returns table (changed boolean, reason text, reservation_id text, status text)
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_status text;
+  v_dispatch_token text;
+begin
+  if p_reservation_id is null or p_reservation_id = ''
+     or p_dispatch_token is null or p_dispatch_token = '' then
+    raise exception 'invalid_spend_indeterminate';
+  end if;
+  select r.status, r.dispatch_token
+    into v_status, v_dispatch_token
+    from public.supermega_spend_reservations as r
+   where r.reservation_id=p_reservation_id
+   for update;
+  if not found then
+    changed := false; reason := 'reservation_not_found'; reservation_id := p_reservation_id; return next; return;
+  end if;
+  if v_dispatch_token is distinct from p_dispatch_token then
+    changed := false; reason := 'dispatch_token_mismatch';
+  elsif v_status = 'indeterminate' then
+    changed := true; reason := 'idempotent';
+  elsif v_status <> 'dispatched' then
+    changed := false; reason := 'invalid_reservation_state';
+  else
+    update public.supermega_spend_reservations as r
+       set status='indeterminate', updated_at=now()
+     where r.reservation_id=p_reservation_id;
+    changed := true; reason := 'indeterminate'; v_status := 'indeterminate';
+  end if;
+  reservation_id := p_reservation_id; status := v_status; return next;
+end;
+$$;
+
+create or replace function public.supermega_settle_token_spend(
+  p_reservation_id text,
+  p_dispatch_token text,
+  p_in_tokens bigint,
+  p_out_tokens bigint,
+  p_calls bigint
+)
+returns table (
+  settled boolean,
+  reason text,
+  reservation_id text,
+  status text,
+  in_tokens bigint,
+  out_tokens bigint,
+  calls bigint,
+  reserved_tokens bigint,
+  committed_tokens bigint,
+  spend_total bigint
+)
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_tenant text;
+  v_window text;
+  v_status text;
+  v_reserved_for_call bigint;
+  v_actual_in bigint;
+  v_actual_out bigint;
+  v_actual_calls bigint;
+  v_dispatch_token text;
+  v_in bigint;
+  v_out bigint;
+  v_calls bigint;
+  v_reserved bigint;
+begin
+  if p_reservation_id is null or p_reservation_id = '' or p_dispatch_token is null or p_dispatch_token = '' or p_in_tokens < 0 or p_out_tokens < 0 or p_calls < 0 then
+    raise exception 'invalid_spend_settlement';
+  end if;
+
+  select r.tenant_id, r."window"
+    into v_tenant, v_window
+    from public.supermega_spend_reservations as r
+   where r.reservation_id = p_reservation_id;
+  if not found then
+    settled := false;
+    reason := 'reservation_not_found';
+    reservation_id := p_reservation_id;
+    return next;
+    return;
+  end if;
+
+  select ledger.in_tokens, ledger.out_tokens, ledger.calls
+    into v_in, v_out, v_calls
+    from public.supermega_token_ledger as ledger
+   where ledger.tenant_id = v_tenant and ledger."window" = v_window
+   for update;
+
+  select r.status, r.reserved_tokens, r.actual_in_tokens, r.actual_out_tokens, r.actual_calls, r.dispatch_token
+    into v_status, v_reserved_for_call, v_actual_in, v_actual_out, v_actual_calls, v_dispatch_token
+    from public.supermega_spend_reservations as r
+   where r.reservation_id = p_reservation_id
+   for update;
+
+  if v_dispatch_token is distinct from p_dispatch_token then
+    settled := false;
+    reason := 'dispatch_token_mismatch';
+  elsif v_status = 'released' then
+    settled := false;
+    reason := 'reservation_released';
+  elsif v_status = 'settled' then
+    settled := v_actual_in = p_in_tokens and v_actual_out = p_out_tokens and v_actual_calls = p_calls;
+    reason := case when settled then 'idempotent' else 'settlement_conflict' end;
+  elsif v_status = 'reserved' then
+    settled := false;
+    reason := 'reservation_not_dispatched';
+  elsif p_in_tokens + p_out_tokens > v_reserved_for_call then
+    settled := false;
+    reason := 'actual_exceeds_reservation';
+  elsif v_status not in ('dispatched','indeterminate') then
+    settled := false;
+    reason := 'invalid_reservation_state';
+  else
+    update public.supermega_token_ledger as ledger set
+      in_tokens = ledger.in_tokens + p_in_tokens,
+      out_tokens = ledger.out_tokens + p_out_tokens,
+      calls = ledger.calls + p_calls,
+      updated_at = now()
+    where ledger.tenant_id = v_tenant and ledger."window" = v_window
+    returning ledger.in_tokens, ledger.out_tokens, ledger.calls into v_in, v_out, v_calls;
+
+    update public.supermega_spend_reservations as r set
+      status = 'settled',
+      actual_in_tokens = p_in_tokens,
+      actual_out_tokens = p_out_tokens,
+      actual_calls = p_calls,
+      updated_at = now()
+    where r.reservation_id = p_reservation_id;
+    settled := true;
+    reason := 'settled';
+    v_status := 'settled';
+  end if;
+
+  select coalesce(sum(r.reserved_tokens), 0)
+    into v_reserved
+    from public.supermega_spend_reservations as r
+   where r.tenant_id = v_tenant and r."window" = v_window and r.status in ('reserved','dispatched','indeterminate');
+  reservation_id := p_reservation_id;
+  status := v_status;
+  in_tokens := v_in;
+  out_tokens := v_out;
+  calls := v_calls;
+  reserved_tokens := v_reserved;
+  committed_tokens := v_in + v_out;
+  spend_total := v_in + v_out + v_reserved;
+  return next;
+end;
+$$;
+
+create or replace function public.supermega_release_token_spend(p_reservation_id text, p_dispatch_token text, p_definitive boolean)
+returns table (
+  released boolean,
+  reason text,
+  reservation_id text,
+  status text,
+  in_tokens bigint,
+  out_tokens bigint,
+  calls bigint,
+  reserved_tokens bigint,
+  committed_tokens bigint,
+  spend_total bigint
+)
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_tenant text;
+  v_window text;
+  v_status text;
+  v_in bigint;
+  v_out bigint;
+  v_calls bigint;
+  v_reserved bigint;
+  v_dispatch_token text;
+begin
+  if p_reservation_id is null or p_reservation_id = '' or p_dispatch_token is null or p_dispatch_token = '' or p_definitive is null then
+    raise exception 'invalid_spend_release';
+  end if;
+  select r.tenant_id, r."window"
+    into v_tenant, v_window
+    from public.supermega_spend_reservations as r
+   where r.reservation_id = p_reservation_id;
+  if not found then
+    released := false;
+    reason := 'reservation_not_found';
+    reservation_id := p_reservation_id;
+    return next;
+    return;
+  end if;
+
+  select ledger.in_tokens, ledger.out_tokens, ledger.calls
+    into v_in, v_out, v_calls
+    from public.supermega_token_ledger as ledger
+   where ledger.tenant_id = v_tenant and ledger."window" = v_window
+   for update;
+  select r.status, r.dispatch_token into v_status, v_dispatch_token
+    from public.supermega_spend_reservations as r
+   where r.reservation_id = p_reservation_id
+   for update;
+
+  if v_dispatch_token is distinct from p_dispatch_token then
+    released := false;
+    reason := 'dispatch_token_mismatch';
+  elsif v_status = 'settled' then
+    released := false;
+    reason := 'reservation_settled';
+  elsif v_status = 'released' then
+    released := true;
+    reason := 'idempotent';
+  elsif v_status = 'indeterminate' then
+    released := false;
+    reason := 'reservation_indeterminate';
+  elsif v_status = 'dispatched' and not p_definitive then
+    released := false;
+    reason := 'dispatch_not_definitive';
+  elsif v_status not in ('reserved','dispatched') then
+    released := false;
+    reason := 'invalid_reservation_state';
+  else
+    update public.supermega_spend_reservations as r
+       set status = 'released', updated_at = now()
+     where r.reservation_id = p_reservation_id;
+    released := true;
+    reason := 'released';
+    v_status := 'released';
+  end if;
+
+  select coalesce(sum(r.reserved_tokens), 0)
+    into v_reserved
+    from public.supermega_spend_reservations as r
+   where r.tenant_id = v_tenant and r."window" = v_window and r.status in ('reserved','dispatched','indeterminate');
+  reservation_id := p_reservation_id;
+  status := v_status;
+  in_tokens := v_in;
+  out_tokens := v_out;
+  calls := v_calls;
+  reserved_tokens := v_reserved;
+  committed_tokens := v_in + v_out;
+  spend_total := v_in + v_out + v_reserved;
+  return next;
+end;
+$$;
+
+create or replace function public.supermega_reconcile_token_spend(
+  p_reservation_id text,
+  p_action text,
+  p_in_tokens bigint,
+  p_out_tokens bigint,
+  p_calls bigint,
+  p_actor text,
+  p_evidence_hash text
+)
+returns table (
+  reconciled boolean,
+  reason text,
+  reservation_id text,
+  status text,
+  in_tokens bigint,
+  out_tokens bigint,
+  calls bigint,
+  reserved_tokens bigint,
+  committed_tokens bigint,
+  spend_total bigint
+)
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_tenant text;
+  v_window text;
+  v_status text;
+  v_reserved_for_call bigint;
+  v_actual_in bigint;
+  v_actual_out bigint;
+  v_actual_calls bigint;
+  v_reconciled_by text;
+  v_evidence_hash text;
+  v_in bigint;
+  v_out bigint;
+  v_calls bigint;
+  v_reserved bigint;
+  v_terminal text;
+begin
+  if p_reservation_id is null or p_reservation_id = ''
+     or p_action is null or p_action not in ('settle','release')
+     or p_in_tokens is null or p_out_tokens is null or p_calls is null
+     or p_in_tokens < 0 or p_out_tokens < 0 or p_calls < 0
+     or p_actor is null or char_length(p_actor) not between 1 and 80
+     or p_evidence_hash is null or p_evidence_hash !~ '^[a-f0-9]{64}$'
+     or (p_action='release' and (p_in_tokens <> 0 or p_out_tokens <> 0 or p_calls <> 0)) then
+    raise exception 'invalid_spend_reconciliation';
+  end if;
+  select r.tenant_id, r."window"
+    into v_tenant, v_window
+    from public.supermega_spend_reservations as r
+   where r.reservation_id=p_reservation_id;
+  if not found then
+    reconciled := false; reason := 'reservation_not_found'; reservation_id := p_reservation_id; return next; return;
+  end if;
+  select ledger.in_tokens, ledger.out_tokens, ledger.calls
+    into v_in, v_out, v_calls
+    from public.supermega_token_ledger as ledger
+   where ledger.tenant_id=v_tenant and ledger."window"=v_window
+   for update;
+  select r.status, r.reserved_tokens, r.actual_in_tokens, r.actual_out_tokens, r.actual_calls, r.reconciled_by, r.reconciliation_evidence_hash
+    into v_status, v_reserved_for_call, v_actual_in, v_actual_out, v_actual_calls, v_reconciled_by, v_evidence_hash
+    from public.supermega_spend_reservations as r
+   where r.reservation_id=p_reservation_id
+   for update;
+  v_terminal := case when p_action='settle' then 'settled' else 'released' end;
+  if v_status=v_terminal
+     and v_reconciled_by=p_actor
+     and v_evidence_hash=p_evidence_hash
+     and (p_action='release' or (v_actual_in=p_in_tokens and v_actual_out=p_out_tokens and v_actual_calls=p_calls)) then
+    reconciled := true;
+    reason := 'idempotent';
+  elsif v_status in ('settled','released') then
+    reconciled := false;
+    reason := 'reconciliation_conflict';
+  elsif v_status not in ('dispatched','indeterminate') then
+    reconciled := false;
+    reason := 'invalid_reservation_state';
+  elsif p_action='settle' and p_in_tokens+p_out_tokens > v_reserved_for_call then
+    reconciled := false;
+    reason := 'actual_exceeds_reservation';
+  else
+    if p_action='settle' then
+      update public.supermega_token_ledger as ledger set
+        in_tokens=ledger.in_tokens+p_in_tokens,
+        out_tokens=ledger.out_tokens+p_out_tokens,
+        calls=ledger.calls+p_calls,
+        updated_at=now()
+      where ledger.tenant_id=v_tenant and ledger."window"=v_window
+      returning ledger.in_tokens, ledger.out_tokens, ledger.calls into v_in, v_out, v_calls;
+    end if;
+    update public.supermega_spend_reservations as r set
+      status=v_terminal,
+      actual_in_tokens=p_in_tokens,
+      actual_out_tokens=p_out_tokens,
+      actual_calls=p_calls,
+      reconciled_by=p_actor,
+      reconciliation_evidence_hash=p_evidence_hash,
+      reconciled_at=now(),
+      updated_at=now()
+    where r.reservation_id=p_reservation_id;
+    v_status := v_terminal;
+    reconciled := true;
+    reason := 'reconciled';
+  end if;
+  select coalesce(sum(r.reserved_tokens),0)
+    into v_reserved
+    from public.supermega_spend_reservations as r
+   where r.tenant_id=v_tenant and r."window"=v_window and r.status in ('reserved','dispatched','indeterminate');
+  reservation_id := p_reservation_id;
+  status := v_status;
+  in_tokens := v_in;
+  out_tokens := v_out;
+  calls := v_calls;
+  reserved_tokens := v_reserved;
+  committed_tokens := v_in+v_out;
+  spend_total := v_in+v_out+v_reserved;
+  return next;
+end;
+$$;
+revoke execute on function public.supermega_get_token_usage(text, text) from public, anon, authenticated;
+revoke execute on function public.supermega_reserve_token_spend(text, text, text, bigint, bigint, timestamptz, text, jsonb) from public, anon, authenticated;
+revoke execute on function public.supermega_mark_token_spend_dispatched(text, text) from public, anon, authenticated;
+revoke execute on function public.supermega_mark_token_spend_indeterminate(text, text) from public, anon, authenticated;
+revoke execute on function public.supermega_settle_token_spend(text, text, bigint, bigint, bigint) from public, anon, authenticated;
+revoke execute on function public.supermega_release_token_spend(text, text, boolean) from public, anon, authenticated;
+revoke execute on function public.supermega_reconcile_token_spend(text, text, bigint, bigint, bigint, text, text) from public, anon, authenticated;
+grant execute on function public.supermega_get_token_usage(text, text) to service_role;
+grant execute on function public.supermega_reserve_token_spend(text, text, text, bigint, bigint, timestamptz, text, jsonb) to service_role;
+grant execute on function public.supermega_mark_token_spend_dispatched(text, text) to service_role;
+grant execute on function public.supermega_mark_token_spend_indeterminate(text, text) to service_role;
+grant execute on function public.supermega_settle_token_spend(text, text, bigint, bigint, bigint) to service_role;
+grant execute on function public.supermega_release_token_spend(text, text, boolean) to service_role;
+grant execute on function public.supermega_reconcile_token_spend(text, text, bigint, bigint, bigint, text, text) to service_role;
 
 -- Reload PostgREST schema cache
 notify pgrst, 'reload schema';

--- a/kernel/supabase/control-records-migration.sql
+++ b/kernel/supabase/control-records-migration.sql
@@ -1,0 +1,225 @@
+-- AI-009: move Agent Company authority out of the ephemeral model-response cache.
+-- This migration intentionally does not copy rows from supermega_ai_cache. Legacy cache rows are
+-- inert; an operator must recreate or explicitly reconcile authority through the control APIs.
+
+begin;
+
+create table if not exists public.supermega_control_records (
+  record_key text primary key,
+  record_type text not null,
+  tenant_id text not null,
+  status text not null,
+  plan_hash text not null,
+  payload jsonb not null,
+  payload_hash text not null,
+  record_version bigint not null default 1 check (record_version >= 1),
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint supermega_control_records_key_check check (char_length(record_key) between 1 and 240),
+  constraint supermega_control_records_type_check check (record_type in ('sign_in_code','operator_session','mission','work_order','work_order_review','work_order_evaluation','ceo_outcome_operation','ceo_outcome_evaluation','ceo_outcome_delivery','ceo_outcome_action')),
+  constraint supermega_control_records_tenant_check check (char_length(tenant_id) between 1 and 80),
+  constraint supermega_control_records_status_check check (status ~ '^[a-z][a-z_]{0,39}$'),
+  constraint supermega_control_records_plan_hash_check check (plan_hash ~ '^[a-f0-9]{64}$'),
+  constraint supermega_control_records_payload_hash_check check (payload_hash ~ '^[a-f0-9]{64}$')
+);
+
+-- Databases migrated before the CEO outcome record types existed carry the narrower constraint;
+-- widen it idempotently so re-running this migration upgrades them in place.
+do $widen$
+begin
+  if exists (
+    select 1 from pg_constraint
+     where conrelid='public.supermega_control_records'::regclass
+       and conname='supermega_control_records_type_check'
+       and pg_get_constraintdef(oid) not like '%ceo_outcome_operation%'
+  ) then
+    alter table public.supermega_control_records drop constraint supermega_control_records_type_check;
+    alter table public.supermega_control_records add constraint supermega_control_records_type_check
+      check (record_type in ('sign_in_code','operator_session','mission','work_order','work_order_review','work_order_evaluation','ceo_outcome_operation','ceo_outcome_evaluation','ceo_outcome_delivery','ceo_outcome_action'));
+  end if;
+end;
+$widen$;
+
+create index if not exists supermega_control_records_tenant_type_status_idx
+  on public.supermega_control_records (tenant_id, record_type, status, updated_at desc);
+
+create table if not exists public.supermega_control_transitions (
+  transition_id bigint generated always as identity primary key,
+  record_key text not null references public.supermega_control_records(record_key) on delete restrict,
+  record_type text not null,
+  tenant_id text not null,
+  event_type text not null check (event_type in ('created','replaced','transitioned')),
+  from_status text,
+  to_status text not null,
+  from_record_version bigint,
+  to_record_version bigint not null,
+  prior_payload_hash text,
+  next_payload_hash text not null,
+  created_at timestamptz not null default now(),
+  constraint supermega_control_transition_version_check check (
+    to_record_version >= 1
+    and (from_record_version is null or from_record_version + 1 = to_record_version)
+  ),
+  constraint supermega_control_transition_prior_hash_check check (
+    prior_payload_hash is null or prior_payload_hash ~ '^[a-f0-9]{64}$'
+  ),
+  constraint supermega_control_transition_next_hash_check check (next_payload_hash ~ '^[a-f0-9]{64}$')
+);
+
+create unique index if not exists supermega_control_transitions_record_version_uidx
+  on public.supermega_control_transitions (record_key, to_record_version);
+
+create or replace function public.supermega_reject_control_transition_mutation()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $immutable$
+begin
+  raise exception 'control_transition_history_is_immutable';
+end;
+$immutable$;
+
+drop trigger if exists supermega_control_transitions_immutable on public.supermega_control_transitions;
+create trigger supermega_control_transitions_immutable
+before update or delete on public.supermega_control_transitions
+for each row execute function public.supermega_reject_control_transition_mutation();
+
+create or replace function public.supermega_put_control_record(
+  p_record_key text,
+  p_record_type text,
+  p_tenant_id text,
+  p_status text,
+  p_plan_hash text,
+  p_payload jsonb,
+  p_payload_hash text
+)
+returns table (updated boolean, version bigint)
+language plpgsql
+security definer
+set search_path = ''
+as $control$
+declare
+  existing public.supermega_control_records%rowtype;
+  next_version bigint;
+begin
+  select * into existing
+    from public.supermega_control_records
+   where record_key = p_record_key
+   for update;
+
+  if not found then
+    insert into public.supermega_control_records (
+      record_key, record_type, tenant_id, status, plan_hash, payload, payload_hash, record_version
+    ) values (
+      p_record_key, p_record_type, p_tenant_id, p_status, p_plan_hash, p_payload, p_payload_hash, 1
+    );
+    insert into public.supermega_control_transitions (
+      record_key, record_type, tenant_id, event_type, to_status, to_record_version, next_payload_hash
+    ) values (
+      p_record_key, p_record_type, p_tenant_id, 'created', p_status, 1, p_payload_hash
+    );
+    return query select true, 1::bigint;
+    return;
+  end if;
+
+  if existing.record_type <> p_record_type or existing.tenant_id <> p_tenant_id then
+    raise exception 'control_record_identity_conflict';
+  end if;
+
+  next_version := existing.record_version + 1;
+  update public.supermega_control_records
+     set status = p_status,
+         plan_hash = p_plan_hash,
+         payload = p_payload,
+         payload_hash = p_payload_hash,
+         record_version = next_version,
+         updated_at = now()
+   where record_key = p_record_key;
+  insert into public.supermega_control_transitions (
+    record_key, record_type, tenant_id, event_type, from_status, to_status,
+    from_record_version, to_record_version, prior_payload_hash, next_payload_hash
+  ) values (
+    p_record_key, p_record_type, p_tenant_id, 'replaced', existing.status, p_status,
+    existing.record_version, next_version, existing.payload_hash, p_payload_hash
+  );
+  return query select true, next_version;
+end;
+$control$;
+
+create or replace function public.supermega_transition_control_record(
+  p_record_key text,
+  p_expected_status text,
+  p_expected_plan_hash text,
+  p_has_revision boolean,
+  p_expected_revision bigint,
+  p_record_type text,
+  p_tenant_id text,
+  p_status text,
+  p_plan_hash text,
+  p_payload jsonb,
+  p_payload_hash text
+)
+returns table (updated boolean, version bigint)
+language plpgsql
+security definer
+set search_path = ''
+as $control$
+declare
+  existing public.supermega_control_records%rowtype;
+  next_version bigint;
+begin
+  select * into existing
+    from public.supermega_control_records
+   where record_key = p_record_key
+     and status = p_expected_status
+     and plan_hash = p_expected_plan_hash
+     and (not p_has_revision or payload->>'revision' = p_expected_revision::text)
+   for update;
+
+  if not found then
+    return query select false, null::bigint;
+    return;
+  end if;
+  if existing.record_type <> p_record_type or existing.tenant_id <> p_tenant_id then
+    raise exception 'control_record_identity_conflict';
+  end if;
+
+  next_version := existing.record_version + 1;
+  update public.supermega_control_records
+     set status = p_status,
+         plan_hash = p_plan_hash,
+         payload = p_payload,
+         payload_hash = p_payload_hash,
+         record_version = next_version,
+         updated_at = now()
+   where record_key = p_record_key;
+  insert into public.supermega_control_transitions (
+    record_key, record_type, tenant_id, event_type, from_status, to_status,
+    from_record_version, to_record_version, prior_payload_hash, next_payload_hash
+  ) values (
+    p_record_key, p_record_type, p_tenant_id, 'transitioned', existing.status, p_status,
+    existing.record_version, next_version, existing.payload_hash, p_payload_hash
+  );
+  return query select true, next_version;
+end;
+$control$;
+
+alter table public.supermega_control_records enable row level security;
+alter table public.supermega_control_transitions enable row level security;
+
+revoke all on public.supermega_control_records from public, anon, authenticated, service_role;
+revoke all on public.supermega_control_transitions from public, anon, authenticated, service_role;
+grant select on public.supermega_control_records to service_role;
+
+revoke all on function public.supermega_put_control_record(text,text,text,text,text,jsonb,text) from public, anon, authenticated;
+revoke all on function public.supermega_transition_control_record(text,text,text,boolean,bigint,text,text,text,text,jsonb,text) from public, anon, authenticated;
+grant execute on function public.supermega_put_control_record(text,text,text,text,text,jsonb,text) to service_role;
+grant execute on function public.supermega_transition_control_record(text,text,text,boolean,bigint,text,text,text,text,jsonb,text) to service_role;
+
+comment on table public.supermega_control_records is
+  'Versioned Agent Company authority. Never hydrate from supermega_ai_cache.';
+comment on table public.supermega_control_transitions is
+  'Append-only evidence for every control-record create, replacement, and compare-and-swap transition.';
+
+commit;

--- a/kernel/supabase/control-records-rollback.sql
+++ b/kernel/supabase/control-records-rollback.sql
@@ -1,0 +1,32 @@
+-- AI-009 rollback fixture. This is intentionally fail-closed: authority rows must be explicitly
+-- reconciled and removed before the dedicated control plane can be dropped.
+
+begin;
+
+do $rollback$
+declare
+  has_rows boolean;
+begin
+  if to_regclass('public.supermega_control_records') is not null then
+    execute 'select exists (select 1 from public.supermega_control_records limit 1)' into has_rows;
+    if has_rows then
+      raise exception 'control_records_require_explicit_reconciliation_before_rollback';
+    end if;
+  end if;
+  if to_regclass('public.supermega_control_transitions') is not null then
+    execute 'select exists (select 1 from public.supermega_control_transitions limit 1)' into has_rows;
+    if has_rows then
+      raise exception 'control_transition_history_requires_explicit_reconciliation_before_rollback';
+    end if;
+    execute 'drop trigger if exists supermega_control_transitions_immutable on public.supermega_control_transitions';
+  end if;
+end;
+$rollback$;
+
+drop function if exists public.supermega_reject_control_transition_mutation();
+drop function if exists public.supermega_transition_control_record(text,text,text,boolean,bigint,text,text,text,text,jsonb,text);
+drop function if exists public.supermega_put_control_record(text,text,text,text,text,jsonb,text);
+drop table if exists public.supermega_control_transitions;
+drop table if exists public.supermega_control_records;
+
+commit;

--- a/kernel/supabase/workcell-client.sql
+++ b/kernel/supabase/workcell-client.sql
@@ -14,6 +14,7 @@ create table if not exists public.supermega_console_activity (
 create table if not exists public.supermega_token_ledger (
   tenant_id text not null,
   "window" text not null,
+  cap_tokens bigint check (cap_tokens is null or cap_tokens > 0),
   in_tokens bigint not null default 0,
   out_tokens bigint not null default 0,
   calls bigint not null default 0,
@@ -104,6 +105,88 @@ as $supermega$
   where r."window" = p_window and r.status <> 'released'
 $supermega$;
 
+alter table public.supermega_token_ledger add column if not exists cap_tokens bigint;
+do $migration$
+begin
+  if not exists (select 1 from pg_constraint where conname='supermega_token_ledger_cap_positive') then
+    alter table public.supermega_token_ledger add constraint supermega_token_ledger_cap_positive check (cap_tokens is null or cap_tokens > 0);
+  end if;
+end;
+$migration$;
+
+create table if not exists public.supermega_spend_reservations (
+  reservation_id text primary key check (char_length(reservation_id) between 1 and 120),
+  tenant_id text not null check (char_length(tenant_id) between 1 and 200),
+  "window" text not null check ("window" ~ '^\d{4}-\d{2}$'),
+  reserved_tokens bigint not null check (reserved_tokens > 0),
+  status text not null default 'reserved' check (status in ('reserved', 'dispatched', 'indeterminate', 'settled', 'released')),
+  dispatch_token text not null check (char_length(dispatch_token) between 1 and 160),
+  context jsonb not null default '{}'::jsonb,
+  actual_in_tokens bigint not null default 0 check (actual_in_tokens >= 0),
+  actual_out_tokens bigint not null default 0 check (actual_out_tokens >= 0),
+  actual_calls bigint not null default 0 check (actual_calls >= 0),
+  reconciled_by text,
+  reconciliation_evidence_hash text,
+  reconciled_at timestamptz,
+  expires_at timestamptz not null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+alter table public.supermega_spend_reservations add column if not exists dispatch_token text;
+alter table public.supermega_spend_reservations add column if not exists context jsonb not null default '{}'::jsonb;
+alter table public.supermega_spend_reservations add column if not exists reconciled_by text;
+alter table public.supermega_spend_reservations add column if not exists reconciliation_evidence_hash text;
+alter table public.supermega_spend_reservations add column if not exists reconciled_at timestamptz;
+do $migration$
+begin
+  if exists (select 1 from public.supermega_spend_reservations where status='active') then
+    raise exception 'legacy_active_reservations_require_reconciliation';
+  end if;
+  if exists (
+    select 1 from pg_constraint
+     where conrelid='public.supermega_spend_reservations'::regclass
+       and conname='supermega_spend_reservations_status_check'
+       and pg_get_constraintdef(oid) not like '%indeterminate%'
+  ) then
+    alter table public.supermega_spend_reservations drop constraint supermega_spend_reservations_status_check;
+  end if;
+  if not exists (
+    select 1 from pg_constraint
+     where conrelid='public.supermega_spend_reservations'::regclass
+       and conname='supermega_spend_reservations_status_check'
+       and pg_get_constraintdef(oid) like '%indeterminate%'
+  ) then
+    alter table public.supermega_spend_reservations alter column status set default 'reserved';
+    alter table public.supermega_spend_reservations add constraint supermega_spend_reservations_status_check check (status in ('reserved', 'dispatched', 'indeterminate', 'settled', 'released'));
+  end if;
+  update public.supermega_spend_reservations
+     set dispatch_token='legacy-terminal:' || md5(reservation_id)
+   where dispatch_token is null and status in ('settled','released');
+  if exists (select 1 from public.supermega_spend_reservations where dispatch_token is null) then
+    raise exception 'reservation_dispatch_token_reconciliation_required';
+  end if;
+  alter table public.supermega_spend_reservations alter column dispatch_token set not null;
+  if not exists (
+    select 1 from pg_constraint
+     where conrelid='public.supermega_spend_reservations'::regclass
+       and conname='supermega_spend_reservations_dispatch_token_check'
+  ) then
+    alter table public.supermega_spend_reservations add constraint supermega_spend_reservations_dispatch_token_check check (char_length(dispatch_token) between 1 and 160);
+  end if;
+  if not exists (
+    select 1 from pg_constraint
+     where conrelid='public.supermega_spend_reservations'::regclass
+       and conname='supermega_spend_reservations_reconciliation_check'
+  ) then
+    alter table public.supermega_spend_reservations add constraint supermega_spend_reservations_reconciliation_check check (
+      (reconciled_by is null and reconciliation_evidence_hash is null and reconciled_at is null)
+      or (char_length(reconciled_by) between 1 and 80 and reconciliation_evidence_hash ~ '^[a-f0-9]{64}$' and reconciled_at is not null)
+    );
+  end if;
+end;
+$migration$;
+
 create table if not exists public.supermega_ai_cache (
   cache_key text primary key,
   payload jsonb not null,
@@ -150,12 +233,16 @@ create table if not exists public.supermega_owner_evidence (
 create index if not exists supermega_action_queue_status_created_idx
   on public.supermega_action_queue (status, created_at desc);
 
+create index if not exists supermega_spend_reservations_active_idx
+  on public.supermega_spend_reservations (tenant_id, "window", status);
+
 create index if not exists supermega_owner_evidence_occurred_idx
   on public.supermega_owner_evidence (occurred_at desc, id);
 
 alter table public.supermega_console_activity enable row level security;
 alter table public.supermega_token_ledger enable row level security;
 alter table public.supermega_ai_budget_reservations enable row level security;
+alter table public.supermega_spend_reservations enable row level security;
 alter table public.supermega_ai_cache enable row level security;
 alter table public.supermega_action_queue enable row level security;
 alter table public.supermega_owner_evidence enable row level security;
@@ -163,12 +250,16 @@ alter table public.supermega_owner_evidence enable row level security;
 revoke all on public.supermega_console_activity from anon, authenticated;
 revoke all on public.supermega_token_ledger from anon, authenticated;
 revoke all on public.supermega_ai_budget_reservations from anon, authenticated;
+revoke all on public.supermega_token_ledger from public, service_role;
+revoke all on public.supermega_spend_reservations from public, anon, authenticated, service_role;
 revoke all on public.supermega_ai_cache from anon, authenticated;
 revoke all on public.supermega_action_queue from anon, authenticated;
 revoke all on public.supermega_owner_evidence from anon, authenticated;
 
 grant select, insert, update, delete on public.supermega_console_activity to service_role;
-grant select, insert, update, delete on public.supermega_token_ledger to service_role;
+-- The token ledger is deliberately NOT granted to service_role: all ledger mutation flows through
+-- the security-definer spend RPCs below. The company budget reservation table keeps direct grants
+-- because supermega_reserve_ai_budget is security invoker and settlement PATCHes the row directly.
 grant select, insert, update, delete on public.supermega_ai_budget_reservations to service_role;
 grant select, insert, update, delete on public.supermega_ai_cache to service_role;
 grant select, insert, update, delete on public.supermega_action_queue to service_role;
@@ -177,6 +268,641 @@ revoke all on function public.supermega_reserve_ai_budget(text,text,bigint,bigin
 grant execute on function public.supermega_reserve_ai_budget(text,text,bigint,bigint,text,text,text) to service_role;
 revoke all on function public.supermega_get_ai_budget_usage(text) from public, anon, authenticated;
 grant execute on function public.supermega_get_ai_budget_usage(text) to service_role;
+
+create or replace function public.supermega_get_token_usage(p_tenant_id text, p_window text)
+returns table (
+  tenant_id text,
+  "window" text,
+  cap_tokens bigint,
+  in_tokens bigint,
+  out_tokens bigint,
+  calls bigint,
+  reserved_tokens bigint,
+  committed_tokens bigint,
+  spend_total bigint
+)
+language sql
+stable
+security definer
+set search_path = ''
+as $$
+  select
+    p_tenant_id,
+    p_window,
+    ledger.cap_tokens,
+    coalesce(ledger.in_tokens, 0),
+    coalesce(ledger.out_tokens, 0),
+    coalesce(ledger.calls, 0),
+    coalesce((select sum(r.reserved_tokens) from public.supermega_spend_reservations as r where r.tenant_id=p_tenant_id and r."window"=p_window and r.status in ('reserved','dispatched','indeterminate')), 0),
+    coalesce(ledger.in_tokens, 0) + coalesce(ledger.out_tokens, 0),
+    coalesce(ledger.in_tokens, 0) + coalesce(ledger.out_tokens, 0)
+      + coalesce((select sum(r.reserved_tokens) from public.supermega_spend_reservations as r where r.tenant_id=p_tenant_id and r."window"=p_window and r.status in ('reserved','dispatched','indeterminate')), 0)
+  from (values (1)) as seed(n)
+  left join public.supermega_token_ledger as ledger
+    on ledger.tenant_id=p_tenant_id and ledger."window"=p_window
+  where p_tenant_id is not null and p_tenant_id <> '' and p_window ~ '^\d{4}-\d{2}$';
+$$;
+
+drop function if exists public.supermega_add_token_usage(text, text, bigint, bigint, bigint);
+
+drop function if exists public.supermega_reserve_token_spend(text, text, text, bigint, bigint, timestamptz);
+drop function if exists public.supermega_settle_token_spend(text, bigint, bigint, bigint);
+drop function if exists public.supermega_release_token_spend(text);
+
+create or replace function public.supermega_reserve_token_spend(
+  p_reservation_id text,
+  p_tenant_id text,
+  p_window text,
+  p_reserved_tokens bigint,
+  p_cap_tokens bigint,
+  p_expires_at timestamptz,
+  p_dispatch_token text,
+  p_context jsonb
+)
+returns table (
+  accepted boolean,
+  reason text,
+  reservation_id text,
+  status text,
+  in_tokens bigint,
+  out_tokens bigint,
+  calls bigint,
+  reserved_tokens bigint,
+  committed_tokens bigint,
+  spend_total bigint
+)
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_in bigint;
+  v_out bigint;
+  v_calls bigint;
+  v_cap bigint;
+  v_reserved bigint;
+  v_existing_tenant text;
+  v_existing_window text;
+  v_existing_reserved bigint;
+  v_existing_status text;
+  v_existing_dispatch_token text;
+  v_existing_context jsonb;
+  v_existing_expires_at timestamptz;
+  v_same_scope boolean;
+begin
+  if p_reservation_id is null or char_length(p_reservation_id) not between 1 and 120
+     or p_tenant_id is null or char_length(p_tenant_id) not between 1 and 200
+     or p_window !~ '^\d{4}-\d{2}$' or p_reserved_tokens <= 0 or p_cap_tokens <= 0
+     or p_expires_at is null or p_expires_at <= now()
+     or p_dispatch_token is null or char_length(p_dispatch_token) not between 1 and 160
+     or p_context is null or jsonb_typeof(p_context) <> 'object' or pg_column_size(p_context) > 4096 then
+    raise exception 'invalid_spend_reservation';
+  end if;
+
+  insert into public.supermega_token_ledger (tenant_id, "window", cap_tokens)
+  values (p_tenant_id, p_window, p_cap_tokens)
+  on conflict do nothing;
+
+  select ledger.cap_tokens, ledger.in_tokens, ledger.out_tokens, ledger.calls
+    into v_cap, v_in, v_out, v_calls
+    from public.supermega_token_ledger as ledger
+   where ledger.tenant_id = p_tenant_id and ledger."window" = p_window
+   for update;
+
+  if v_cap is null then
+    update public.supermega_token_ledger as ledger
+       set cap_tokens=p_cap_tokens, updated_at=now()
+     where ledger.tenant_id=p_tenant_id and ledger."window"=p_window
+     returning ledger.cap_tokens, ledger.in_tokens, ledger.out_tokens, ledger.calls into v_cap, v_in, v_out, v_calls;
+  end if;
+
+  select r.tenant_id, r."window", r.reserved_tokens, r.status, r.dispatch_token, r.context, r.expires_at
+    into v_existing_tenant, v_existing_window, v_existing_reserved, v_existing_status, v_existing_dispatch_token, v_existing_context, v_existing_expires_at
+    from public.supermega_spend_reservations as r
+   where r.reservation_id = p_reservation_id;
+
+  select coalesce(sum(r.reserved_tokens), 0)
+    into v_reserved
+    from public.supermega_spend_reservations as r
+   where r.tenant_id = p_tenant_id and r."window" = p_window and r.status in ('reserved','dispatched','indeterminate');
+
+  if v_cap <> p_cap_tokens then
+    accepted := false;
+    reason := 'cap_mismatch';
+    reservation_id := p_reservation_id;
+    status := 'rejected';
+    in_tokens := v_in;
+    out_tokens := v_out;
+    calls := v_calls;
+    reserved_tokens := v_reserved;
+    committed_tokens := v_in + v_out;
+    spend_total := v_in + v_out + v_reserved;
+    return next;
+    return;
+  end if;
+
+  if v_existing_status is not null then
+    v_same_scope := v_existing_tenant = p_tenant_id
+      and v_existing_window = p_window
+      and v_existing_reserved = p_reserved_tokens
+      and v_existing_context = p_context;
+    if v_same_scope and v_existing_status = 'reserved' and v_existing_dispatch_token = p_dispatch_token then
+      accepted := true;
+      reason := 'idempotent';
+    elsif v_same_scope and v_existing_status = 'reserved' and v_existing_expires_at <= now() then
+      update public.supermega_spend_reservations as r
+         set dispatch_token=p_dispatch_token, context=p_context, expires_at=p_expires_at, updated_at=now()
+       where r.reservation_id=p_reservation_id;
+      accepted := true;
+      reason := 'reservation_reclaimed';
+    else
+      accepted := false;
+      reason := case
+        when v_same_scope and v_existing_status in ('dispatched','indeterminate') then 'reconciliation_required'
+        when v_same_scope and v_existing_status = 'reserved' then 'reservation_in_progress'
+        else 'reservation_exists'
+      end;
+    end if;
+    reservation_id := p_reservation_id;
+    status := v_existing_status;
+    in_tokens := v_in;
+    out_tokens := v_out;
+    calls := v_calls;
+    reserved_tokens := v_reserved;
+    committed_tokens := v_in + v_out;
+    spend_total := v_in + v_out + v_reserved;
+    return next;
+    return;
+  end if;
+
+  if v_in + v_out + v_reserved + p_reserved_tokens > v_cap then
+    accepted := false;
+    reason := 'cap_reached';
+    reservation_id := p_reservation_id;
+    status := 'rejected';
+    in_tokens := v_in;
+    out_tokens := v_out;
+    calls := v_calls;
+    reserved_tokens := v_reserved;
+    committed_tokens := v_in + v_out;
+    spend_total := v_in + v_out + v_reserved;
+    return next;
+    return;
+  end if;
+
+  insert into public.supermega_spend_reservations (reservation_id, tenant_id, "window", reserved_tokens, status, expires_at, dispatch_token, context)
+  values (p_reservation_id, p_tenant_id, p_window, p_reserved_tokens, 'reserved', p_expires_at, p_dispatch_token, p_context);
+
+  accepted := true;
+  reason := 'reserved';
+  reservation_id := p_reservation_id;
+  status := 'reserved';
+  in_tokens := v_in;
+  out_tokens := v_out;
+  calls := v_calls;
+  reserved_tokens := v_reserved + p_reserved_tokens;
+  committed_tokens := v_in + v_out;
+  spend_total := v_in + v_out + v_reserved + p_reserved_tokens;
+  return next;
+end;
+$$;
+
+create or replace function public.supermega_mark_token_spend_dispatched(
+  p_reservation_id text,
+  p_dispatch_token text
+)
+returns table (changed boolean, reason text, reservation_id text, status text)
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_status text;
+  v_dispatch_token text;
+  v_expires_at timestamptz;
+begin
+  if p_reservation_id is null or p_reservation_id = ''
+     or p_dispatch_token is null or p_dispatch_token = '' then
+    raise exception 'invalid_spend_dispatch';
+  end if;
+  select r.status, r.dispatch_token, r.expires_at
+    into v_status, v_dispatch_token, v_expires_at
+    from public.supermega_spend_reservations as r
+   where r.reservation_id=p_reservation_id
+   for update;
+  if not found then
+    changed := false; reason := 'reservation_not_found'; reservation_id := p_reservation_id; return next; return;
+  end if;
+  if v_dispatch_token is distinct from p_dispatch_token then
+    changed := false; reason := 'dispatch_token_mismatch';
+  elsif v_status = 'dispatched' then
+    changed := true; reason := 'idempotent';
+  elsif v_status <> 'reserved' then
+    changed := false; reason := 'invalid_reservation_state';
+  elsif v_expires_at <= now() then
+    changed := false; reason := 'reservation_stale';
+  else
+    update public.supermega_spend_reservations as r
+       set status='dispatched', updated_at=now()
+     where r.reservation_id=p_reservation_id;
+    changed := true; reason := 'dispatched'; v_status := 'dispatched';
+  end if;
+  reservation_id := p_reservation_id; status := v_status; return next;
+end;
+$$;
+
+create or replace function public.supermega_mark_token_spend_indeterminate(
+  p_reservation_id text,
+  p_dispatch_token text
+)
+returns table (changed boolean, reason text, reservation_id text, status text)
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_status text;
+  v_dispatch_token text;
+begin
+  if p_reservation_id is null or p_reservation_id = ''
+     or p_dispatch_token is null or p_dispatch_token = '' then
+    raise exception 'invalid_spend_indeterminate';
+  end if;
+  select r.status, r.dispatch_token
+    into v_status, v_dispatch_token
+    from public.supermega_spend_reservations as r
+   where r.reservation_id=p_reservation_id
+   for update;
+  if not found then
+    changed := false; reason := 'reservation_not_found'; reservation_id := p_reservation_id; return next; return;
+  end if;
+  if v_dispatch_token is distinct from p_dispatch_token then
+    changed := false; reason := 'dispatch_token_mismatch';
+  elsif v_status = 'indeterminate' then
+    changed := true; reason := 'idempotent';
+  elsif v_status <> 'dispatched' then
+    changed := false; reason := 'invalid_reservation_state';
+  else
+    update public.supermega_spend_reservations as r
+       set status='indeterminate', updated_at=now()
+     where r.reservation_id=p_reservation_id;
+    changed := true; reason := 'indeterminate'; v_status := 'indeterminate';
+  end if;
+  reservation_id := p_reservation_id; status := v_status; return next;
+end;
+$$;
+
+create or replace function public.supermega_settle_token_spend(
+  p_reservation_id text,
+  p_dispatch_token text,
+  p_in_tokens bigint,
+  p_out_tokens bigint,
+  p_calls bigint
+)
+returns table (
+  settled boolean,
+  reason text,
+  reservation_id text,
+  status text,
+  in_tokens bigint,
+  out_tokens bigint,
+  calls bigint,
+  reserved_tokens bigint,
+  committed_tokens bigint,
+  spend_total bigint
+)
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_tenant text;
+  v_window text;
+  v_status text;
+  v_reserved_for_call bigint;
+  v_actual_in bigint;
+  v_actual_out bigint;
+  v_actual_calls bigint;
+  v_dispatch_token text;
+  v_in bigint;
+  v_out bigint;
+  v_calls bigint;
+  v_reserved bigint;
+begin
+  if p_reservation_id is null or p_reservation_id = '' or p_dispatch_token is null or p_dispatch_token = '' or p_in_tokens < 0 or p_out_tokens < 0 or p_calls < 0 then
+    raise exception 'invalid_spend_settlement';
+  end if;
+
+  select r.tenant_id, r."window"
+    into v_tenant, v_window
+    from public.supermega_spend_reservations as r
+   where r.reservation_id = p_reservation_id;
+  if not found then
+    settled := false;
+    reason := 'reservation_not_found';
+    reservation_id := p_reservation_id;
+    return next;
+    return;
+  end if;
+
+  select ledger.in_tokens, ledger.out_tokens, ledger.calls
+    into v_in, v_out, v_calls
+    from public.supermega_token_ledger as ledger
+   where ledger.tenant_id = v_tenant and ledger."window" = v_window
+   for update;
+
+  select r.status, r.reserved_tokens, r.actual_in_tokens, r.actual_out_tokens, r.actual_calls, r.dispatch_token
+    into v_status, v_reserved_for_call, v_actual_in, v_actual_out, v_actual_calls, v_dispatch_token
+    from public.supermega_spend_reservations as r
+   where r.reservation_id = p_reservation_id
+   for update;
+
+  if v_dispatch_token is distinct from p_dispatch_token then
+    settled := false;
+    reason := 'dispatch_token_mismatch';
+  elsif v_status = 'released' then
+    settled := false;
+    reason := 'reservation_released';
+  elsif v_status = 'settled' then
+    settled := v_actual_in = p_in_tokens and v_actual_out = p_out_tokens and v_actual_calls = p_calls;
+    reason := case when settled then 'idempotent' else 'settlement_conflict' end;
+  elsif v_status = 'reserved' then
+    settled := false;
+    reason := 'reservation_not_dispatched';
+  elsif p_in_tokens + p_out_tokens > v_reserved_for_call then
+    settled := false;
+    reason := 'actual_exceeds_reservation';
+  elsif v_status not in ('dispatched','indeterminate') then
+    settled := false;
+    reason := 'invalid_reservation_state';
+  else
+    update public.supermega_token_ledger as ledger set
+      in_tokens = ledger.in_tokens + p_in_tokens,
+      out_tokens = ledger.out_tokens + p_out_tokens,
+      calls = ledger.calls + p_calls,
+      updated_at = now()
+    where ledger.tenant_id = v_tenant and ledger."window" = v_window
+    returning ledger.in_tokens, ledger.out_tokens, ledger.calls into v_in, v_out, v_calls;
+
+    update public.supermega_spend_reservations as r set
+      status = 'settled',
+      actual_in_tokens = p_in_tokens,
+      actual_out_tokens = p_out_tokens,
+      actual_calls = p_calls,
+      updated_at = now()
+    where r.reservation_id = p_reservation_id;
+    settled := true;
+    reason := 'settled';
+    v_status := 'settled';
+  end if;
+
+  select coalesce(sum(r.reserved_tokens), 0)
+    into v_reserved
+    from public.supermega_spend_reservations as r
+   where r.tenant_id = v_tenant and r."window" = v_window and r.status in ('reserved','dispatched','indeterminate');
+  reservation_id := p_reservation_id;
+  status := v_status;
+  in_tokens := v_in;
+  out_tokens := v_out;
+  calls := v_calls;
+  reserved_tokens := v_reserved;
+  committed_tokens := v_in + v_out;
+  spend_total := v_in + v_out + v_reserved;
+  return next;
+end;
+$$;
+
+create or replace function public.supermega_release_token_spend(p_reservation_id text, p_dispatch_token text, p_definitive boolean)
+returns table (
+  released boolean,
+  reason text,
+  reservation_id text,
+  status text,
+  in_tokens bigint,
+  out_tokens bigint,
+  calls bigint,
+  reserved_tokens bigint,
+  committed_tokens bigint,
+  spend_total bigint
+)
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_tenant text;
+  v_window text;
+  v_status text;
+  v_in bigint;
+  v_out bigint;
+  v_calls bigint;
+  v_reserved bigint;
+  v_dispatch_token text;
+begin
+  if p_reservation_id is null or p_reservation_id = '' or p_dispatch_token is null or p_dispatch_token = '' or p_definitive is null then
+    raise exception 'invalid_spend_release';
+  end if;
+  select r.tenant_id, r."window"
+    into v_tenant, v_window
+    from public.supermega_spend_reservations as r
+   where r.reservation_id = p_reservation_id;
+  if not found then
+    released := false;
+    reason := 'reservation_not_found';
+    reservation_id := p_reservation_id;
+    return next;
+    return;
+  end if;
+
+  select ledger.in_tokens, ledger.out_tokens, ledger.calls
+    into v_in, v_out, v_calls
+    from public.supermega_token_ledger as ledger
+   where ledger.tenant_id = v_tenant and ledger."window" = v_window
+   for update;
+  select r.status, r.dispatch_token into v_status, v_dispatch_token
+    from public.supermega_spend_reservations as r
+   where r.reservation_id = p_reservation_id
+   for update;
+
+  if v_dispatch_token is distinct from p_dispatch_token then
+    released := false;
+    reason := 'dispatch_token_mismatch';
+  elsif v_status = 'settled' then
+    released := false;
+    reason := 'reservation_settled';
+  elsif v_status = 'released' then
+    released := true;
+    reason := 'idempotent';
+  elsif v_status = 'indeterminate' then
+    released := false;
+    reason := 'reservation_indeterminate';
+  elsif v_status = 'dispatched' and not p_definitive then
+    released := false;
+    reason := 'dispatch_not_definitive';
+  elsif v_status not in ('reserved','dispatched') then
+    released := false;
+    reason := 'invalid_reservation_state';
+  else
+    update public.supermega_spend_reservations as r
+       set status = 'released', updated_at = now()
+     where r.reservation_id = p_reservation_id;
+    released := true;
+    reason := 'released';
+    v_status := 'released';
+  end if;
+
+  select coalesce(sum(r.reserved_tokens), 0)
+    into v_reserved
+    from public.supermega_spend_reservations as r
+   where r.tenant_id = v_tenant and r."window" = v_window and r.status in ('reserved','dispatched','indeterminate');
+  reservation_id := p_reservation_id;
+  status := v_status;
+  in_tokens := v_in;
+  out_tokens := v_out;
+  calls := v_calls;
+  reserved_tokens := v_reserved;
+  committed_tokens := v_in + v_out;
+  spend_total := v_in + v_out + v_reserved;
+  return next;
+end;
+$$;
+
+create or replace function public.supermega_reconcile_token_spend(
+  p_reservation_id text,
+  p_action text,
+  p_in_tokens bigint,
+  p_out_tokens bigint,
+  p_calls bigint,
+  p_actor text,
+  p_evidence_hash text
+)
+returns table (
+  reconciled boolean,
+  reason text,
+  reservation_id text,
+  status text,
+  in_tokens bigint,
+  out_tokens bigint,
+  calls bigint,
+  reserved_tokens bigint,
+  committed_tokens bigint,
+  spend_total bigint
+)
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_tenant text;
+  v_window text;
+  v_status text;
+  v_reserved_for_call bigint;
+  v_actual_in bigint;
+  v_actual_out bigint;
+  v_actual_calls bigint;
+  v_reconciled_by text;
+  v_evidence_hash text;
+  v_in bigint;
+  v_out bigint;
+  v_calls bigint;
+  v_reserved bigint;
+  v_terminal text;
+begin
+  if p_reservation_id is null or p_reservation_id = ''
+     or p_action is null or p_action not in ('settle','release')
+     or p_in_tokens is null or p_out_tokens is null or p_calls is null
+     or p_in_tokens < 0 or p_out_tokens < 0 or p_calls < 0
+     or p_actor is null or char_length(p_actor) not between 1 and 80
+     or p_evidence_hash is null or p_evidence_hash !~ '^[a-f0-9]{64}$'
+     or (p_action='release' and (p_in_tokens <> 0 or p_out_tokens <> 0 or p_calls <> 0)) then
+    raise exception 'invalid_spend_reconciliation';
+  end if;
+  select r.tenant_id, r."window"
+    into v_tenant, v_window
+    from public.supermega_spend_reservations as r
+   where r.reservation_id=p_reservation_id;
+  if not found then
+    reconciled := false; reason := 'reservation_not_found'; reservation_id := p_reservation_id; return next; return;
+  end if;
+  select ledger.in_tokens, ledger.out_tokens, ledger.calls
+    into v_in, v_out, v_calls
+    from public.supermega_token_ledger as ledger
+   where ledger.tenant_id=v_tenant and ledger."window"=v_window
+   for update;
+  select r.status, r.reserved_tokens, r.actual_in_tokens, r.actual_out_tokens, r.actual_calls, r.reconciled_by, r.reconciliation_evidence_hash
+    into v_status, v_reserved_for_call, v_actual_in, v_actual_out, v_actual_calls, v_reconciled_by, v_evidence_hash
+    from public.supermega_spend_reservations as r
+   where r.reservation_id=p_reservation_id
+   for update;
+  v_terminal := case when p_action='settle' then 'settled' else 'released' end;
+  if v_status=v_terminal
+     and v_reconciled_by=p_actor
+     and v_evidence_hash=p_evidence_hash
+     and (p_action='release' or (v_actual_in=p_in_tokens and v_actual_out=p_out_tokens and v_actual_calls=p_calls)) then
+    reconciled := true;
+    reason := 'idempotent';
+  elsif v_status in ('settled','released') then
+    reconciled := false;
+    reason := 'reconciliation_conflict';
+  elsif v_status not in ('dispatched','indeterminate') then
+    reconciled := false;
+    reason := 'invalid_reservation_state';
+  elsif p_action='settle' and p_in_tokens+p_out_tokens > v_reserved_for_call then
+    reconciled := false;
+    reason := 'actual_exceeds_reservation';
+  else
+    if p_action='settle' then
+      update public.supermega_token_ledger as ledger set
+        in_tokens=ledger.in_tokens+p_in_tokens,
+        out_tokens=ledger.out_tokens+p_out_tokens,
+        calls=ledger.calls+p_calls,
+        updated_at=now()
+      where ledger.tenant_id=v_tenant and ledger."window"=v_window
+      returning ledger.in_tokens, ledger.out_tokens, ledger.calls into v_in, v_out, v_calls;
+    end if;
+    update public.supermega_spend_reservations as r set
+      status=v_terminal,
+      actual_in_tokens=p_in_tokens,
+      actual_out_tokens=p_out_tokens,
+      actual_calls=p_calls,
+      reconciled_by=p_actor,
+      reconciliation_evidence_hash=p_evidence_hash,
+      reconciled_at=now(),
+      updated_at=now()
+    where r.reservation_id=p_reservation_id;
+    v_status := v_terminal;
+    reconciled := true;
+    reason := 'reconciled';
+  end if;
+  select coalesce(sum(r.reserved_tokens),0)
+    into v_reserved
+    from public.supermega_spend_reservations as r
+   where r.tenant_id=v_tenant and r."window"=v_window and r.status in ('reserved','dispatched','indeterminate');
+  reservation_id := p_reservation_id;
+  status := v_status;
+  in_tokens := v_in;
+  out_tokens := v_out;
+  calls := v_calls;
+  reserved_tokens := v_reserved;
+  committed_tokens := v_in+v_out;
+  spend_total := v_in+v_out+v_reserved;
+  return next;
+end;
+$$;
+revoke execute on function public.supermega_get_token_usage(text, text) from public, anon, authenticated;
+revoke execute on function public.supermega_reserve_token_spend(text, text, text, bigint, bigint, timestamptz, text, jsonb) from public, anon, authenticated;
+revoke execute on function public.supermega_mark_token_spend_dispatched(text, text) from public, anon, authenticated;
+revoke execute on function public.supermega_mark_token_spend_indeterminate(text, text) from public, anon, authenticated;
+revoke execute on function public.supermega_settle_token_spend(text, text, bigint, bigint, bigint) from public, anon, authenticated;
+revoke execute on function public.supermega_release_token_spend(text, text, boolean) from public, anon, authenticated;
+revoke execute on function public.supermega_reconcile_token_spend(text, text, bigint, bigint, bigint, text, text) from public, anon, authenticated;
+grant execute on function public.supermega_get_token_usage(text, text) to service_role;
+grant execute on function public.supermega_reserve_token_spend(text, text, text, bigint, bigint, timestamptz, text, jsonb) to service_role;
+grant execute on function public.supermega_mark_token_spend_dispatched(text, text) to service_role;
+grant execute on function public.supermega_mark_token_spend_indeterminate(text, text) to service_role;
+grant execute on function public.supermega_settle_token_spend(text, text, bigint, bigint, bigint) to service_role;
+grant execute on function public.supermega_release_token_spend(text, text, boolean) to service_role;
+grant execute on function public.supermega_reconcile_token_spend(text, text, bigint, bigint, bigint, text, text) to service_role;
 
 notify pgrst, 'reload schema';
 

--- a/kernel/workcell-provision.test.mjs
+++ b/kernel/workcell-provision.test.mjs
@@ -528,7 +528,10 @@ test('client SQL bootstrap contains the exact durable workcell contract', async 
   assert.match(sql, /create or replace function public\.supermega_get_ai_budget_usage/)
   assert.match(sql, /pg_advisory_xact_lock/)
   assert.match(sql, /security invoker/)
-  assert.doesNotMatch(sql, /security definer/)
+  // The company budget functions stay security invoker. The tenant spend/ledger RPCs are
+  // security definer BY DESIGN (direct table access is revoked from service_role), so every
+  // definer function must pin an empty search_path — an unpinned definer is still forbidden.
+  assert.doesNotMatch(sql, /security definer(?!\s+set search_path = '')/)
   assert.match(sql, /grant execute on function public\.supermega_reserve_ai_budget\(text,text,bigint,bigint,text,text,text\) to service_role/)
   assert.match(sql, /grant execute on function public\.supermega_get_ai_budget_usage\(text\) to service_role/)
   assert.match(sql, /grant select, insert on public\.supermega_owner_evidence to service_role/)


### PR DESCRIPTION
Moves authority data (sign-in codes, operator sessions, missions, work orders, reviews, evaluations, and main's newer CEO outcome records) out of supermega_ai_cache into versioned supermega_control_records with append-only supermega_control_transitions evidence, plus fail-closed tenant spend reservations and v2 tenant-scoped response-cache keys. Semantically merged with main's company daily budget and console features: tenant reservation is taken before company budget; a budget refusal releases the undispatched reservation; platform tenant resolves to a server-owned plan so internal calls keep their requested tier under cap.

- Tests: 187/187 — the 4 lane suites (34) plus main's gateway.budget/gateway suites and adjacent kernel suites.
- Reviewer notes: workcell-provision's no-definer assertion narrowed to allow search_path-pinned definers (spend RPCs are definer-by-design with table access revoked); migration widens control-record types idempotently; rollback SQL unchanged and fail-closed. Full decisions documented in the commit message of a154ff19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)