### PR TITLE
Pilot evidence kit: day-one materials for the Shop design partner

### DIFF
--- a/docs/pilot-kit/README.md
+++ b/docs/pilot-kit/README.md
@@ -1,0 +1,27 @@
+# SuperMega Shop pilot kit
+
+Everything a Shop design partner needs on day one of the five-day managed pilot, prepared before any partner is named, so recruitment has zero friction the moment the founder names a business.
+
+## Why this kit exists
+
+The managed-pilot readiness ledger (contract `supermega.managed-pilot-readiness.v3`, stored at `hq/readiness/managed-pilot-readiness.json`) blocks every managed claim behind one founder decision with the id `bounded-managed-pilot-rehearsal`. That decision requires exactly two inputs: `approve_preview_branch_target` and `name_shop_pilot_operator`. Its operator block requires a named business (`namedBusinessRequired`), a named operator (`namedOperatorRequired`), a measured baseline (`measuredBaselineRequired`), and acceptance evidence (`acceptanceEvidenceRequired`). The Shop work order `shop-managed-order-close-pilot` stays `owner-gated` until those inputs exist.
+
+This kit is the paperwork for those inputs. It authorizes nothing: the founder decision remains `required` with `proposal_only` authority, and nothing in this kit touches a hosted service, spends a credential, or performs any network mutation.
+
+## The documents, in order of use
+
+1. [baseline-measurement.md](baseline-measurement.md) — the form the founder fills in WITH the shop owner before day 1: named business, named operator, the measured process, at least three observed timings, error and cost counts, and the four baseline numbers the handoff generator requires. Includes a worked fictional example.
+2. [acceptance-checklist.md](acceptance-checklist.md) — the day-by-day five-day plan: the four start gates, what evidence gets captured daily, what an accepted run means, and how each day maps to the readiness contract's acceptance-evidence requirement.
+3. [pilot-agreement-outline.md](pilot-agreement-outline.md) — a plain-language outline of what the partner gets and gives. Outline only, marked NOT LEGAL ADVICE; it contains no invented commitments.
+
+## How it connects to the existing machinery
+
+- The concrete five-day evidence plan, the four owner gates, and the required baseline fields come verbatim from the pilot handoff generator, tools/create_shop_pilot_handoff.mjs (npm script `client:pilot:handoff`). This kit is the human-facing preparation for the inputs that generator refuses to run without.
+- The private sales workspace flow around a real contact event is documented in `docs/supermega-shop-sales-agent.md`; its reporting boundary applies to everything captured with this kit: customer identity stays private.
+- The in-person demo that usually precedes recruitment is docs/demo-playbooks/shop.md.
+
+## Boundary
+
+The pilot itself runs on the browser-local working sample. The readiness contract's does-not-authorize list holds for the entire pilot: `production_database_change`, `production_deploy`, `customer_message`, `payment`, `stock_move`, `managed_product_activation`, `hosted_scheduler_activation`. Any hosted rehearsal happens only after the founder decision is approved, on an isolated `preview_branch`, bounded by `maximumLifetimeHours` of 24 with `deleteAfterEvidence` set.
+
+Every backticked token in this kit is a verbatim contract checked against the repo sources by the drift guard tools/test_demo_playbooks.mjs (npm script `demo:playbooks:verify`).

