### PR TITLE
Managed-billing rail: manual-first design and invoice tooling

### DIFF
--- a/docs/billing/managed-billing-design.md
+++ b/docs/billing/managed-billing-design.md
@@ -1,0 +1,200 @@
+# Managed-Tier Billing Rail — Design (audit gate 9)
+
+Status: design + minimal manual tooling. No payment processor integration. No price is set
+anywhere in this design or its tooling; pricing is a founder decision the design parameterizes.
+
+This document PREPARES founder actions. Nothing here requires founder credentials, touches
+Supabase, or performs a network mutation. The managed-pilot readiness ledger keeps `payment`
+in `founderDecision.doesNotAuthorize` and `controls.forbiddenUntilReady`
+(`kernel/managed-pilot-readiness.mjs`), and this design does not change that: every billing
+event is a founder-manual, owner-approved action until a separate founder decision.
+
+## 1. Grounding (what the repo already establishes)
+
+- **Payment adapters are deliberately deferred and manual.** The ecommerce lifecycle accepts
+  only manual adapters — `_PAYMENT_ADAPTERS = {"pay_on_pickup", "cash_on_delivery",
+  "kbzpay_manual"}` (`supermega_runtime/ecommerce_buying_lifecycle.py`), mirrored in
+  `showroom/src/core/commerce-workspace.ts` (`CommercePaymentAdapter`) and
+  `showroom/src/products/ecommerce/ecommerce-buying-lifecycle.ts`. The portfolio gate for
+  ecommerce reads: "add tax, shipping, and payment adapters only behind accountable approval
+  and duplicate-safe recovery" (`hq/portfolio.json`, pinned by `tools/verify_hq_contract.mjs`).
+- **Customer payment reality as reflected in the repo** is manual rails: `KBZPay`, `WavePay`,
+  `Cash`, `Cash on delivery`, `Card` (`showroom/src/core/channel-order-intake.ts`,
+  `supermega_runtime/order_intake.py`), plus `manual_qr` and `manual_bank_transfer` on the
+  website order form (`showroom/src/products/WebsiteCommerceIntake.tsx`,
+  `showroom/src/products/product-handoff.ts`). This design uses only the generic categories
+  those imply: **mobile money, bank transfer, cash** — with concrete channel labels supplied
+  by founder config, never hardcoded.
+- **The public offer is free-vs-managed with no prices.** "Free product. Managed
+  intelligence." — and "No prices — the public site carries none" is the approved framing
+  (`tools/create_public_vercel_output.mjs`, `tools/verify_public_vercel_output.mjs`,
+  `docs/demo-playbooks/*.md`; `hq/NOW.md`: four browser-local products stay free; managed adds
+  approved company intelligence after identity, tenant, recovery, and write controls pass).
+- **The kernel already has the storage and approval model billing needs.** Control records are
+  versioned envelopes — `record_key` (typed prefix), `tenant_id`, `status`, `plan_hash`
+  (64-hex sha256), `payload`, `payload_hash` (sha256 of stable JSON), `revision` — with
+  compare-and-set transitions via `transitionControlRecord(recordKey, expected, payload)`
+  (`kernel/store.mjs`). Owner approval proofs already have a canonical shape:
+  `{ actionId, capturedAt, actor, reason, evidenceReference }`
+  (`supermega_runtime/ecommerce_buying_lifecycle.py` `_payment_policy(...).proof`;
+  `showroom/src/core/commerce-workspace.ts` demo payment-policy proof).
+- **Managed activation is fail-closed and owner-named** (`supermega_runtime/managed_activation.py`):
+  named workspace, named owner, exact owner review. Billing inherits that posture.
+
+## 2. Design principles
+
+1. **Manual-first.** The founder issues every invoice; the customer pays out-of-band
+   (bank transfer / mobile money / cash); the founder verifies receipt and marks paid.
+   The software's job is records, determinism, and approval evidence — not money movement.
+2. **Parameterized, never defaulted.** Amounts, currency, currency exponent, payment-channel
+   labels, and tax lines come only from founder-supplied config. The tooling has no default
+   price, no default currency, and refuses to fabricate any monetary value.
+3. **Every charge event is an owner-approved control record.** An invoice and each of its
+   status transitions map onto the kernel control-record model with an explicit approval proof.
+4. **Digest-bound.** The invoice core is canonicalized (stable key order) and bound by sha256;
+   the digest is the `plan_hash` for storage and the cross-reference on the printable copy.
+5. **Fail-closed validation, duplicate-safe by construction.** Strict schemas, bounded text,
+   `wx` file writes (never overwrite), idempotent verification.
+
+## 3. Manual-first billing lifecycle
+
+```
+founder writes invoice config (amounts/currency are founder decisions)
+        │
+        ▼
+tools/prepare_managed_invoice.mjs  → deterministic invoice packet (JSON + printable text), status: draft
+        │  (local, zero network, wx-writes)
+        ▼
+founder reviews packet → approves → records issued transition, sends invoice to customer  [founder action]
+        │
+        ▼
+customer pays by bank transfer / mobile money / cash  [entirely outside this system]
+        │
+        ▼
+founder verifies funds against the named channel reference → records paid transition
+   (or records void with a reason at draft/issued)         [founder action]
+```
+
+The tool prepares; the founder acts. No step in this repo sends an invoice, requests money,
+or confirms payment on its own.
+
+## 4. Data model — contract `supermega.managed-billing.v1` (proposal)
+
+### 4.1 Invoice record (immutable core)
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `contract` | `"supermega.managed-billing.v1"` | Version pin. |
+| `invoiceId` | string, `^INV-[A-Za-z0-9-]{4,40}$` | Founder-assigned, unique per workspace. |
+| `workspace` | `{ id, name }` | `id` must satisfy the kernel tenant id rule `^[A-Za-z0-9][A-Za-z0-9._:-]{0,79}$` (`kernel/store.mjs` `CONTROL_ID_RE`). |
+| `customer` | `{ name, contact? }` | Bounded text; contact optional, never required for the record to be valid. |
+| `period` | `{ label: "YYYY-MM", start: "YYYY-MM-DD", end: "YYYY-MM-DD" }` | The service period billed. `start <= end`, both inside `label`'s month unless the founder deliberately bills a custom span (then `label` is free-form bounded text plus explicit dates). |
+| `lineItems[]` | `{ description, amountMinor }` | 1–20 items; integer minor units; each ≥ 0; at least one > 0. |
+| `amount` | `{ currency, exponent, totalMinor }` | `currency` = 3-letter uppercase code from config; `exponent` = integer 0–4 from config (positions of the minor-unit point); `totalMinor` must equal the line-item sum. **No default currency, exponent, or amount exists anywhere.** |
+| `tax` | `{ decided: false }` or `{ decided: true, description, amountMinor }` | Tax treatment is undecided by default and stays a founder decision; when decided it is one explicit line, included in `totalMinor`. |
+| `paymentChannels[]` | `{ category, label, reference }` | 1–5 entries. `category` ∈ `bank_transfer \| mobile_money \| cash` (the generic categories the repo's manual rails imply). `label`/`reference` are founder-supplied strings (e.g. an account name/number or wallet handle) — never emitted by default. |
+| `issuedToPayBy` | `{ issuedAt: ISO instant, dueDate: "YYYY-MM-DD" }` | Both from config; the tool never reads the wall clock for record content, so packets are deterministic. |
+| `issuer` | `{ name }` | Bounded text. |
+| `notes?` | string | Optional bounded text. |
+
+### 4.2 Digest binding
+
+`invoiceDigest = "sha256:" + hex(sha256(stableJson(invoiceCore)))` where `stableJson` is
+recursive sorted-key serialization exactly as in `kernel/store.mjs` / `readinessDigest`
+(`kernel/managed-pilot-readiness.mjs`). The packet also records `configDigest` — sha256 of the
+exact founder config bytes (CRLF normalized to LF) — so any packet can be re-derived and
+byte-compared from its inputs. The printable text copy carries the digest so a paper/PDF copy
+cross-references the record.
+
+### 4.3 Status lifecycle
+
+`draft → issued → paid` with `void` reachable from `draft` and `issued`. `paid` and `void`
+are terminal. No other transition is legal.
+
+| Transition | Meaning | Required proof evidence |
+| --- | --- | --- |
+| `draft → issued` | Founder approved the packet and sent it to the customer. | How it was delivered (evidenceReference: message/thread/handover reference). |
+| `issued → paid` | Founder verified funds arrived on a named channel. | `paymentReference` — the transfer/mobile-money/cash receipt reference, plus `paidAt` instant and channel category. |
+| `draft → void`, `issued → void` | Founder cancels (error, renegotiation, non-payment). | Reason text. |
+
+Every transition carries an owner-approval proof in the repo's canonical shape:
+`{ actionId, capturedAt, actor, reason, evidenceReference }` — the same fields the ecommerce
+payment policy requires (`supermega_runtime/ecommerce_buying_lifecycle.py`). The actor is the
+founder (or a founder-named delegate); there is no automated transition.
+
+### 4.4 Control-record storage (per the kernel model)
+
+When billing is wired into the kernel store, each invoice lives as one control record:
+
+- `record_key`: `managed-billing-invoice:<workspace.id>:<invoiceId>` — requires adding
+  `['managed-billing-invoice:', 'managed_billing_invoice']` to `CONTROL_RECORD_PREFIXES` in
+  `kernel/store.mjs` so billing records are typed control-plane records and can never be
+  read or written through the response-cache APIs (which reject control-plane keys).
+- `tenant_id`: `workspace.id`; `status`: the lifecycle status; `plan_hash`: the invoice
+  digest hex (satisfies `CONTROL_HASH_RE`); `payload`: the invoice core + current status +
+  the append-only `transitions[]` list (each with its proof); `payload_hash`/`revision` as the
+  envelope computes today.
+- Transitions use `transitionControlRecord(recordKey, expectedStatus, nextPayload)` — the
+  existing compare-and-set — so a double "mark paid" or a stale issue attempt fails closed
+  (duplicate-safe recovery, the same property the ecommerce gate demands of future adapters).
+
+That storage wiring is intentionally **not** part of this change: it is a kernel change that
+should ride with the managed-persistence gates. Until then, the invoice packet JSON produced
+by the CLI **is** the record, kept in founder-controlled storage, and its
+`proposedControlRecord` block spells out exactly the envelope above so the later wiring is a
+transcription, not a design step.
+
+## 5. Upgrade path to automated adapters (later, founder-gated)
+
+The manual rail is the v1 adapter. A future `billing adapter` interface slots in beneath the
+same lifecycle without changing the record model:
+
+1. **Adapter contract**: an adapter may only (a) deliver an `issued` invoice to a customer
+   channel and (b) *propose* an `issued → paid` transition with machine-collected evidence
+   (e.g. a provider webhook reference). The founder approval proof remains mandatory on every
+   transition until a separate founder decision explicitly delegates it per-workspace.
+2. **Same records, same digests**: adapters emit the identical control-record transitions;
+   automation changes who *collects* evidence, never the record shape. This mirrors how the
+   ecommerce product treats adapters — manual now, "tax, shipping, and payment adapters only
+   behind accountable approval and duplicate-safe recovery" later (`hq/portfolio.json`).
+3. **Sequencing**: no adapter work starts before the managed-pilot readiness gates pass
+   (`hq/readiness/managed-pilot-readiness.json` — all seven hosted gates are currently
+   blocked) and the founder separately approves a billing adapter decision. `payment` stays in
+   the readiness forbidden-actions list until that decision.
+
+## 6. Explicitly NOT decided here
+
+- **Price.** No amount for the managed tier exists in this repo, and this design does not
+  create one. The config schema forces the founder to supply every monetary value per invoice.
+- **Currency mix.** Whether managed billing is MMK-only, USD-only, or mixed is open;
+  the model parameterizes `currency` + `exponent` per invoice so any mix works.
+- **Tax.** Whether/what tax applies is undecided; the record carries `tax.decided: false`
+  until the founder decides, and the tool refuses implicit tax lines.
+- **Payment processor.** No processor, gateway, or API integration is chosen or implied.
+- **Billing cadence and dunning.** Period granularity is parameterized (`period`); reminder
+  or escalation flows are out of scope for the manual rail.
+
+## 7. Minimal manual tooling shipped with this design
+
+`tools/prepare_managed_invoice.mjs` — local CLI, zero network, deterministic, `wx`-writes:
+
+- `node tools/prepare_managed_invoice.mjs --config <config.json> --out <dir>` reads a
+  founder-supplied config (schema `supermega.managed-billing.invoice-config.v1`, section 4
+  fields), validates fail-closed, and writes `<invoiceId>.json` (packet, status `draft`,
+  digest-bound, with the `proposedControlRecord` envelope) and `<invoiceId>.txt` (printable
+  invoice carrying the digest). Existing files are never overwritten (`wx`).
+- `node tools/prepare_managed_invoice.mjs --verify <packet.json>` recomputes the digest from
+  the packet's own invoice core and fails on any mismatch or shape violation.
+- `node tools/prepare_managed_invoice.mjs --self-test` runs the built-in test (validation
+  rejections including missing/zero/defaulted amounts, deterministic double-build digest
+  equality, wx overwrite refusal, verify round-trip) in a temp directory.
+
+npm scripts (standalone; no existing verify chain was modified — the guard-pinned chains in
+`package.json` are asserted by substring in `tools/verify_hq_contract.mjs` and stay intact):
+
+- `billing:invoice:prepare` → `node tools/prepare_managed_invoice.mjs`
+- `billing:invoice:self-test` → `node tools/prepare_managed_invoice.mjs --self-test`
+
+Because `package.json` is a digest-bound readiness source
+(`tools/manage_managed_pilot_readiness.mjs`), this change regenerates
+`hq/readiness/managed-pilot-readiness.json` and re-proves `npm run hq:verify`.

--- a/hq/readiness/managed-pilot-readiness.json
+++ b/hq/readiness/managed-pilot-readiness.json
@@ -1,7 +1,7 @@
 {
   "contract": "supermega.managed-pilot-readiness.v3",
   "asOf": "2026-08-04T11:04:24.490Z",
-  "sourceDigest": "sha256:94d601d824239432fa8b98a799e88207cf82f040afd893015fb9b3db16c5b568",
+  "sourceDigest": "sha256:3220291dc2a02480dfce69cd9883225b65ca4e6ca0f02d334748c6339b5f4462",
   "overall": {
     "status": "blocked",
     "localDatabaseProofReady": true,
@@ -213,7 +213,7 @@
     },
     {
       "path": "package.json",
-      "digest": "sha256:4f96e8c21dcb212f2469b5de7dd5a7e7ed6e6a380cdda81ad18591d9b5310c93"
+      "digest": "sha256:230fe76bb55a448a1bd440823761fb52c29bf1decaa60a5858a209a22788a32d"
     },
     {
       "path": "kernel/managed-pilot-readiness.mjs",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,8 @@
     "readiness:managed:self-test": "node --test kernel/managed-pilot-readiness.test.mjs",
     "readiness:supabase-security:verify": "node tools/verify_supabase_security_advisor_audit.mjs",
     "readiness:supabase-security:self-test": "node tools/verify_supabase_security_advisor_audit.mjs --self-test",
+    "billing:invoice:prepare": "node tools/prepare_managed_invoice.mjs",
+    "billing:invoice:self-test": "node tools/prepare_managed_invoice.mjs --self-test",
     "database:migrations:verify": "node tools/verify_private_trial_migrations.mjs",
     "smoke:local": "bash tools/run_local_smoke.sh",
     "smoke:public": "npm run public:prebuilt",

--- a/tools/prepare_managed_invoice.mjs
+++ b/tools/prepare_managed_invoice.mjs
@@ -1,0 +1,458 @@
+// Managed-tier billing rail: deterministic manual invoice packet preparation.
+//
+// Design: docs/billing/managed-billing-design.md (audit gate 9).
+// This tool PREPARES a founder action. It performs zero network activity, writes
+// only with `wx` (never overwrites), and takes every monetary value exclusively
+// from the founder-supplied config file. There are no default amounts, prices,
+// currencies, or exponents anywhere in this file. Marking an invoice issued,
+// paid, or void is a founder action outside this tool.
+
+import { createHash } from 'node:crypto'
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { basename, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+export const MANAGED_BILLING_CONTRACT = 'supermega.managed-billing.v1'
+export const INVOICE_CONFIG_CONTRACT = 'supermega.managed-billing.invoice-config.v1'
+export const INVOICE_PACKET_CONTRACT = 'supermega.managed-billing.invoice-packet.v1'
+
+const INVOICE_ID_RE = /^INV-[A-Za-z0-9-]{4,40}$/
+// Kernel tenant id rule (kernel/store.mjs CONTROL_ID_RE).
+const TENANT_ID_RE = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,79}$/
+const CURRENCY_RE = /^[A-Z]{3}$/
+const PAYMENT_CATEGORIES = Object.freeze(['bank_transfer', 'mobile_money', 'cash'])
+const STATUS_LIFECYCLE = Object.freeze({
+  initial: 'draft',
+  terminal: ['paid', 'void'],
+  transitions: ['draft->issued', 'draft->void', 'issued->paid', 'issued->void'],
+})
+const MAX_LINE_ITEMS = 20
+const MAX_CHANNELS = 5
+
+function fail(code) {
+  throw new Error(code)
+}
+
+function isRecord(value) {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
+}
+
+function exactKeys(value, field, required, optional = []) {
+  if (!isRecord(value)) fail(`${field}_invalid`)
+  const keys = Object.keys(value)
+  for (const key of required) if (!(key in value)) fail(`${field}_${key}_missing`)
+  for (const key of keys) if (!required.includes(key) && !optional.includes(key)) fail(`${field}_unknown_key_${key}`)
+  return value
+}
+
+function boundedText(value, field, max = 180) {
+  if (typeof value !== 'string' || !value.trim()) fail(`${field}_required`)
+  const normalized = value.trim().replace(/\s+/g, ' ')
+  if (normalized.length > max || /[\u0000-\u001f\u007f]/.test(normalized)) fail(`${field}_invalid`)
+  return normalized
+}
+
+function minorAmount(value, field) {
+  // Monetary values must be explicit non-negative integers in minor units.
+  // A string, float, or missing value fails closed; nothing is defaulted.
+  if (typeof value !== 'number' || !Number.isSafeInteger(value) || value < 0) fail(`${field}_invalid`)
+  return value
+}
+
+function dateOnly(value, field) {
+  if (typeof value !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(value)) fail(`${field}_invalid`)
+  const instant = Date.parse(`${value}T00:00:00.000Z`)
+  if (!Number.isFinite(instant) || new Date(instant).toISOString().slice(0, 10) !== value) fail(`${field}_invalid`)
+  return { value, instant }
+}
+
+function isoInstant(value, field) {
+  if (typeof value !== 'string') fail(`${field}_invalid`)
+  const instant = Date.parse(value)
+  if (!Number.isFinite(instant) || new Date(instant).toISOString() !== value) fail(`${field}_invalid`)
+  return value
+}
+
+function stableJson(value) {
+  if (value === null || typeof value !== 'object') return JSON.stringify(value ?? null)
+  if (Array.isArray(value)) return `[${value.map(stableJson).join(',')}]`
+  return `{${Object.keys(value).sort().map((key) => `${JSON.stringify(key)}:${stableJson(value[key])}`).join(',')}}`
+}
+
+function sha256Hex(text) {
+  return createHash('sha256').update(text).digest('hex')
+}
+
+export function invoiceDigest(core) {
+  return `sha256:${sha256Hex(stableJson(core))}`
+}
+
+export function formatMinorAmount(minor, exponent, currency) {
+  const digits = String(minor)
+  if (exponent === 0) return `${digits} ${currency}`
+  const padded = digits.padStart(exponent + 1, '0')
+  return `${padded.slice(0, -exponent)}.${padded.slice(-exponent)} ${currency}`
+}
+
+export function validateInvoiceConfig(config) {
+  exactKeys(config, 'config', [
+    'contract', 'invoiceId', 'workspace', 'customer', 'period', 'amount',
+    'lineItems', 'tax', 'paymentChannels', 'issuedAt', 'dueDate', 'issuer',
+  ], ['notes'])
+  if (config.contract !== INVOICE_CONFIG_CONTRACT) fail('config_contract_invalid')
+  const invoiceId = boundedText(config.invoiceId, 'config_invoice_id', 44)
+  if (!INVOICE_ID_RE.test(invoiceId)) fail('config_invoice_id_invalid')
+
+  exactKeys(config.workspace, 'config_workspace', ['id', 'name'])
+  const workspaceId = boundedText(config.workspace.id, 'config_workspace_id', 80)
+  if (!TENANT_ID_RE.test(workspaceId)) fail('config_workspace_id_invalid')
+  const workspace = { id: workspaceId, name: boundedText(config.workspace.name, 'config_workspace_name') }
+
+  exactKeys(config.customer, 'config_customer', ['name'], ['contact'])
+  const customer = { name: boundedText(config.customer.name, 'config_customer_name') }
+  if (config.customer.contact !== undefined) customer.contact = boundedText(config.customer.contact, 'config_customer_contact')
+
+  exactKeys(config.period, 'config_period', ['label', 'start', 'end'])
+  const periodStart = dateOnly(config.period.start, 'config_period_start')
+  const periodEnd = dateOnly(config.period.end, 'config_period_end')
+  if (periodStart.instant > periodEnd.instant) fail('config_period_order_invalid')
+  const period = { label: boundedText(config.period.label, 'config_period_label', 40), start: periodStart.value, end: periodEnd.value }
+
+  exactKeys(config.amount, 'config_amount', ['currency', 'exponent', 'totalMinor'])
+  if (typeof config.amount.currency !== 'string' || !CURRENCY_RE.test(config.amount.currency)) fail('config_currency_invalid')
+  if (!Number.isSafeInteger(config.amount.exponent) || config.amount.exponent < 0 || config.amount.exponent > 4) fail('config_exponent_invalid')
+  const totalMinor = minorAmount(config.amount.totalMinor, 'config_total_minor')
+  if (totalMinor < 1) fail('config_total_minor_invalid')
+
+  if (!Array.isArray(config.lineItems) || config.lineItems.length < 1 || config.lineItems.length > MAX_LINE_ITEMS) fail('config_line_items_invalid')
+  const lineItems = config.lineItems.map((item, index) => {
+    exactKeys(item, `config_line_item_${index}`, ['description', 'amountMinor'])
+    return {
+      description: boundedText(item.description, `config_line_item_${index}_description`),
+      amountMinor: minorAmount(item.amountMinor, `config_line_item_${index}_amount`),
+    }
+  })
+  if (!lineItems.some((item) => item.amountMinor > 0)) fail('config_line_items_all_zero')
+
+  exactKeys(config.tax, 'config_tax', ['decided'], ['description', 'amountMinor'])
+  let tax
+  if (config.tax.decided === false) {
+    if ('description' in config.tax || 'amountMinor' in config.tax) fail('config_tax_undecided_extra')
+    tax = { decided: false }
+  } else if (config.tax.decided === true) {
+    tax = {
+      decided: true,
+      description: boundedText(config.tax.description, 'config_tax_description'),
+      amountMinor: minorAmount(config.tax.amountMinor, 'config_tax_amount'),
+    }
+  } else fail('config_tax_invalid')
+
+  const lineSum = lineItems.reduce((sum, item) => sum + item.amountMinor, 0) + (tax.decided ? tax.amountMinor : 0)
+  if (lineSum !== totalMinor) fail('config_total_mismatch')
+
+  if (!Array.isArray(config.paymentChannels) || config.paymentChannels.length < 1 || config.paymentChannels.length > MAX_CHANNELS) fail('config_payment_channels_invalid')
+  const paymentChannels = config.paymentChannels.map((channel, index) => {
+    exactKeys(channel, `config_payment_channel_${index}`, ['category', 'label', 'reference'])
+    if (!PAYMENT_CATEGORIES.includes(channel.category)) fail(`config_payment_channel_${index}_category_invalid`)
+    return {
+      category: channel.category,
+      label: boundedText(channel.label, `config_payment_channel_${index}_label`),
+      reference: boundedText(channel.reference, `config_payment_channel_${index}_reference`),
+    }
+  })
+
+  const issuedAt = isoInstant(config.issuedAt, 'config_issued_at')
+  const dueDate = dateOnly(config.dueDate, 'config_due_date')
+  if (dueDate.instant < Date.parse(issuedAt.slice(0, 10) + 'T00:00:00.000Z')) fail('config_due_date_before_issue')
+
+  exactKeys(config.issuer, 'config_issuer', ['name'])
+  const core = {
+    contract: MANAGED_BILLING_CONTRACT,
+    invoiceId,
+    workspace,
+    customer,
+    period,
+    lineItems,
+    tax,
+    amount: { currency: config.amount.currency, exponent: config.amount.exponent, totalMinor },
+    paymentChannels,
+    issuedToPayBy: { issuedAt, dueDate: dueDate.value },
+    issuer: { name: boundedText(config.issuer.name, 'config_issuer_name') },
+  }
+  if (config.notes !== undefined) core.notes = boundedText(config.notes, 'config_notes', 400)
+  return core
+}
+
+export function buildInvoicePacket(configText) {
+  const normalized = String(configText).replace(/\r\n?/g, '\n')
+  let parsed
+  try { parsed = JSON.parse(normalized) } catch { fail('config_json_invalid') }
+  const invoice = validateInvoiceConfig(parsed)
+  const digest = invoiceDigest(invoice)
+  const packet = {
+    contract: INVOICE_PACKET_CONTRACT,
+    status: STATUS_LIFECYCLE.initial,
+    statusLifecycle: STATUS_LIFECYCLE,
+    invoice,
+    invoiceDigest: digest,
+    configDigest: `sha256:${sha256Hex(normalized)}`,
+    proposedControlRecord: {
+      record_key: `managed-billing-invoice:${invoice.workspace.id}:${invoice.invoiceId}`,
+      record_type: 'managed_billing_invoice',
+      tenant_id: invoice.workspace.id,
+      status: STATUS_LIFECYCLE.initial,
+      plan_hash: digest.slice('sha256:'.length),
+      note: 'Proposal only. Storage requires the managed-billing-invoice: prefix in kernel CONTROL_RECORD_PREFIXES and a separate founder decision; every status transition needs an owner-approval proof (actionId, capturedAt, actor, reason, evidenceReference).',
+    },
+    controls: {
+      networkActivity: 'none',
+      externalWritesPerformed: false,
+      founderActionRequired: true,
+      monetaryValuesFromConfigOnly: true,
+      pricingDecided: false,
+      taxDecided: invoice.tax.decided,
+    },
+  }
+  return { packet, text: printableInvoice(packet) }
+}
+
+export function printableInvoice(packet) {
+  const invoice = packet.invoice
+  const { currency, exponent } = invoice.amount
+  const money = (minor) => formatMinorAmount(minor, exponent, currency)
+  const lines = [
+    'SUPERMEGA MANAGED SERVICE INVOICE (DRAFT - founder approval required before issue)',
+    '='.repeat(78),
+    `Invoice        ${invoice.invoiceId}`,
+    `Issuer         ${invoice.issuer.name}`,
+    `Workspace      ${invoice.workspace.name} (${invoice.workspace.id})`,
+    `Customer       ${invoice.customer.name}${invoice.customer.contact ? ` — ${invoice.customer.contact}` : ''}`,
+    `Period         ${invoice.period.label} (${invoice.period.start} to ${invoice.period.end})`,
+    `Issued at      ${invoice.issuedToPayBy.issuedAt}`,
+    `Pay by         ${invoice.issuedToPayBy.dueDate}`,
+    '-'.repeat(78),
+    'Line items',
+    ...invoice.lineItems.map((item) => `  ${item.description.padEnd(56).slice(0, 56)} ${money(item.amountMinor)}`),
+    invoice.tax.decided
+      ? `  ${invoice.tax.description.padEnd(56).slice(0, 56)} ${money(invoice.tax.amountMinor)}`
+      : '  Tax: not decided (founder decision pending; no tax line applied)',
+    '-'.repeat(78),
+    `TOTAL DUE      ${money(invoice.amount.totalMinor)}`,
+    '-'.repeat(78),
+    'Pay through one founder-named channel and quote the invoice id:',
+    ...invoice.paymentChannels.map((channel) => `  [${channel.category}] ${channel.label} — ${channel.reference}`),
+    ...(invoice.notes ? ['-'.repeat(78), `Notes: ${invoice.notes}`] : []),
+    '-'.repeat(78),
+    `Record digest  ${packet.invoiceDigest}`,
+    'Payment is verified manually by the issuer before this invoice is marked paid.',
+    '',
+  ]
+  return lines.join('\n')
+}
+
+export function verifyInvoicePacket(packetText) {
+  let parsed
+  try { parsed = JSON.parse(String(packetText)) } catch { fail('packet_json_invalid') }
+  if (!isRecord(parsed) || parsed.contract !== INVOICE_PACKET_CONTRACT) fail('packet_contract_invalid')
+  if (parsed.status !== 'draft') fail('packet_status_invalid')
+  if (stableJson(parsed.statusLifecycle) !== stableJson(STATUS_LIFECYCLE)) fail('packet_lifecycle_invalid')
+  const rebuilt = validateInvoiceConfig({
+    contract: INVOICE_CONFIG_CONTRACT,
+    invoiceId: parsed.invoice?.invoiceId,
+    workspace: parsed.invoice?.workspace,
+    customer: parsed.invoice?.customer,
+    period: parsed.invoice?.period,
+    amount: parsed.invoice?.amount,
+    lineItems: parsed.invoice?.lineItems,
+    tax: parsed.invoice?.tax,
+    paymentChannels: parsed.invoice?.paymentChannels,
+    issuedAt: parsed.invoice?.issuedToPayBy?.issuedAt,
+    dueDate: parsed.invoice?.issuedToPayBy?.dueDate,
+    issuer: parsed.invoice?.issuer,
+    ...(parsed.invoice?.notes !== undefined ? { notes: parsed.invoice.notes } : {}),
+  })
+  if (stableJson(rebuilt) !== stableJson(parsed.invoice)) fail('packet_invoice_not_canonical')
+  const digest = invoiceDigest(rebuilt)
+  if (parsed.invoiceDigest !== digest) fail('packet_digest_mismatch')
+  if (!/^sha256:[0-9a-f]{64}$/.test(parsed.configDigest || '')) fail('packet_config_digest_invalid')
+  const control = parsed.proposedControlRecord
+  if (!isRecord(control)
+    || control.record_key !== `managed-billing-invoice:${rebuilt.workspace.id}:${rebuilt.invoiceId}`
+    || control.record_type !== 'managed_billing_invoice'
+    || control.tenant_id !== rebuilt.workspace.id
+    || control.status !== 'draft'
+    || control.plan_hash !== digest.slice('sha256:'.length)) fail('packet_control_record_invalid')
+  if (parsed.controls?.externalWritesPerformed !== false
+    || parsed.controls?.founderActionRequired !== true
+    || parsed.controls?.monetaryValuesFromConfigOnly !== true
+    || parsed.controls?.pricingDecided !== false) fail('packet_controls_invalid')
+  return { invoiceId: rebuilt.invoiceId, workspaceId: rebuilt.workspace.id, invoiceDigest: digest }
+}
+
+async function prepare(configPath, outDir) {
+  const configText = await readFile(resolve(configPath), 'utf8')
+  const { packet, text } = buildInvoicePacket(configText)
+  const directory = resolve(outDir)
+  await mkdir(directory, { recursive: true })
+  const jsonPath = join(directory, `${packet.invoice.invoiceId}.json`)
+  const textPath = join(directory, `${packet.invoice.invoiceId}.txt`)
+  // wx: refuse to overwrite an existing packet. Reissuing requires a new invoice id
+  // or the founder explicitly removing the stale draft.
+  await writeFile(jsonPath, `${JSON.stringify(packet, null, 2)}\n`, { encoding: 'utf8', flag: 'wx' })
+  await writeFile(textPath, text, { encoding: 'utf8', flag: 'wx' })
+  return { packet, jsonPath, textPath }
+}
+
+function expectFailure(fn, expectedCode, label) {
+  try {
+    fn()
+  } catch (error) {
+    if (String(error.message) !== expectedCode) throw new Error(`self_test_${label}_wrong_error_${error.message}`)
+    return
+  }
+  throw new Error(`self_test_${label}_did_not_fail`)
+}
+
+function sampleConfig() {
+  // Self-test fixture only. These numbers are arbitrary test values, not prices:
+  // real amounts exist only in founder-supplied configs.
+  return {
+    contract: INVOICE_CONFIG_CONTRACT,
+    invoiceId: 'INV-SELFTEST-0001',
+    workspace: { id: 'selftest-workspace', name: 'Self Test Workspace' },
+    customer: { name: 'Self Test Customer', contact: 'owner@example.test' },
+    period: { label: '2026-07', start: '2026-07-01', end: '2026-07-31' },
+    amount: { currency: 'MMK', exponent: 0, totalMinor: 125000 },
+    lineItems: [
+      { description: 'Managed workspace service period', amountMinor: 120000 },
+      { description: 'Support window', amountMinor: 5000 },
+    ],
+    tax: { decided: false },
+    paymentChannels: [
+      { category: 'bank_transfer', label: 'Test Bank', reference: 'ACCT-000-TEST' },
+      { category: 'mobile_money', label: 'Test Wallet', reference: '09-0000-TEST' },
+    ],
+    issuedAt: '2026-08-01T03:30:00.000Z',
+    dueDate: '2026-08-15',
+    issuer: { name: 'Super Mega Inc' },
+  }
+}
+
+async function selfTest() {
+  const configText = `${JSON.stringify(sampleConfig(), null, 2)}\n`
+
+  // Determinism: identical config bytes produce byte-identical packets and digests.
+  const first = buildInvoicePacket(configText)
+  const second = buildInvoicePacket(configText)
+  if (JSON.stringify(first.packet) !== JSON.stringify(second.packet)) throw new Error('self_test_packet_not_deterministic')
+  if (first.text !== second.text) throw new Error('self_test_text_not_deterministic')
+  if (!/^sha256:[0-9a-f]{64}$/.test(first.packet.invoiceDigest)) throw new Error('self_test_digest_shape_invalid')
+
+  // Verify round-trip on the serialized packet.
+  const verified = verifyInvoicePacket(`${JSON.stringify(first.packet, null, 2)}\n`)
+  if (verified.invoiceDigest !== first.packet.invoiceDigest) throw new Error('self_test_verify_mismatch')
+
+  // Tampered amount must fail digest verification.
+  const tampered = JSON.parse(JSON.stringify(first.packet))
+  tampered.invoice.amount.totalMinor = 999999
+  tampered.invoice.lineItems[0].amountMinor = 994999
+  expectFailure(() => verifyInvoicePacket(JSON.stringify(tampered)), 'packet_digest_mismatch', 'tampered_amount')
+
+  // Fail-closed validation: no defaults, no fabricated money.
+  const withoutAmount = sampleConfig(); delete withoutAmount.amount
+  expectFailure(() => validateInvoiceConfig(withoutAmount), 'config_amount_missing', 'missing_amount')
+  const noTotal = sampleConfig(); delete noTotal.amount.totalMinor
+  expectFailure(() => validateInvoiceConfig(noTotal), 'config_amount_totalMinor_missing', 'missing_total')
+  const zeroTotal = sampleConfig()
+  zeroTotal.amount.totalMinor = 0
+  zeroTotal.lineItems = [{ description: 'Zero', amountMinor: 0 }]
+  expectFailure(() => validateInvoiceConfig(zeroTotal), 'config_total_minor_invalid', 'zero_total')
+  const mismatch = sampleConfig(); mismatch.amount.totalMinor = 125001
+  expectFailure(() => validateInvoiceConfig(mismatch), 'config_total_mismatch', 'total_mismatch')
+  const floatAmount = sampleConfig(); floatAmount.lineItems[0].amountMinor = 120000.5
+  expectFailure(() => validateInvoiceConfig(floatAmount), 'config_line_item_0_amount_invalid', 'float_amount')
+  const stringAmount = sampleConfig(); stringAmount.amount.totalMinor = '125000'
+  expectFailure(() => validateInvoiceConfig(stringAmount), 'config_total_minor_invalid', 'string_amount')
+  const badCurrency = sampleConfig(); badCurrency.amount.currency = 'mmk'
+  expectFailure(() => validateInvoiceConfig(badCurrency), 'config_currency_invalid', 'bad_currency')
+  const badChannel = sampleConfig(); badChannel.paymentChannels[0].category = 'card_gateway'
+  expectFailure(() => validateInvoiceConfig(badChannel), 'config_payment_channel_0_category_invalid', 'bad_channel')
+  const noChannels = sampleConfig(); noChannels.paymentChannels = []
+  expectFailure(() => validateInvoiceConfig(noChannels), 'config_payment_channels_invalid', 'no_channels')
+  const implicitTax = sampleConfig(); implicitTax.tax = { decided: true }
+  expectFailure(() => validateInvoiceConfig(implicitTax), 'config_tax_description_required', 'implicit_tax')
+  const unknownKey = sampleConfig(); unknownKey.autoCharge = true
+  expectFailure(() => validateInvoiceConfig(unknownKey), 'config_unknown_key_autoCharge', 'unknown_key')
+  const badWorkspace = sampleConfig(); badWorkspace.workspace.id = ' bad id '
+  expectFailure(() => validateInvoiceConfig(badWorkspace), 'config_workspace_id_invalid', 'bad_workspace_id')
+  const dueBeforeIssue = sampleConfig(); dueBeforeIssue.dueDate = '2026-07-31'
+  expectFailure(() => validateInvoiceConfig(dueBeforeIssue), 'config_due_date_before_issue', 'due_before_issue')
+
+  // Filesystem behaviour: wx-writes never overwrite an existing packet.
+  const scratch = await mkdtemp(join(tmpdir(), 'managed-invoice-selftest-'))
+  try {
+    const configPath = join(scratch, 'config.json')
+    await writeFile(configPath, configText, { encoding: 'utf8', flag: 'wx' })
+    const outDir = join(scratch, 'out')
+    const written = await prepare(configPath, outDir)
+    const reread = await readFile(written.jsonPath, 'utf8')
+    if (reread !== `${JSON.stringify(first.packet, null, 2)}\n`) throw new Error('self_test_written_packet_differs')
+    verifyInvoicePacket(reread)
+    let overwriteError = null
+    try { await prepare(configPath, outDir) } catch (error) { overwriteError = error }
+    if (overwriteError?.code !== 'EEXIST') throw new Error('self_test_wx_overwrite_not_refused')
+  } finally {
+    await rm(scratch, { recursive: true, force: true })
+  }
+
+  return {
+    ok: true,
+    contract: INVOICE_PACKET_CONTRACT,
+    checks: 20,
+    deterministic: true,
+    networkActivity: 'none',
+    monetaryDefaults: 'none',
+  }
+}
+
+function argValue(args, flag) {
+  const index = args.indexOf(flag)
+  if (index === -1 || !args[index + 1]) fail(`argument_${flag.replace(/^--/, '')}_required`)
+  return args[index + 1]
+}
+
+async function main() {
+  const args = process.argv.slice(2)
+  if (args[0] === '--self-test' && args.length === 1) {
+    console.log(JSON.stringify(await selfTest()))
+    return
+  }
+  if (args[0] === '--verify' && args.length === 2) {
+    const result = verifyInvoicePacket(await readFile(resolve(args[1]), 'utf8'))
+    console.log(JSON.stringify({ ok: true, ...result }))
+    return
+  }
+  if (args.includes('--config') && args.includes('--out') && args.length === 4) {
+    const { packet, jsonPath, textPath } = await prepare(argValue(args, '--config'), argValue(args, '--out'))
+    console.log(JSON.stringify({
+      ok: true,
+      invoiceId: packet.invoice.invoiceId,
+      status: packet.status,
+      invoiceDigest: packet.invoiceDigest,
+      packet: basename(jsonPath),
+      printable: basename(textPath),
+      founderActionRequired: true,
+    }))
+    return
+  }
+  fail('usage: prepare_managed_invoice --config <config.json> --out <dir> | --verify <packet.json> | --self-test')
+}
+
+const invokedDirectly = process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+if (invokedDirectly) {
+  main().catch((error) => {
+    console.error(JSON.stringify({ ok: false, error: String(error?.message || 'managed_invoice_failed').slice(0, 240), externalWritesPerformed: false }))
+    process.exitCode = 1
+  })
+}


### PR DESCRIPTION
Closes the go/no-go audit's gate 9 (billing was entirely absent). Design: manual-first lifecycle (founder issues → customer pays out-of-band → founder verifies and marks paid), mirroring the repo's own ecommerce adapter deferral; payment channels are generic categories (bank_transfer | mobile_money | cash) derived strictly from rails already in the codebase; contract supermega.managed-billing.v1 with draft→issued→paid/void lifecycle, sha256 digest binding, and a transcription-ready control-record envelope (kernel prefix wiring deliberately deferred to ride with the managed-persistence gates). Price, currency mix, and tax are explicitly undecided founder parameters — the CLI takes amounts only from founder-supplied config, with no monetary defaults anywhere (verifier-grepped).

tools/prepare_managed_invoice.mjs: deterministic digest-bound invoice packets, --verify and --self-test (20 checks: byte-identical determinism, tamper detection, 13 fail-closed rejections, wx overwrite refusal). Standalone scripts, no guard-pinned chains touched; ledger regenerated; hq:verify green. Adversarially verified (pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)