### PR TITLE
Console: fail-closed leads review with auditable mark-reviewed

### DIFF
--- a/kernel/console-leads-review.test.mjs
+++ b/kernel/console-leads-review.test.mjs
@@ -1,0 +1,206 @@
+// Founder lead-review surface: fail-closed without a configured leads source, review decisions
+// recorded as tenant-scoped control records, and zero outbound/lead-mutating side effects.
+import { readFile } from 'node:fs/promises'
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import realStore from './store.mjs'
+import {
+  LEAD_REVIEW_RECORD_PREFIX,
+  LEADS_REVIEW_TENANT,
+  LEADS_SOURCE_REQUIRED_ENV,
+  leadReviewRecordKey,
+  leadsSourceConfigured,
+  listLeadsForReview,
+  markLeadReviewed,
+} from './console/leads-review.mjs'
+
+const HASH_RE = /^[a-f0-9]{64}$/
+
+const LEADS = [
+  { id: 'lead-1', lead_id: 'lead-1', source: 'website', name: 'Aye', company: 'Alpha Co', contact: 'aye@example.com', package: 'build', message: 'Automate intake', score: 80, stage: 'new', created_at: '2026-08-01T00:00:00.000Z' },
+  { id: 'lead-2', lead_id: 'lead-2', source: 'website', name: 'Ba', company: 'Beta Co', contact: 'ba@example.com', package: 'dashboard', message: 'Dashboard', score: 60, stage: 'qualified', created_at: '2026-08-02T00:00:00.000Z' },
+]
+
+function fakeStore({ leads = LEADS, converted = [], mode = 'supabase', putResult = true } = {}) {
+  const controlRecords = new Map()
+  const calls = []
+  return {
+    mode,
+    calls,
+    controlRecords,
+    async listLeads(limit) { calls.push('listLeads'); return leads.slice(0, limit) },
+    async getLead(id) { calls.push('getLead'); return leads.find((l) => l.id === id) || null },
+    async convertedLeadIds() { calls.push('convertedLeadIds'); return converted },
+    async listControlRecords({ prefix, clientId, status, limit }) {
+      calls.push('listControlRecords')
+      const records = [...controlRecords.entries()]
+        .filter(([key]) => key.startsWith(prefix))
+        .map(([key, payload]) => ({ key, payload }))
+        .filter((record) => (!clientId || record.payload.clientId === clientId)
+          && (!status || record.payload.status === status))
+        .slice(0, limit)
+      return { durable: true, records }
+    },
+    async getControlRecord(key) { calls.push('getControlRecord'); return controlRecords.get(key) || null },
+    async putControlRecord(key, payload) {
+      calls.push('putControlRecord')
+      if (!putResult) return false
+      controlRecords.set(key, payload)
+      return true
+    },
+    // The review surface is read + record only. Any of these firing is a defect.
+    async updateLead() { throw new Error('updateLead_must_not_be_called') },
+    async insertLead() { throw new Error('insertLead_must_not_be_called') },
+    async saveDeal() { throw new Error('saveDeal_must_not_be_called') },
+  }
+}
+
+test('leads review fails closed when no durable leads source is configured', async () => {
+  assert.equal(realStore.mode, 'memory', 'these tests must run without database credentials')
+  assert.equal(leadsSourceConfigured(realStore), false)
+
+  const list = await listLeadsForReview({}, realStore)
+  assert.equal(list.ok, false)
+  assert.equal(list.reason, 'leads_source_not_configured')
+  assert.deepEqual(list.requiredEnv, ['SUPABASE_URL', 'SUPABASE_SERVICE_ROLE_KEY'])
+  assert.deepEqual(list.requiredEnv, [...LEADS_SOURCE_REQUIRED_ENV])
+  assert.equal('leads' in list, false, 'fail-closed responses must not carry a leads list')
+
+  const mark = await markLeadReviewed({ leadId: 'lead-1' }, realStore)
+  assert.equal(mark.ok, false)
+  assert.equal(mark.reason, 'leads_source_not_configured')
+})
+
+test('configured source lists recent leads with converted + reviewed state', async () => {
+  const store = fakeStore({ converted: ['lead-2'] })
+  const first = await listLeadsForReview({ limit: 10 }, store)
+  assert.equal(first.ok, true)
+  assert.equal(first.source, 'configured')
+  assert.equal(first.leads.length, 2)
+  assert.deepEqual(first.leads.map((l) => l.reviewed), [false, false])
+  assert.equal(first.leads[1].converted, true)
+
+  const marked = await markLeadReviewed({ leadId: 'lead-1', reviewedBy: 'founder' }, store, () => '2026-08-07T10:00:00.000Z')
+  assert.equal(marked.ok, true)
+  assert.equal(marked.replayed, false)
+
+  const second = await listLeadsForReview({ limit: 10 }, store)
+  const lead1 = second.leads.find((l) => l.id === 'lead-1')
+  assert.equal(lead1.reviewed, true)
+  assert.deepEqual(Object.keys(lead1.review).sort(), ['leadId', 'reviewHash', 'reviewedAt', 'reviewedBy'])
+  assert.equal(lead1.review.reviewedBy, 'founder')
+  assert.equal(lead1.review.reviewedAt, '2026-08-07T10:00:00.000Z')
+  assert.match(lead1.review.reviewHash, HASH_RE)
+  assert.equal(second.leads.find((l) => l.id === 'lead-2').reviewed, false)
+})
+
+test('review records are tenant-scoped: a foreign-tenant record never marks a lead reviewed', async () => {
+  const store = fakeStore()
+  store.controlRecords.set(leadReviewRecordKey('lead-2'), {
+    version: 1, status: 'reviewed', leadId: 'lead-2', clientId: 'some-other-tenant',
+    reviewedBy: 'intruder', reviewedAt: '2026-08-07T00:00:00.000Z', reviewHash: 'a'.repeat(64),
+  })
+  const list = await listLeadsForReview({}, store)
+  assert.equal(list.leads.find((l) => l.id === 'lead-2').reviewed, false)
+
+  const mark = await markLeadReviewed({ leadId: 'lead-2' }, store)
+  assert.equal(mark.ok, false)
+  assert.equal(mark.reason, 'lead_review_conflict')
+})
+
+test('mark-reviewed stores a well-formed lead_review control record and is idempotent', async () => {
+  const store = fakeStore()
+  const result = await markLeadReviewed({ leadId: 'lead-1', reviewedBy: 'founder' }, store, () => '2026-08-07T10:00:00.000Z')
+  assert.equal(result.ok, true)
+
+  const stored = store.controlRecords.get(leadReviewRecordKey('lead-1'))
+  assert.ok(stored, 'record stored under console-lead-review-record:<lead_id>')
+  assert.equal(stored.status, 'reviewed')
+  assert.equal(stored.clientId, LEADS_REVIEW_TENANT)
+  assert.equal(stored.leadId, 'lead-1')
+  assert.equal(stored.version, 1)
+  assert.match(stored.reviewHash, HASH_RE)
+  assert.match(stored.leadHash, HASH_RE)
+
+  const replay = await markLeadReviewed({ leadId: 'lead-1', reviewedBy: 'founder' }, store)
+  assert.equal(replay.ok, true)
+  assert.equal(replay.replayed, true)
+  assert.deepEqual(replay.review, { leadId: 'lead-1', reviewedBy: 'founder', reviewedAt: '2026-08-07T10:00:00.000Z', reviewHash: stored.reviewHash })
+  assert.equal(store.calls.filter((name) => name === 'putControlRecord').length, 1, 'replay must not write again')
+})
+
+test('mark-reviewed validates input and surfaces store failures without side effects', async () => {
+  const store = fakeStore()
+  assert.equal((await markLeadReviewed({ leadId: '' }, store)).reason, 'invalid_lead_id')
+  assert.equal((await markLeadReviewed({ leadId: '../escape' }, store)).reason, 'invalid_lead_id')
+  assert.equal((await markLeadReviewed({ leadId: 'lead-1', reviewedBy: '<script>' }, store)).reason, 'invalid_reviewer')
+  assert.equal(store.calls.length, 0, 'invalid input must fail before any store access')
+
+  assert.equal((await markLeadReviewed({ leadId: 'lead-404' }, store)).reason, 'lead_not_found')
+
+  const failing = fakeStore({ putResult: false })
+  const blocked = await markLeadReviewed({ leadId: 'lead-1' }, failing)
+  assert.equal(blocked.ok, false)
+  assert.equal(blocked.reason, 'lead_review_store_unavailable')
+})
+
+test('store routes lead-review keys into the control-record store, never the response cache', async () => {
+  const key = leadReviewRecordKey('routing-check')
+  const reviewHash = 'b'.repeat(64)
+  const payload = {
+    version: 1, status: 'reviewed', leadId: 'routing-check', clientId: LEADS_REVIEW_TENANT,
+    reviewedBy: 'founder', reviewedAt: '2026-08-07T10:00:00.000Z', reviewHash,
+  }
+  assert.equal(await realStore.putControlRecord(key, payload), true)
+  assert.deepEqual(await realStore.getControlRecord(key), payload)
+  assert.equal(await realStore.getResponseCache(key), null, 'authority keys must never resolve from the AI cache')
+  assert.deepEqual(await realStore.getCachedResponse(key), payload, 'compatibility adapter must route the prefix to the control store')
+})
+
+test('console API exposes the review surface behind the ops key and fails closed in memory mode', async () => {
+  const savedKey = { present: Object.hasOwn(process.env, 'SUPERMEGA_OPS_KEY'), value: process.env.SUPERMEGA_OPS_KEY }
+  try {
+    process.env.SUPERMEGA_OPS_KEY = 'leads-review-test-key'
+    const { handle } = await import(`./console/api.mjs?leads-review=${Date.now()}`)
+
+    const unauthorized = await handle({ method: 'GET', path: '/api/leads/review', headers: {} })
+    assert.equal(unauthorized.status, 401)
+
+    const headers = { 'x-ops-key': 'leads-review-test-key' }
+    const list = await handle({ method: 'GET', path: '/api/leads/review', headers })
+    assert.equal(list.status, 503)
+    assert.equal(list.json.reason, 'leads_source_not_configured')
+    assert.deepEqual(list.json.requiredEnv, ['SUPABASE_URL', 'SUPABASE_SERVICE_ROLE_KEY'])
+
+    const mark = await handle({ method: 'POST', path: '/api/leads/lead-1/review', headers, body: {} })
+    assert.equal(mark.status, 503)
+    assert.equal(mark.json.reason, 'leads_source_not_configured')
+  } finally {
+    if (savedKey.present) process.env.SUPERMEGA_OPS_KEY = savedKey.value
+    else delete process.env.SUPERMEGA_OPS_KEY
+  }
+})
+
+test('console UI wires the review surface: fail-closed banner, reviewed pill, mark-reviewed action', async () => {
+  const html = await readFile(new URL('./public/index.html', import.meta.url), 'utf8')
+  assert.match(html, /api\('GET','\/api\/leads\/review'\)/)
+  assert.match(html, /leads_source_not_configured/)
+  assert.match(html, /SUPABASE_URL','SUPABASE_SERVICE_ROLE_KEY/)
+  assert.match(html, /data-review="\$\{esc\(l\.id\)\}">Mark reviewed<\/button>/)
+  assert.match(html, /✓ reviewed/)
+  assert.match(html, /'\/api\/leads\/'\+encodeURIComponent\(b\.dataset\.review\)\+'\/review'/)
+})
+
+test('lead_review is registered across store, SQL migration, and gateway isolation', async () => {
+  const storeSource = await readFile(new URL('./store.mjs', import.meta.url), 'utf8')
+  assert.match(storeSource, /\['console-lead-review-record:', 'lead_review'\]/)
+  assert.match(storeSource, /supermega_control_records_type_check check \(record_type in \([^)]*'lead_review'\)\)/)
+
+  const migration = await readFile(new URL('./supabase/control-records-migration.sql', import.meta.url), 'utf8')
+  const occurrences = migration.match(/'lead_review'/g) || []
+  assert.equal(occurrences.length, 2, 'both the create-table constraint and the widen block must allow lead_review')
+  assert.match(migration, /not like '%lead_review%'/)
+
+  const gatewaySource = await readFile(new URL('./gateway.mjs', import.meta.url), 'utf8')
+  assert.match(gatewaySource, /'console-lead-review-record:',/)
+})