--- a/docs/pilot-kit/acceptance-checklist.md
+++ b/docs/pilot-kit/acceptance-checklist.md
@@ -1,0 +1,106 @@
+# Shop pilot acceptance checklist — the five-day evidence plan
+
+The readiness ledger requires acceptance evidence (`acceptanceEvidenceRequired`) before the founder decision `bounded-managed-pilot-rehearsal` can be prepared, and the Shop work order's required proof names "a named operator, baseline, and five-day evidence plan". This checklist is that plan, day by day. The five days, their proofs, the four start gates, and the five required measurements are taken verbatim from the pilot handoff generator (tools/create_shop_pilot_handoff.mjs), so the paper plan and the generated private handoff can never disagree.
+
+## Before day 1 — start gates
+
+The generator holds the handoff at status `blocked-owner-review` until the founder has explicitly confirmed all four gates; only then does it read `ready-for-private-pilot`. Confirm each one deliberately; every gate defaults to false.
+
+- [ ] `isolatedNonProductionTenantApproved` — the founder has approved an isolated, non-production tenant label for the pilot. No hosted target exists or is touched at this point.
+- [ ] `namedOperatorAuthorized` — the named operator from the baseline form has agreed, and the owner has authorized them to review every run.
+- [ ] `pilotDataHandlingApproved` — the owner understands and approves how pilot data is handled (browser-local; identity kept private; see the agreement outline).
+- [ ] `ownerReviewedCommercialDraft` — the owner has seen the commercial draft and knows no payment happens during the pilot (the draft records `paymentAccepted` as false).
+
+Also before day 1:
+
+- [ ] Baseline measurement form completed with the owner ([baseline-measurement.md](baseline-measurement.md)).
+- [ ] Agreement outline read together ([pilot-agreement-outline.md](pilot-agreement-outline.md)).
+- [ ] Pilot dates fixed: the review date is exactly the start date plus four days; the generator rejects anything else (`review_date_must_close_five_day_plan`).
+- [ ] Workspace created on the shop's own device at `https://app.supermega.dev/settings/?product=shop`, with the real business name typed into `Business name`. Setup states `Stays on this device. Nothing is sent or published.`
+- [ ] Sidebar badge confirmed to read `Demo mode`.
+
+## What an accepted run means
+
+A pilot run counts as accepted only when all of the following hold, following the owner-observed pilot measurement reference:
+
+1. The run completed — the order reached its end state (or the return exception reached its resolution).
+2. The end state is verifiable in the record, not just remembered.
+3. The named operator reviewed the run and recorded the outcome as correct.
+4. Zero wrong-target actions — nothing was done to the wrong order, item, or customer record.
+5. Zero external effects — no real message, payment, or stock movement happened because of the run.
+
+Any run failing any condition is recorded as not accepted, with the correction minutes it cost. Missing evidence is recorded as missing — per the generator's evidence rule: `Record failures and operator interventions; do not convert missing evidence into a success claim.` The measurement reference promotes a workflow only after 20 consecutive accepted runs; the five-day pilot feeds that same counting discipline, and the count restarts on any non-accepted run.
+
+## The five days
+
+Each day's focus and proof line is verbatim from the generator's evidence plan.
+
+### Day 1 — Baseline and operator walkthrough
+
+Proof: `Record the baseline metrics and complete one observation-only walkthrough.`
+
+- [ ] Baseline numbers from the form re-confirmed with the owner on-site.
+- [ ] One observation-only walkthrough: the founder demonstrates the order flow on the working sample (`/shop/?tab=counter`, then `Review order`, `Create order`, and the order steps in `/shop/?tab=orders`); the operator watches. No evidence run is counted today.
+- [ ] Evidence captured: baseline sheet finalized; walkthrough noted with date, time, and who was present.
+
+### Day 2 — Order entry and review
+
+Proof: `Create and human-confirm test orders; record completion time and corrections.`
+
+- [ ] The operator creates test orders themselves: items in, `Review order`, cashier name at the `Review counter order` gate, `Create order`, then `Start preparing`, `Mark ready`, `Reconcile payment`, `Complete`.
+- [ ] Per run, record: run number, minutes taken, review outcome (correct or not), corrections needed, wrong-target actions (must be zero), external effects (must be none).
+- [ ] Day closed with `Save daily close`; note total runs and the consecutive accepted count.
+
+### Day 3 — Daily close and exception
+
+Proof: `Run a reviewed close and one controlled exception without external posting.`
+
+- [ ] Normal order runs continue; same per-run records as day 2.
+- [ ] One controlled exception is rehearsed (for example a payment mismatch caught at `Reconcile payment`) with no external posting of any kind.
+- [ ] A reviewed daily close: the operator runs `Save daily close` and the owner checks the day's numbers against the paper day book. Record close minutes for comparison with `close_minutes_per_day`.
+
+### Day 4 — Return and recovery
+
+Proof: `Rehearse one return exception plus reload and safe retry evidence.`
+
+- [ ] One return exception rehearsed end to end — the process the work order `shop-managed-order-close-pilot` names.
+- [ ] Reload evidence: close and reopen the browser mid-day and confirm the record survived; retry a step safely and confirm no duplicate was created. This is the `reload_and_retry_result` measurement.
+- [ ] Stock checked against reality on `/shop/?tab=inventory` after the return.
+
+### Day 5 — Replay, export, and acceptance
+
+Proof: `Verify retained evidence, compare measurements, and record the operator decision.`
+
+- [ ] All per-run records and daily closes gathered and counted: total runs, accepted runs, best consecutive accepted streak.
+- [ ] Comparison against the baseline, per the generator: `Compare median order time, exception rate, close time, operator corrections, and reload/retry evidence with the recorded baseline.`
+- [ ] The operator's decision recorded in their own words. No improvement claim is made before this review — the handoff contract records `improvementClaimAllowedBeforeReview` as false.
+- [ ] Owner keeps a backup of their workspace (`Download workspace backup`).
+
+## The five required measurements
+
+The handoff contract requires exactly these, and the daily records above produce all of them:
+
+| Measurement | Produced by |
+| --- | --- |
+| `median_minutes_per_order` | Per-run minutes, days 2 through 5 |
+| `weekly_exception_rate` | Exception runs counted across the week against total runs |
+| `close_minutes_per_day` | Timed daily close, days 2 through 5 |
+| `operator_corrections` | Corrections column of the per-run records |
+| `reload_and_retry_result` | Day 4 reload and safe-retry rehearsal |
+
+## Boundary for all five days
+
+Nothing on the readiness contract's does-not-authorize list ever happens during the pilot: `customer_message`, `payment`, `stock_move`, `production_database_change`, `production_deploy`, `managed_product_activation`, `hosted_scheduler_activation`. The app's own gate states the same boundary: `Browser-local sample only. Confirming creates a sample order and reserves sample stock in this browser. Payment and fulfilment stay pending for review in Orders. No payment is captured, no customer is contacted, no server or company account is written, and no real stock is moved.`
+
+A hosted rehearsal is not part of these five days. If the founder separately approves the decision `bounded-managed-pilot-rehearsal`, that rehearsal runs on an isolated `preview_branch`, is bounded by `maximumLifetimeHours` of 24, starts with no production data, and is deleted after evidence (`delete_preview_branch_after_evidence`).
+
+## Mapping to the readiness contract
+
+| Contract requirement | Satisfied by |
+| --- | --- |
+| `namedBusinessRequired` | Baseline form section 1, business name |
+| `namedOperatorRequired` | Baseline form section 1 plus the `namedOperatorAuthorized` gate |
+| `measuredBaselineRequired` | Baseline form sections 3 through 5 |
+| `acceptanceEvidenceRequired` | This checklist's daily records, the five required measurements, and the day 5 operator decision |
+| `name_shop_pilot_operator` (decision input) | The founder carries the completed baseline form into the decision |
+| `approve_preview_branch_target` (decision input) | Founder-only; nothing in this kit performs it |

