### PR TITLE
Shop: business-type templates with deep-linkable demos

### DIFF
--- a/showroom/src/core/ProductOnboardingPage.tsx
+++ b/showroom/src/core/ProductOnboardingPage.tsx
@@ -1,5 +1,5 @@
 import { type FormEvent, useEffect, useState } from 'react'
-import { useNavigate, useOutletContext } from 'react-router'
+import { useLocation, useNavigate, useOutletContext } from 'react-router'
 
 import { activateLocalWebsiteWorkingSample } from '../products/website/website-starter'
 import { recordBehaviorSignal } from './behavior-trail'
@@ -22,10 +22,17 @@ import {
 } from './product-setup'
 import {
   provisionLocalPlantWorkingSample,
+  provisionLocalShopBusinessTemplateSample,
   provisionLocalShopIndustryPack,
   provisionLocalShopWorkingSample,
   readLocalShopIndustryPackId,
 } from './product-onboarding-runtime'
+import {
+  shopBusinessTemplate,
+  shopBusinessTemplateFromQuery,
+  shopBusinessTemplates,
+  type ShopBusinessTemplateId,
+} from '../products/shop/business-templates'
 import {
   readPlantIndustryPackId,
   savePlantIndustryPackId,
@@ -76,6 +83,7 @@ const onboardingJourneys: Record<SetupProductId, { outcome: string; detail: stri
 export function ProductOnboardingPage({ product }: ProductOnboardingPageProps) {
   const runtime = useOutletContext<RuntimeHealth>()
   const navigate = useNavigate()
+  const location = useLocation()
   const [setup, setSetup] = useSetupWorkspace()
   const [actions] = useAccountableActions()
   const [production] = useProductionWorkspace()
@@ -84,10 +92,15 @@ export function ProductOnboardingPage({ product }: ProductOnboardingPageProps) {
   const [workspaceBusy, setWorkspaceBusy] = useState(false)
   const [shopIndustryPackId] = useState<ShopIndustryPackId>(readLocalShopIndustryPackId)
   const [plantIndustryPackId] = useState<PlantIndustryPackId>(() => readPlantIndustryPackId(typeof window === 'undefined' ? undefined : window.localStorage))
+  const [businessTemplateId, setBusinessTemplateId] = useState<ShopBusinessTemplateId | null>(
+    () => (product === 'commerce' ? shopBusinessTemplateFromQuery(new URLSearchParams(location.search).get('template')) : null),
+  )
+  const [businessTypeOpen, setBusinessTypeOpen] = useState(() => businessTemplateId !== null)
 
   const onboardingProduct = productContracts[product]
   const onboardingJourney = onboardingJourneys[product]
-  const selectedShopIndustryPack = shopIndustryPack(shopIndustryPackId)
+  const selectedBusinessTemplate = product === 'commerce' && businessTemplateId ? shopBusinessTemplate(businessTemplateId) : null
+  const selectedShopIndustryPack = shopIndustryPack(selectedBusinessTemplate?.industryPackId ?? shopIndustryPackId)
   const onboardingTemplate = setup.product === product
     ? templateFor(product, setup.templateId)
     : product === 'commerce'
@@ -137,6 +150,12 @@ export function ProductOnboardingPage({ product }: ProductOnboardingPageProps) {
     return () => window.clearTimeout(packTimer)
   }, [product, selectedShopIndustryPack.entryPoint, selectedShopIndustryPack.workflowTemplateId, setSetup, setup.entryPoint, setup.product, setup.templateId])
 
+  function changeBusinessTemplate(value: string) {
+    const next = shopBusinessTemplateFromQuery(value)
+    setBusinessTemplateId(next)
+    setSetup((current) => (current.product === 'commerce' ? { ...current, startedAt: undefined, savedAt: undefined } : current))
+  }
+
   function updateSetup(patch: Partial<SetupState>) {
     setSetup((current) => {
       const template = current.product === product
@@ -171,8 +190,12 @@ export function ProductOnboardingPage({ product }: ProductOnboardingPageProps) {
     setNotice(`Preparing the working ${onboardingProduct.name} workspace...`)
     try {
       if (product === 'commerce') {
-        provisionLocalShopIndustryPack(shopIndustryPackId)
-        await provisionLocalShopWorkingSample(shopIndustryPackId, onboardingTemplate.id)
+        provisionLocalShopIndustryPack(selectedShopIndustryPack.id)
+        if (selectedBusinessTemplate) {
+          await provisionLocalShopBusinessTemplateSample(selectedBusinessTemplate.id)
+        } else {
+          await provisionLocalShopWorkingSample(shopIndustryPackId, onboardingTemplate.id)
+        }
       }
       if (product === 'production') {
         savePlantIndustryPackId(plantIndustryPackId, window.localStorage)
@@ -244,6 +267,18 @@ export function ProductOnboardingPage({ product }: ProductOnboardingPageProps) {
           <div className="product-onboarding-intro"><span className="core-eyebrow">One step</span><h2>Name your workspace</h2><p>We will add realistic sample records now; replace them with your data whenever you are ready.</p></div>
           <p className="product-onboarding-boundary"><strong>First useful result: {onboardingJourney.outcome}.</strong><br />{onboardingJourney.detail}</p>
           <label className="product-onboarding-business-name">Business name<input autoComplete="organization" maxLength={60} onChange={(event) => updateSetup({ workspace: event.target.value })} placeholder="Example: Golden Valley Trading" required value={setup.workspace} /></label>
+          {product === 'commerce' ? (
+            <details className="compact-disclosure product-onboarding-business-type" onToggle={(event) => setBusinessTypeOpen(event.currentTarget.open)} open={businessTypeOpen}>
+              <summary><span>Business type</span><small>{selectedBusinessTemplate ? `${selectedBusinessTemplate.name.en} starter data` : 'Standard retail sample'}</small></summary>
+              <label className="demo-pack-select">Starter data
+                <select onChange={(event) => changeBusinessTemplate(event.target.value)} value={businessTemplateId ?? ''}>
+                  <option value="">Standard sample (current industry pack)</option>
+                  {shopBusinessTemplates.map((template) => <option key={template.id} value={template.id}>{template.name.en} · {template.name.my}</option>)}
+                </select>
+                <small>{selectedBusinessTemplate ? `${selectedBusinessTemplate.description} ${selectedBusinessTemplate.catalog.length} starter items with whole-MMK prices and reorder levels.` : 'Keep the standard sample, or pick a business type for a fuller starter catalog.'}</small>
+              </label>
+            </details>
+          ) : null}
           <div className="product-onboarding-primary">
             <button className="core-button primary" disabled={!workflowReady || workspaceBusy} type="submit">{workspaceBusy ? 'Preparing your workspace...' : workspaceStarted ? `Open my ${onboardingProduct.name}` : onboardingJourney.actionLabel}</button>
             <small>{workspaceStarted ? `${setup.workspace} is ready. Opening it will not run setup again.` : workflowReady ? 'Creates local sample records, then opens the first task.' : 'Enter a business name to continue.'}</small>

--- a/showroom/src/core/core-app.css
+++ b/showroom/src/core/core-app.css
@@ -784,6 +784,8 @@ textarea { min-height: 72px; resize: vertical; }
 .product-onboarding-form { min-height: 0; }
 .product-onboarding-form > label { display: grid; gap: 6px; }
 .product-onboarding-business-name input { min-height: 50px; font-size: 15px; }
+.product-onboarding-business-type > summary small { color: var(--core-quiet); font-size: 9px; font-weight: 600; }
+.product-onboarding-business-type > .demo-pack-select { margin-top: 8px; }
 .product-onboarding-primary { display: flex; align-items: center; gap: 12px; border-top: 1px solid var(--core-line); padding-top: 13px; }
 .product-onboarding-primary .core-button { flex: 0 0 auto; }
 .product-onboarding-primary small { color: var(--core-quiet); font-size: 10px; line-height: 1.4; }

--- a/showroom/src/core/product-onboarding-runtime.ts
+++ b/showroom/src/core/product-onboarding-runtime.ts
@@ -24,6 +24,11 @@ import {
   type ShopIndustryPackId,
 } from './shop-service-scheduling'
 import { plantIndustryPack, type PlantIndustryPackId } from './plant-industry-packs'
+import {
+  shopBusinessTemplate,
+  shopBusinessTemplateCatalogCsv,
+  type ShopBusinessTemplateId,
+} from '../products/shop/business-templates'
 
 export function readLocalShopIndustryPackId() {
   if (typeof window === 'undefined') return clientDemoPresets[0].shopIndustryPackId
@@ -70,6 +75,43 @@ export async function provisionLocalShopWorkingSample(industryPackId: ShopIndust
     const next = installCommerceWorkingSampleCatalog(current, {
       sampleId: pack.id,
       sampleName: pack.name,
+      items,
+      capturedAt: new Date().toISOString(),
+    })
+    if (!next) return current
+    disposition = next === current ? 'current' : 'installed'
+    return next
+  })
+  if (!result.ok) throw new Error(result.error)
+  return disposition
+}
+
+export async function provisionLocalShopBusinessTemplateSample(businessTemplateId: ShopBusinessTemplateId) {
+  const template = shopBusinessTemplate(businessTemplateId)
+  const preview = await createClientImportPreview(
+    shopBusinessTemplateCatalogCsv(template.id),
+    'commerce',
+    undefined,
+    `sample-${template.id}.csv`,
+    template.workflowTemplateId,
+  )
+  if (!preview.readyForStaging || preview.rows.some((row) => row.status !== 'ready')) {
+    throw new Error(`The ${template.name.en} business template did not pass its local data checks.`)
+  }
+  const items: CommerceItem[] = preview.rows.map((row) => ({
+    sku: row.values.sku,
+    name: row.values.name,
+    onHand: Number(row.values.onHand),
+    reorderAt: Number(row.values.reorderAt),
+    price: Number(row.values.price),
+  }))
+  const commerceWorkspace = loadCommerceWorkspace()
+  if (commerceWorkspace.error) throw new Error(commerceWorkspace.error)
+  let disposition: 'installed' | 'current' | 'preserved' = 'preserved'
+  const result = await mutateCommerceWorkspace((current) => {
+    const next = installCommerceWorkingSampleCatalog(current, {
+      sampleId: template.id,
+      sampleName: template.name.en,
       items,
       capturedAt: new Date().toISOString(),
     })

--- a/showroom/src/products/shop/business-templates.ts
+++ b/showroom/src/products/shop/business-templates.ts
@@ -1,0 +1,432 @@
+import type { CommerceItem, CommerceProductionMaterialUnit } from '../../core/commerce-workspace.ts'
+import type { ShopIndustryPackId } from '../../core/shop-service-scheduling.ts'
+
+export const SHOP_BUSINESS_TEMPLATE_SCHEMA = 'supermega.shop.business_template.v1' as const
+
+export type ShopBusinessTemplateId =
+  | 'mini-mart'
+  | 'pharmacy'
+  | 'phone-electronics'
+  | 'fashion'
+  | 'hardware'
+  | 'tea-coffee'
+  | 'auto-parts'
+
+export type ShopBusinessTemplateUnit = CommerceProductionMaterialUnit
+
+export const shopBusinessTemplateUnits: readonly ShopBusinessTemplateUnit[] = ['kg', 'g', 'l', 'ml', 'pcs', 'pack', 'bag', 'roll', 'sheet', 'm', 'cm'] as const
+
+export type ShopBusinessTemplateItem = {
+  sku: string
+  name: string
+  unit: ShopBusinessTemplateUnit
+  costMmk: number
+  priceMmk: number
+  openingStock: number
+  reorderAt: number
+}
+
+export type ShopBusinessSamplePayment = 'Cash' | 'KBZPay' | 'WavePay'
+
+export type ShopBusinessSampleLine = {
+  sku: string
+  quantity: number
+}
+
+export type ShopBusinessSampleSale = {
+  id: string
+  recordedAt: string
+  payment: ShopBusinessSamplePayment
+  lines: readonly ShopBusinessSampleLine[]
+}
+
+export type ShopBusinessSampleOrder = {
+  id: string
+  customerName: string
+  contact: string
+  requestedAt: string
+  promisedFor: string
+  status: 'pending'
+  note: string
+  lines: readonly ShopBusinessSampleLine[]
+}
+
+export type ShopBusinessTemplate = {
+  id: ShopBusinessTemplateId
+  schema: typeof SHOP_BUSINESS_TEMPLATE_SCHEMA
+  name: { en: string; my: string }
+  description: string
+  industryPackId: ShopIndustryPackId
+  workflowTemplateId: 'retail-wholesale' | 'restaurant-ordering' | 'social-commerce'
+  catalog: readonly ShopBusinessTemplateItem[]
+  counterSales: readonly ShopBusinessSampleSale[]
+  pendingOrder: ShopBusinessSampleOrder
+}
+
+type ItemRow = readonly [sku: string, name: string, unit: ShopBusinessTemplateUnit, costMmk: number, priceMmk: number, openingStock: number, reorderAt: number]
+
+const rows = (source: readonly ItemRow[]): readonly ShopBusinessTemplateItem[] =>
+  source.map(([sku, name, unit, costMmk, priceMmk, openingStock, reorderAt]) => ({ sku, name, unit, costMmk, priceMmk, openingStock, reorderAt }))
+
+export const shopBusinessTemplates: readonly ShopBusinessTemplate[] = [
+  {
+    id: 'mini-mart',
+    schema: SHOP_BUSINESS_TEMPLATE_SCHEMA,
+    name: { en: 'Mini-mart & grocery', my: 'ကုန်စုံဆိုင်' },
+    description: 'Everyday groceries, household items, and counter sales with reorder levels.',
+    industryPackId: 'retail',
+    workflowTemplateId: 'retail-wholesale',
+    catalog: rows([
+      ['RICE-25KG', 'Premium rice 25kg', 'bag', 68_000, 75_000, 14, 6],
+      ['OIL-1L', 'Cooking oil 1L', 'l', 8_200, 9_500, 40, 16],
+      ['SUGAR-1KG', 'White sugar 1kg', 'kg', 3_600, 4_300, 30, 10],
+      ['SALT-500G', 'Iodized salt 500g', 'g', 500, 800, 48, 12],
+      ['EGG-TRAY30', 'Chicken eggs tray of 30', 'pack', 8_500, 9_800, 20, 8],
+      ['NOODLE-CUP', 'Instant noodle cup', 'pcs', 700, 1_000, 96, 30],
+      ['MILK-COND', 'Condensed milk can', 'pcs', 1_900, 2_500, 36, 12],
+      ['COFFEE-3IN1', 'Coffee mix 30 sachets', 'pack', 6_800, 8_000, 24, 8],
+      ['SOAP-BAR', 'Bath soap bar', 'pcs', 900, 1_300, 40, 15],
+      ['SHAMPOO-170ML', 'Shampoo 170ml', 'ml', 2_800, 3_600, 18, 6],
+      ['TOOTHPASTE-150G', 'Toothpaste 150g', 'g', 2_300, 3_000, 22, 8],
+      ['DETERGENT-900G', 'Detergent powder 900g', 'pack', 3_900, 4_800, 16, 6],
+      ['WATER-1L', 'Purified drinking water 1L', 'pcs', 350, 600, 4, 12],
+    ]),
+    counterSales: [
+      { id: 'mini-mart-sale-1', recordedAt: '2026-08-03T02:35:00.000Z', payment: 'Cash', lines: [{ sku: 'RICE-25KG', quantity: 1 }, { sku: 'OIL-1L', quantity: 2 }] },
+      { id: 'mini-mart-sale-2', recordedAt: '2026-08-03T04:10:00.000Z', payment: 'KBZPay', lines: [{ sku: 'COFFEE-3IN1', quantity: 1 }, { sku: 'MILK-COND', quantity: 2 }] },
+      { id: 'mini-mart-sale-3', recordedAt: '2026-08-03T08:45:00.000Z', payment: 'Cash', lines: [{ sku: 'SOAP-BAR', quantity: 2 }, { sku: 'TOOTHPASTE-150G', quantity: 1 }] },
+    ],
+    pendingOrder: {
+      id: 'mini-mart-order-1',
+      customerName: 'Daw Khin Aye',
+      contact: '09-782-000-111',
+      requestedAt: '2026-08-03T05:00:00.000Z',
+      promisedFor: '2026-08-05T03:30:00.000Z',
+      status: 'pending',
+      note: 'Monthly household restock. Pickup at the counter.',
+      lines: [{ sku: 'EGG-TRAY30', quantity: 2 }, { sku: 'RICE-25KG', quantity: 1 }, { sku: 'DETERGENT-900G', quantity: 1 }],
+    },
+  },
+  {
+    id: 'pharmacy',
+    schema: SHOP_BUSINESS_TEMPLATE_SCHEMA,
+    name: { en: 'Pharmacy', my: 'ဆေးဆိုင်' },
+    description: 'Over-the-counter medicine and clinic supplies with strict reorder levels.',
+    industryPackId: 'retail',
+    workflowTemplateId: 'retail-wholesale',
+    catalog: rows([
+      ['PARA-500-STRIP', 'Paracetamol 500mg strip of 10', 'pack', 700, 1_000, 60, 20],
+      ['ORS-SACHET', 'ORS rehydration sachet', 'pcs', 300, 500, 80, 30],
+      ['VITC-1000', 'Vitamin C 1000mg bottle', 'pcs', 5_200, 6_500, 24, 8],
+      ['COUGH-100ML', 'Cough syrup 100ml', 'ml', 2_600, 3_500, 18, 6],
+      ['ANTACID-TAB', 'Antacid tablets strip', 'pack', 900, 1_400, 40, 15],
+      ['BANDAGE-ROLL', 'Elastic bandage roll', 'roll', 1_500, 2_200, 25, 10],
+      ['GAUZE-PACK', 'Sterile gauze pack', 'pack', 1_000, 1_500, 30, 12],
+      ['ALCOHOL-250ML', 'Rubbing alcohol 250ml', 'ml', 1_400, 2_000, 20, 8],
+      ['THERMO-DIG', 'Digital thermometer', 'pcs', 7_500, 9_500, 10, 4],
+      ['MASK-BOX50', 'Surgical mask box of 50', 'pack', 6_500, 8_500, 15, 6],
+      ['GLOVES-BOX', 'Examination gloves box', 'pack', 8_800, 11_000, 12, 5],
+      ['BP-MONITOR', 'Blood pressure monitor', 'pcs', 38_000, 46_000, 3, 4],
+      ['SALINE-500ML', 'Normal saline 500ml', 'ml', 1_800, 2_500, 26, 10],
+    ]),
+    counterSales: [
+      { id: 'pharmacy-sale-1', recordedAt: '2026-08-03T03:05:00.000Z', payment: 'Cash', lines: [{ sku: 'PARA-500-STRIP', quantity: 2 }, { sku: 'ORS-SACHET', quantity: 4 }] },
+      { id: 'pharmacy-sale-2', recordedAt: '2026-08-03T06:20:00.000Z', payment: 'WavePay', lines: [{ sku: 'VITC-1000', quantity: 1 }, { sku: 'MASK-BOX50', quantity: 1 }] },
+    ],
+    pendingOrder: {
+      id: 'pharmacy-order-1',
+      customerName: 'U Tun Lin (Shwe Clinic)',
+      contact: '09-965-222-333',
+      requestedAt: '2026-08-03T04:30:00.000Z',
+      promisedFor: '2026-08-04T07:00:00.000Z',
+      status: 'pending',
+      note: 'Clinic weekly consumables. Confirm gauze batch dates on handover.',
+      lines: [{ sku: 'GAUZE-PACK', quantity: 6 }, { sku: 'GLOVES-BOX', quantity: 2 }, { sku: 'ALCOHOL-250ML', quantity: 4 }],
+    },
+  },
+  {
+    id: 'phone-electronics',
+    schema: SHOP_BUSINESS_TEMPLATE_SCHEMA,
+    name: { en: 'Phone & electronics', my: 'ဖုန်းနှင့် အီလက်ထရွန်နစ်ဆိုင်' },
+    description: 'Phone accessories and small electronics with fast-moving counter stock.',
+    industryPackId: 'retail',
+    workflowTemplateId: 'retail-wholesale',
+    catalog: rows([
+      ['CHARGER-TYPEC', 'Type-C fast charger 25W', 'pcs', 9_500, 13_500, 20, 8],
+      ['CABLE-USBC-1M', 'USB-C cable 1m', 'm', 2_800, 4_500, 35, 12],
+      ['EARBUD-TWS', 'Wireless earbuds', 'pcs', 24_000, 32_000, 12, 5],
+      ['POWERBANK-10K', 'Power bank 10000mAh', 'pcs', 28_000, 36_000, 10, 4],
+      ['SCREEN-67', 'Screen protector 6.7 inch', 'pcs', 1_500, 3_000, 50, 15],
+      ['CASE-CLEAR', 'Clear phone case', 'pcs', 2_500, 4_500, 40, 12],
+      ['SPEAKER-BT', 'Bluetooth speaker', 'pcs', 32_000, 42_000, 8, 3],
+      ['MEMORY-64GB', 'MicroSD card 64GB', 'pcs', 12_000, 16_000, 18, 6],
+      ['ADAPTER-3PIN', '3-pin travel adapter', 'pcs', 3_500, 5_500, 25, 8],
+      ['HOLDER-CAR', 'Car phone holder', 'pcs', 6_500, 9_500, 14, 5],
+      ['SIM-TOOL', 'SIM ejector tool set', 'pcs', 500, 1_200, 2, 6],
+      ['BULB-LED9W', 'LED bulb 9W', 'pcs', 1_800, 2_800, 45, 15],
+      ['EXTENSION-4WAY', 'Extension socket 4-way', 'pcs', 8_500, 12_000, 16, 6],
+    ]),
+    counterSales: [
+      { id: 'phone-electronics-sale-1', recordedAt: '2026-08-03T03:40:00.000Z', payment: 'KBZPay', lines: [{ sku: 'CHARGER-TYPEC', quantity: 1 }, { sku: 'CABLE-USBC-1M', quantity: 1 }] },
+      { id: 'phone-electronics-sale-2', recordedAt: '2026-08-03T05:55:00.000Z', payment: 'Cash', lines: [{ sku: 'SCREEN-67', quantity: 2 }, { sku: 'CASE-CLEAR', quantity: 1 }] },
+      { id: 'phone-electronics-sale-3', recordedAt: '2026-08-03T09:15:00.000Z', payment: 'WavePay', lines: [{ sku: 'EARBUD-TWS', quantity: 1 }] },
+    ],
+    pendingOrder: {
+      id: 'phone-electronics-order-1',
+      customerName: 'Ko Zaw Myo',
+      contact: '09-450-444-555',
+      requestedAt: '2026-08-03T06:30:00.000Z',
+      promisedFor: '2026-08-05T06:30:00.000Z',
+      status: 'pending',
+      note: 'Office order. Wants one receipt for all items.',
+      lines: [{ sku: 'EXTENSION-4WAY', quantity: 3 }, { sku: 'BULB-LED9W', quantity: 10 }, { sku: 'ADAPTER-3PIN', quantity: 3 }],
+    },
+  },
+  {
+    id: 'fashion',
+    schema: SHOP_BUSINESS_TEMPLATE_SCHEMA,
+    name: { en: 'Fashion & clothing', my: 'ဖက်ရှင်အထည်ဆိုင်' },
+    description: 'Clothing and accessories with size-level SKUs and seasonal reorder levels.',
+    industryPackId: 'retail',
+    workflowTemplateId: 'retail-wholesale',
+    catalog: rows([
+      ['TSHIRT-M-WHT', 'Cotton T-shirt medium white', 'pcs', 6_500, 11_000, 25, 8],
+      ['TSHIRT-L-BLK', 'Cotton T-shirt large black', 'pcs', 6_500, 11_000, 22, 8],
+      ['JEANS-32', 'Denim jeans size 32', 'pcs', 18_000, 28_000, 15, 5],
+      ['LONGYI-MEN', 'Men pasoe longyi', 'pcs', 9_500, 15_000, 20, 6],
+      ['LONGYI-WMN', 'Women htamein longyi', 'pcs', 10_500, 16_500, 18, 6],
+      ['BLOUSE-S', 'Chiffon blouse small', 'pcs', 8_500, 14_000, 12, 4],
+      ['HOODIE-L', 'Fleece hoodie large', 'pcs', 16_500, 24_000, 3, 5],
+      ['CAP-BASE', 'Baseball cap', 'pcs', 4_500, 7_500, 30, 10],
+      ['SOCKS-3PACK', 'Cotton socks 3 pack', 'pack', 3_000, 5_000, 40, 12],
+      ['BELT-LTHR', 'Leather belt', 'pcs', 7_500, 12_000, 14, 5],
+      ['SCARF-COT', 'Cotton scarf', 'pcs', 5_000, 8_500, 16, 6],
+      ['SLIPPER-42', 'Velvet slippers size 42', 'pcs', 4_000, 6_500, 24, 8],
+    ]),
+    counterSales: [
+      { id: 'fashion-sale-1', recordedAt: '2026-08-03T04:25:00.000Z', payment: 'Cash', lines: [{ sku: 'TSHIRT-M-WHT', quantity: 2 }, { sku: 'CAP-BASE', quantity: 1 }] },
+      { id: 'fashion-sale-2', recordedAt: '2026-08-03T07:50:00.000Z', payment: 'KBZPay', lines: [{ sku: 'LONGYI-WMN', quantity: 1 }, { sku: 'SCARF-COT', quantity: 1 }] },
+    ],
+    pendingOrder: {
+      id: 'fashion-order-1',
+      customerName: 'Ma Thiri Win',
+      contact: '09-799-666-777',
+      requestedAt: '2026-08-03T08:10:00.000Z',
+      promisedFor: '2026-08-06T04:00:00.000Z',
+      status: 'pending',
+      note: 'Uniform order for a tea shop team. Sizes confirmed by phone.',
+      lines: [{ sku: 'TSHIRT-L-BLK', quantity: 6 }, { sku: 'SOCKS-3PACK', quantity: 6 }],
+    },
+  },
+  {
+    id: 'hardware',
+    schema: SHOP_BUSINESS_TEMPLATE_SCHEMA,
+    name: { en: 'Hardware & construction supply', my: 'ဆောက်လုပ်ရေးပစ္စည်းဆိုင်' },
+    description: 'Building materials, tools, and site consumables with bulk counter orders.',
+    industryPackId: 'retail',
+    workflowTemplateId: 'retail-wholesale',
+    catalog: rows([
+      ['CEMENT-50KG', 'Cement 50kg bag', 'bag', 14_500, 16_500, 40, 15],
+      ['REBAR-10MM', 'Steel rebar 10mm 12m', 'm', 7_800, 9_500, 60, 20],
+      ['NAIL-2IN-KG', 'Common nails 2 inch per kg', 'kg', 3_200, 4_500, 25, 8],
+      ['PAINT-4L-WHT', 'Emulsion paint 4L white', 'l', 26_000, 34_000, 12, 4],
+      ['BRUSH-3IN', 'Paint brush 3 inch', 'pcs', 1_800, 3_000, 20, 6],
+      ['PVC-PIPE-1IN', 'PVC pipe 1 inch 4m', 'pcs', 4_200, 6_000, 35, 12],
+      ['WIRE-2.5MM', 'Electrical wire 2.5mm 90m roll', 'roll', 42_000, 52_000, 8, 3],
+      ['PLYWOOD-9MM', 'Plywood sheet 9mm', 'sheet', 19_500, 25_500, 2, 6],
+      ['HAMMER-CLAW', 'Claw hammer', 'pcs', 6_500, 9_500, 10, 4],
+      ['SAW-HAND', 'Hand saw 20 inch', 'pcs', 7_500, 11_000, 8, 3],
+      ['LOCK-PAD60', 'Padlock 60mm', 'pcs', 5_500, 8_500, 15, 5],
+      ['TAPE-MEAS5M', 'Measuring tape 5m', 'pcs', 3_200, 5_000, 18, 6],
+      ['GLOVES-WORK', 'Work gloves', 'pcs', 1_500, 2_500, 30, 10],
+    ]),
+    counterSales: [
+      { id: 'hardware-sale-1', recordedAt: '2026-08-03T02:50:00.000Z', payment: 'Cash', lines: [{ sku: 'CEMENT-50KG', quantity: 5 }, { sku: 'NAIL-2IN-KG', quantity: 2 }] },
+      { id: 'hardware-sale-2', recordedAt: '2026-08-03T05:30:00.000Z', payment: 'KBZPay', lines: [{ sku: 'PAINT-4L-WHT', quantity: 2 }, { sku: 'BRUSH-3IN', quantity: 2 }] },
+      { id: 'hardware-sale-3', recordedAt: '2026-08-03T09:40:00.000Z', payment: 'Cash', lines: [{ sku: 'LOCK-PAD60', quantity: 1 }, { sku: 'TAPE-MEAS5M', quantity: 1 }] },
+    ],
+    pendingOrder: {
+      id: 'hardware-order-1',
+      customerName: 'U Myint Soe (site foreman)',
+      contact: '09-681-888-999',
+      requestedAt: '2026-08-03T07:20:00.000Z',
+      promisedFor: '2026-08-04T02:00:00.000Z',
+      status: 'pending',
+      note: 'Site delivery before concrete pour. Needs loading help at 8:30.',
+      lines: [{ sku: 'CEMENT-50KG', quantity: 20 }, { sku: 'REBAR-10MM', quantity: 30 }, { sku: 'GLOVES-WORK', quantity: 10 }],
+    },
+  },
+  {
+    id: 'tea-coffee',
+    schema: SHOP_BUSINESS_TEMPLATE_SCHEMA,
+    name: { en: 'Tea & coffee shop', my: 'လက်ဖက်ရည်ဆိုင်' },
+    description: 'Tea shop menu with counter orders, daily prep counts, and large preorders.',
+    industryPackId: 'cafe',
+    workflowTemplateId: 'restaurant-ordering',
+    catalog: rows([
+      ['TEA-SWEET', 'Myanmar sweet milk tea', 'pcs', 700, 1_500, 150, 40],
+      ['TEA-PLAIN', 'Plain green tea pot', 'pcs', 200, 500, 120, 30],
+      ['COFFEE-BLACK', 'Black coffee', 'pcs', 900, 2_000, 100, 30],
+      ['COFFEE-MILK', 'Milk coffee', 'pcs', 1_200, 2_500, 90, 25],
+      ['MOHINGA-BOWL', 'Mohinga bowl', 'pcs', 1_800, 3_500, 60, 20],
+      ['NANPYAR-PE', 'Naan with pe byouk', 'pcs', 900, 2_000, 70, 20],
+      ['EKYAKWAY', 'E kya kway pair', 'pcs', 500, 1_200, 80, 25],
+      ['SAMOSA-VEG', 'Vegetable samosa', 'pcs', 400, 1_000, 90, 30],
+      ['PARATA-SWEET', 'Sweet parata', 'pcs', 800, 1_800, 5, 20],
+      ['BUN-CREAM', 'Cream bun', 'pcs', 600, 1_400, 40, 15],
+      ['RICE-CHICKEN', 'Chicken rice plate', 'pcs', 3_200, 5_500, 40, 12],
+      ['WATER-BOTTLE', 'Drinking water bottle', 'pcs', 350, 700, 96, 24],
+    ]),
+    counterSales: [
+      { id: 'tea-coffee-sale-1', recordedAt: '2026-08-03T00:45:00.000Z', payment: 'Cash', lines: [{ sku: 'TEA-SWEET', quantity: 2 }, { sku: 'EKYAKWAY', quantity: 2 }] },
+      { id: 'tea-coffee-sale-2', recordedAt: '2026-08-03T01:30:00.000Z', payment: 'KBZPay', lines: [{ sku: 'MOHINGA-BOWL', quantity: 1 }, { sku: 'TEA-PLAIN', quantity: 1 }] },
+      { id: 'tea-coffee-sale-3', recordedAt: '2026-08-03T05:05:00.000Z', payment: 'Cash', lines: [{ sku: 'RICE-CHICKEN', quantity: 2 }, { sku: 'WATER-BOTTLE', quantity: 2 }] },
+    ],
+    pendingOrder: {
+      id: 'tea-coffee-order-1',
+      customerName: 'Daw Mya Sandar (office admin)',
+      contact: '09-254-111-222',
+      requestedAt: '2026-08-03T03:15:00.000Z',
+      promisedFor: '2026-08-04T01:30:00.000Z',
+      status: 'pending',
+      note: 'Meeting breakfast for 20 people. Collect at 8:00, pack to go.',
+      lines: [{ sku: 'TEA-SWEET', quantity: 20 }, { sku: 'SAMOSA-VEG', quantity: 20 }, { sku: 'BUN-CREAM', quantity: 20 }],
+    },
+  },
+  {
+    id: 'auto-parts',
+    schema: SHOP_BUSINESS_TEMPLATE_SCHEMA,
+    name: { en: 'Auto parts', my: 'ကားပစ္စည်းဆိုင်' },
+    description: 'Vehicle consumables and spares with workshop counter sales.',
+    industryPackId: 'retail',
+    workflowTemplateId: 'retail-wholesale',
+    catalog: rows([
+      ['OIL-ENG-4L', 'Engine oil 10W-40 4L', 'l', 38_000, 48_000, 16, 6],
+      ['FILTER-OIL', 'Oil filter', 'pcs', 6_500, 9_500, 24, 8],
+      ['FILTER-AIR', 'Air filter', 'pcs', 8_500, 12_500, 18, 6],
+      ['PLUG-SPARK', 'Spark plug', 'pcs', 4_500, 7_000, 40, 12],
+      ['PAD-BRAKE-FR', 'Front brake pad set', 'pack', 28_000, 38_000, 10, 4],
+      ['BATT-12V60', 'Car battery 12V 60Ah', 'pcs', 145_000, 175_000, 6, 2],
+      ['BULB-H4', 'Headlight bulb H4', 'pcs', 3_500, 6_000, 30, 10],
+      ['WIPER-20IN', 'Wiper blade 20 inch', 'pcs', 5_500, 8_500, 20, 6],
+      ['COOLANT-4L', 'Radiator coolant 4L', 'l', 9_500, 13_500, 14, 5],
+      ['BELT-FAN', 'Fan belt', 'pcs', 7_500, 11_000, 1, 4],
+      ['FLUID-BRAKE', 'Brake fluid DOT4 500ml', 'ml', 6_000, 9_000, 12, 4],
+      ['GREASE-500G', 'Multipurpose grease 500g', 'g', 4_200, 6_500, 15, 5],
+      ['FUSE-KIT', 'Blade fuse assortment kit', 'pack', 2_500, 4_500, 22, 8],
+    ]),
+    counterSales: [
+      { id: 'auto-parts-sale-1', recordedAt: '2026-08-03T03:20:00.000Z', payment: 'Cash', lines: [{ sku: 'OIL-ENG-4L', quantity: 1 }, { sku: 'FILTER-OIL', quantity: 1 }] },
+      { id: 'auto-parts-sale-2', recordedAt: '2026-08-03T06:45:00.000Z', payment: 'KBZPay', lines: [{ sku: 'PLUG-SPARK', quantity: 4 }, { sku: 'BULB-H4', quantity: 2 }] },
+    ],
+    pendingOrder: {
+      id: 'auto-parts-order-1',
+      customerName: 'Ko Aung Ko (Golden Gate workshop)',
+      contact: '09-540-333-444',
+      requestedAt: '2026-08-03T04:50:00.000Z',
+      promisedFor: '2026-08-04T05:00:00.000Z',
+      status: 'pending',
+      note: 'Workshop service job for two taxis. Invoice under workshop account.',
+      lines: [{ sku: 'PAD-BRAKE-FR', quantity: 2 }, { sku: 'OIL-ENG-4L', quantity: 2 }, { sku: 'FILTER-AIR', quantity: 2 }],
+    },
+  },
+] as const
+
+export function shopBusinessTemplate(id: ShopBusinessTemplateId) {
+  const template = shopBusinessTemplates.find((candidate) => candidate.id === id)
+  if (!template) throw new Error('Choose a supported Shop business template.')
+  return template
+}
+
+export function shopBusinessTemplateFromQuery(value: string | null): ShopBusinessTemplateId | null {
+  if (!value) return null
+  const requested = value.trim().toLowerCase()
+  return shopBusinessTemplates.find((template) => template.id === requested)?.id ?? null
+}
+
+export function shopBusinessTemplateSetupPath(id: ShopBusinessTemplateId) {
+  return `/settings/?product=shop&template=${encodeURIComponent(shopBusinessTemplate(id).id)}`
+}
+
+export function shopBusinessTemplateCatalogCsv(id: ShopBusinessTemplateId) {
+  const template = shopBusinessTemplate(id)
+  const lines = template.catalog.map((item) => `${item.sku},${item.name},${item.openingStock},${item.reorderAt},${item.priceMmk}`)
+  return `sku,item_name,opening_stock,reorder_at,price_mmk\r\n${lines.join('\r\n')}\r\n`
+}
+
+export function shopBusinessTemplateCommerceItems(id: ShopBusinessTemplateId): CommerceItem[] {
+  return shopBusinessTemplate(id).catalog.map((item) => ({
+    sku: item.sku,
+    name: item.name,
+    onHand: item.openingStock,
+    reorderAt: item.reorderAt,
+    price: item.priceMmk,
+  }))
+}
+
+export function shopBusinessTemplateLowStockItems(id: ShopBusinessTemplateId) {
+  return shopBusinessTemplate(id).catalog.filter((item) => item.openingStock <= item.reorderAt)
+}
+
+export function shopBusinessTemplateSaleTotalMmk(id: ShopBusinessTemplateId, sale: ShopBusinessSampleSale) {
+  const catalog = shopBusinessTemplate(id).catalog
+  return sale.lines.reduce((total, line) => {
+    const item = catalog.find((candidate) => candidate.sku === line.sku)
+    if (!item) throw new Error(`Sample sale ${sale.id} references unknown SKU ${line.sku}.`)
+    return total + item.priceMmk * line.quantity
+  }, 0)
+}
+
+export function validateShopBusinessTemplates() {
+  const templateIds = new Set<string>()
+  const allowedUnits = new Set<string>(shopBusinessTemplateUnits)
+  for (const template of shopBusinessTemplates) {
+    if (template.schema !== SHOP_BUSINESS_TEMPLATE_SCHEMA) throw new Error(`${template.id} uses an unsupported schema.`)
+    if (templateIds.has(template.id)) throw new Error(`Duplicate business template ${template.id}.`)
+    templateIds.add(template.id)
+    if (!/^[a-z][a-z0-9-]{1,39}$/.test(template.id)) throw new Error(`${template.id} is not a canonical template id.`)
+    if (!template.name.en.trim() || !template.name.my.trim()) throw new Error(`${template.id} needs both English and Myanmar display names.`)
+    if (template.catalog.length < 12 || template.catalog.length > 20) throw new Error(`${template.id} must carry 12 to 20 starter items.`)
+    const skus = new Set<string>()
+    for (const item of template.catalog) {
+      if (!/^[A-Z0-9][A-Z0-9._/-]{0,79}$/.test(item.sku)) throw new Error(`${template.id} item ${item.sku} is not a canonical SKU.`)
+      if (skus.has(item.sku)) throw new Error(`${template.id} repeats SKU ${item.sku}.`)
+      skus.add(item.sku)
+      if (!item.name.trim() || item.name.length > 180 || item.name.includes(',')) throw new Error(`${template.id} item ${item.sku} has an invalid name.`)
+      if (!allowedUnits.has(item.unit)) throw new Error(`${template.id} item ${item.sku} uses an unsupported unit.`)
+      if (!Number.isSafeInteger(item.costMmk) || item.costMmk < 1) throw new Error(`${template.id} item ${item.sku} needs a positive whole MMK cost.`)
+      if (!Number.isSafeInteger(item.priceMmk) || item.priceMmk < 1) throw new Error(`${template.id} item ${item.sku} needs a positive whole MMK price.`)
+      if (item.costMmk >= item.priceMmk) throw new Error(`${template.id} item ${item.sku} must price above cost.`)
+      if (!Number.isSafeInteger(item.openingStock) || item.openingStock < 0) throw new Error(`${template.id} item ${item.sku} needs whole opening stock.`)
+      if (!Number.isSafeInteger(item.reorderAt) || item.reorderAt < 0) throw new Error(`${template.id} item ${item.sku} needs a whole reorder level.`)
+    }
+    if (shopBusinessTemplateLowStockItems(template.id).length !== 1) throw new Error(`${template.id} must stage exactly one low-stock situation.`)
+    if (template.counterSales.length < 2 || template.counterSales.length > 3) throw new Error(`${template.id} must stage 2 or 3 sample counter sales.`)
+    const saleIds = new Set<string>()
+    for (const sale of template.counterSales) {
+      if (saleIds.has(sale.id)) throw new Error(`${template.id} repeats sample sale ${sale.id}.`)
+      saleIds.add(sale.id)
+      if (Number.isNaN(Date.parse(sale.recordedAt)) || new Date(Date.parse(sale.recordedAt)).toISOString() !== sale.recordedAt) throw new Error(`${sale.id} needs an exact ISO timestamp.`)
+      if (!sale.lines.length) throw new Error(`${sale.id} needs at least one line.`)
+      for (const line of sale.lines) {
+        if (!skus.has(line.sku)) throw new Error(`${sale.id} references unknown SKU ${line.sku}.`)
+        if (!Number.isSafeInteger(line.quantity) || line.quantity < 1) throw new Error(`${sale.id} needs whole positive quantities.`)
+      }
+      if (shopBusinessTemplateSaleTotalMmk(template.id, sale) < 1) throw new Error(`${sale.id} must total a positive MMK amount.`)
+    }
+    const order = template.pendingOrder
+    if (order.status !== 'pending') throw new Error(`${template.id} must stage one pending customer order.`)
+    if (!order.customerName.trim() || !order.contact.trim() || !order.note.trim()) throw new Error(`${order.id} needs customer details.`)
+    for (const stamp of [order.requestedAt, order.promisedFor]) {
+      if (Number.isNaN(Date.parse(stamp)) || new Date(Date.parse(stamp)).toISOString() !== stamp) throw new Error(`${order.id} needs exact ISO timestamps.`)
+    }
+    if (Date.parse(order.promisedFor) <= Date.parse(order.requestedAt)) throw new Error(`${order.id} must promise after the request time.`)
+    if (!order.lines.length) throw new Error(`${order.id} needs at least one line.`)
+    for (const line of order.lines) {
+      if (!skus.has(line.sku)) throw new Error(`${order.id} references unknown SKU ${line.sku}.`)
+      if (!Number.isSafeInteger(line.quantity) || line.quantity < 1) throw new Error(`${order.id} needs whole positive quantities.`)
+    }
+  }
+  if (templateIds.size !== 7) throw new Error('The Shop business template registry must carry exactly 7 templates.')
+  return shopBusinessTemplates
+}

--- a/tools/shop_business_templates.test.mjs
+++ b/tools/shop_business_templates.test.mjs
@@ -1,0 +1,143 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
+import { test } from 'node:test'
+
+const root = resolve(import.meta.dirname, '..')
+const modulePath = resolve(root, 'showroom', 'src', 'products', 'shop', 'business-templates.ts')
+const moduleHref = pathToFileURL(modulePath).href
+const model = await import(moduleHref)
+
+const expectedTemplateIds = ['mini-mart', 'pharmacy', 'phone-electronics', 'fashion', 'hardware', 'tea-coffee', 'auto-parts']
+
+test('registry carries exactly the 7 supported Myanmar business types', () => {
+  assert.deepEqual(model.shopBusinessTemplates.map((template) => template.id), expectedTemplateIds)
+  assert.equal(new Set(model.shopBusinessTemplates.map((template) => template.id)).size, 7)
+  assert.doesNotThrow(() => model.validateShopBusinessTemplates())
+  for (const template of model.shopBusinessTemplates) {
+    assert.ok(template.name.en.trim().length > 0, `${template.id} needs an English name`)
+    assert.ok(template.name.my.trim().length > 0, `${template.id} needs a Myanmar name`)
+    assert.ok(['retail', 'cafe', 'restaurant', 'spa', 'gym', 'school'].includes(template.industryPackId))
+    assert.ok(['retail-wholesale', 'restaurant-ordering', 'social-commerce'].includes(template.workflowTemplateId))
+  }
+})
+
+test('every catalog is realistic: 12-20 items, unique SKUs, whole positive MMK, cost below price', () => {
+  for (const template of model.shopBusinessTemplates) {
+    assert.ok(template.catalog.length >= 12 && template.catalog.length <= 20, `${template.id} catalog size ${template.catalog.length}`)
+    const skus = new Set(template.catalog.map((item) => item.sku))
+    assert.equal(skus.size, template.catalog.length, `${template.id} repeats a SKU`)
+    for (const item of template.catalog) {
+      assert.match(item.sku, /^[A-Z0-9][A-Z0-9._/-]{0,79}$/, `${template.id} ${item.sku}`)
+      assert.ok(Number.isSafeInteger(item.costMmk) && item.costMmk >= 1, `${item.sku} cost`)
+      assert.ok(Number.isSafeInteger(item.priceMmk) && item.priceMmk >= 1, `${item.sku} price`)
+      assert.ok(item.costMmk < item.priceMmk, `${item.sku} must price above cost`)
+      assert.ok(Number.isSafeInteger(item.openingStock) && item.openingStock >= 0, `${item.sku} opening stock`)
+      assert.ok(Number.isSafeInteger(item.reorderAt) && item.reorderAt >= 0, `${item.sku} reorder level`)
+    }
+  }
+})
+
+test('units come from the app commerce unit set', async () => {
+  const commerceSource = await readFile(resolve(root, 'showroom', 'src', 'core', 'commerce-workspace.ts'), 'utf8')
+  const unionMatch = commerceSource.match(/export type CommerceProductionMaterialUnit = ([^\n]+)/)
+  assert.ok(unionMatch, 'commerce unit union missing')
+  const appUnits = new Set([...unionMatch[1].matchAll(/'([a-z]+)'/g)].map((match) => match[1]))
+  assert.deepEqual(new Set(model.shopBusinessTemplateUnits), appUnits, 'registry unit list drifted from the app unit set')
+  for (const template of model.shopBusinessTemplates) {
+    for (const item of template.catalog) {
+      assert.ok(appUnits.has(item.unit), `${template.id} ${item.sku} unit ${item.unit} is not an app unit`)
+    }
+  }
+})
+
+test('each template stages one low-stock situation, 2-3 counter sales, and one pending order', () => {
+  for (const template of model.shopBusinessTemplates) {
+    const lowStock = model.shopBusinessTemplateLowStockItems(template.id)
+    assert.equal(lowStock.length, 1, `${template.id} low-stock situations: ${lowStock.length}`)
+    assert.ok(template.counterSales.length >= 2 && template.counterSales.length <= 3, `${template.id} sales`)
+    const skus = new Set(template.catalog.map((item) => item.sku))
+    for (const sale of template.counterSales) {
+      assert.ok(['Cash', 'KBZPay', 'WavePay'].includes(sale.payment), `${sale.id} payment`)
+      assert.equal(new Date(Date.parse(sale.recordedAt)).toISOString(), sale.recordedAt, `${sale.id} timestamp`)
+      for (const line of sale.lines) {
+        assert.ok(skus.has(line.sku), `${sale.id} unknown SKU ${line.sku}`)
+        assert.ok(Number.isSafeInteger(line.quantity) && line.quantity >= 1, `${sale.id} quantity`)
+      }
+      assert.ok(model.shopBusinessTemplateSaleTotalMmk(template.id, sale) >= 1, `${sale.id} total`)
+    }
+    const order = template.pendingOrder
+    assert.equal(order.status, 'pending')
+    assert.ok(order.customerName.trim() && order.contact.trim() && order.note.trim(), `${order.id} details`)
+    assert.equal(new Date(Date.parse(order.requestedAt)).toISOString(), order.requestedAt)
+    assert.equal(new Date(Date.parse(order.promisedFor)).toISOString(), order.promisedFor)
+    assert.ok(Date.parse(order.promisedFor) > Date.parse(order.requestedAt), `${order.id} promise ordering`)
+    for (const line of order.lines) {
+      assert.ok(skus.has(line.sku), `${order.id} unknown SKU ${line.sku}`)
+      assert.ok(Number.isSafeInteger(line.quantity) && line.quantity >= 1, `${order.id} quantity`)
+    }
+  }
+})
+
+test('registry output is deterministic', async () => {
+  const source = await readFile(modulePath, 'utf8')
+  for (const banned of ['Date.now', 'Math.random', 'new Date()', 'crypto.randomUUID', 'performance.now']) {
+    assert.ok(!source.includes(banned), `module must not use ${banned}`)
+  }
+  const reimported = await import(`${moduleHref}?determinism=${Date.now()}`)
+  assert.equal(JSON.stringify(reimported.shopBusinessTemplates), JSON.stringify(model.shopBusinessTemplates))
+  for (const template of model.shopBusinessTemplates) {
+    assert.equal(model.shopBusinessTemplateCatalogCsv(template.id), reimported.shopBusinessTemplateCatalogCsv(template.id))
+    assert.equal(JSON.stringify(model.shopBusinessTemplateCommerceItems(template.id)), JSON.stringify(reimported.shopBusinessTemplateCommerceItems(template.id)))
+  }
+})
+
+test('catalog CSV passes the accountable Shop import checks', async () => {
+  const onboarding = await import(pathToFileURL(resolve(root, 'showroom', 'src', 'core', 'client-onboarding.ts')).href)
+  for (const template of model.shopBusinessTemplates) {
+    const preview = await onboarding.createClientImportPreview(
+      model.shopBusinessTemplateCatalogCsv(template.id),
+      'commerce',
+      undefined,
+      `sample-${template.id}.csv`,
+      template.workflowTemplateId,
+    )
+    assert.ok(preview.readyForStaging, `${template.id} CSV not ready for staging`)
+    assert.equal(preview.totals.rows, template.catalog.length, `${template.id} row count`)
+    assert.ok(preview.rows.every((row) => row.status === 'ready'), `${template.id} has non-ready rows`)
+  }
+})
+
+test('catalog installs into a fresh commerce workspace as a working sample', async () => {
+  const commerce = await import(pathToFileURL(resolve(root, 'showroom', 'src', 'core', 'commerce-workspace.ts')).href)
+  for (const template of model.shopBusinessTemplates) {
+    const seed = commerce.createSeedCommerce()
+    const installed = commerce.installCommerceWorkingSampleCatalog(seed, {
+      sampleId: template.id,
+      sampleName: template.name.en,
+      items: model.shopBusinessTemplateCommerceItems(template.id),
+      capturedAt: '2026-08-03T09:00:00.000Z',
+    })
+    assert.ok(installed, `${template.id} did not install`)
+    assert.equal(commerce.commerceWorkingSampleCatalogId(installed), template.id)
+    for (const item of template.catalog) {
+      const stored = installed.items.find((candidate) => candidate.sku === item.sku)
+      assert.ok(stored, `${template.id} missing ${item.sku}`)
+      assert.equal(stored.onHand, item.openingStock)
+      assert.equal(stored.reorderAt, item.reorderAt)
+      assert.equal(stored.price, item.priceMmk)
+    }
+  }
+})
+
+test('deep links select templates and unknown values fall back safely', () => {
+  assert.equal(model.shopBusinessTemplateFromQuery('pharmacy'), 'pharmacy')
+  assert.equal(model.shopBusinessTemplateFromQuery(' PHARMACY '), 'pharmacy')
+  assert.equal(model.shopBusinessTemplateFromQuery('tea-coffee'), 'tea-coffee')
+  assert.equal(model.shopBusinessTemplateFromQuery('unknown-type'), null)
+  assert.equal(model.shopBusinessTemplateFromQuery(''), null)
+  assert.equal(model.shopBusinessTemplateFromQuery(null), null)
+  assert.equal(model.shopBusinessTemplateSetupPath('pharmacy'), '/settings/?product=shop&template=pharmacy')
+  assert.throws(() => model.shopBusinessTemplate('unknown'))
+})

--- a/tools/verify_app_build.mjs
+++ b/tools/verify_app_build.mjs
@@ -34,6 +34,7 @@ let operatingBaselineRuntimeChecks = 0
 let plantEquipmentImportRuntimeChecks = 0
 let shopInventoryRuntimeChecks = 0
 let shopServiceScheduleRuntimeChecks = 0
+let shopBusinessTemplateRuntimeChecks = 0
 let plantOrderRuntimeChecks = 0
 let websiteReleaseRuntimeChecks = 0
 let shopOperatingFlowRuntimeChecks = 0
@@ -127,6 +128,7 @@ const ecommerceBuyingWorkspaceSource = await readFile(resolve(root, 'showroom', 
 const workspaceControlsPageSource = await readFile(resolve(root, 'showroom', 'src', 'core', 'WorkspaceControlsPage.tsx'), 'utf8')
 const productOnboardingPageSource = await readFile(resolve(root, 'showroom', 'src', 'core', 'ProductOnboardingPage.tsx'), 'utf8')
 const productOnboardingRuntimeSource = await readFile(resolve(root, 'showroom', 'src', 'core', 'product-onboarding-runtime.ts'), 'utf8')
+const shopBusinessTemplatesSource = await readFile(resolve(root, 'showroom', 'src', 'products', 'shop', 'business-templates.ts'), 'utf8')
 const publicGeneratorSource = await readFile(resolve(root, 'tools', 'create_public_vercel_output.mjs'), 'utf8')
 const managedLoginPageSource = await readFile(resolve(root, 'showroom', 'src', 'core', 'ManagedLoginPage.tsx'), 'utf8')
 const managedAccountPageSource = await readFile(resolve(root, 'showroom', 'src', 'core', 'ManagedAccountPage.tsx'), 'utf8')
@@ -7129,6 +7131,85 @@ async function verifyShopServiceScheduleRuntime() {
     assertThrows(() => model.readShopServiceSchedule('{"schema":"wrong"}'), 'shop_service_invalid_storage_accepted')
   } catch (error) {
     fail(`shop_service_schedule_runtime:${error instanceof Error ? error.message : 'unknown'}`)
+  }
+}
+
+async function verifyShopBusinessTemplateRuntime() {
+  const assert = (condition, reason) => {
+    if (!condition) throw new Error(reason)
+    shopBusinessTemplateRuntimeChecks += 1
+  }
+  const assertThrows = (action, reason) => {
+    try { action() } catch { shopBusinessTemplateRuntimeChecks += 1; return }
+    throw new Error(reason)
+  }
+  if (!shopBusinessTemplatesSource.includes("SHOP_BUSINESS_TEMPLATE_SCHEMA = 'supermega.shop.business_template.v1'")
+    || !shopBusinessTemplatesSource.includes('export function validateShopBusinessTemplates()')
+    || !shopBusinessTemplatesSource.includes('export function shopBusinessTemplateFromQuery(')
+    || !shopBusinessTemplatesSource.includes('export function shopBusinessTemplateCatalogCsv(')
+    || !shopBusinessTemplatesSource.includes('export function shopBusinessTemplateCommerceItems(')
+    || ['Date.now', 'Math.random', 'new Date()', 'crypto.randomUUID', 'performance.now', 'fetch(', 'XMLHttpRequest', 'WebSocket(', 'EventSource(', 'localStorage'].some((marker) => shopBusinessTemplatesSource.includes(marker))
+    || !productOnboardingRuntimeSource.includes('export async function provisionLocalShopBusinessTemplateSample')
+    || !productOnboardingPageSource.includes('provisionLocalShopBusinessTemplateSample(selectedBusinessTemplate.id)')
+    || !productOnboardingPageSource.includes("shopBusinessTemplateFromQuery(new URLSearchParams(location.search).get('template'))")
+    || !productOnboardingPageSource.includes('className="compact-disclosure product-onboarding-business-type"')
+    || !productOnboardingPageSource.includes('shopBusinessTemplates.map((template)')
+    || !productOnboardingPageSource.includes('Standard sample (current industry pack)')
+    || !productOnboardingPageSource.includes('await provisionLocalShopWorkingSample(shopIndustryPackId, onboardingTemplate.id)')
+    || !coreCssSource.includes('.product-onboarding-business-type')) fail('shop_business_template_contract_missing')
+  try {
+    const model = await import(`${pathToFileURL(resolve(root, 'showroom', 'src', 'products', 'shop', 'business-templates.ts')).href}?shop-business-template-verify=${Date.now()}`)
+    const onboardingModel = await import(`${pathToFileURL(resolve(root, 'showroom', 'src', 'core', 'client-onboarding.ts')).href}?shop-business-template-import-verify=${Date.now()}`)
+    const commerceModel = await import(`${pathToFileURL(resolve(root, 'showroom', 'src', 'core', 'commerce-workspace.ts')).href}?shop-business-template-commerce-verify=${Date.now()}`)
+    assert(model.validateShopBusinessTemplates() === model.shopBusinessTemplates, 'shop_business_template_registry_invalid')
+    assert(model.shopBusinessTemplates.map((template) => template.id).join(',') === 'mini-mart,pharmacy,phone-electronics,fashion,hardware,tea-coffee,auto-parts'
+      && new Set(model.shopBusinessTemplates.map((template) => template.id)).size === 7, 'shop_business_template_catalog_wrong')
+    const commerceUnits = new Set(['kg', 'g', 'l', 'ml', 'pcs', 'pack', 'bag', 'roll', 'sheet', 'm', 'cm'])
+    assert(model.shopBusinessTemplateUnits.length === commerceUnits.size && model.shopBusinessTemplateUnits.every((unit) => commerceUnits.has(unit)), 'shop_business_template_unit_set_drifted')
+    for (const template of model.shopBusinessTemplates) {
+      assert(template.catalog.length >= 12 && template.catalog.length <= 20
+        && new Set(template.catalog.map((item) => item.sku)).size === template.catalog.length
+        && template.catalog.every((item) => commerceUnits.has(item.unit)
+          && Number.isSafeInteger(item.costMmk) && item.costMmk >= 1
+          && Number.isSafeInteger(item.priceMmk) && item.priceMmk > item.costMmk
+          && Number.isSafeInteger(item.openingStock) && item.openingStock >= 0
+          && Number.isSafeInteger(item.reorderAt) && item.reorderAt >= 0), `shop_business_template_${template.id}_catalog_invalid`)
+      assert(model.shopBusinessTemplateLowStockItems(template.id).length === 1, `shop_business_template_${template.id}_low_stock_missing`)
+      const catalogSkus = new Set(template.catalog.map((item) => item.sku))
+      assert(template.counterSales.length >= 2 && template.counterSales.length <= 3
+        && template.counterSales.every((sale) => sale.lines.length >= 1
+          && sale.lines.every((line) => catalogSkus.has(line.sku) && Number.isSafeInteger(line.quantity) && line.quantity >= 1)
+          && model.shopBusinessTemplateSaleTotalMmk(template.id, sale) >= 1), `shop_business_template_${template.id}_sales_invalid`)
+      assert(template.pendingOrder.status === 'pending'
+        && template.pendingOrder.lines.length >= 1
+        && template.pendingOrder.lines.every((line) => catalogSkus.has(line.sku) && Number.isSafeInteger(line.quantity) && line.quantity >= 1)
+        && Date.parse(template.pendingOrder.promisedFor) > Date.parse(template.pendingOrder.requestedAt), `shop_business_template_${template.id}_pending_order_invalid`)
+      const preview = await onboardingModel.createClientImportPreview(
+        model.shopBusinessTemplateCatalogCsv(template.id),
+        'commerce',
+        undefined,
+        `sample-${template.id}.csv`,
+        template.workflowTemplateId,
+      )
+      assert(preview.readyForStaging && preview.totals.rows === template.catalog.length && preview.rows.every((row) => row.status === 'ready'), `shop_business_template_${template.id}_import_not_ready`)
+      const installed = commerceModel.installCommerceWorkingSampleCatalog(commerceModel.createSeedCommerce(), {
+        sampleId: template.id,
+        sampleName: template.name.en,
+        items: model.shopBusinessTemplateCommerceItems(template.id),
+        capturedAt: '2026-08-03T09:00:00.000Z',
+      })
+      assert(installed && commerceModel.commerceWorkingSampleCatalogId(installed) === template.id, `shop_business_template_${template.id}_install_failed`)
+    }
+    const reimported = await import(`${pathToFileURL(resolve(root, 'showroom', 'src', 'products', 'shop', 'business-templates.ts')).href}?shop-business-template-determinism=${Date.now()}`)
+    assert(JSON.stringify(reimported.shopBusinessTemplates) === JSON.stringify(model.shopBusinessTemplates), 'shop_business_template_output_not_deterministic')
+    assert(model.shopBusinessTemplateFromQuery('pharmacy') === 'pharmacy'
+      && model.shopBusinessTemplateFromQuery(' PHARMACY ') === 'pharmacy'
+      && model.shopBusinessTemplateFromQuery('unknown-type') === null
+      && model.shopBusinessTemplateFromQuery(null) === null, 'shop_business_template_query_selection_wrong')
+    assert(model.shopBusinessTemplateSetupPath('pharmacy') === '/settings/?product=shop&template=pharmacy', 'shop_business_template_setup_path_wrong')
+    assertThrows(() => model.shopBusinessTemplate('unknown'), 'shop_business_unknown_template_accepted')
+  } catch (error) {
+    fail(`shop_business_template_runtime:${error instanceof Error ? error.message : 'unknown'}`)
   }
 }
 
@@ -18628,6 +18709,7 @@ await verifyShopNextActionRuntime()
 await verifyChannelOrderRuntime()
 await verifyShopInventoryRuntime()
 await verifyShopServiceScheduleRuntime()
+await verifyShopBusinessTemplateRuntime()
 await verifyShopProductionDemandRuntime()
 await verifyShopDemandIntelligenceRuntime()
 await verifyPlantOrderRuntime()
@@ -19156,4 +19238,4 @@ if (failures.length) {
   console.error(JSON.stringify({ ok: false, contract: 'supermega_app_build', failures }, null, 2))
   process.exit(1)
 }
-console.log(JSON.stringify({ ok: true, contract: 'supermega_app_build', customerProducts: 4, sharedCapabilities: 1, primaryRoutes: 5, operatingModules: 2, makerModules: 2, compatibilityRedirects: 5, workflowProfiles, behaviorTrailRuntimeChecks, operationalReportRuntimeChecks, shopOperatingFlowRuntimeChecks, shopNextActionRuntimeChecks, channelOrderRuntimeChecks, shopInventoryRuntimeChecks, shopServiceScheduleRuntimeChecks, shopProductionDemandRuntimeChecks, shopDemandIntelligenceRuntimeChecks, shopReplenishmentRuntimeChecks, shopProcurementDecisionRuntimeChecks, plantOrderRuntimeChecks, websiteReleaseRuntimeChecks, catalogImportRuntimeChecks, clientOnboardingRuntimeChecks, managedClientImportRuntimeChecks, plantEquipmentImportRuntimeChecks, managedContextRuntimeChecks, operatingBaselineRuntimeChecks, websiteRuntimeChecks, orderCompletionRuntimeChecks, commerceOrderDraftRuntimeChecks, storefrontDraftRuntimeChecks, storefrontRuntimeChecks, storefrontRequestRuntimeChecks, managedWebsiteRuntimeChecks, managedStorefrontRuntimeChecks, ecommerceActivationRuntimeChecks, ecommerceHandoffRuntimeChecks, ecommerceBuyingRuntimeChecks, commerceRuntimeChecks, productionRuntimeChecks, businessCommandRuntimeChecks, ownerControlRuntimeChecks, pilotOutcomeRuntimeChecks, companyBackupRuntimeChecks, largestJavascriptBytes, bytes }, null, 2))
+console.log(JSON.stringify({ ok: true, contract: 'supermega_app_build', customerProducts: 4, sharedCapabilities: 1, primaryRoutes: 5, operatingModules: 2, makerModules: 2, compatibilityRedirects: 5, workflowProfiles, behaviorTrailRuntimeChecks, operationalReportRuntimeChecks, shopOperatingFlowRuntimeChecks, shopNextActionRuntimeChecks, channelOrderRuntimeChecks, shopInventoryRuntimeChecks, shopServiceScheduleRuntimeChecks, shopBusinessTemplateRuntimeChecks, shopProductionDemandRuntimeChecks, shopDemandIntelligenceRuntimeChecks, shopReplenishmentRuntimeChecks, shopProcurementDecisionRuntimeChecks, plantOrderRuntimeChecks, websiteReleaseRuntimeChecks, catalogImportRuntimeChecks, clientOnboardingRuntimeChecks, managedClientImportRuntimeChecks, plantEquipmentImportRuntimeChecks, managedContextRuntimeChecks, operatingBaselineRuntimeChecks, websiteRuntimeChecks, orderCompletionRuntimeChecks, commerceOrderDraftRuntimeChecks, storefrontDraftRuntimeChecks, storefrontRuntimeChecks, storefrontRequestRuntimeChecks, managedWebsiteRuntimeChecks, managedStorefrontRuntimeChecks, ecommerceActivationRuntimeChecks, ecommerceHandoffRuntimeChecks, ecommerceBuyingRuntimeChecks, commerceRuntimeChecks, productionRuntimeChecks, businessCommandRuntimeChecks, ownerControlRuntimeChecks, pilotOutcomeRuntimeChecks, companyBackupRuntimeChecks, largestJavascriptBytes, bytes }, null, 2))


### PR DESCRIPTION
Shop is now demo-ready for any kind of business: a deterministic template registry with 7 Myanmar-relevant types — mini-mart/grocery, pharmacy, phone & electronics, fashion, hardware & construction supply, tea & coffee shop, auto parts — each with Burmese+English names and a realistic 12–13 item starter catalog (whole-MMK, real units type-pinned to the commerce unit set, reorder levels, a surfacing low-stock situation). Selectable in onboarding (default remains the current standard sample — all existing pins/tests unchanged) and deep-linkable: /settings/?product=shop&template=pharmacy opens Shop as a pharmacy.

Catalog installation rides the existing accountable import path; sample transactions/orders are validated registry data (deterministic, fixed timestamps) — injecting them into the ledger stays behind human-review proofs by design. verify_app_build gains a 49-check template runtime block; commerce checks unchanged at 347. Registry suite 8/8; build+security contract green; adversarially verified (realism, determinism, deep-link injection safety — pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)