--- a/kernel/console/api.mjs
+++ b/kernel/console/api.mjs
@@ -6,6 +6,7 @@ import { generateDeal } from './deal.mjs'
 import { onDealSaved, onProjectShipped } from './graduation.mjs'
 import connectors from '../connectors/index.mjs'
 import { companyDailyBudgetCap, currentDailyBudgetWindow, providerChain } from '../gateway.mjs'
+import { listLeadsForReview, markLeadReviewed } from './leads-review.mjs'
 import crypto from 'node:crypto'
 
 const OPS_KEY = (process.env.SUPERMEGA_OPS_KEY || '').trim()
@@ -117,6 +118,29 @@ export async function handle({ method, path, query = {}, body = {}, headers = {}
 
     // ---- LEADS ----
     if (seg[0] === 'leads') {
+      // Founder review surface. Fail-closed: without a durable leads source this returns 503
+      // `leads_source_not_configured` (never a silent empty list). Read + record only.
+      if (method === 'GET' && seg[1] === 'review' && !seg[2]) {
+        const limit = query.limit != null && String(query.limit).trim() !== '' ? Number(query.limit) : 50
+        const result = await listLeadsForReview({ limit })
+        if (!result.ok) return { status: result.reason === 'leads_source_not_configured' ? 503 : 400, json: result }
+        return ok(result)
+      }
+      if (method === 'POST' && seg[1] && seg[1] !== 'review' && seg[2] === 'review' && !seg[3]) {
+        const result = await markLeadReviewed({
+          leadId: seg[1],
+          reviewedBy: body.reviewedBy != null ? String(body.reviewedBy).slice(0, 80) : undefined,
+        })
+        if (!result.ok) {
+          const status = result.reason === 'leads_source_not_configured' ? 503
+            : result.reason === 'lead_not_found' ? 404
+            : result.reason === 'lead_review_store_unavailable' ? 503
+            : 400
+          return { status, json: result }
+        }
+        if (!result.replayed) log('review', 'Lead marked reviewed', seg[1])
+        return ok(result)
+      }
       if (method === 'GET' && !seg[1]) {
         try {
           const [leads, converted] = await Promise.all([store.listLeads(), store.convertedLeadIds()])

--- a/kernel/console/leads-review.mjs
+++ b/kernel/console/leads-review.mjs
@@ -1,0 +1,149 @@
+// SUPERMEGA console — founder lead review (read + record only).
+// Lists real `supermega_leads` rows through the existing store read path and records the owner's
+// mark-reviewed decision as a versioned control record (record_type 'lead_review', see
+// supabase/control-records-migration.sql). This module NEVER contacts a lead: no sends, no
+// outbound drafts, no lead mutation — the only write is the review control record.
+// Fail-closed: without a durable leads source (SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY, or a
+// Postgres connection string) every call returns `leads_source_not_configured` instead of
+// silently pretending the funnel is empty.
+import { createHash } from 'node:crypto'
+import defaultStore from '../store.mjs'
+
+export const LEADS_REVIEW_TENANT = 'supermega-hq'
+export const LEAD_REVIEW_RECORD_PREFIX = 'console-lead-review-record:'
+// Either pair/one of these makes the leads source durable. The public /contact/ function writes
+// supermega_leads with the SAME two Supabase variables in the public-site Vercel project — the
+// kernel deployment must point at the SAME Supabase project for the founder to see those leads.
+export const LEADS_SOURCE_REQUIRED_ENV = Object.freeze(['SUPABASE_URL', 'SUPABASE_SERVICE_ROLE_KEY'])
+export const LEADS_SOURCE_ALTERNATE_ENV = Object.freeze(['POSTGRES_URL_NON_POOLING', 'POSTGRES_URL', 'DATABASE_URL_UNPOOLED', 'POSTGRES_PRISMA_URL', 'SUPERMEGA_DATABASE_URL', 'DATABASE_URL'])
+
+const LEAD_ID_RE = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,79}$/
+const REVIEWER_RE = /^[A-Za-z0-9][A-Za-z0-9 ._:@-]{0,79}$/
+const MAX_LIST_LIMIT = 200
+const REVIEW_RECORD_SCAN_LIMIT = 250
+
+const sha256 = (value) => createHash('sha256').update(value).digest('hex')
+
+function stableJson(value) {
+  if (value === null || typeof value !== 'object') return JSON.stringify(value ?? null)
+  if (Array.isArray(value)) return `[${value.map(stableJson).join(',')}]`
+  return `{${Object.keys(value).sort().map((key) => `${JSON.stringify(key)}:${stableJson(value[key])}`).join(',')}}`
+}
+
+export const leadReviewRecordKey = (leadId) => `${LEAD_REVIEW_RECORD_PREFIX}${leadId}`
+
+// The leads source is configured only when the store runs against a durable database. Memory mode
+// means the kernel deployment has no SUPABASE_URL/SUPABASE_SERVICE_ROLE_KEY (or Postgres URL) —
+// real contact-form leads exist somewhere this deployment cannot see, so fail closed.
+export function leadsSourceConfigured(store = defaultStore) {
+  return store.mode === 'supabase' || store.mode === 'postgres'
+}
+
+function sourceNotConfigured() {
+  return {
+    ok: false,
+    reason: 'leads_source_not_configured',
+    requiredEnv: [...LEADS_SOURCE_REQUIRED_ENV],
+    alternateEnv: [...LEADS_SOURCE_ALTERNATE_ENV],
+  }
+}
+
+function publicReview(payload) {
+  return {
+    leadId: payload.leadId,
+    reviewedBy: payload.reviewedBy,
+    reviewedAt: payload.reviewedAt,
+    reviewHash: payload.reviewHash,
+  }
+}
+
+function leadSnapshotHash(lead) {
+  return sha256(stableJson({
+    id: String(lead.id || ''),
+    name: String(lead.name || ''),
+    company: String(lead.company || ''),
+    contact: String(lead.contact || ''),
+    stage: String(lead.stage || ''),
+    created_at: String(lead.created_at || ''),
+  }))
+}
+
+export async function listLeadsForReview({ limit = 50 } = {}, store = defaultStore) {
+  const bounded = Number(limit)
+  if (!Number.isInteger(bounded) || bounded < 1 || bounded > MAX_LIST_LIMIT) {
+    return { ok: false, reason: 'invalid_leads_review_query' }
+  }
+  if (!leadsSourceConfigured(store)) return sourceNotConfigured()
+  const [leads, converted, reviews] = await Promise.all([
+    store.listLeads(bounded),
+    store.convertedLeadIds().catch(() => []),
+    store.listControlRecords({
+      prefix: LEAD_REVIEW_RECORD_PREFIX,
+      clientId: LEADS_REVIEW_TENANT,
+      status: 'reviewed',
+      limit: REVIEW_RECORD_SCAN_LIMIT,
+    }),
+  ])
+  const reviewByLead = new Map()
+  for (const record of reviews?.records || []) {
+    const payload = record?.payload
+    if (payload && payload.status === 'reviewed' && typeof payload.leadId === 'string') {
+      reviewByLead.set(payload.leadId, payload)
+    }
+  }
+  const convertedSet = new Set(converted)
+  return {
+    ok: true,
+    mode: store.mode,
+    source: 'configured',
+    leads: leads.map((lead) => {
+      const review = reviewByLead.get(lead.id)
+      return {
+        ...lead,
+        converted: convertedSet.has(lead.id),
+        reviewed: Boolean(review),
+        ...(review ? { review: publicReview(review) } : {}),
+      }
+    }),
+  }
+}
+
+// Records the founder's review decision. Idempotent: marking an already-reviewed lead replays the
+// stored record. The control record is the ONLY side effect — no message leaves the platform.
+export async function markLeadReviewed({ leadId, reviewedBy = 'owner-console' } = {}, store = defaultStore, now = () => new Date().toISOString()) {
+  const id = String(leadId || '').trim()
+  const reviewer = String(reviewedBy || '').trim()
+  if (!LEAD_ID_RE.test(id)) return { ok: false, reason: 'invalid_lead_id' }
+  if (!REVIEWER_RE.test(reviewer)) return { ok: false, reason: 'invalid_reviewer' }
+  if (!leadsSourceConfigured(store)) return sourceNotConfigured()
+
+  const recordKey = leadReviewRecordKey(id)
+  const existing = await store.getControlRecord(recordKey)
+  if (existing) {
+    if (existing.status === 'reviewed' && existing.leadId === id && existing.clientId === LEADS_REVIEW_TENANT) {
+      return { ok: true, replayed: true, review: publicReview(existing) }
+    }
+    return { ok: false, reason: 'lead_review_conflict' }
+  }
+
+  const lead = await store.getLead(id)
+  if (!lead) return { ok: false, reason: 'lead_not_found' }
+
+  const reviewedAt = String(now())
+  const reviewInput = {
+    leadId: id,
+    clientId: LEADS_REVIEW_TENANT,
+    stage: String(lead.stage || ''),
+    leadHash: leadSnapshotHash(lead),
+    reviewedBy: reviewer,
+    reviewedAt,
+  }
+  const reviewHash = sha256(stableJson(reviewInput))
+  const payload = { version: 1, status: 'reviewed', ...reviewInput, reviewHash }
+  let stored = false
+  try { stored = Boolean(await store.putControlRecord(recordKey, payload)) } catch { stored = false }
+  if (!stored) return { ok: false, reason: 'lead_review_store_unavailable' }
+  return { ok: true, replayed: false, review: publicReview(payload) }
+}
+
+export default { LEADS_REVIEW_TENANT, LEAD_REVIEW_RECORD_PREFIX, LEADS_SOURCE_REQUIRED_ENV, leadReviewRecordKey, leadsSourceConfigured, listLeadsForReview, markLeadReviewed }

--- a/kernel/gateway.cache-isolation.test.mjs
+++ b/kernel/gateway.cache-isolation.test.mjs
@@ -88,6 +88,7 @@ test('reserved control-record prefixes are rejected case-insensitively', async (
     'company-work-order-record:customer-controlled',
     ' AGENT-COMPANY-SIGN-IN-CODE:customer-controlled ',
     'company-mission-record:customer-controlled',
+    'console-lead-review-record:customer-controlled',
   ]) {
     await assert.rejects(
       () => ask('reserved prefix', { clientId: 'tenant-reserved-prefix', cacheKey }),

--- a/kernel/gateway.mjs
+++ b/kernel/gateway.mjs
@@ -52,6 +52,7 @@ const RESERVED_CONTROL_CACHE_PREFIXES = [
   'ceo-outcome-evaluation:',
   'ceo-outcome-delivery:',
   'ceo-outcome-action:',
+  'console-lead-review-record:',
 ]
 const PLATFORM_TENANT_ID = 'supermega-platform'
 const PLATFORM_PLAN = 'platform' // server-owned internal plan: requested tier honored, cap still enforced

--- a/kernel/public/index.html
+++ b/kernel/public/index.html
@@ -1565,22 +1565,27 @@ async function loadOverview(){
 async function loadLeads(){
   const box=$('#leads');box.innerHTML='<div class="loading-pulse">Loading leads…</div>'
   let r
-  try{r=await api('GET','/api/leads')}catch(e){box.innerHTML=`<div class="err-banner">Could not load leads — ${esc(String(e.message||'network error'))}</div>`;return}
+  try{r=await api('GET','/api/leads/review')}catch(e){box.innerHTML=`<div class="err-banner">Could not load leads — ${esc(String(e.message||'network error'))}</div>`;return}
+  if(r.reason==='leads_source_not_configured'){$('#addLead').hidden=true;box.innerHTML=`<div class="err-banner">Leads source not configured — this console cannot see contact-form leads. Set ${esc((r.requiredEnv||['SUPABASE_URL','SUPABASE_SERVICE_ROLE_KEY']).join(' + '))} on the kernel deployment (the same Supabase project the /contact/ form writes to), then reload.</div>`;return}
+  if(!r.ok){box.innerHTML=`<div class="err-banner">Could not load leads — ${esc(String(r.reason||'error'))}</div>`;return}
   $('#addLead').hidden=(r.mode!=='memory')
   box.innerHTML=''
   if(!r.leads||!r.leads.length){box.innerHTML='<div class="empty">No leads yet. They arrive here from the /contact/ form.</div>';return}
   for(const l of r.leads){
     const el=document.createElement('div');el.className='lead'
     const stage=l.stage?`<span class="pill">${esc(l.stage)}</span>`:''
-    el.innerHTML=`<div><h3>${esc(l.company||l.name||'—')} ${stage} <span class="muted" style="font-size:12px;font-weight:600">${l.score?'· '+l.score+'/100':''}</span></h3>
+    const reviewed=l.reviewed?`<span class="pill">✓ reviewed</span>`:''
+    el.innerHTML=`<div><h3>${esc(l.company||l.name||'—')} ${stage} ${reviewed} <span class="muted" style="font-size:12px;font-weight:600">${l.score?'· '+l.score+'/100':''}</span></h3>
       <div class="meta">${esc(l.name||'')}${l.contact?' · '+esc(l.contact):''}${l.package?' · '+esc(l.package):''} · ${esc(String(l.source||'').replace('-',' '))}</div>
       ${l.message?`<div class="msg">${esc(l.message)}</div>`:''}</div>
       <div class="row" style="align-items:flex-start">
+        ${l.reviewed?'':`<button class="sm" data-review="${esc(l.id)}">Mark reviewed</button>`}
         ${l.converted?`<span class="pill won">✓ in pipeline</span>`:`<button class="sm primary" data-conv="${esc(l.id)}">Win → project</button>`}
         <button class="sm" data-deal="${esc(l.id)}">Run a deal</button>
       </div>`
     box.appendChild(el)
   }
+  box.querySelectorAll('[data-review]').forEach(b=>b.onclick=async()=>{const x=await api('POST','/api/leads/'+encodeURIComponent(b.dataset.review)+'/review',{});if(x.ok){toast('Review recorded');loadLeads()}})
   box.querySelectorAll('[data-conv]').forEach(b=>b.onclick=async()=>{const x=await api('POST','/api/leads/'+encodeURIComponent(b.dataset.conv)+'?action=convert',{});if(x.ok){toast('Project created');loadLeads()}})
   box.querySelectorAll('[data-deal]').forEach(b=>b.onclick=()=>{const l=r.leads.find(x=>x.id===b.dataset.deal);dealLead=l;openConsoleView('deal');$('#d-name').value=l.name||'';$('#d-company').value=l.company||'';$('#d-contact').value=l.contact||'';$('#d-workflow').value=l.message||'';$('#d-leadtag').textContent='for '+(l.company||l.name||'request')})
 }

--- a/kernel/store.mjs
+++ b/kernel/store.mjs
@@ -202,7 +202,7 @@ async function ensurePgTables() {
       created_at timestamptz not null default now(),
       updated_at timestamptz not null default now(),
       constraint supermega_control_records_key_check check (char_length(record_key) between 1 and 240),
-      constraint supermega_control_records_type_check check (record_type in ('sign_in_code','operator_session','mission','work_order','work_order_review','work_order_evaluation','ceo_outcome_operation','ceo_outcome_evaluation','ceo_outcome_delivery','ceo_outcome_action')),
+      constraint supermega_control_records_type_check check (record_type in ('sign_in_code','operator_session','mission','work_order','work_order_review','work_order_evaluation','ceo_outcome_operation','ceo_outcome_evaluation','ceo_outcome_delivery','ceo_outcome_action','lead_review')),
       constraint supermega_control_records_tenant_check check (char_length(tenant_id) between 1 and 80),
       constraint supermega_control_records_status_check check (status ~ '^[a-z][a-z_]{0,39}$'),
       constraint supermega_control_records_plan_hash_check check (plan_hash ~ '^[a-f0-9]{64}$'),
@@ -1231,6 +1231,8 @@ const CONTROL_RECORD_PREFIXES = Object.freeze([
   ['company-work-order-record:', 'work_order'],
   ['company-work-order-review-record:', 'work_order_review'],
   ['company-work-order-evaluation:', 'work_order_evaluation'],
+  // Founder lead-review decisions (console Leads view). Authority evidence, never response cache.
+  ['console-lead-review-record:', 'lead_review'],
   // CEO outcome records are execution authority (completions, evaluations, deliveries, follow-up
   // actions) recorded by agent-company-operations.mjs. They must never live in the response cache.
   ['ceo-outcome-operation:', 'ceo_outcome_operation'],

--- a/kernel/supabase/control-records-migration.sql
+++ b/kernel/supabase/control-records-migration.sql
@@ -16,26 +16,26 @@ create table if not exists public.supermega_control_records (
   created_at timestamptz not null default now(),
   updated_at timestamptz not null default now(),
   constraint supermega_control_records_key_check check (char_length(record_key) between 1 and 240),
-  constraint supermega_control_records_type_check check (record_type in ('sign_in_code','operator_session','mission','work_order','work_order_review','work_order_evaluation','ceo_outcome_operation','ceo_outcome_evaluation','ceo_outcome_delivery','ceo_outcome_action')),
+  constraint supermega_control_records_type_check check (record_type in ('sign_in_code','operator_session','mission','work_order','work_order_review','work_order_evaluation','ceo_outcome_operation','ceo_outcome_evaluation','ceo_outcome_delivery','ceo_outcome_action','lead_review')),
   constraint supermega_control_records_tenant_check check (char_length(tenant_id) between 1 and 80),
   constraint supermega_control_records_status_check check (status ~ '^[a-z][a-z_]{0,39}$'),
   constraint supermega_control_records_plan_hash_check check (plan_hash ~ '^[a-f0-9]{64}$'),
   constraint supermega_control_records_payload_hash_check check (payload_hash ~ '^[a-f0-9]{64}$')
 );
 
--- Databases migrated before the CEO outcome record types existed carry the narrower constraint;
--- widen it idempotently so re-running this migration upgrades them in place.
+-- Databases migrated before the CEO outcome or lead-review record types existed carry a narrower
+-- constraint; widen it idempotently so re-running this migration upgrades them in place.
 do $widen$
 begin
   if exists (
     select 1 from pg_constraint
      where conrelid='public.supermega_control_records'::regclass
        and conname='supermega_control_records_type_check'
-       and pg_get_constraintdef(oid) not like '%ceo_outcome_operation%'
+       and pg_get_constraintdef(oid) not like '%lead_review%'
   ) then
     alter table public.supermega_control_records drop constraint supermega_control_records_type_check;
     alter table public.supermega_control_records add constraint supermega_control_records_type_check
-      check (record_type in ('sign_in_code','operator_session','mission','work_order','work_order_review','work_order_evaluation','ceo_outcome_operation','ceo_outcome_evaluation','ceo_outcome_delivery','ceo_outcome_action'));
+      check (record_type in ('sign_in_code','operator_session','mission','work_order','work_order_review','work_order_evaluation','ceo_outcome_operation','ceo_outcome_evaluation','ceo_outcome_delivery','ceo_outcome_action','lead_review'));
   end if;
 end;
 $widen$;


### PR DESCRIPTION
Closes the lead-lifecycle gap and a silent-failure bug: a kernel deployment without database env runs in memory mode and showed "No leads yet" — indistinguishable from an empty funnel, so contact-form leads could be invisible with no signal why. The Leads view now fails closed with a banner naming the exact env vars, and the founder can mark leads reviewed as tenant-scoped, idempotent control records (sha256-bound; no outbound contact, no lead mutation).

New kernel/console/leads-review.mjs + ops-key-gated API routes + UI; control-record prefix registered in store/gateway (reserved from the AI cache per the #389 isolation model); migration constraint widened idempotently. 9 new focused tests; kernel verify 365/365 green; adversarially verified (pass) including empty-env fail-closed probing.

Founder wiring to activate (documented in-branch): SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY on the kernel Vercel project (same Supabase project the public contact function writes to) + one idempotent re-run of control-records-migration.sql.

🤖 Generated with [Claude Code](https://claude.com/claude-code)