--- a/docs/pilot-kit/baseline-measurement.md
+++ b/docs/pilot-kit/baseline-measurement.md
@@ -1,0 +1,84 @@
+# Shop pilot baseline measurement form
+
+Fill this in WITH the shop owner, in person, before day 1 of the five-day pilot. Print it or copy it into a private note; it stays in the founder's private workspace.
+
+Why it exists: the readiness ledger (contract `supermega.managed-pilot-readiness.v3`) requires a named business (`namedBusinessRequired`), a named operator (`namedOperatorRequired`), and a measured baseline (`measuredBaselineRequired`) before the founder decision `bounded-managed-pilot-rehearsal` can be prepared. The four derived numbers in section 4 are exactly the baseline fields the pilot handoff generator (tools/create_shop_pilot_handoff.mjs, npm script `client:pilot:handoff`) refuses to run without.
+
+## Rules of measurement
+
+- Measure the owner's current manual process as it runs today — notebook, phone, paper, memory. Do not measure the SuperMega demo; the demo is not a baseline.
+- Observe at least three real runs end to end with a timer. The pilot measurement reference accepts a baseline only when it is owner-observed across three or more runs. Numbers recalled from memory go in as estimates and are marked as estimates.
+- The observer watches and times; the observer does not help. If a run is interrupted, discard it and observe another.
+- Privacy: this sheet names a real business and a real person. Keep it private. Per `docs/supermega-shop-sales-agent.md`, reporting outside the private workspace carries stage and hashes only — never the contact name, email, or company.
+
+## 1. Business and operator (who)
+
+| Field | Value |
+| --- | --- |
+| Business name — exactly as it will be typed into the `Business name` field during setup | |
+| Named operator — the one person who handles orders daily and will review every pilot run | |
+| Operator role, in the owner's words | |
+| Founder recording this baseline | |
+| Date and place of observation | |
+
+## 2. The measured process (what)
+
+The Shop work order `shop-managed-order-close-pilot` pins the process: one order taken from creation to close, plus the return exception. Capture it in the owner's words.
+
+| Field | Value |
+| --- | --- |
+| The process in one sentence | |
+| Where an order starts (walk-in, phone call, social message, ...) | |
+| Where an order ends (payment in hand, goods handed over, book updated) | |
+| How a return or wrong order is handled today | |
+| Where the record lives today (notebook, phone, nowhere) | |
+
+## 3. Observed runs (minimum three)
+
+One row per observed run of the real process, timed start to end.
+
+| Run | Date and time | Started when / ended when | Human minutes | Error in this run? | Cost of the error |
+| --- | --- | --- | --- | --- | --- |
+| 1 | | | | | |
+| 2 | | | | | |
+| 3 | | | | | |
+| more... | | | | | |
+
+## 4. Derived baseline — the four numbers the handoff requires
+
+| Field | Contract name | How to derive it | Value |
+| --- | --- | --- | --- |
+| Weekly orders | `weekly_orders` | Owner's count, confirmed against last week's records, not memory alone | |
+| Median minutes per order | `median_minutes_per_order` | Middle value of the observed run timings in section 3 | |
+| Weekly exception count | `weekly_exception_count` | Returns, wrong orders, and payment mismatches in a normal week | |
+| Daily close minutes | `close_minutes_per_day` | Minutes the owner spends closing the day (counting cash, updating the book) | |
+
+## 5. Errors and cost
+
+| Field | Value |
+| --- | --- |
+| Observed runs that contained an error (of the runs in section 3) | |
+| Total observed error cost across those runs (money lost, goods written off, rework) | |
+| The most expensive error the owner remembers from the last month, and its cost (marked estimate) | |
+
+## 6. Owner sign-off
+
+| Field | Value |
+| --- | --- |
+| Owner confirms these numbers describe the current process | yes / no |
+| Operator agrees to review every pilot run personally | yes / no |
+| Proposed pilot start date (day 1) | |
+| Review date — must be exactly start date plus four days; the handoff generator rejects anything else (`review_date_must_close_five_day_plan`) | |
+
+## Worked example — entirely fictional
+
+Golden Valley Trading is the fictional example business the app itself uses (setup shows `Example: Golden Valley Trading`). Every number below is invented for illustration.
+
+- Business name: Golden Valley Trading. Named operator: Ma Thiri (fictional), counter lead. Founder observed on-site on 2026-08-12, morning shift.
+- Process in one sentence: a customer orders at the counter or by phone, Ma Thiri writes it in the day book, collects payment, hands over goods, and crosses it off; returns are re-entered by hand.
+- Observed runs: run 1 took 9 minutes, run 2 took 7 minutes, run 3 took 8 minutes. Run 2 had one error — wrong change given, 5,000 kyat lost.
+- Derived baseline: weekly orders 120 (counted from last week's day book), median minutes per order 8 (middle of 7, 8, 9), weekly exception count 12, daily close minutes 45.
+- Errors and cost: 1 of 3 observed runs had an error; total observed error cost 5,000 kyat.
+- Sign-off: owner confirmed; operator agreed; start Monday 2026-08-17, review Friday 2026-08-21 (start plus four days).
+
+These fictional numbers match the handoff generator's own built-in example payload (weekly orders 120, median 8, exceptions 12, close 45), so the founder can print that example from the generator and recognize the shape, and can dry-run the whole private workspace flow with fictional data via `npm.cmd run client:pilot:workspace:self-test`.

--- a/docs/pilot-kit/pilot-agreement-outline.md
+++ b/docs/pilot-kit/pilot-agreement-outline.md
@@ -1,0 +1,45 @@
+# Shop pilot agreement — plain-language outline
+
+NOT LEGAL ADVICE. This is an outline of talking points to align on with the design partner before day 1, in plain language. It is not a contract, it creates no obligations, and anything either side wants to be binding needs its own properly reviewed document. It contains no commitments beyond what the repo's own contracts already state.
+
+## What the partner gets
+
+- The working Shop product, free, on their own device. The approved framing is `Free product. Managed intelligence.` — the free lane needs `No account or model call required`, and the pilot runs entirely in it.
+- Five founder-led days on their real workflow: orders to close plus the return exception, with the founder on-site per the [acceptance checklist](acceptance-checklist.md).
+- Their own measured numbers, before and after: baseline first, then the five pilot measurements (`median_minutes_per_order`, `weekly_exception_rate`, `close_minutes_per_day`, `operator_corrections`, `reload_and_retry_result`). The numbers belong to them.
+- A backup of their workspace at the end (`Download workspace backup`), whatever they decide.
+
+## What the partner gives
+
+- One named operator's attention: the operator personally runs and reviews every pilot run, day 2 through day 5.
+- Permission for the founder to observe at least three runs of their current manual process before day 1, with a timer, for the baseline.
+- A few review minutes per day and an honest verdict on each run — an error recorded honestly is worth more to the pilot than a polite pass.
+- An honest day-5 decision, in their own words.
+
+## Their data stays theirs
+
+- The pilot runs browser-local on the shop's own device. Setup states it directly: `Stays on this device. Nothing is sent or published.` SuperMega's servers receive no customer records, no sales, and no stock data during the pilot.
+- The shop's identity stays private on SuperMega's side. The sales workflow's reporting boundary applies: notes leaving the private workspace carry stage and hashes, never the contact's name, email, or company (`docs/supermega-shop-sales-agent.md`).
+- If the founder later runs the approved hosted rehearsal, it is bounded and disposable: an isolated `preview_branch`, never production, starting with no production data, `maximumLifetimeHours` of 24, and deleted after the evidence is captured (`delete_preview_branch_after_evidence`). That rehearsal needs its own separate founder decision (`bounded-managed-pilot-rehearsal`) and is not part of the five pilot days.
+
+## Money
+
+- No payment during the pilot. The readiness contract's does-not-authorize list includes `payment`, and the handoff's commercial draft records `paymentAccepted` as false with tax and payment terms unapproved. A fixed pilot fee exists only as draft text for a later, separate conversation.
+- No price is quoted during the pilot; the public site carries no pricing.
+
+## What the pilot never does
+
+Read the app's own gate line together — it is the whole boundary in one sentence: `Browser-local sample only. Confirming creates a sample order and reserves sample stock in this browser. Payment and fulfilment stay pending for review in Orders. No payment is captured, no customer is contacted, no server or company account is written, and no real stock is moved.`
+
+In the handoff generator's words: `This pilot does not include automatic customer messages, provider payment, accounting posting, deployment, or production activation.` And on results: `no improvement is guaranteed before the final review`.
+
+Managed activation afterward is gated, not implied: `Managed activation proceeds only after identity, tenant isolation, recovery, and write controls pass for the company.`
+
+## Stopping
+
+- Either side can stop the pilot at any time, any day, for any reason. Nothing needs to be justified.
+- If the pilot stops, the shop keeps its device, its data, and its backup; SuperMega keeps only the private evidence notes, under the same privacy boundary.
+
+## What this outline deliberately does not contain
+
+No uptime or availability promise, no delivery dates, no roadmap commitments, no exclusivity, no discount or future-price promise, no data-processing terms, no liability terms. If the pilot goes well and both sides want more, those belong in a real agreement drafted with proper advice.

--- a/tools/test_demo_playbooks.mjs
+++ b/tools/test_demo_playbooks.mjs
@@ -1,10 +1,14 @@
-// Drift guard for docs/demo-playbooks/. Every backticked token in a playbook is
-// a verbatim contract: it must exist in the app source (showroom/src), the
-// public-site generator (tools/create_public_vercel_output.mjs), the site
-// manifest, or package.json — or be derivable from a pattern that is itself
-// pinned here (product-parameterised links the generator or app builds at
-// runtime). If a route, query parameter, button label, or copy string drifts,
-// this test fails and the playbook must be re-grounded.
+// Drift guard for docs/demo-playbooks/ and docs/pilot-kit/. Every backticked
+// token in a playbook or pilot-kit document is a verbatim contract: it must
+// exist in the app source (showroom/src), the public-site generator
+// (tools/create_public_vercel_output.mjs), the site manifest, or package.json —
+// or be derivable from a pattern that is itself pinned here (product-
+// parameterised links the generator or app builds at runtime). Pilot-kit
+// documents additionally ground against the managed-pilot readiness kernel and
+// ledger, the portfolio work order, the sales-agent guide, and the pilot
+// handoff generator. If a route, query parameter, button label, copy string,
+// or contract field drifts, this test fails and the document must be
+// re-grounded.
 import assert from 'node:assert/strict'
 import { readdirSync, readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
@@ -112,4 +116,64 @@ for (const name of ['shop.md', 'plant.md', 'website.md', 'ecommerce.md']) {
   check(readme.includes(name), `readme_indexes:${name}`)
 }
 
-console.log(JSON.stringify({ ok: true, contract: 'supermega_demo_playbooks', playbooks: files.length, checks }))
+// docs/pilot-kit/: the Shop design-partner pilot kit. Same token discipline,
+// with an extended corpus: the readiness kernel and ledger, the portfolio work
+// order, the sales-agent guide, and the pilot handoff generator. Reading each
+// source also proves the cited file path exists, so those paths become tokens.
+const kitSourcePaths = [
+  'kernel/managed-pilot-readiness.mjs',
+  'hq/readiness/managed-pilot-readiness.json',
+  'hq/portfolio.json',
+  'docs/supermega-shop-sales-agent.md',
+  'tools/create_shop_pilot_handoff.mjs',
+]
+const kitCorpus = kitSourcePaths.map(read).join('\n')
+const kitDerived = new Set(kitSourcePaths)
+const kitTokenOk = (token) => kitDerived.has(token) || kitCorpus.includes(token) || tokenOk(token)
+
+// Pins for the contract facts the kit states in prose: the decision id, its
+// two inputs, the 24-hour preview-branch bound, the five-day duration, the
+// review-date closure rule, and the no-payment commercial draft.
+const readinessKernel = read('kernel/managed-pilot-readiness.mjs')
+check(readinessKernel.includes("const NEXT_ACTION_DECISION_ID = 'bounded-managed-pilot-rehearsal'"), 'kit_kernel_decision_id_pin')
+check(readinessKernel.includes("const NEXT_ACTION_REQUIREMENTS = ['approve_preview_branch_target', 'name_shop_pilot_operator']"), 'kit_kernel_decision_inputs_pin')
+check(readinessKernel.includes('maximumLifetimeHours: 24'), 'kit_kernel_lifetime_pin')
+check(readinessKernel.includes("environment: 'preview_branch'"), 'kit_kernel_environment_pin')
+const handoffGenerator = read('tools/create_shop_pilot_handoff.mjs')
+check(handoffGenerator.includes('durationDays: 5'), 'kit_handoff_duration_pin')
+check(handoffGenerator.includes("throw new Error('review_date_must_close_five_day_plan')"), 'kit_handoff_review_date_pin')
+check(handoffGenerator.includes('paymentAccepted: false'), 'kit_handoff_no_payment_pin')
+
+const kitDir = 'docs/pilot-kit'
+const kitFiles = readdirSync(resolve(root, kitDir)).sort()
+check(kitFiles.join(',') === 'README.md,acceptance-checklist.md,baseline-measurement.md,pilot-agreement-outline.md', `pilot_kit_file_set:${kitFiles.join(',')}`)
+
+for (const file of kitFiles) {
+  const text = read(`${kitDir}/${file}`)
+  const tokens = [...text.matchAll(/`([^`\n]+)`/g)].map((match) => match[1])
+  check(tokens.length >= 5, `pilot-kit/${file}:token_floor:${tokens.length}`)
+  for (const token of tokens) check(kitTokenOk(token), `pilot-kit/${file}:unknown_token:${token}`)
+}
+
+const kitReadme = read(`${kitDir}/README.md`)
+check(kitReadme.includes('bounded-managed-pilot-rehearsal'), 'pilot_kit_readme_names_decision_id')
+for (const name of ['baseline-measurement.md', 'acceptance-checklist.md', 'pilot-agreement-outline.md']) {
+  check(kitReadme.includes(name), `pilot_kit_readme_indexes:${name}`)
+}
+
+const kitBaseline = read(`${kitDir}/baseline-measurement.md`)
+for (const fieldName of ['weekly_orders', 'median_minutes_per_order', 'weekly_exception_count', 'close_minutes_per_day']) {
+  check(kitBaseline.includes(`\`${fieldName}\``), `pilot_kit_baseline_field:${fieldName}`)
+}
+
+const kitAcceptance = read(`${kitDir}/acceptance-checklist.md`)
+for (const measurement of ['median_minutes_per_order', 'weekly_exception_rate', 'close_minutes_per_day', 'operator_corrections', 'reload_and_retry_result']) {
+  check(kitAcceptance.includes(`\`${measurement}\``), `pilot_kit_acceptance_measurement:${measurement}`)
+}
+for (const gateName of ['isolatedNonProductionTenantApproved', 'namedOperatorAuthorized', 'pilotDataHandlingApproved', 'ownerReviewedCommercialDraft']) {
+  check(kitAcceptance.includes(`\`${gateName}\``), `pilot_kit_acceptance_gate:${gateName}`)
+}
+
+check(read(`${kitDir}/pilot-agreement-outline.md`).includes('NOT LEGAL ADVICE'), 'pilot_kit_agreement_disclaimer')
+
+console.log(JSON.stringify({ ok: true, contract: 'supermega_demo_playbooks', playbooks: files.length, pilotKitDocs: kitFiles.length, checks }))


### PR DESCRIPTION
docs/pilot-kit/: the baseline-measurement form (field-matched to the readiness v3 operator requirements), the 5-day acceptance checklist (quoting the canonical machinery in create_shop_pilot_handoff.mjs verbatim — 4 baseline fields, 5 measurements, review date = start+4d, paymentAccepted:false), and a NOT-LEGAL-ADVICE pilot agreement outline with no invented commitments. Worked example reuses the repo's own fictional Golden Valley Trading data.

The demo-playbooks drift guard extends over the kit (531 checks total, negative-tested) with zero package.json changes. Both deploy guards green; hq:verify green. Adversarially verified field-by-field against the readiness contract (pass).

With this merged, the moment a design partner is named the pilot can start same-day.

🤖 Generated with [Claude Code](https://claude.com/claude-code)