### PR TITLE
Fix deploy-guard pin stranded on deleted command-center UI

### DIFF
--- a/tools/verify_app_deploy_workflow.mjs
+++ b/tools/verify_app_deploy_workflow.mjs
@@ -123,7 +123,7 @@ requireContract('ordered integration batches preserve production safeguards and 
   && releaseIntegrationBatch.includes('const ProductSystemNavigator = lazy(')
   && releaseIntegrationBatch.includes('Choose what you want to run.')
   && releaseIntegrationBatch.includes('.product-system-workflows { display: grid; grid-template-columns: repeat(4,minmax(0,1fr)); gap: 8px; }')
-  && releaseIntegrationBatch.includes('aria-label="Ask SuperMega business command center"')
+  && releaseIntegrationBatch.includes('startGuidedWorkspace')
   && releaseIntegrationBatch.includes('function ecommerceOrderAmendmentSummary')
   && releaseIntegrationBatch.includes('Already saved for this company as revision')
   && releaseIntegrationBatch.includes('<details aria-label="Enterprise order controls"')


### PR DESCRIPTION
Main's validate went red after #399: verify_app_deploy_workflow.mjs pins literal tokens that must exist in prepare_release_integration_batch.mjs, and one pin — aria-label="Ask SuperMega business command center" — anchored UI that only existed in the ProductHomeReadiness.tsx surface deleted by #398. #399's group rewrite (correctly) dropped the dead token, leaving the guard conjunct unsatisfiable.

One-line fix: the pin now anchors startGuidedWorkspace, present in the successor batch group and in ProductOnboardingPage.tsx. Both deploy-guard verifiers green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)