### PR TITLE
Website product: add a guided 'Get this live' step after publish

### DIFF
--- a/showroom/src/products/website/PublishWorkspace.tsx
+++ b/showroom/src/products/website/PublishWorkspace.tsx
@@ -42,6 +42,8 @@ type PublishWorkspaceProps = {
 
 type PublishStep = 'checks' | 'evidence' | 'approval' | 'snapshot'
 
+const GO_LIVE_CONTACT_URL = 'https://supermega.dev/contact/?product=website&source=go-live&utm_source=app&utm_medium=guided_trial'
+
 const publishSteps: Array<{ id: PublishStep; label: string }> = [
   { id: 'checks', label: 'Checks' },
   { id: 'evidence', label: 'Evidence' },
@@ -527,6 +529,31 @@ export function PublishWorkspace({
                 </button>
               </div>
             </div>
+
+            {publishIsCurrent ? (
+              <section className="website-go-live" aria-labelledby="go-live-title">
+                <header>
+                  <span className="website-eyebrow">Next step</span>
+                  <h4 id="go-live-title">Get this live</h4>
+                  <p>The downloaded site file is the whole website. Put it online yourself, or ask about managed hosting.</p>
+                </header>
+                <details className="website-go-live-option" open>
+                  <summary>Host it yourself</summary>
+                  <ol>
+                    <li>Download the site file above.</li>
+                    <li>If your host expects a home page named <code>index.html</code>, rename the file to match.</li>
+                    <li>Upload the file to the public folder of any static file host you already use.</li>
+                    <li>Open your site address and check every page and link once.</li>
+                  </ol>
+                  <p>Any host that serves plain HTML files works. The upload happens outside this app.</p>
+                </details>
+                <details className="website-go-live-option">
+                  <summary>Request managed hosting</summary>
+                  <p>Describe the site and where it should live. We reply with the smallest useful next step. Nothing deploys from this app.</p>
+                  <a className="website-button is-secondary" href={GO_LIVE_CONTACT_URL} rel="noreferrer" target="_blank">Open the contact form</a>
+                </details>
+              </section>
+            ) : null}
 
             <Suspense fallback={<div className="website-release-loading">Loading client release controls...</div>}>
               <WebsiteReleaseFoundation

--- a/showroom/src/products/website/publish-workspace.css
+++ b/showroom/src/products/website/publish-workspace.css
@@ -420,6 +420,72 @@
   min-height: 44px;
 }
 
+.website-go-live {
+  overflow: hidden;
+  margin: 0 14px 14px;
+  border: 1px solid color-mix(in srgb, var(--publish-accent) 22%, var(--website-line));
+  border-radius: 10px;
+  background: var(--website-panel-raised);
+}
+
+.website-go-live > header {
+  padding: 14px 14px 8px;
+}
+
+.website-go-live > header h4 {
+  margin: 2px 0 0;
+  color: var(--website-ink);
+  font-size: 16px;
+}
+
+.website-go-live > header p {
+  margin: 4px 0 0;
+  color: var(--website-muted);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.website-go-live-option {
+  border-top: 1px solid var(--website-line);
+  padding: 0 14px;
+}
+
+.website-go-live-option > summary {
+  min-height: 44px;
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+  color: var(--website-ink);
+  font-size: 12px;
+  font-weight: 800;
+}
+
+.website-go-live-option ol {
+  display: grid;
+  gap: 6px;
+  margin: 0 0 10px;
+  padding-left: 20px;
+  color: var(--website-muted);
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+.website-go-live-option ol code {
+  color: var(--website-ink);
+  font-size: 12px;
+}
+
+.website-go-live-option p {
+  margin: 0 0 12px;
+  color: var(--website-muted);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.website-go-live-option .website-button {
+  margin-bottom: 12px;
+}
+
 .website-release-loading,
 .website-release-foundation {
   margin: 0 14px 14px;
@@ -745,8 +811,13 @@
 
   .website-release-loading,
   .website-release-foundation,
+  .website-go-live,
   .website-publish-history-disclosure {
     margin-inline: 10px;
+  }
+
+  .website-go-live-option .website-button {
+    width: 100%;
   }
 
   .website-release-foundation > header,

--- a/tools/verify_app_build.mjs
+++ b/tools/verify_app_build.mjs
@@ -17983,8 +17983,8 @@ await verifyBusinessCommandRuntime()
 await verifyOwnerControlRuntime()
 
 const bytes = (await Promise.all(files.map(async (path) => (await stat(path)).size))).reduce((total, size) => total + size, 0)
-// Bounded allowance for supplier return claims, credit evidence, and credit-adjusted invoice matching.
-if (bytes > 2_800_000) fail(`artifact_budget:${bytes}`)
+// Bounded allowance for the Website go-live handoff panel (self-host steps plus managed contact route).
+if (bytes > 2_806_000) fail(`artifact_budget:${bytes}`)
 const javascriptFiles = files.filter((path) => path.endsWith('.js'))
 const builtIndexSource = await readFile(rootPage, 'utf8')
 const initialEntryMatch = builtIndexSource.match(/<script[^>]+src="\/assets\/([^"]+\.js)"/)


### PR DESCRIPTION
Closes the top-ranked trial-UX gap from the 2026-08-07 build review: the Website product's first-use path ended at a downloaded HTML file with no path to a live site.

After a successful publish, a "Get this live" panel now appears under the site-file controls using the product's existing details/summary idiom: vendor-neutral self-hosting steps (open by default), plus the managed path linking to the existing contact flow with the accepted product=website parameter. No new claims, no pricing, no external requests.

Green: verify_app_security_contract (95 checks), full tsc+vite build + verify_app_build (including the website runtime dist checks), focused tests. Independently re-verified (pass): panel gating on publishIsCurrent, contact URL matches the public form's allowlist, UI idiom consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)