### PR TITLE
Codify the retired public ops API contract (404, not 401)

### DIFF
--- a/hq/readiness/managed-pilot-readiness.json
+++ b/hq/readiness/managed-pilot-readiness.json
@@ -1,7 +1,7 @@
 {
   "contract": "supermega.managed-pilot-readiness.v2",
   "asOf": "2026-08-03T07:01:07.469Z",
-  "sourceDigest": "sha256:850060ffd433ac659489eade428de80c77a3e62b102ff3f06c2c5d547edbda60",
+  "sourceDigest": "sha256:6d1fff3fe65a66781e28399c55bcffdf3dd13df3e7b017edf101d0730d3d4e57",
   "overall": {
     "status": "blocked",
     "localDatabaseProofReady": true,
@@ -184,7 +184,7 @@
     },
     {
       "path": "package.json",
-      "digest": "sha256:02b1e43364629fa0466eb285a452d8ba51988d8cd5dd7f508bea75c6cdff98eb"
+      "digest": "sha256:5973d3e024b0190d6deef0e55c5b63c4e52d714f11838df6d2bc80b84dd99129"
     },
     {
       "path": "kernel/managed-pilot-readiness.mjs",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "vercel:contracts:test": "node --test tools/scheduler_authority_contract.test.mjs tools/write_app_vercel_config.test.mjs && node tools/test_vercel_environment_state.mjs && node tools/verify_managed_runtime_environment_values.mjs --self-test && node tools/test_vercel_project_state.mjs && node tools/test_vercel_domain_state.mjs",
     "public:release:guard": "node tools/verify_public_deploy_guard.mjs",
     "public:build": "node tools/create_public_vercel_output.mjs",
-    "public:verify": "node tools/verify_public_vercel_artifact_budget.mjs && node tools/verify_public_vercel_output.mjs && node tools/test_public_contact_function.mjs && npm run vercel:contracts:test && npm run hq:verify",
+    "public:verify": "node tools/verify_public_vercel_artifact_budget.mjs && node tools/verify_public_vercel_output.mjs && node tools/test_public_contact_function.mjs && node tools/test_public_retired_api_function.mjs && npm run vercel:contracts:test && npm run hq:verify",
     "public:prebuilt": "npm run public:build && npm run public:verify",
     "public:verify:live": "node tools/verify_public_release_live.mjs",
     "public:verify:live:current": "node tools/verify_public_release_live.mjs --current-head",

--- a/tools/create_public_vercel_output.mjs
+++ b/tools/create_public_vercel_output.mjs
@@ -470,6 +470,12 @@ module.exports = async function handler(_req, res) {
 }
 `
 
+// Retired public API surface. The legacy ops endpoints (pipeline-control,
+// commercial-control, checkout-start, product-activation, sales-daily,
+// behavior-events, campaign-clicks, public-app-handoff) were deliberately
+// removed in the public-site consolidation (f8c5299e). Their old ops-key 401
+// contract is retired with them: every unknown /api/* request — anonymous or
+// credentialed — answers 404 {"status":"not_found"} with no auth semantics.
 const notFoundFunction = `'use strict'
 module.exports = function handler(_req, res) {
   res.statusCode = 404

--- a/tools/test_public_retired_api_function.mjs
+++ b/tools/test_public_retired_api_function.mjs
@@ -1,0 +1,68 @@
+// Proves the retired public API contract on the BUILT artifact: every request to a
+// retired ops endpoint (for example /api/pipeline-control/status) answers
+// 404 {"status":"not_found"} — anonymous or credentialed. The legacy ops-key 401
+// contract was deliberately retired with the public-site consolidation (f8c5299e);
+// this test pins the replacement behavior so the old expectation cannot resurface.
+import assert from 'node:assert/strict'
+import { createRequire } from 'node:module'
+import { resolve } from 'node:path'
+
+const require = createRequire(import.meta.url)
+const handler = require(resolve('.vercel', 'output', 'functions', 'api', 'not-found.js.func', 'index.js'))
+
+function responseRecorder() {
+  return {
+    statusCode: 0,
+    headers: {},
+    payload: '',
+    setHeader(name, value) {
+      this.headers[String(name).toLowerCase()] = String(value)
+    },
+    end(value = '') {
+      this.payload = String(value)
+    },
+  }
+}
+
+function invoke({ method = 'GET', url = '/api/pipeline-control/status', headers = {} } = {}) {
+  const req = {
+    method,
+    url,
+    headers: { host: 'supermega.dev', accept: 'application/json', ...headers },
+  }
+  const res = responseRecorder()
+  handler(req, res)
+  return { status: res.statusCode, headers: res.headers, body: JSON.parse(res.payload || '{}') }
+}
+
+let checks = 0
+function expectRetired(result) {
+  assert.equal(result.status, 404)
+  assert.deepEqual(result.body, { status: 'not_found' })
+  assert.equal(result.headers['content-type'], 'application/json; charset=utf-8')
+  assert.equal(result.headers['cache-control'], 'no-store')
+  checks += 4
+}
+
+// Anonymous request: 404 not_found — NOT the retired 401 ops-key contract.
+expectRetired(invoke())
+
+// Credentialed attempts get the identical retirement response. The endpoint has no
+// auth surface any more, so no credential may change the status, body, or headers.
+expectRetired(invoke({ headers: { authorization: 'Bearer some-ops-key' } }))
+expectRetired(invoke({ headers: { 'x-ops-key': 'some-ops-key' } }))
+expectRetired(invoke({ method: 'POST', headers: { authorization: 'Bearer some-ops-key' } }))
+
+// Every other retired legacy endpoint shares the same single contract.
+for (const url of [
+  '/api/pipeline-control',
+  '/api/commercial-control/status',
+  '/api/checkout-start',
+  '/api/product-activation',
+  '/api/sales-daily',
+  '/api/behavior-events',
+  '/api/campaign-clicks',
+  '/api/public-app-handoff',
+]) expectRetired(invoke({ url }))
+
+console.log(JSON.stringify({ ok: true, contract: 'supermega_public_retired_api_behavior', checks }, null, 2))

--- a/tools/verify_public_deploy_guard.mjs
+++ b/tools/verify_public_deploy_guard.mjs
@@ -49,6 +49,10 @@ for (const [label, verifier] of Object.entries({ previewVerifier, liveVerifier }
     failures.push(`guided_product_route_contract_missing:${label}`)
   }
 }
+// The retired ops endpoints (for example /api/pipeline-control/status) must stay
+// pinned to 404 {"status":"not_found"} in the live health contract — never the
+// retired ops-key 401 — so the mismatch cannot silently reappear.
+if (!liveVerifier.includes('retired_api_status_wrong') || !liveVerifier.includes('retired_api_body_wrong') || !liveVerifier.includes('/api/pipeline-control/status')) failures.push('retired_api_live_contract_missing')
 if (previewVerifier.includes("'--silent'") || previewVerifier.includes("'--show-error'") || previewVerifier.includes("'--location'")) failures.push('preview_verifier_uses_platform_specific_curl_flags')
 if (previewVerifier.includes("'--token'") || !previewVerifier.includes('protected_preview_inspect_failed:') || !previewVerifier.includes('process.env.VERCEL_TOKEN')) failures.push('preview_verifier_credential_handling_unsafe')
 if (!rollbackResolver.includes("mode === 'alias'") || !rollbackResolver.includes("mode === 'deployment'") || !rollbackResolver.includes("state.projectId !== expectedProjectId") || !rollbackResolver.includes("nestedDeploymentId !== deploymentId") || !rollbackResolver.includes("state.id !== expectedDeploymentId") || !rollbackResolver.includes("state.target !== 'production'") || !rollbackResolver.includes("state.readyState !== 'READY'")) failures.push('rollback_alias_resolver_incomplete')
@@ -65,7 +69,7 @@ for (const [name, expected] of Object.entries({
   'vercel:deploy': 'node tools/deny_stale_public_deploy.mjs',
   'vercel:deploy:prod': 'node tools/deny_stale_public_deploy.mjs',
   'public:build': 'node tools/create_public_vercel_output.mjs',
-  'public:verify': 'node tools/verify_public_vercel_artifact_budget.mjs && node tools/verify_public_vercel_output.mjs && node tools/test_public_contact_function.mjs && npm run vercel:contracts:test && npm run hq:verify',
+  'public:verify': 'node tools/verify_public_vercel_artifact_budget.mjs && node tools/verify_public_vercel_output.mjs && node tools/test_public_contact_function.mjs && node tools/test_public_retired_api_function.mjs && npm run vercel:contracts:test && npm run hq:verify',
   'public:prebuilt': 'npm run public:build && npm run public:verify',
   'public:verify:live': 'node tools/verify_public_release_live.mjs',
   'deploy:public:prod': 'node tools/deny_stale_public_deploy.mjs',

--- a/tools/verify_public_release_live.mjs
+++ b/tools/verify_public_release_live.mjs
@@ -147,6 +147,18 @@ async function verifyOnce() {
   assert(contact.status === 'ready' && contact.accepting === true, 'contact_not_accepting', contact)
   assert(contact.controls?.idempotency === 'required' && contact.controls?.edge_rate_limit === 'required' && contact.controls?.trial_proof === 'optional_client_provided', 'contact_controls_wrong', contact)
 
+  // Retired public API surface. The legacy ops endpoints (for example
+  // /api/pipeline-control/status) were deliberately removed in the public-site
+  // consolidation (f8c5299e). The live contract for anonymous requests is
+  // 404 {"status":"not_found"} — not the retired ops-key 401 — because the
+  // endpoints no longer exist and carry no auth surface.
+  await Promise.all(['/api/pipeline-control/status', '/api/pipeline-control'].map(async (path) => {
+    const retired = await request(path, { accept: 'application/json' })
+    assert(retired.status === 404, 'retired_api_status_wrong', { path, status: retired.status })
+    const retiredBody = await retired.json().catch(() => null)
+    assert(retiredBody !== null && retiredBody.status === 'not_found' && Object.keys(retiredBody).length === 1, 'retired_api_body_wrong', { path, retiredBody })
+  }))
+
   await Promise.all([
     verifyRedirect('/products/shop/', '/#shop'),
     verifyRedirect('/products/factory/', '/#plant'),

--- a/tools/verify_public_vercel_output.mjs
+++ b/tools/verify_public_vercel_output.mjs
@@ -310,6 +310,38 @@ for (const route of [
 if (!config.routes.some((entry) => entry.handle === 'filesystem')) fail('filesystem_route_missing')
 if (!config.routes.some((entry) => entry.src === '^/(.*)$' && entry.status === 404 && entry.dest === '/404.html')) fail('not_found_route_missing')
 
+// Retired public API surface. The legacy ops endpoints were deliberately removed
+// in the public-site consolidation (f8c5299e); their old ops-key 401 contract is
+// retired with them. Every unknown /api/* path must resolve to the not-found
+// function, which answers 404 {"status":"not_found"} with no auth semantics.
+const apiFallthrough = config.routes.find((entry) => entry.src === '^/api/(.*)$')
+if (apiFallthrough?.dest !== '/api/not-found.js') fail('retired_api_fallthrough_route_missing', { apiFallthrough })
+const firstApiMatch = (path) => config.routes.find((entry) => typeof entry.src === 'string' && entry.continue !== true && new RegExp(entry.src).test(path))
+const retiredApiPaths = [
+  '/api/pipeline-control/status',
+  '/api/pipeline-control',
+  '/api/commercial-control/status',
+  '/api/commercial-control',
+  '/api/checkout-start',
+  '/api/product-activation',
+  '/api/sales-daily',
+  '/api/behavior-events',
+  '/api/campaign-clicks',
+  '/api/public-app-handoff',
+]
+for (const path of retiredApiPaths) {
+  const match = firstApiMatch(path)
+  if (match?.dest !== '/api/not-found.js') fail('retired_api_path_not_retired', { path, match })
+}
+for (const path of ['/api/health', '/api/contact-submissions', '/api/contact-submissions/status']) {
+  const match = firstApiMatch(path)
+  if (match?.dest === '/api/not-found.js' || !match?.dest) fail('active_api_path_retired', { path, match })
+}
+const notFoundFunction = readFileSync(resolve(functionsDir, 'not-found.js.func', 'index.js'), 'utf8')
+if (!notFoundFunction.includes('res.statusCode = 404')
+  || !notFoundFunction.includes("JSON.stringify({ status: 'not_found' })")) fail('retired_api_not_found_contract_drift')
+if (/\b401\b|unauthorized|SUPERMEGA_OPS_KEY|authorization|x-ops-key/i.test(notFoundFunction)) fail('retired_api_function_carries_auth_semantics')
+
 console.log(JSON.stringify({
   ok: true,
   contract: 'supermega_public_output',


### PR DESCRIPTION
Production /api/pipeline-control/status returns 404 {"status":"not_found"} — correct behavior since f8c5299e (2026-07-22) deliberately retired the legacy public ops API; the 401 expectation was stale. This codifies the contract so it cannot drift: verify_public_vercel_output.mjs now simulates first-match routing proving every retired path hits not-found.js while active paths stay live; new tools/test_public_retired_api_function.mjs (48 checks) proves the built function returns the identical 404 to anonymous and credentialed requests; verify_public_release_live.mjs asserts the live 404 contract daily.

- Tests: retired-API 48/48, contact function 128/128, public build+verify, deploy guard, app deploy workflow 81/81, live release verify (read-only) — all green.
- If any external monitoring still expects 401 on this route, update it to expect 404 {"status":"not_found"}.

🤖 Generated with [Claude Code](https://claude.com/claude-code)