### PR TITLE
Add per-product landing pages with SEO depth

### DIFF
--- a/hq/readiness/managed-pilot-readiness.json
+++ b/hq/readiness/managed-pilot-readiness.json
@@ -1,7 +1,7 @@
 {
   "contract": "supermega.managed-pilot-readiness.v2",
   "asOf": "2026-08-03T07:01:07.469Z",
-  "sourceDigest": "sha256:6d1fff3fe65a66781e28399c55bcffdf3dd13df3e7b017edf101d0730d3d4e57",
+  "sourceDigest": "sha256:b649b07f2aa4a0ddce94a4817aa9cab3c692328c8ce21652606beee2d198c0c1",
   "overall": {
     "status": "blocked",
     "localDatabaseProofReady": true,
@@ -184,7 +184,7 @@
     },
     {
       "path": "package.json",
-      "digest": "sha256:5973d3e024b0190d6deef0e55c5b63c4e52d714f11838df6d2bc80b84dd99129"
+      "digest": "sha256:0b794b5fc80b504371b89ea1f7dce31f0ff9d014965887075706e374e7d6bfc7"
     },
     {
       "path": "kernel/managed-pilot-readiness.mjs",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "vercel:contracts:test": "node --test tools/scheduler_authority_contract.test.mjs tools/write_app_vercel_config.test.mjs && node tools/test_vercel_environment_state.mjs && node tools/verify_managed_runtime_environment_values.mjs --self-test && node tools/test_vercel_project_state.mjs && node tools/test_vercel_domain_state.mjs",
     "public:release:guard": "node tools/verify_public_deploy_guard.mjs",
     "public:build": "node tools/create_public_vercel_output.mjs",
-    "public:verify": "node tools/verify_public_vercel_artifact_budget.mjs && node tools/verify_public_vercel_output.mjs && node tools/test_public_contact_function.mjs && node tools/test_public_retired_api_function.mjs && npm run vercel:contracts:test && npm run hq:verify",
+    "public:verify": "node tools/verify_public_vercel_artifact_budget.mjs && node tools/verify_public_vercel_output.mjs && node tools/test_public_contact_function.mjs && node tools/test_public_retired_api_function.mjs && node tools/test_public_landing_pages.mjs && npm run vercel:contracts:test && npm run hq:verify",
     "public:prebuilt": "npm run public:build && npm run public:verify",
     "public:verify:live": "node tools/verify_public_release_live.mjs",
     "public:verify:live:current": "node tools/verify_public_release_live.mjs --current-head",

--- a/site-manifest.json
+++ b/site-manifest.json
@@ -407,14 +407,20 @@
   ],
   "pages": [
     { "route": "/", "file": "index.html", "title": "SuperMega | Four products" },
+    { "route": "/shop/", "file": "shop/index.html", "title": "Shop | Sell, track stock, and close the day | SuperMega", "productId": "shop", "liveGate": "post-release" },
+    { "route": "/plant/", "file": "plant/index.html", "title": "Plant | Plan jobs, record output, and close shifts | SuperMega", "productId": "plant", "liveGate": "post-release" },
+    { "route": "/website/", "file": "website/index.html", "title": "Website | Build a simple company website from a brief | SuperMega", "productId": "website", "liveGate": "post-release", "description": "Answer a short business brief, edit finite pages, review a responsive preview, and download a standalone website. Request managed hosting when needed." },
+    { "route": "/ecommerce/", "file": "ecommerce/index.html", "title": "Ecommerce | Online ordering connected to Shop | SuperMega", "productId": "ecommerce", "liveGate": "post-release", "description": "Choose Shop-backed products, build a cart, review a deterministic 15-minute quote, and save a recoverable request receipt. Payment, fulfilment, returns, and refunds are completed in Shop." },
     { "route": "/contact/", "file": "contact/index.html", "title": "Contact | SuperMega" },
     { "route": "/privacy/", "file": "privacy/index.html", "title": "Privacy | SuperMega" }
   ],
   "redirects": [
     { "source": "^/solutions/?$", "destination": "/#products" },
     { "source": "^/trust/?$", "destination": "/#trust" },
-    { "source": "^/shop(?:/.*)?$", "destination": "/#shop" },
-    { "source": "^/plant(?:/.*)?$", "destination": "/#plant" },
+    { "source": "^/shop(?:/.+)?$", "destination": "/shop/" },
+    { "source": "^/plant(?:/.+)?$", "destination": "/plant/" },
+    { "source": "^/website(?:/.+)?$", "destination": "/website/" },
+    { "source": "^/ecommerce(?:/.+)?$", "destination": "/ecommerce/" },
     { "source": "^/templates(?:/.*)?$", "destination": "/#products" },
     { "source": "^/work(?:/.*)?$", "destination": "/#products" },
     { "source": "^/(?:products?|offers|pricing|plans|packages)/?$", "destination": "/#products" },

--- a/tools/create_public_vercel_output.mjs
+++ b/tools/create_public_vercel_output.mjs
@@ -257,6 +257,7 @@ const sharedStyle = `
   .compact-solution h3 { margin: 20px 0 9px; font-size: 30px; }
   .compact-solution > p { min-height: 44px; color: var(--muted); font-size: 13px; }
   .compact-solution > .card-link { margin-top: auto; }
+  .compact-solution > .card-link + .card-link { margin-top: 2px; }
   .product-roadmap { display: grid; grid-template-columns: repeat(2,minmax(0,1fr)); gap: 14px; margin-top: 14px; }
   .roadmap-solution { min-height: 228px; display: flex; flex-direction: column; }
   .roadmap-solution > p { min-height: 0; }
@@ -353,6 +354,7 @@ function productCardHtml(product, index) {
     <h3>${escapeHtml(product.name)}</h3>
     <p>${escapeHtml(product.headline)}</p>
     <div class="module-tags" role="group" aria-label="Core capabilities">${capabilities.map((capability) => `<span>${escapeHtml(capability)}</span>`).join('')}</div>
+    <a class="card-link" href="/${escapeHtml(product.id)}/">${escapeHtml(product.name)} overview</a>
     <a class="card-link" href="${escapeHtml(guidedSampleRoute)}">Start free sample</a>
   </article>`
 }
@@ -368,6 +370,25 @@ const homeHtml = documentHtml({
     <section class="frame trust-strip" id="trust" aria-label="Security boundary"><div class="control-line"><span class="eyebrow">Secure by default</span><p>Every real send, payment, publish, access change, stock movement, or production write stays behind explicit authority and verified server-side controls.</p></div></section>
   </main>`,
 })
+
+function productLandingHtml(product, page) {
+  const guidedSampleRoute = `https://app.supermega.dev/settings/?product=${encodeURIComponent(product.id)}`
+  const setupLabel = product.secondaryCta?.label || `Set up ${product.name} data`
+  const description = page.description || product.description
+  const moduleItems = product.modules?.length ? product.modules : product.id === 'website' ? product.workflow : product.views
+  return documentHtml({
+    route: page.route,
+    title: page.title,
+    description,
+    content: `<main>
+    <section class="frame page-hero"><span class="eyebrow">${escapeHtml(product.eyebrow)}</span><h1>${escapeHtml(product.headline)}</h1><p class="lede">${escapeHtml(description)}</p><div class="actions"><a class="button primary" href="${escapeHtml(guidedSampleRoute)}">Start free sample</a><a class="button" href="/contact/?product=${escapeHtml(product.id)}">${escapeHtml(setupLabel)}</a></div><div class="hero-note"><span>Free browser sample</span><span>No account or model call required</span><span>Mobile-ready workflows</span></div></section>
+    <section class="frame section" id="modules"><div class="section-head"><span class="eyebrow">${escapeHtml(product.name)} modules</span><h2>What the working sample covers.</h2></div><div class="solution-modules" aria-label="${escapeHtml(product.name)} modules">${moduleItems.map((item, index) => `<span><i>0${index + 1}</i>${escapeHtml(item)}</span>`).join('')}</div></section>
+    <section class="frame section" id="free-sample"><div class="section-head"><span class="eyebrow">Free local workspace</span><h2>Operate without a stripped-down plan.</h2><p>Start a free browser sample with a client name and owner. Your data stays optional until the workflow makes sense.</p></div><ul class="offer-model-list"><li>Full local operating modules and imports</li><li>Grounded answers from validated local records</li><li>Approvals, evidence, backup, and export</li><li>No account or model call required</li></ul></section>
+    <section class="frame trust-strip" aria-label="Security boundary"><div class="control-line"><span class="eyebrow">Secure by default</span><p>Every real send, payment, publish, access change, stock movement, or production write stays behind explicit authority and verified server-side controls.</p></div></section>
+    <section class="frame section"><div class="closing-strip"><div><h2>Free product. Managed intelligence.</h2><p>Managed activation proceeds only after identity, tenant isolation, recovery, and write controls pass for the company.</p></div><a class="button primary" href="${escapeHtml(guidedSampleRoute)}">Start free sample</a></div></section>
+  </main>`,
+  })
+}
 
 const contactScript = `<script>(function(){
   var form=document.querySelector('[data-contact-form]');if(!form)return;
@@ -942,6 +963,14 @@ const pageFiles = new Map([
   ['404.html', notFoundHtml],
 ])
 
+for (const page of manifest.pages.filter((entry) => entry.productId)) {
+  const product = publicProducts.find((candidate) => candidate.id === page.productId)
+  assert(product, `landing_page_product_missing:${page.productId}`)
+  assert(page.route === `/${product.id}/` && page.file === `${product.id}/index.html`, `landing_page_route_drift:${page.route}`)
+  assert(page.liveGate === 'post-release', `landing_page_live_gate_missing:${page.route}`)
+  pageFiles.set(page.file, productLandingHtml(product, page))
+}
+
 const vercelConfig = {
   version: 3,
   routes: [
@@ -980,7 +1009,7 @@ for (const [relativePath, content] of pageFiles) await writeStatic(relativePath,
 await writeStatic('favicon.svg', faviconSvg)
 await writeStatic('__release.json', `${JSON.stringify(release, null, 2)}\n`)
 await writeStatic('robots.txt', 'User-agent: *\nAllow: /\nDisallow: /api/\nSitemap: https://supermega.dev/sitemap.xml\n')
-await writeStatic('sitemap.xml', `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${manifest.pages.map((page) => `  <url><loc>${escapeHtml(canonical(page.route))}</loc><changefreq>${page.route === '/privacy/' ? 'yearly' : 'weekly'}</changefreq></url>`).join('\n')}\n</urlset>\n`)
+await writeStatic('sitemap.xml', `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${manifest.pages.map((page) => `  <url><loc>${escapeHtml(canonical(page.route))}</loc><lastmod>${release.generatedAt.slice(0, 10)}</lastmod><changefreq>${page.route === '/privacy/' ? 'yearly' : 'weekly'}</changefreq></url>`).join('\n')}\n</urlset>\n`)
 await writeStatic('site.webmanifest', `${JSON.stringify({ name: 'SuperMega', short_name: 'SuperMega', start_url: '/', display: 'browser', background_color: brand.colors.background, theme_color: brand.colors.background, icons: [{ src: '/favicon.svg', sizes: 'any', type: 'image/svg+xml', purpose: 'any' }] }, null, 2)}\n`)
 
 await writeFunction('health.js', healthFunction)

--- a/tools/test_public_landing_pages.mjs
+++ b/tools/test_public_landing_pages.mjs
@@ -1,0 +1,82 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const root = process.cwd()
+const staticDir = resolve(root, '.vercel', 'output', 'static')
+const manifest = JSON.parse(readFileSync(resolve(root, 'site-manifest.json'), 'utf8'))
+const config = JSON.parse(readFileSync(resolve(root, '.vercel', 'output', 'config.json'), 'utf8'))
+const readStatic = (path) => readFileSync(resolve(staticDir, path), 'utf8')
+
+let checks = 0
+function check(condition, label) {
+  checks += 1
+  assert.ok(condition, label)
+}
+
+const landingPages = manifest.pages.filter((page) => page.productId)
+check(landingPages.map((page) => page.route).join(',') === '/shop/,/plant/,/website/,/ecommerce/', 'landing_route_set')
+
+// Route resolution: landing routes must reach the filesystem handler untouched, while the
+// slash-less and deep variants must 308 onto the canonical landing route.
+const redirectRoutes = config.routes.filter((route) => route.status === 308 && route.src)
+for (const page of landingPages) {
+  const productId = page.productId
+  for (const path of [page.route]) {
+    const intercepted = redirectRoutes.find((route) => new RegExp(route.src).test(path))
+    check(!intercepted, `landing_route_not_redirected:${path}:${intercepted?.src || ''}`)
+  }
+  for (const path of [`/${productId}`, `/${productId}/legacy-deep-link`]) {
+    const redirect = redirectRoutes.find((route) => new RegExp(route.src).test(path))
+    check(redirect?.headers?.Location === page.route, `landing_variant_redirects:${path}`)
+  }
+  check(page.liveGate === 'post-release', `landing_live_gate_declared:${page.route}`)
+}
+check(config.routes.at(-1)?.dest === '/404.html' && config.routes.at(-1)?.status === 404, 'not_found_fallback_last')
+
+// Page content markers, SEO metadata, and CTA wiring.
+const descriptions = []
+for (const page of landingPages) {
+  const product = manifest.customerProducts.find((candidate) => candidate.id === page.productId)
+  check(Boolean(product), `landing_product_exists:${page.productId}`)
+  const html = readStatic(page.file)
+  const canonical = new URL(page.route, `${manifest.release.productionDomain}/`).href
+  const description = page.description || product.description
+  check(typeof description === 'string' && description.length >= 40, `landing_description_present:${page.route}`)
+  descriptions.push(description)
+  check(html.includes(`<title>${page.title}</title>`), `landing_title:${page.route}`)
+  check(html.includes(`<link rel="canonical" href="${canonical}" />`), `landing_canonical:${page.route}`)
+  check(html.includes(`<meta name="description" content="${description}" />`), `landing_meta_description:${page.route}`)
+  check(html.includes(`<meta property="og:title" content="${page.title}" />`), `landing_og_title:${page.route}`)
+  check(html.includes(`<meta property="og:url" content="${canonical}" />`), `landing_og_url:${page.route}`)
+  check(html.includes('<meta name="robots" content="index,follow" />'), `landing_indexable:${page.route}`)
+  check(html.includes(`<h1>${product.headline}</h1>`), `landing_headline:${page.route}`)
+  check(html.includes(`href="https://app.supermega.dev/settings/?product=${product.id}"`), `landing_primary_cta:${page.route}`)
+  check(html.includes(`href="/contact/?product=${product.id}"`), `landing_secondary_cta:${page.route}`)
+  check(!html.includes(`href="${product.appRoute}"`), `landing_no_direct_app_route:${page.route}`)
+  check(html.includes('href="/contact/">Contact</a>') && html.includes('href="/privacy/">Privacy</a>'), `landing_footer_parity:${page.route}`)
+  check(html.includes('aria-label="SuperMega home"'), `landing_home_navigation:${page.route}`)
+}
+check(new Set(descriptions).size === descriptions.length, 'landing_descriptions_unique')
+const titles = manifest.pages.map((page) => page.title)
+check(new Set(titles).size === titles.length, 'page_titles_unique')
+
+// Homepage links each product to its landing page without replacing the guided sample CTA.
+const home = readStatic('index.html')
+for (const page of landingPages) {
+  const product = manifest.customerProducts.find((candidate) => candidate.id === page.productId)
+  check(home.includes(`href="${page.route}">${product.name} overview</a>`), `home_links_landing:${page.route}`)
+  check(home.includes(`href="https://app.supermega.dev/settings/?product=${product.id}"`), `home_keeps_guided_cta:${product.id}`)
+}
+
+// Sitemap covers every public route exactly once with a well-formed lastmod.
+const sitemap = readStatic('sitemap.xml')
+check((sitemap.match(/<url>/g) || []).length === manifest.pages.length, 'sitemap_url_count')
+for (const page of manifest.pages) {
+  const canonical = new URL(page.route, `${manifest.release.productionDomain}/`).href
+  check(sitemap.includes(`<loc>${canonical}</loc>`), `sitemap_route:${page.route}`)
+}
+check(/<lastmod>\d{4}-\d{2}-\d{2}<\/lastmod>/.test(sitemap), 'sitemap_lastmod_format')
+check(readStatic('robots.txt').includes('Sitemap: https://supermega.dev/sitemap.xml'), 'robots_references_sitemap')
+
+console.log(JSON.stringify({ ok: true, contract: 'supermega_public_landing_pages', checks, routes: landingPages.map((page) => page.route) }))

--- a/tools/verify_public_deploy_guard.mjs
+++ b/tools/verify_public_deploy_guard.mjs
@@ -69,7 +69,7 @@ for (const [name, expected] of Object.entries({
   'vercel:deploy': 'node tools/deny_stale_public_deploy.mjs',
   'vercel:deploy:prod': 'node tools/deny_stale_public_deploy.mjs',
   'public:build': 'node tools/create_public_vercel_output.mjs',
-  'public:verify': 'node tools/verify_public_vercel_artifact_budget.mjs && node tools/verify_public_vercel_output.mjs && node tools/test_public_contact_function.mjs && node tools/test_public_retired_api_function.mjs && npm run vercel:contracts:test && npm run hq:verify',
+  'public:verify': 'node tools/verify_public_vercel_artifact_budget.mjs && node tools/verify_public_vercel_output.mjs && node tools/test_public_contact_function.mjs && node tools/test_public_retired_api_function.mjs && node tools/test_public_landing_pages.mjs && npm run vercel:contracts:test && npm run hq:verify',
   'public:prebuilt': 'npm run public:build && npm run public:verify',
   'public:verify:live': 'node tools/verify_public_release_live.mjs',
   'deploy:public:prod': 'node tools/deny_stale_public_deploy.mjs',

--- a/tools/verify_public_release_live.mjs
+++ b/tools/verify_public_release_live.mjs
@@ -105,8 +105,25 @@ async function verifyRedirect(path, destination) {
   assert(actual === expected, 'redirect_destination_wrong', { path, expected, actual })
 }
 
+// Pages marked liveGate: "post-release" ship with a release, so before that release is
+// promoted the deployed site legitimately serves a redirect or 404 for them. Without an
+// exact expected commit (availability scope) those routes are skipped while pending; the
+// post-deploy release verification always runs with EXPECTED_RELEASE_COMMIT set, which
+// asserts every manifest page — including gated landing pages — against the promoted build.
+async function readPageOrPending(page, pendingRoutes) {
+  if (page.liveGate === 'post-release' && !expectedCommit) {
+    const probe = await request(page.route, { redirect: 'manual' })
+    if (probe.status !== 200) {
+      pendingRoutes.add(page.route)
+      return [page.route, null]
+    }
+  }
+  return [page.route, await readPage(page.route)]
+}
+
 async function verifyOnce() {
-  const pageResults = await Promise.all(manifest.pages.map(async (page) => [page.route, await readPage(page.route)]))
+  const pendingRoutes = new Set()
+  const pageResults = await Promise.all(manifest.pages.map(async (page) => readPageOrPending(page, pendingRoutes)))
   const pages = new Map(pageResults)
   assert(pages.get('/')?.includes(manifest.company.headline), 'homepage_headline_wrong')
   assert(pages.get('/')?.includes('href="#products">Choose a product</a>'), 'homepage_product_cta_missing')
@@ -120,6 +137,14 @@ async function verifyOnce() {
     assert(homepage.includes(`href="${guidedSampleRoute}"`), 'guided_product_route_missing', { product: product.id, guidedSampleRoute })
     assert(!homepage.includes(`href="${product.appRoute}"`), 'direct_product_route_remains_primary', { product: product.id, appRoute: product.appRoute })
     for (const template of product.templates) assert(!homepage.includes(template.name), 'template_catalog_exposed', { template: template.id })
+    const landingRoute = `/${product.id}/`
+    const landing = pages.get(landingRoute)
+    if (pendingRoutes.has(landingRoute) || landing == null) continue
+    assert(landing.includes(product.headline), 'landing_headline_missing', { product: product.id })
+    assert(landing.includes(`href="${guidedSampleRoute}"`), 'landing_guided_product_route_missing', { product: product.id })
+    assert(!landing.includes(`href="${product.appRoute}"`), 'landing_direct_product_route_present', { product: product.id })
+    assert(landing.includes(`href="/contact/?product=${product.id}"`), 'landing_contact_route_missing', { product: product.id })
+    assert(homepage.includes(`href="${landingRoute}"`), 'landing_route_link_missing_on_home', { product: product.id })
   }
   for (const internalLabel of ['SuperMega HQ', 'One next action for the company', 'Gated R&amp;D']) assert(!pages.get('/')?.includes(internalLabel), 'internal_system_exposed', { internalLabel })
   assert(pages.get('/')?.includes('id="trust"'), 'control_boundary_missing')
@@ -175,7 +200,12 @@ async function verifyOnce() {
   const wwwHtml = await www.text()
   assert(wwwHtml.includes(manifest.company.headline), 'www_release_drift')
 
-  return { pages: manifest.pages.map((page) => page.route), release, contact: contact.status }
+  return {
+    pages: manifest.pages.map((page) => page.route).filter((route) => !pendingRoutes.has(route)),
+    pendingGatedRoutes: [...pendingRoutes],
+    release,
+    contact: contact.status,
+  }
 }
 
 let lastError

--- a/tools/verify_public_vercel_output.mjs
+++ b/tools/verify_public_vercel_output.mjs
@@ -70,7 +70,11 @@ for (const product of publicProducts) {
     if (!template.outcome?.trim() || !template.metric?.trim() || template.workflow?.length < 5 || template.entryPoints?.length < 3) fail('public_template_contract_incomplete', { product: product.id, template: template.id })
   }
 }
-if (manifest.pages?.map((page) => page.route).join(',') !== '/,/contact/,/privacy/') fail('public_page_surface_not_minimal')
+if (manifest.pages?.map((page) => page.route).join(',') !== '/,/shop/,/plant/,/website/,/ecommerce/,/contact/,/privacy/') fail('public_page_surface_not_minimal')
+for (const landingPage of manifest.pages.filter((page) => page.productId)) {
+  if (landingPage.route !== `/${landingPage.productId}/` || landingPage.file !== `${landingPage.productId}/index.html`) fail('landing_page_route_drift', { route: landingPage.route })
+  if (landingPage.liveGate !== 'post-release') fail('landing_page_live_gate_missing', { route: landingPage.route })
+}
 
 const expectedStaticFiles = new Set([
   ...manifest.pages.map((page) => page.file),
@@ -153,8 +157,14 @@ for (const [route, page] of pages) {
   if (/target\s*=\s*["']?_blank/i.test(page.html) || page.html.includes('window.open(')) fail('new_tab_navigation_present', { route })
   if (page.html.includes('href="/solutions/"') || page.html.includes('href="/trust/"')) fail('retired_public_navigation_present', { route })
   if (!page.html.includes(`<link rel="canonical" href="${new URL(route, `${manifest.release.productionDomain}/`).href}"`)) fail('canonical_url_wrong', { route })
+  if (!/<meta name="description" content="[^"]{20,}" \/>/.test(page.html)) fail('page_description_missing', { route })
+  for (const token of ['<meta property="og:type" content="website" />', '<meta property="og:site_name" content="SuperMega" />', `<meta property="og:url" content="${new URL(route, `${manifest.release.productionDomain}/`).href}" />`, '<meta name="twitter:card" content="summary" />']) {
+    if (!page.html.includes(token)) fail('page_open_graph_missing', { route, token })
+  }
   if (route !== '/' && !page.html.includes('href="/contact/">Contact</a>')) fail('support_footer_contact_missing', { route })
 }
+const pageTitles = manifest.pages.map((page) => page.title)
+if (new Set(pageTitles).size !== pageTitles.length) fail('page_titles_not_unique')
 
 const home = pages.get('/')?.html || ''
 if (/\.brand-name\s*\{[^}]*display\s*:\s*none/i.test(home)) fail('mobile_brand_name_hidden')
@@ -212,6 +222,7 @@ if ((home.match(/>Request managed pilot<\/a>/g) || []).length !== 1) fail('manag
 if (home.includes('Start guided trial') || home.includes('aria-label="Templates"')) fail('retired_public_setup_copy_returned')
 for (const product of publicProducts) {
   if (home.includes(`href="${product.appRoute}"`)) fail('direct_product_route_remains_primary', { product: product.id })
+  if (!home.includes(`href="/${product.id}/">${product.name} overview</a>`)) fail('landing_route_link_missing', { product: product.id })
 }
 for (const internalLabel of ['SuperMega HQ', 'One next action for the company', 'Owners, evidence, review, and release', 'Gated R&amp;D']) {
   if (home.includes(internalLabel)) fail('internal_system_exposed_on_public_home', { internalLabel })
@@ -220,7 +231,37 @@ for (const retiredLabel of ['>Open Commerce<', '>Open Production<']) {
   if (home.includes(retiredLabel)) fail('ambiguous_demo_cta_present', { retiredLabel })
 }
 if (home.includes('Commerce and Production carry real records and actions.')) fail('unsupported_live_record_claim_present')
-if ((home.match(/<a\b/g) || []).length > 9) fail('homepage_link_surface_too_large')
+if ((home.match(/<a\b/g) || []).length > 13) fail('homepage_link_surface_too_large')
+
+for (const product of publicProducts) {
+  const landingRoute = `/${product.id}/`
+  const landing = pages.get(landingRoute)?.html || ''
+  const guidedSampleRoute = `https://app.supermega.dev/settings/?product=${encodeURIComponent(product.id)}`
+  const setupLabel = product.secondaryCta?.label || `Set up ${product.name} data`
+  for (const token of [
+    product.eyebrow,
+    `<h1>${product.headline}</h1>`,
+    `href="${guidedSampleRoute}"`,
+    '>Start free sample</a>',
+    `href="/contact/?product=${product.id}">${setupLabel}</a>`,
+    'Free browser sample',
+    'Mobile-ready workflows',
+    'What the working sample covers.',
+    'Operate without a stripped-down plan.',
+    'Start a free browser sample with a client name and owner. Your data stays optional until the workflow makes sense.',
+    'No account or model call required',
+    'aria-label="Security boundary"',
+    'Every real send, payment, publish, access change, stock movement, or production write stays behind explicit authority and verified server-side controls.',
+    'Free product. Managed intelligence.',
+    'Managed activation proceeds only after identity, tenant isolation, recovery, and write controls pass for the company.',
+  ]) {
+    if (!landing.includes(token)) fail('landing_page_contract_missing', { route: landingRoute, token })
+  }
+  if (landing.includes(`href="${product.appRoute}"`)) fail('landing_direct_product_route_present', { route: landingRoute })
+  for (const capability of (product.modules?.length ? product.modules : product.id === 'website' ? product.workflow : product.views)) {
+    if (!landing.includes(capability)) fail('landing_module_missing', { route: landingRoute, capability })
+  }
+}
 
 const contact = pages.get('/contact/')?.html || ''
 for (const token of ['data-contact-form', 'action="/api/contact-submissions"', 'name="name"', 'name="email"', 'name="company"', 'name="product"', 'value="shop"', 'value="plant"', 'value="website"', 'value="ecommerce"', 'name="template"', 'name="goal"', 'name="idempotency_key"', 'name="proof_contract"', 'name="proof_version"', 'name="proof_digest"', 'name="proof_product"', 'name="proof_template"', 'name="proof_readiness"', 'name="proof_sources"', 'name="proof_behavior"', 'name="proof_decisions"', 'proof_outcome', 'proof_outcome_digest', 'proof_outcome_accepted', 'name="proof_raw_records"', 'class="contact-honeypot" name="website" tabindex="-1" autocomplete="off" aria-hidden="true" inert', 'x-idempotency-key', 'rate_limited', 'trial_proof_invalid', 'Describe one real workflow or recurring handoff, and note any screenshot or spreadsheet you can share.', '>Shop<', '>Plant<', '>Website<', '>Ecommerce<', 'No account, data connection, automation, or external action begins from this form.', 'Reply email', 'data-contact-heading', 'data-contact-lede', 'data-contact-copy-heading', 'data-contact-copy', 'data-trial-proof', 'Client-provided trial proof', 'Reviewed setup summary', 'it does not verify a managed account.', 'digest-bound aggregate summary', 'location.hash.slice(1)', '/^(guide|shop|plant|website|ecommerce)$/.test(requestedProduct||\'\')', "handoff.get('company')", "handoff.get('goal')", "history.replaceState(null,'',location.pathname+location.search)", "heading.textContent='Finish your '+productName+' request.'", 'Your company and goal are already filled. Add your name and reply email, review the request, then send it.', 'Only this summary moves forward. No raw product records, account connection, automation, or external action begins from this form.', 'Raw records, questions, approval contents, and account details stay out.', 'Trial summary attached for review. Nothing has been sent.', 'Trial summary detached. Review the updated request before sending.', 'Company and goal are ready for review from your AI memory.', 'Request received:', 'Keep this ID for follow-up.', 'Too many requests from this connection. Please wait ten minutes and try again.', 'Could not route the request here. Please wait and try again.']) {


### PR DESCRIPTION
Adds /shop/, /plant/, /website/, /ecommerce/ to the generated public site so every product CTA has an on-domain page before the cross-origin jump to app.supermega.dev — closing the SEO/funnel gap flagged in the 2026-08-06 site audit (3 internal routes, text-only shares, zero per-product landing surface).

- Generator-first: pages emitted by tools/create_public_vercel_output.mjs reusing the jade-v2 tokens and byte-identical sharedStyle (CSP hashes recomputed automatically). Copy strictly reused from site-manifest.json product definitions and the merged #383 free-vs-managed homepage messaging — no new claims, no pricing tokens.
- Homepage: pinned CTAs untouched; each product card gains a light "{Name} overview" link (verifier <a> cap raised 9 → 13 with per-link pins).
- SEO: unique title/description/canonical/OG per page, sitemap.xml now lists all 7 routes with lastmod, legacy /{product} paths 308-canonicalize to /{product}/.
- Verifiers: page-surface, per-landing contract block, live verifier gates new routes with liveGate:"post-release" (pending pre-deploy, hard-asserted once EXPECTED_RELEASE_COMMIT is set post-promote — verified green against current production). New tools/test_public_landing_pages.mjs (94 checks) wired into public:verify + deploy-guard pin.
- Full chain green at 1201f2cb: public:prebuilt, artifact budget (23 files / 0.27 MB), contact function 128 checks, vercel:contracts:test, hq:verify (readiness ledger regenerated), deploy guard. Independently re-verified by a second agent (pass, no failures).
- Merge note: coexists with #390 — verifiers auto-merge; package.json public:verify string and its deploy-guard mirror conflict trivially (include both new tests), then regenerate the readiness ledger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)